### PR TITLE
Implement debugger halt-on-throw

### DIFF
--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1292,6 +1292,31 @@ Example::
 
 Logger output redirected from Duktape logger calls.
 
+Throw notification (0x05)
+-------------------------
+
+Format::
+
+    NFY <int: 5> <int: fatal> <str: msg> <str: filename> <int: linenumber> EOM
+
+Example::
+
+    NFY 5 1 "ReferenceError: identifier not defined" "pig.js" 812 EOM
+
+Fatal is one of:
+
+* 0x00: caught
+* 0x01: fatal (uncaught)
+
+Duktape sends a Throw notification whenever an error is thrown, either by
+Duktape due to a runtime error or directly by Ecmascript code.
+
+msg is the string-coerced value being thrown. Filename and line number are
+taken directly from the thrown object if it is an Error instance (after
+augmentation), otherwise these values are calculated from the bytecode
+executor state.
+
+
 Commands sent by debug client
 =============================
 

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1316,7 +1316,6 @@ taken directly from the thrown object if it is an Error instance (after
 augmentation), otherwise these values are calculated from the bytecode
 executor state.
 
-
 Commands sent by debug client
 =============================
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -847,6 +847,51 @@ DUK_INTERNAL void duk_debug_send_status(duk_hthread *thr) {
 	duk_debug_write_eom(thr);
 }
 
+DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
+	/*
+	 * NFY <int: 5> <int: fatal> <str: msg> <str: filename> <int: linenumber> EOM
+	 */
+
+	duk_context *ctx = (duk_context *)thr;
+	duk_activation *act;
+	duk_uint32_t pc;
+
+	DUK_ASSERT(thr->valstack_top > thr->valstack);  /* ... [err] */
+
+	duk_debug_write_notify(thr, DUK_DBG_CMD_THROW);
+	duk_debug_write_int(thr, fatal);
+
+	/* Report thrown value to client coerced to string */
+	duk_dup(ctx, -1);
+	duk_safe_to_string(ctx, -1);
+	duk_debug_write_hstring(thr, duk_require_hstring(ctx, -1));
+	duk_pop(ctx);
+
+	if (duk_is_error(ctx, -1)) {
+		/* Error instance, use augmented error data directly */
+		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_FILE_NAME);
+		duk_safe_to_string(ctx, -1);
+		duk_debug_write_hstring(thr, duk_require_hstring(ctx, -1));
+		duk_get_prop_stridx(ctx, -2, DUK_STRIDX_LINE_NUMBER);
+		duk_debug_write_uint(thr, duk_get_uint(ctx, -1));
+		duk_pop_2(ctx);
+	} else {
+		/* For anything other than an Error instance, we calculate the error
+		 * location directly from the current activation.
+		 */
+		act = thr->callstack + thr->callstack_top - 1;
+		duk_push_hobject(ctx, act->func);
+		duk_get_prop_string(ctx, -1, "fileName");
+		duk_safe_to_string(ctx, -1);
+		duk_debug_write_hstring(thr, duk_require_hstring(ctx, -1));
+		pc = duk_hthread_get_act_prev_pc(thr, act);
+		duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_pc2line_query(ctx, -2, pc));
+		duk_pop_2(ctx);
+	}
+
+	duk_debug_write_eom(thr);
+}
+
 /*
  *  Debug message processing
  */
