### PR TITLE
Specify the output filename of wget explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -703,7 +703,7 @@ compiler-latest.zip:
 closure-compiler:
 	# https://github.com/google/closure-compiler
 	@rm -f v20140814.tar.gz
-	$(WGET) https://github.com/google/closure-compiler/archive/v20140814.tar.gz
+	$(WGET) https://github.com/google/closure-compiler/archive/v20140814.tar.gz -O v20140814.tar.gz
 	tar xfz v20140814.tar.gz
 	mv closure-compiler-20140814 closure-compiler
 	@rm -f v20140814.tar.gz


### PR DESCRIPTION
Currently, it saves the output as `v20140814`, not `v20140814.tar.gz`.
And it causes build failures.
This change fixes it by specifying the output name explicitly.
