### PR TITLE
Add Duktape.env OS string for TI-Nspire

### DIFF
--- a/src/duk_features.h.in
+++ b/src/duk_features.h.in
@@ -497,7 +497,7 @@ static __inline__ unsigned long long duk_rdtsc(void) {
 #include <sys/param.h>
 #include <sys/time.h>
 #include <time.h>
-#elif defined(_TINSPIRE)
+#elif defined(DUK_F_TINSPIRE)
 #define DUK_USE_DATE_NOW_GETTIMEOFDAY
 #define DUK_USE_DATE_TZO_GMTIME_R
 #define DUK_USE_DATE_PRS_STRPTIME
@@ -2184,6 +2184,8 @@ typedef FILE duk_file;
 #define DUK_USE_OS_STRING "amigaos"
 #elif defined(DUK_F_QNX)
 #define DUK_USE_OS_STRING "qnx"
+#elif defined(DUK_F_TINSPIRE)
+#define DUK_USE_OS_STRING "tinspire"
 #else
 #define DUK_USE_OS_STRING "unknown"
 #endif


### PR DESCRIPTION
In #113, I forgot to add the Duktape.env OS string for the TI-Nspire, so I'm adding that now. I made it "tinspire".
Also, I had used _TINSPIRE in the date provider selection, so I changed that to DUK_F_TINSPIRE.