### PR TITLE
Update Makefile

### DIFF
--- a/examples/eventloop/Makefile
+++ b/examples/eventloop/Makefile
@@ -6,5 +6,5 @@ evloop:
 		socket.c \
 		fileio.c \
 		ncurses.c \
-		../../src/duktape.c \
+		../../dist/src/duktape.c \
 		-lm -lncurses


### PR DESCRIPTION
if all you build is `make duk` in the root dir, `make` would fail building `evloop` executable.

Not sure if worth mentioning this in the README.txt too