@@ -1637,6 +1682,55 @@ DUK_LOCAL void duk__debug_process_message(duk_hthread *thr) {
  fail:
 	DUK__SET_CONN_BROKEN(thr);
 	return;
+}
+
+/* Halt execution and enter a debugger message loop until execution is resumed
+ * by the client. PC for the current activation may be temporarily decremented
+ * so that the "current" instruction will be shown by the client.
+ */
+
+DUK_INTERNAL void duk_debug_halt_execution(duk_hthread *thr, duk_bool_t use_prev_pc) {
+	duk_activation *act;
+	duk_hcompiledfunction *fun;
+	duk_instr_t *old_pc;
+
+	DUK_HEAP_SET_PAUSED(thr->heap);
+
+	act = duk_hthread_get_current_activation(thr);
+
+	/* NOTE: act may be NULL if an error is thrown outside of any activation, which may
+	 * happen in the case of, e.g. syntax errors.
+	 */
+
+	/* Decrement PC if that was requested, this requires a PC sync */
+	if (act != NULL) {
+		duk_hthread_sync_currpc(thr);
+		old_pc = act->curr_pc;
+		fun = (duk_hcompiledfunction *)DUK_ACT_GET_FUNC(act);
+		if (use_prev_pc && act->curr_pc != NULL &&
+			act->curr_pc > DUK_HCOMPILEDFUNCTION_GET_CODE_BASE(thr->heap, fun)) {
+			act->curr_pc--;
+		}
+	}
+
+	/* Process debug messages until we are no longer paused. */
+
+	/* NOTE: This is a bit fragile. It's important to ensure that neither
+	 * duk_debug_send_status() or duk_debug_process_messages() throws an error
+	 * or act->curr_pc will never be reset.
+	 */
+
+	thr->heap->dbg_processing = 1;
+	duk_debug_send_status(thr);
+	while (thr->heap->dbg_paused) {
+		DUK_ASSERT(thr->heap->dbg_processing);
+		duk_debug_process_messages(thr, 0 /* no_block */);
+	}
+	thr->heap->dbg_processing = 0;
+
+	if (act != NULL) {
+		act->curr_pc = old_pc;  /* restore PC */
+	}
 }
 
 DUK_INTERNAL duk_bool_t duk_debug_process_messages(duk_hthread *thr, duk_bool_t no_block) {

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -880,7 +880,7 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 		 * location directly from the current activation.
 		 */
 		act = thr->callstack + thr->callstack_top - 1;
-		duk_push_hobject(ctx, act->func);
+		duk_push_tval(ctx, &act->tv_func);
 		duk_get_prop_string(ctx, -1, "fileName");
 		duk_safe_to_string(ctx, -1);
 		duk_debug_write_hstring(thr, duk_require_hstring(ctx, -1));

--- a/src/duk_debugger.h
+++ b/src/duk_debugger.h
@@ -19,6 +19,7 @@
 #define DUK_DBG_CMD_PRINT         0x02
 #define DUK_DBG_CMD_ALERT         0x03
 #define DUK_DBG_CMD_LOG           0x04
+#define DUK_DBG_CMD_THROW         0x05
 
 /* Initiated by debug client */
 #define DUK_DBG_CMD_BASICINFO     0x10
@@ -86,7 +87,9 @@ DUK_INTERNAL_DECL void duk_debug_write_eom(duk_hthread *thr);
 
 DUK_INTERNAL duk_uint_fast32_t duk_debug_curr_line(duk_hthread *thr);
 DUK_INTERNAL void duk_debug_send_status(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal);
 
+DUK_INTERNAL_DECL void duk_debug_halt_execution(duk_hthread *thr, duk_bool_t use_prev_pc);
 DUK_INTERNAL_DECL duk_bool_t duk_debug_process_messages(duk_hthread *thr, duk_bool_t no_block);
 
 DUK_INTERNAL_DECL duk_small_int_t duk_debug_add_breakpoint(duk_hthread *thr, duk_hstring *filename, duk_uint32_t line);

--- a/src/duk_error_misc.c
+++ b/src/duk_error_misc.c
@@ -5,6 +5,35 @@
 #include "duk_internal.h"
 
 /*
+ * Helper to walk the thread chain and see if there is an active error
+ * catcher. Protected calls aren't considered.
+ */
+
+DUK_LOCAL duk_bool_t duk__have_active_catcher(duk_hthread *thr) {
+	/*
+	 * XXX: As noted above, a protected API call won't be counted as a
+	 * catcher. This is usually convenient, e.g. in the case of a top-
+	 * level duk_pcall(), but may not always be desirable. Perhaps add an
+	 * argument to treat them as catchers?
+	 */
+
+	duk_size_t i;
+
+	DUK_ASSERT(thr != NULL);
+
+	while (thr != NULL) {
+		for (i = 0; i < thr->catchstack_top; i++) {
+			duk_catcher *cat = thr->catchstack + i;
+			if (DUK_CAT_HAS_CATCH_ENABLED(cat)) {
+				return 1;  /* all we need to know */
+			}
+		}
+		thr = thr->resumer;
+	}
+	return 0;
+}
+
+/*
  *  Get prototype object for an integer error code.
  */
 
@@ -41,6 +70,49 @@ DUK_INTERNAL duk_hobject *duk_error_prototype_from_code(duk_hthread *thr, duk_er
 
 DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t lj_type) {
 	duk_tval tv_tmp;
+
+#if defined(DUK_USE_DEBUGGER_SUPPORT)
+
+	/* If something is thrown with the debugger attached and nobody will
+	 * catch it, execution is paused before the longjmp, turning over
+	 * control to the debug client. This allows local state to be examined
+	 * before the stack is unwound.
+	 */
+
+	/* TODO: Allow customizing the pause and notify behavior */
+
+	if (DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap) && lj_type == DUK_LJ_TYPE_THROW) {
+		duk_context *ctx = (duk_context *) thr;
+		duk_bool_t fatal;
+		duk_bool_t is_syntax_err;
+		duk_hobject *hobj;
+
+		/* Don't intercept a DoubleError, we may have caused the initial double
+		 * fault and attempting to intercept it will cause us to be called
+		 * recursively and exhaust the C stack.
+		 */
+		hobj = duk_get_hobject(ctx, -1);
+		if (hobj == thr->builtins[DUK_BIDX_DOUBLE_ERROR]) {
+			DUK_D(DUK_DPRINT("built-in DoubleError instance thrown, not intercepting"));
+			goto skip_throw_intercept;
+		}
+
+		DUK_D(DUK_DPRINT("throw with debugger attached, report to client"));
+
+		fatal = !duk__have_active_catcher(thr);
+
+		/* Report it to the debug client */
+		duk_debug_send_throw(thr, fatal);
+
+		if (fatal && !is_syntax_err) {
+			DUK_D(DUK_DPRINT("throw will be fatal, halt before longjmp"));
+			duk_debug_halt_execution(thr, 1 /* use_prev_pc */);
+		}
+	}
+
+skip_throw_intercept:
+
+#endif
 
 	thr->heap->lj.type = lj_type;
 


### PR DESCRIPTION
When the debugger is attached and an error is thrown with no active catch site, either a runtime error thrown by Duktape or directly by Ecmascript code, the debug client is notified and execution is paused at the error site to allow the developer to view program state.  This is useful, as this information will be lost once the stack is unwound.

Implementation checklist:
- [x] Implement the basic logic for debugger error intercept.
- [x] Add a Throw notification to alert the client to the error.
- [x] Ensure yield/resume awareness to avoid spurious pauses.
- [x] Fix C stack overflow when an error is thrown at max recursion (double error pileup).
- [x] Fix crashes when intercepting errors originating from the compiler (fixed by not intercepting them).
- [x] Fix an assert failure when execution is stopped inside a Duktape/C call.
- [x] Finalize changes and ensure consistency with Duktape codebase.
