### PR TITLE
Example changes and fixes

### DIFF
--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -772,6 +772,11 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "Cleaning up...\n");
 		fflush(stderr);
 	}
+#ifdef DUK_CMDLINE_DEBUGGER_SUPPORT
+	if (debugger) {
+		duk_trans_socket_finish();
+	}
+#endif
 
 #ifdef DUK_CMDLINE_AJSHEAP
 	if (alloc_provider == ALLOC_AJSHEAP) {

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -15,7 +15,9 @@
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || \
     defined(WIN64) || defined(_WIN64) || defined(__WIN64__)
 /* Suppress warnings about plain fopen() etc. */
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #endif
 
 #define  GREET_CODE(variant)  \

--- a/examples/custom-c-object/README.rst
+++ b/examples/custom-c-object/README.rst
@@ -1,0 +1,14 @@
+====================
+Example Custom objects.
+====================
+
+This creates two new objects for the ECMAScript engine. These objects are as 
+follows...
+
+Shape Object type - A simple object that also uses a built in ecmascript 
+function to override the toString built in.
+
+vector2D Object type - A more complex object that features user pointers, two
+pairs of getter and setter functions, and a c powered toString function. This
+also shows how to customize the constructor with variable arguments and 
+argument types.

--- a/examples/custom-c-object/custom-object-main.c
+++ b/examples/custom-c-object/custom-object-main.c
@@ -243,8 +243,8 @@ int main(int argc, char *argv[]) {
 	return 0;
  usage:
 	fprintf(stderr, "Usage: duk [options] [<filenames>]\n"
-	                "\n"
-	                "   --shapeExample    Run built in shape example script.\n"
+					"\n"
+					"   --shapeExample    Run built in shape example script.\n"
 					"   --vectorExample   Run built in vector example script.\n"
 					);
 	fflush(stderr);

--- a/examples/custom-c-object/custom-object-main.c
+++ b/examples/custom-c-object/custom-object-main.c
@@ -1,0 +1,253 @@
+/* Example that creates two different Objects 
+ *
+ * Object 1 - Shape 
+ * This object shows how to construct a basic object with C functions to
+ * define the function move.
+ *
+ * Object 2 - vector2D 
+ * This object shows how to properly clean up user data in a custom C object.
+ *
+ */
+
+#include "custom-object.h"
+
+
+duk_context* createMyHeap()
+{
+	duk_context *ctx = NULL;
+	/* FIXME: resource limits */
+	ctx = duk_create_heap_default();
+	if (!ctx) {
+		fprintf(stderr, "cannot allocate heap for testcase\n");
+		return NULL;
+	}
+	return ctx;
+}
+
+void run_pcompile_file(const char* file)
+{
+	duk_context *ctx = NULL;
+	ctx = createMyHeap();
+	if (ctx) {
+		duk_register_shape(ctx);
+		duk_register_Vector2D(ctx);
+		printf("\n\nduk_pcompile_file Test: on %s\n", file);
+		if (duk_pcompile_file(ctx, 0, "myVectors2B.js") != 0) {
+			printf("compile failed: %s\n", duk_safe_to_string(ctx, -1));
+		}
+		else {
+			duk_call(ctx, 0);      /* [ func ] -> [ result ] */
+			printf("program result: %s\n", duk_safe_to_string(ctx, -1));
+		}
+		duk_destroy_heap(ctx);
+	}
+}
+
+void run_peval_file(const char* file)
+{
+	duk_context *ctx = NULL;
+	ctx = createMyHeap();
+	if (ctx) {
+		duk_register_shape(ctx);
+		duk_register_Vector2D(ctx);
+		printf("\n\nduk_peval_file_noresult Test on %s \n",file);
+		if (duk_peval_file_noresult(ctx, file) != 0) {
+			printf("duk_peval_file_noresult: eval failed\n");
+		}
+		else {
+			printf("duk_peval_file_noresult: eval successful\n");
+		}
+		duk_destroy_heap(ctx);
+	}
+}
+
+/* Shape Example Built In */
+const char *ShapeExamplePartA[] = {
+	"var myShape = new Shape(0,1,2);\n",
+	"print(myShape);\n",
+	"myShape.move(3,9);\n",
+	"print(myShape.toString());\n",
+	NULL };
+	
+const char *ShapeExamplePartB[] = {
+	{"myShape.move(9,3);\n" },
+	{ "print(myShape);\n" },
+	{ "if (myShape instanceof vector2D) {\n"
+	  "\tprint(\"myShape is an Instance of vector2D\");\n"
+	  "} else {\n"
+	  "\tprint(\"myShape is not an instance of vector2D\");\n"
+	  "}\n"
+	 },
+	/* This Next Item looks odd, but it is Valid C/C++*/
+	{ "if (myShape instanceof Shape) {\n" 
+	  "print(\"myShape is an Instance of Shape\");\n"
+	  "} else {\n"
+	  "print(\"myShape is not an instance of Shape\");\n"
+	  "}\n" },
+	  {
+		  "if (isVector2D(myShape)) {\n"
+		  "\tprint(\"myShape is 2D Vector.\");"
+		  "} else {\n"
+		  "\t print(\"myShape is not a 2D Vector.\");\n}\n"
+	  },
+	  {
+		  "if (isShape(myShape)) {\n"
+		  "\tprint(\"myShape is Shape.\");"
+		  "} else {\n"
+		  "\t print(\"myShape is not a Shape.\");\n}\n"
+	  },
+	  { "try {\n"
+	  "\tvar myShapeB = Shape(1,2,3); print(myShapeB);\n"
+	  "\tif (isShape(myShapeB)) {\n"
+	  "\t\tprint(\"myShapeB is a Shape\");\n"
+	  "\t} else {\n"
+	  "\t\t print(\"myShapeB is not a Shape\");\n\t}\n"
+	  "} catch (e) {\n"
+	  "\tprint(\"Failed to Create myShapeOneArg: \" + e);\n"
+	  "}\n" },
+	NULL };
+
+void run_Shape_example()
+{
+	duk_context *ctx = NULL;
+	int i = 0;
+	ctx = createMyHeap();
+	if (ctx) {
+		printf("---------------------------------------\n");
+		printf("Shape Example Script:\n");
+		printf("---------------------------------------\n");
+		duk_register_shape(ctx);
+		duk_register_Vector2D(ctx);
+
+		for (i = 0; ShapeExamplePartA[i]; i++) {
+			printf("Eval: %s\n", ShapeExamplePartA[i]);
+			if (duk_peval_string_noresult(ctx, ShapeExamplePartA[i])) {
+				printf("eval failed\n");
+			}
+		}
+		/* In this part you do internal stuff.*/
+		/* TODO: Add internal stuff */
+
+		for (i = 0; ShapeExamplePartB[i]; i++) {
+			printf("Eval: %s\n", ShapeExamplePartB[i]);
+			if (duk_peval_string_noresult(ctx, ShapeExamplePartB[i])) {
+				printf("eval failed\n");
+			}
+		}
+		duk_destroy_heap(ctx);
+	}
+}
+
+/* Vector Example Built In */
+const char * VectorExample[] = {
+	"myVectorT = new vector2D(1.0, 2.0);\n",
+	"myVectorTX = new vector2D(myVectorT);\n",
+	"print(myVectorT);\n",
+	{ "\ntry {\n"
+	  "\tvar myBadVector = vector2D(1.0, 2.0);\n"
+	  "} catch (e) {\n"
+	  "\tprint(\"Error creating myBadVector: \" + e);\n"
+	  "}\n" },
+	  {
+		  "if (myVectorT instanceof vector2D) {\n"
+		  "\tprint(\"myVectorT is an Instance of vector2D\");\n"
+		  "} else {\n"
+		  "\tprint(\"myVectorT is not an instance of vector2D\");\n"
+		  "}\n"
+	  },
+	  {
+		  "if (isShape(myVectorTX)) {\n"
+		  "\tprint(\"myVectorTX is a Shape\");\n"
+		  "} else {\n"
+		  "\t print(\"myVectorTX is not a Shape\");\n}\n"
+	  },
+	  {
+		  "if (isVector2D(myVectorTX)) {\n"
+		  "\tprint(\"myVectorTX is 2D Vector.\");\n"
+		  "} else {\n"
+		  "\t print(\"myVectorTX is not a 2D Vector.\");\n}\n"
+	  },
+	/* Force the Vector Finalizer to run */
+	"delete myVectorT;\n",
+	"myVectorT = null;\n",
+	"print(myVectorT);\n",
+	/* myVectorTX still exists. */
+	"print(myVectorTX);\n",
+	NULL};
+	
+void run_Vector_example()
+{
+	duk_context *ctx = NULL;
+	int i = 0;
+	ctx = createMyHeap();
+	if (ctx) {
+
+		printf("---------------------------------------\n");
+		printf("Vector Example Script:\n");
+		printf("---------------------------------------\n");
+		duk_register_shape(ctx);
+		duk_register_Vector2D(ctx);
+
+		/* This works */
+		for (i = 0; VectorExample[i]; i++) {
+			printf("Eval: %s\n", VectorExample[i]);
+			if (duk_peval_string_noresult(ctx, VectorExample[i])) {
+				printf("eval failed\n");
+			}
+		}
+		duk_destroy_heap(ctx);
+	}
+}
+int main(int argc, char *argv[]) {
+	int i;
+	int have_files = 0;
+	int runVectorExample = 0;
+	int runShapeExample = 0;
+	for (i = 1; i < argc; i++) {
+		char *arg = argv[i];
+		if (!arg) {
+			goto usage;
+		}
+		if (strcmp(arg, "--vectorExample") == 0) {
+			runVectorExample = 1;
+		} else if (strcmp(arg, "--shapeExample") == 0) {
+			runShapeExample = 1;
+		} else {
+			have_files = 1;
+		}
+	}
+	if (have_files) {
+		for (i = 1; i < argc; i++) {
+			char *arg = argv[i];
+			if (!arg) {
+				goto usage;
+			}
+			if (strcmp(arg, "--vectorExample") == 0) {
+				continue;
+			}
+			else if (strcmp(arg, "--shapeExample") == 0) {
+				continue;
+			}
+			else {
+				run_peval_file(arg);
+			}
+		}
+	}
+	
+	if (runShapeExample) {
+		run_Shape_example();
+	}
+	if (runVectorExample) {
+		run_Vector_example();
+	}
+	return 0;
+ usage:
+	fprintf(stderr, "Usage: duk [options] [<filenames>]\n"
+	                "\n"
+	                "   --shapeExample    Run built in shape example script.\n"
+					"   --vectorExample   Run built in vector example script.\n"
+					);
+	fflush(stderr);
+	exit(1);
+ 	return 0;
+}

--- a/examples/custom-c-object/custom-object-main.c
+++ b/examples/custom-c-object/custom-object-main.c
@@ -14,240 +14,239 @@
 
 duk_context* createMyHeap()
 {
-	duk_context *ctx = NULL;
-	/* FIXME: resource limits */
-	ctx = duk_create_heap_default();
-	if (!ctx) {
-		fprintf(stderr, "cannot allocate heap for testcase\n");
-		return NULL;
-	}
-	return ctx;
+    duk_context *ctx = NULL;
+    /* FIXME: resource limits */
+    ctx = duk_create_heap_default();
+    if (!ctx) {
+        fprintf(stderr, "cannot allocate heap for testcase\n");
+        return NULL;
+    }
+    return ctx;
 }
 
 void run_pcompile_file(const char* file)
 {
-	duk_context *ctx = NULL;
-	ctx = createMyHeap();
-	if (ctx) {
-		duk_register_shape(ctx);
-		duk_register_Vector2D(ctx);
-		printf("\n\nduk_pcompile_file Test: on %s\n", file);
-		if (duk_pcompile_file(ctx, 0, "myVectors2B.js") != 0) {
-			printf("compile failed: %s\n", duk_safe_to_string(ctx, -1));
-		}
-		else {
-			duk_call(ctx, 0);      /* [ func ] -> [ result ] */
-			printf("program result: %s\n", duk_safe_to_string(ctx, -1));
-		}
-		duk_destroy_heap(ctx);
-	}
+    duk_context *ctx = NULL;
+    ctx = createMyHeap();
+    if (ctx) {
+        duk_register_shape(ctx);
+        duk_register_Vector2D(ctx);
+        printf("\n\nduk_pcompile_file Test: on %s\n", file);
+        if (duk_pcompile_file(ctx, 0, "myVectors2B.js") != 0) {
+            printf("compile failed: %s\n", duk_safe_to_string(ctx, -1));
+        } else {
+            duk_call(ctx, 0);      /* [ func ] -> [ result ] */
+            printf("program result: %s\n", duk_safe_to_string(ctx, -1));
+        }
+        duk_destroy_heap(ctx);
+    }
 }
 
 void run_peval_file(const char* file)
 {
-	duk_context *ctx = NULL;
-	ctx = createMyHeap();
-	if (ctx) {
-		duk_register_shape(ctx);
-		duk_register_Vector2D(ctx);
-		printf("\n\nduk_peval_file_noresult Test on %s \n",file);
-		if (duk_peval_file_noresult(ctx, file) != 0) {
-			printf("duk_peval_file_noresult: eval failed\n");
-		}
-		else {
-			printf("duk_peval_file_noresult: eval successful\n");
-		}
-		duk_destroy_heap(ctx);
-	}
+    duk_context *ctx = NULL;
+    ctx = createMyHeap();
+    if (ctx) {
+        duk_register_shape(ctx);
+        duk_register_Vector2D(ctx);
+        printf("\n\nduk_peval_file_noresult Test on %s \n",file);
+        if (duk_peval_file_noresult(ctx, file) != 0) {
+            printf("duk_peval_file_noresult: eval failed\n");
+        }
+        else {
+            printf("duk_peval_file_noresult: eval successful\n");
+        }
+        duk_destroy_heap(ctx);
+    }
 }
 
 /* Shape Example Built In */
 const char *ShapeExamplePartA[] = {
-	"var myShape = new Shape(0,1,2);\n",
-	"print(myShape);\n",
-	"myShape.move(3,9);\n",
-	"print(myShape.toString());\n",
-	NULL };
-	
+    "var myShape = new Shape(0,1,2);\n",
+    "print(myShape);\n",
+    "myShape.move(3,9);\n",
+    "print(myShape.toString());\n",
+    NULL };
+    
 const char *ShapeExamplePartB[] = {
-	{"myShape.move(9,3);\n" },
-	{ "print(myShape);\n" },
-	{ "if (myShape instanceof vector2D) {\n"
-	  "\tprint(\"myShape is an Instance of vector2D\");\n"
-	  "} else {\n"
-	  "\tprint(\"myShape is not an instance of vector2D\");\n"
-	  "}\n"
-	 },
-	/* This Next Item looks odd, but it is Valid C/C++*/
-	{ "if (myShape instanceof Shape) {\n" 
-	  "print(\"myShape is an Instance of Shape\");\n"
-	  "} else {\n"
-	  "print(\"myShape is not an instance of Shape\");\n"
-	  "}\n" },
-	  {
-		  "if (isVector2D(myShape)) {\n"
-		  "\tprint(\"myShape is 2D Vector.\");"
-		  "} else {\n"
-		  "\t print(\"myShape is not a 2D Vector.\");\n}\n"
-	  },
-	  {
-		  "if (isShape(myShape)) {\n"
-		  "\tprint(\"myShape is Shape.\");"
-		  "} else {\n"
-		  "\t print(\"myShape is not a Shape.\");\n}\n"
-	  },
-	  { "try {\n"
-	  "\tvar myShapeB = Shape(1,2,3); print(myShapeB);\n"
-	  "\tif (isShape(myShapeB)) {\n"
-	  "\t\tprint(\"myShapeB is a Shape\");\n"
-	  "\t} else {\n"
-	  "\t\t print(\"myShapeB is not a Shape\");\n\t}\n"
-	  "} catch (e) {\n"
-	  "\tprint(\"Failed to Create myShapeOneArg: \" + e);\n"
-	  "}\n" },
-	NULL };
+    {"myShape.move(9,3);\n" },
+    { "print(myShape);\n" },
+    { "if (myShape instanceof vector2D) {\n"
+      "\tprint(\"myShape is an Instance of vector2D\");\n"
+      "} else {\n"
+      "\tprint(\"myShape is not an instance of vector2D\");\n"
+      "}\n"
+     },
+    /* This Next Item looks odd, but it is Valid C/C++*/
+    { "if (myShape instanceof Shape) {\n" 
+      "print(\"myShape is an Instance of Shape\");\n"
+      "} else {\n"
+      "print(\"myShape is not an instance of Shape\");\n"
+      "}\n" },
+      {
+          "if (isVector2D(myShape)) {\n"
+          "\tprint(\"myShape is 2D Vector.\");"
+          "} else {\n"
+          "\t print(\"myShape is not a 2D Vector.\");\n}\n"
+      },
+      {
+          "if (isShape(myShape)) {\n"
+          "\tprint(\"myShape is Shape.\");"
+          "} else {\n"
+          "\t print(\"myShape is not a Shape.\");\n}\n"
+      },
+      { "try {\n"
+      "\tvar myShapeB = Shape(1,2,3); print(myShapeB);\n"
+      "\tif (isShape(myShapeB)) {\n"
+      "\t\tprint(\"myShapeB is a Shape\");\n"
+      "\t} else {\n"
+      "\t\t print(\"myShapeB is not a Shape\");\n\t}\n"
+      "} catch (e) {\n"
+      "\tprint(\"Failed to Create myShapeOneArg: \" + e);\n"
+      "}\n" },
+    NULL };
 
 void run_Shape_example()
 {
-	duk_context *ctx = NULL;
-	int i = 0;
-	ctx = createMyHeap();
-	if (ctx) {
-		printf("---------------------------------------\n");
-		printf("Shape Example Script:\n");
-		printf("---------------------------------------\n");
-		duk_register_shape(ctx);
-		duk_register_Vector2D(ctx);
+    duk_context *ctx = NULL;
+    int i = 0;
+    ctx = createMyHeap();
+    if (ctx) {
+        printf("---------------------------------------\n");
+        printf("Shape Example Script:\n");
+        printf("---------------------------------------\n");
+        duk_register_shape(ctx);
+        duk_register_Vector2D(ctx);
 
-		for (i = 0; ShapeExamplePartA[i]; i++) {
-			printf("Eval: %s\n", ShapeExamplePartA[i]);
-			if (duk_peval_string_noresult(ctx, ShapeExamplePartA[i])) {
-				printf("eval failed\n");
-			}
-		}
-		/* In this part you do internal stuff.*/
-		/* TODO: Add internal stuff */
+        for (i = 0; ShapeExamplePartA[i]; i++) {
+            printf("Eval: %s\n", ShapeExamplePartA[i]);
+            if (duk_peval_string_noresult(ctx, ShapeExamplePartA[i])) {
+                printf("eval failed\n");
+            }
+        }
+        /* In this part you do internal stuff.*/
+        /* TODO: Add internal stuff */
 
-		for (i = 0; ShapeExamplePartB[i]; i++) {
-			printf("Eval: %s\n", ShapeExamplePartB[i]);
-			if (duk_peval_string_noresult(ctx, ShapeExamplePartB[i])) {
-				printf("eval failed\n");
-			}
-		}
-		duk_destroy_heap(ctx);
-	}
+        for (i = 0; ShapeExamplePartB[i]; i++) {
+            printf("Eval: %s\n", ShapeExamplePartB[i]);
+            if (duk_peval_string_noresult(ctx, ShapeExamplePartB[i])) {
+                printf("eval failed\n");
+            }
+        }
+        duk_destroy_heap(ctx);
+    }
 }
 
 /* Vector Example Built In */
 const char * VectorExample[] = {
-	"myVectorT = new vector2D(1.0, 2.0);\n",
-	"myVectorTX = new vector2D(myVectorT);\n",
-	"print(myVectorT);\n",
-	{ "\ntry {\n"
-	  "\tvar myBadVector = vector2D(1.0, 2.0);\n"
-	  "} catch (e) {\n"
-	  "\tprint(\"Error creating myBadVector: \" + e);\n"
-	  "}\n" },
-	  {
-		  "if (myVectorT instanceof vector2D) {\n"
-		  "\tprint(\"myVectorT is an Instance of vector2D\");\n"
-		  "} else {\n"
-		  "\tprint(\"myVectorT is not an instance of vector2D\");\n"
-		  "}\n"
-	  },
-	  {
-		  "if (isShape(myVectorTX)) {\n"
-		  "\tprint(\"myVectorTX is a Shape\");\n"
-		  "} else {\n"
-		  "\t print(\"myVectorTX is not a Shape\");\n}\n"
-	  },
-	  {
-		  "if (isVector2D(myVectorTX)) {\n"
-		  "\tprint(\"myVectorTX is 2D Vector.\");\n"
-		  "} else {\n"
-		  "\t print(\"myVectorTX is not a 2D Vector.\");\n}\n"
-	  },
-	/* Force the Vector Finalizer to run */
-	"delete myVectorT;\n",
-	"myVectorT = null;\n",
-	"print(myVectorT);\n",
-	/* myVectorTX still exists. */
-	"print(myVectorTX);\n",
-	NULL};
-	
+    "myVectorT = new vector2D(1.0, 2.0);\n",
+    "myVectorTX = new vector2D(myVectorT);\n",
+    "print(myVectorT);\n",
+    { "\ntry {\n"
+      "\tvar myBadVector = vector2D(1.0, 2.0);\n"
+      "} catch (e) {\n"
+      "\tprint(\"Error creating myBadVector: \" + e);\n"
+      "}\n" },
+      {
+          "if (myVectorT instanceof vector2D) {\n"
+          "\tprint(\"myVectorT is an Instance of vector2D\");\n"
+          "} else {\n"
+          "\tprint(\"myVectorT is not an instance of vector2D\");\n"
+          "}\n"
+      },
+      {
+          "if (isShape(myVectorTX)) {\n"
+          "\tprint(\"myVectorTX is a Shape\");\n"
+          "} else {\n"
+          "\t print(\"myVectorTX is not a Shape\");\n}\n"
+      },
+      {
+          "if (isVector2D(myVectorTX)) {\n"
+          "\tprint(\"myVectorTX is 2D Vector.\");\n"
+          "} else {\n"
+          "\t print(\"myVectorTX is not a 2D Vector.\");\n}\n"
+      },
+    /* Force the Vector Finalizer to run */
+    "delete myVectorT;\n",
+    "myVectorT = null;\n",
+    "print(myVectorT);\n",
+    /* myVectorTX still exists. */
+    "print(myVectorTX);\n",
+    NULL};
+    
 void run_Vector_example()
 {
-	duk_context *ctx = NULL;
-	int i = 0;
-	ctx = createMyHeap();
-	if (ctx) {
+    duk_context *ctx = NULL;
+    int i = 0;
+    ctx = createMyHeap();
+    if (ctx) {
 
-		printf("---------------------------------------\n");
-		printf("Vector Example Script:\n");
-		printf("---------------------------------------\n");
-		duk_register_shape(ctx);
-		duk_register_Vector2D(ctx);
+        printf("---------------------------------------\n");
+        printf("Vector Example Script:\n");
+        printf("---------------------------------------\n");
+        duk_register_shape(ctx);
+        duk_register_Vector2D(ctx);
 
-		/* This works */
-		for (i = 0; VectorExample[i]; i++) {
-			printf("Eval: %s\n", VectorExample[i]);
-			if (duk_peval_string_noresult(ctx, VectorExample[i])) {
-				printf("eval failed\n");
-			}
-		}
-		duk_destroy_heap(ctx);
-	}
+        /* This works */
+        for (i = 0; VectorExample[i]; i++) {
+            printf("Eval: %s\n", VectorExample[i]);
+            if (duk_peval_string_noresult(ctx, VectorExample[i])) {
+                printf("eval failed\n");
+            }
+        }
+        duk_destroy_heap(ctx);
+    }
 }
 int main(int argc, char *argv[]) {
-	int i;
-	int have_files = 0;
-	int runVectorExample = 0;
-	int runShapeExample = 0;
-	for (i = 1; i < argc; i++) {
-		char *arg = argv[i];
-		if (!arg) {
-			goto usage;
-		}
-		if (strcmp(arg, "--vectorExample") == 0) {
-			runVectorExample = 1;
-		} else if (strcmp(arg, "--shapeExample") == 0) {
-			runShapeExample = 1;
-		} else {
-			have_files = 1;
-		}
-	}
-	if (have_files) {
-		for (i = 1; i < argc; i++) {
-			char *arg = argv[i];
-			if (!arg) {
-				goto usage;
-			}
-			if (strcmp(arg, "--vectorExample") == 0) {
-				continue;
-			}
-			else if (strcmp(arg, "--shapeExample") == 0) {
-				continue;
-			}
-			else {
-				run_peval_file(arg);
-			}
-		}
-	}
-	
-	if (runShapeExample) {
-		run_Shape_example();
-	}
-	if (runVectorExample) {
-		run_Vector_example();
-	}
-	return 0;
+    int i;
+    int have_files = 0;
+    int runVectorExample = 0;
+    int runShapeExample = 0;
+    for (i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (!arg) {
+            goto usage;
+        }
+        if (strcmp(arg, "--vectorExample") == 0) {
+            runVectorExample = 1;
+        } else if (strcmp(arg, "--shapeExample") == 0) {
+            runShapeExample = 1;
+        } else {
+            have_files = 1;
+        }
+    }
+    if (have_files) {
+        for (i = 1; i < argc; i++) {
+            char *arg = argv[i];
+            if (!arg) {
+                goto usage;
+            }
+            if (strcmp(arg, "--vectorExample") == 0) {
+                continue;
+            }
+            else if (strcmp(arg, "--shapeExample") == 0) {
+                continue;
+            }
+            else {
+                run_peval_file(arg);
+            }
+        }
+    }
+    
+    if (runShapeExample) {
+        run_Shape_example();
+    }
+    if (runVectorExample) {
+        run_Vector_example();
+    }
+    return 0;
  usage:
-	fprintf(stderr, "Usage: duk [options] [<filenames>]\n"
-					"\n"
-					"   --shapeExample    Run built in shape example script.\n"
-					"   --vectorExample   Run built in vector example script.\n"
-					);
-	fflush(stderr);
-	exit(1);
- 	return 0;
+    fprintf(stderr, "Usage: duk [options] [<filenames>]\n"
+                    "\n"
+                    "   --shapeExample    Run built in shape example script.\n"
+                    "   --vectorExample   Run built in vector example script.\n"
+                    );
+    fflush(stderr);
+    exit(1);
+    return 0;
 }

--- a/examples/custom-c-object/custom-object-shape.c
+++ b/examples/custom-c-object/custom-object-shape.c
@@ -1,0 +1,152 @@
+#include "custom-object.h"
+#include <string.h>
+#include <stdio.h>
+
+/* These Functions usually will go in a Header */
+duk_ret_t duk_class_shape_constructor(duk_context *ctx);
+duk_ret_t duk_class_shape_finalizer(duk_context *ctx);
+duk_ret_t duk_class_shape_func_move(duk_context *ctx);
+duk_ret_t duk_class_shape_func_toString(duk_context *ctx);
+duk_ret_t duk_class_shape_staticFunc(duk_context *ctx);
+duk_ret_t  duk_isShape(duk_context *ctx);
+
+duk_ret_t  duk_register_shape(duk_context *ctx)
+{
+	duk_idx_t object_id;
+	duk_push_global_object(ctx);
+	printf("Registering: Shape\n");
+	duk_push_c_function(ctx, duk_class_shape_constructor, 3);
+	object_id = duk_push_object(ctx);
+	
+	/* All Functions must be defined at the prototype level */
+	/* move Function  - C Function */
+	duk_put_prop_string(ctx, -2, "prototype"); 
+	duk_put_prop_string(ctx, -2, "Shape");
+
+	/* Add isShape global function */
+	duk_push_c_function(ctx, duk_isShape, 3);
+	duk_put_prop_string(ctx, -2, "isShape");
+	duk_pop(ctx);	
+	return 0;
+}
+
+duk_ret_t duk_class_shape_constructor(duk_context *ctx)
+{
+	int id = duk_require_int(ctx, 0);
+	int x = duk_require_int(ctx, 1);
+	int y = duk_require_int(ctx, 2);
+	duk_idx_t obj_idx;
+	duk_bool_t calledByConstructor = duk_is_constructor_call(ctx);
+	if (!calledByConstructor)
+	{
+		/* Not Called my new operator */
+		/* Create a new instance by duplicating args and calling again */
+		duk_push_global_object(ctx);
+		duk_get_prop_string(ctx, -1, "Shape");
+		duk_dup(ctx, -1);
+		duk_dup(ctx, 0);
+		duk_dup(ctx, 1);
+		duk_dup(ctx, 2);
+		duk_new(ctx, 3);  /* generate Object */
+		return 1;  /* Object created by this function */
+	}
+	else {
+		duk_push_this(ctx); /* Object Already Created by new operator.*/
+		obj_idx = duk_require_normalize_index(ctx, -1);
+		/* This is the Wrong place to put a Finalizer.*/
+		duk_push_c_function(ctx, duk_class_shape_finalizer, 1);
+		duk_set_finalizer(ctx, obj_idx);
+	} 
+
+	duk_push_c_function(ctx, duk_class_shape_func_move, 2 /*nargs*/);
+	duk_put_prop_string(ctx, obj_idx, "move");
+
+	duk_push_string(ctx, "function () { return \"Shape (\" + this.id + \") located at (\"+ this.x +\",\"+this.y+\")\"; }");
+	duk_push_string(ctx, "duk_class_shape_toString"); /* This does not Really matter */
+	duk_compile(ctx, DUK_COMPILE_FUNCTION);
+	duk_put_prop_string(ctx, obj_idx, "toString");
+
+	/* add Properties*/
+	duk_push_int(ctx, id);
+	duk_put_prop_string(ctx, obj_idx, "id");
+	duk_push_int(ctx, x);
+	duk_put_prop_string(ctx, obj_idx, "x");
+	duk_push_int(ctx, y);
+	duk_put_prop_string(ctx, obj_idx, "y");
+	return 0; /* Object already exists */
+}
+duk_ret_t duk_class_shape_finalizer(duk_context *ctx)
+{
+	if (duk_is_constructor_call(ctx))
+	{
+		printf("Shape: Finalizer\n");
+	}
+	/* Take care of New object Clean up Here */
+	return 0;
+}
+duk_ret_t duk_class_shape_staticFunc(duk_context *ctx)
+{
+	printf("Shape: Static Function\n");
+	/* Do something that is normally done in static functions */
+	return 0;
+}
+
+duk_ret_t duk_class_shape_func_move(duk_context *ctx)
+{
+	duk_idx_t idx = 0, object_id;
+	/* Replace the Old Values to "Move " to a new location */
+	duk_push_this(ctx);
+	object_id = duk_require_normalize_index(ctx, -1);
+
+	/* Update X cordinate */
+	duk_get_prop_string(ctx, -1, "x");
+	idx = duk_require_normalize_index(ctx, -1);
+	duk_dup(ctx, 0);
+	duk_replace(ctx, idx);
+	duk_put_prop_string(ctx, object_id, "x");
+
+	/* Update Y cordinate */
+	duk_get_prop_string(ctx, -1, "y");
+	idx = duk_require_normalize_index(ctx, -1);
+	duk_dup(ctx, 1);
+	duk_replace(ctx, idx);
+	duk_put_prop_string(ctx, object_id, "y");
+
+	return 0;
+}
+
+duk_ret_t duk_class_shape_func_toString(duk_context *ctx)
+{
+	duk_push_this(ctx);
+	/* Re-Add constructor*/
+	duk_push_string(ctx, "function () { return \"Shape (\" + this.id + \") located at (\"+ this.x +\",\"+this.y+\")\"; }");
+	duk_push_string(ctx, "duk_class_shape_toString"); /* This does not Really matter */
+	duk_compile(ctx, DUK_COMPILE_FUNCTION);
+	duk_put_prop_string(ctx, -2, "toString");
+	duk_get_prop_string(ctx, 0, "toString");
+	duk_push_this(ctx);
+	duk_push_this(ctx);
+	duk_call(ctx, 1);
+
+	return 1; /* Do nothing.*/
+}
+
+duk_ret_t  duk_isShape(duk_context *ctx)
+{
+	duk_push_global_object(ctx);
+	duk_get_prop_string(ctx, -1, "Shape");
+	if (duk_is_object(ctx, 0)) {
+		if (duk_instanceof(ctx, 0, -1)) {
+			/* Argument is a Shape.*/
+			duk_push_true(ctx);
+		} else{
+			/* Argument is not a Shape */
+			duk_push_false(ctx);
+		}
+	} else {
+		/* default to False.*/
+		duk_push_false(ctx);
+	}
+
+	return 1;
+}

--- a/examples/custom-c-object/custom-object-vector2d.c
+++ b/examples/custom-c-object/custom-object-vector2d.c
@@ -1,0 +1,270 @@
+#include "custom-object.h"
+#include <string.h>
+#include <stdio.h>
+
+/* Define the Property name used for User Data. */
+#define MY_USER_DATA_PROP  "\xff""vecData"
+
+/* Custom Functions */
+duk_ret_t duk_vector2d_toString(duk_context* ctx);
+duk_ret_t duk_vector2d_get_y(duk_context* ctx);
+duk_ret_t duk_vector2d_get_x(duk_context* ctx);
+duk_ret_t duk_vector2d_set_y(duk_context* ctx);
+duk_ret_t duk_vector2d_set_x(duk_context* ctx);
+duk_ret_t duk_vector2d_object_builder(duk_context* ctx, duk_idx_t myThis, float x, float y, int myValue);
+duk_ret_t  duk_isVector2D(duk_context *ctx);
+
+duk_ret_t duk_vector2d_finalizer(duk_context *ctx)
+{
+	vector2D* ptr = NULL;
+	printf("finalizer begin: Vec2D\n");
+	duk_get_prop_string(ctx, 0, MY_USER_DATA_PROP);
+	ptr = duk_get_pointer(ctx, -1);
+	duk_pop_2(ctx);
+	if (ptr) {
+		printf("Freed UserData.\n");
+		free(ptr);
+		ptr = NULL;
+	}
+	printf("finalizer end: Vec2D\n");
+	return 1;
+}
+
+duk_ret_t duk_vector2d_constructor(duk_context* ctx)
+{
+	printf("Constructor begin: Vec2D\n");
+	int n = duk_get_top(ctx);  /* #args */
+	duk_idx_t myThis;
+	double _new_vector_x = 0.0, _new_vector_y = 0.0;
+	duk_bool_t calledByConstructor = duk_is_constructor_call(ctx);
+	if (!calledByConstructor)
+	{
+		duk_push_string(ctx,"vector2D must be instantiated using new.");
+		duk_throw(ctx);
+		return 1;
+	} else {
+		duk_push_this(ctx); /* Object Already Created by new operator.*/
+		myThis = duk_require_normalize_index(ctx, -1);
+	}
+	switch (n) {
+	case 0:
+	{
+		duk_vector2d_object_builder(ctx, myThis, 0.0, 0.0, 12345);
+		return 0;
+	}
+	case 1:
+	{
+		if (duk_is_object(ctx, 0)) {
+			duk_push_global_object(ctx);
+			duk_get_prop_string(ctx, -1, "vector2D");
+			if (duk_instanceof(ctx, 0, -1)) {
+				/* We have ourselves a vector2D object.*/
+
+				/* Get the User Data of the Object to be Cloned.*/
+				vector2D* ptr = NULL;
+				duk_get_prop_string(ctx, 0, MY_USER_DATA_PROP);
+				ptr = duk_get_pointer(ctx, -1);
+				duk_pop(ctx);
+				if (ptr) {
+					duk_vector2d_object_builder(ctx, myThis, ptr->x, ptr->y, 54321);
+					return 0;
+				}
+			} else{
+				duk_push_string(ctx, "vector2D: Argument must be an vector2D object.");
+				duk_throw(ctx);
+			}
+			return 0;
+		} else {
+			duk_push_string(ctx, "vector2D: Argument must be an object.");
+			duk_throw(ctx);
+			printf("Constructor end: Vec2D (ERROR)\n");
+			return 0;
+		}
+	}
+	case 2:
+	{
+		if (!duk_is_number(ctx, 0) || !duk_is_number(ctx, 1)) {
+			duk_push_string(ctx, "vector2D: Both Arguments Must be numbers.");
+			duk_throw(ctx);
+			return 0;
+		} else {
+			_new_vector_x = duk_get_number(ctx, 0);
+			_new_vector_y = duk_get_number(ctx, 1);
+			duk_vector2d_object_builder(ctx, myThis, (float)_new_vector_x, (float)_new_vector_y, 54321);
+			return 0;
+		}
+	}
+	default:
+		duk_push_string(ctx, "vector2D: Incorrect Number of Arguments.");
+		duk_throw(ctx);
+		return 0;
+	}
+
+	duk_push_string(ctx, "vector2D: Unexpected Error.");
+	duk_throw(ctx);
+	return 1;
+
+}
+
+
+duk_ret_t duk_register_Vector2D(duk_context *ctx) {
+	duk_idx_t obj_index;
+	duk_push_global_object(ctx);
+	printf("Registering: Vector2D\n");
+	/* Register vector2D object Constructor(s).*/
+	/* NOTE: if you want multiple constructors, this is the only way. */
+	duk_push_c_function(ctx, duk_vector2d_constructor, DUK_VARARGS);
+	obj_index = duk_push_object(ctx);			
+	duk_put_prop_string(ctx, -2, "prototype"); 
+	duk_put_prop_string(ctx, -2, "vector2D");
+
+	/* Add isVector2D global function.*/
+	duk_push_c_function(ctx, duk_isVector2D, 1);
+	duk_put_prop_string(ctx, -2, "isVector2D");
+	duk_pop(ctx);
+
+	return 0;
+}
+
+
+
+
+
+duk_ret_t duk_vector2d_toString(duk_context* ctx) {
+  vector2D* ptr = NULL;
+   /* The only print out on this functions hould never exceed 64 characters. */
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, MY_USER_DATA_PROP);
+  ptr = duk_get_pointer(ctx, -1);
+  duk_pop_2(ctx);
+  if (ptr) {
+	/* Use Duktape functionality to create string output.*/
+	duk_push_string(ctx, "vector2D( "); /* 1 */
+	duk_push_number(ctx, ptr->x );
+	duk_push_string(ctx, " , ");
+	duk_push_number(ctx, ptr->y);
+	duk_push_string(ctx, " )"); /* 5 */
+	duk_concat(ctx, 5);
+  } else {
+	  duk_push_string(ctx, "vector2D().toString()");
+  }
+  return 1;
+}
+
+duk_ret_t duk_vector2d_get_x(duk_context* ctx) {
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, MY_USER_DATA_PROP);
+  vector2D* ptr = duk_get_pointer(ctx, -1);
+  duk_pop_2(ctx);
+  if (ptr) {
+	  duk_push_number(ctx, ptr->x);
+  }  else {
+	  printf("duk_vector2d_get_x\n");
+	  duk_push_null(ctx);
+  }
+  return 1;  /* one return value */
+}
+
+duk_ret_t duk_vector2d_get_y(duk_context* ctx) {
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, MY_USER_DATA_PROP);
+  vector2D* ptr = duk_get_pointer(ctx, -1);
+  duk_pop_2(ctx);
+  if (ptr) {
+	  duk_push_number(ctx, ptr->y);
+  }  else {
+	  printf("duk_vector2d_get_y\n");
+	  duk_push_null(ctx);
+  }
+  return 1;  /* one return value */
+}
+duk_ret_t duk_vector2d_set_x(duk_context* ctx) {
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, MY_USER_DATA_PROP);
+  vector2D* ptr = duk_get_pointer(ctx, -1);
+  duk_pop_2(ctx);
+  if (ptr) {
+	  ptr->x = (float)duk_to_number(ctx, 0);
+  } else { 
+	  printf("duk_vector2d_set_x\n");
+  }
+  return 0;  /* one return value */
+}
+
+duk_ret_t duk_vector2d_set_y(duk_context* ctx) {
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, MY_USER_DATA_PROP);
+  vector2D* ptr = duk_get_pointer(ctx, -1);
+  duk_pop_2(ctx);
+  if (ptr) {
+	  ptr->y = (float)duk_to_number(ctx, 0);
+  }  else {
+	  printf("duk_vector2d_set_y\n");
+  }
+  return 0;  /* one return value */
+}
+
+
+duk_ret_t duk_vector2d_object_builder(duk_context* ctx, duk_idx_t myThis, float x, float y, int myValue)
+{
+	vector2D* ptr = NULL;
+
+	/* Set the Finalizer First */
+	duk_push_c_function(ctx, duk_vector2d_finalizer, 1 /*nargs*/);
+	duk_set_finalizer(ctx, myThis);
+
+	/* Add a few User Functions*/
+	duk_push_c_function(ctx, duk_vector2d_toString, 1);   /* toString (function) */
+	duk_put_prop_string(ctx, myThis, "toString");
+
+	/* Add a few Properties.*/
+	duk_push_int(ctx, myValue);
+	duk_put_prop_string(ctx, myThis, "myValue");
+
+
+
+	/* Add Some User Data*/
+
+	ptr = calloc(1, sizeof(vector2D));
+	ptr->x = x;
+	ptr->y = y;
+	duk_push_pointer(ctx, ptr);
+	duk_put_prop_string(ctx, myThis, MY_USER_DATA_PROP);
+
+	/* Add some Getter/setter functions to modify User Data.*/
+	duk_push_string(ctx, "y");
+	duk_push_c_function(ctx, duk_vector2d_get_y, 0 /*nargs*/);
+	duk_push_c_function(ctx, duk_vector2d_set_y, 1 /*nargs*/);
+	duk_def_prop(ctx, myThis, DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_SETTER);
+
+	duk_push_string(ctx, "x");
+	duk_push_c_function(ctx, duk_vector2d_get_x, 0 /*nargs*/);
+	duk_push_c_function(ctx, duk_vector2d_set_x, 1 /*nargs*/);
+	duk_def_prop(ctx, myThis, DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_SETTER);
+
+	
+	return 1;
+}
+
+duk_ret_t  duk_isVector2D(duk_context *ctx)
+{
+
+	duk_push_global_object(ctx);
+	duk_get_prop_string(ctx, -1, "vector2D");
+	if (duk_is_object(ctx, 0)) {
+		if (duk_instanceof(ctx, 0, -1)) {
+			/* Argument is a Shape.*/
+			duk_push_true(ctx);
+		}
+		else{
+			/* Argument is not a Shape */
+			duk_push_false(ctx);
+		}
+	}
+	else {
+		/* default to False.*/
+		duk_push_false(ctx);
+	}
+
+	return 1;
+}

--- a/examples/custom-c-object/custom-object.h
+++ b/examples/custom-c-object/custom-object.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "duktape.h"
+
+typedef struct vector2d_t {
+	float x; float y;
+} vector2D;
+
+duk_ret_t duk_register_shape(duk_context *ctx);
+duk_ret_t duk_register_Vector2D(duk_context *ctx); 

--- a/examples/custom-c-object/myShape.js
+++ b/examples/custom-c-object/myShape.js
@@ -1,0 +1,31 @@
+var myShape = new Shape(0,1,2);
+print(myShape);
+myShape.move(3,9);
+print(myShape.toString());
+
+/* These are expected to fail */
+try {
+   var myShapeOneArg = new Shape(1);
+} catch (e) {
+   print("Failed to Create myShapeOneArg: " + e)
+}
+try {
+   var myShapeOneArg = new Shape(1,2);
+} catch (e) {
+   print("Failed to Create myShapeTwoArgs: " + e)
+}
+try {
+   var myShapeInvalidArgParmA = new Shape(myShape,0,0);
+} catch (e) {
+   print("Failed to Create myShapeInvalidArgParmA: " + e)
+}
+try {
+   var myShapeInvalidArgParmB = new Shape(1,myShape,0);
+} catch (e) {
+   print("Failed to Create myShapeInvalidArgParmB: " + e)
+}
+try {
+   var myShapeInvalidArgParmC = new Shape(1,0,"Random String");
+} catch (e) {
+   print("Failed to Create myShapeInvalidArgParmC: " + e)
+}

--- a/examples/custom-c-object/myVectors.js
+++ b/examples/custom-c-object/myVectors.js
@@ -1,0 +1,37 @@
+print("Testing Create:");
+var myVector = new vector2D();
+/* This Should cause the finalizer to run */
+Duktape.fin(myVector);
+myVector = new vector2D();
+var myVectorA = new vector2D(1.0, 2.0); 
+var myVectorEX = new vector2D(myVectorA); 
+print("Create OK");
+// All of these print the same thing, but it shows that the c Functions are tied correctly.
+print("myVector = " + myVector);
+print("myVector.toString() = " + myVector.toString());
+printTest(myVector);
+print("myVectorEX:");
+printTest(myVectorEX);
+print("myVectorA:");
+printTest(myVectora);
+var myVectorB = myVector; // Test Cloning 
+print("myVectorB:");
+printTest(myVectorB);
+
+/* This shows that the Getters and Setters work */
+print("Testing Getter/Setters: ");
+print(myVector.x);myVector.x = 3.25;print(myVector.x);
+print(myVector.y);myVector.y = 6.0;print(myVector.y);
+print("myVector = " + myVector);
+print("myVectorB = " + myVectorB);
+delete myVector; myVector = null;
+print("myVectorB = " + myVectorB);
+myVectorB = null;
+print("myVectorB = " + myVectorB);
+/* This will cause an error since a new value for myVectorC has not been set yet. */
+//print("myVectorC = " + myVectorC);
+
+function printTest(vectorData) {
+	print(vectorData);
+	print(vectorData.myValue);
+};

--- a/examples/custom-c-object/myVectors2B.js
+++ b/examples/custom-c-object/myVectors2B.js
@@ -1,0 +1,15 @@
+/* Odd Bug is shown by this code:
+ * duk_eval_string - This exact Code works without issues.
+ * duk_peval_file_noresult - This code Fails.
+ */
+print ("Testing vector2D");
+var myVectorScript = new vector2D(1.0, 2.0);
+print("Vector Script: " myVectorScript)
+
+/* Modify and access x value. */
+myVectorScript.x = 3.25;
+print(myVectorScript.x);
+
+/* Modify and access y value. */
+myVectorScript.y = 6.0;
+print(myVectorScript.y);

--- a/examples/debug-trans-socket/duk_trans_socket.c
+++ b/examples/debug-trans-socket/duk_trans_socket.c
@@ -10,11 +10,34 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
+
+/* Include Appropriate TCP/IP Data*/
+#ifdef WIN32
+#include <winsock2.h>
+#include <Ws2tcpip.h>
+#include <sys/utime.h>
+/*
+ * Windows uses 32-bit pointers for winsock
+ */
+#ifndef socklen_t
+#define socklen_t int
+#endif
+#ifndef ssize_t
+#define ssize_t SSIZE_T
+#endif
+#ifndef INFTIM
+#define INFTIM -1
+#endif
+#pragma comment(lib, "Ws2_32.lib")
+#else
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <poll.h>
-#include <errno.h>
+#endif
+
+
 #include "duktape.h"
 
 #ifndef DUK_DEBUG_PORT
@@ -27,6 +50,121 @@
 
 static int server_sock = -1;
 static int client_sock = -1;
+/*
+ *  Socket porability helper functions.
+ */
+
+int duk_open_socket(int af, int type, int proto)
+{
+	int return_value = -1;
+#ifdef _WIN32
+	SOCKET mySocket = socket(af, type, proto);
+	if (mySocket == INVALID_SOCKET) {
+		fprintf(stderr, "socket failed with error: %ld\n", WSAGetLastError());
+		WSACleanup();
+		return -1;
+	}
+	return (int)mySocket;
+#else
+	return socket(af, type, proto);
+#endif
+	return return_value;
+}
+void duk_close_socket(int socket)
+{
+#ifdef WIN32
+	closesocket(socket);
+#else
+	(void)close(socket);
+#endif
+}
+
+int duk_accept_socket(int socket, struct sockaddr * addr, int* addrlen)
+{
+#ifdef _WIN32
+	SOCKET return_value = accept(socket, addr, addrlen);
+	if (return_value == INVALID_SOCKET) {
+		fprintf(stderr, "socket failed with error: %ld\n", WSAGetLastError());
+		WSACleanup();
+		return -1;
+	}
+	return (int) return_value;
+#else
+	return accept(socket, addr, addrlen);
+#endif
+}
+
+int duk_poll_socket(struct pollfd *fds, int nfds, int timeout)
+{
+#ifdef _WIN32
+	FILETIME PollStart = { 0, 0 };
+	u_long availableData = 0;
+	int socketRes = 0;
+	struct timeval tv;
+	tv.tv_sec = 0;
+	/*
+	 * Just under 1 Millisecond
+	 */
+	tv.tv_usec = 999; 
+	
+	GetSystemTimeAsFileTime(&PollStart);
+win32RePoll:
+	socketRes = ioctlsocket(fds->fd, FIONREAD, &availableData);
+	if (socketRes == SOCKET_ERROR)
+	{
+		fprintf(stderr, "socket failed with error: %ld\n", WSAGetLastError());
+		WSACleanup();
+		return -1;
+	}
+	if (availableData)
+		return 1;
+	else {
+		if (timeout) return 0;
+	}
+	/*
+	 * The select command can cause a short sleep step.
+	 */
+	select(0, NULL, NULL, NULL, &tv);
+	switch (timeout)
+	{
+	case 0:
+		/*
+		 * No Timeout, finish immediately.
+		 */
+		break;
+	case INFTIM:
+		goto win32RePoll;
+	default:
+		timeout--;
+		goto win32RePoll;
+
+	}
+
+	return -1;
+#else
+	return (int)poll(fds, nfds, timeout);
+#endif
+}
+
+int duk_write_socket(SOCKET socket, const void* buffer, int length)
+{
+#ifdef _WIN32
+	return send(socket, (char*)buffer, length, 0);
+#else
+	return write(client_sock, buffer, (size_t)length);
+#endif
+}
+
+SSIZE_T duk_read_socket(int socket, void *buf, size_t nbyte)
+{
+#ifdef _WIN32
+	int result = recv(socket, (char*)buf, (int)nbyte, 0);
+	return (SSIZE_T)result;
+#else
+	return read(socket, (void *)buffer, (size_t)length);
+#endif
+}
+
 
 /*
  *  Transport init
@@ -36,7 +174,18 @@ void duk_trans_socket_init(void) {
 	struct sockaddr_in addr;
 	int on;
 
-	server_sock = socket(AF_INET, SOCK_STREAM, 0);
+#ifdef WIN32
+	WSADATA wsadata;
+	int err;
+
+	err = WSAStartup(MAKEWORD(2, 0), &wsadata);
+	if (err != 0) {
+		fprintf(stderr, "WSAStartup failed with error: %d\n", err);
+		goto fail;
+	}
+#endif
+
+	server_sock = duk_open_socket(AF_INET, SOCK_STREAM, 0);
 	if (server_sock < 0) {
 		fprintf(stderr, "%s: failed to create server socket: %s\n", __FILE__, strerror(errno));
 		fflush(stderr);
@@ -66,9 +215,17 @@ void duk_trans_socket_init(void) {
 
  fail:
 	if (server_sock >= 0) {
-		(void) close(server_sock);
+		duk_close_socket(server_sock);
 		server_sock = -1;
 	}
+}
+
+
+void duk_trans_socket_finish(void)
+{
+#ifdef WIN32
+	WSACleanup();
+#endif
 }
 
 void duk_trans_socket_waitconn(void) {
@@ -81,7 +238,7 @@ void duk_trans_socket_waitconn(void) {
 		return;
 	}
 	if (client_sock >= 0) {
-		(void) close(client_sock);
+		duk_close_socket(client_sock);
 		client_sock = -1;
 	}
 
@@ -89,7 +246,7 @@ void duk_trans_socket_waitconn(void) {
 	fflush(stderr);
 
 	sz = (socklen_t) sizeof(addr);
-	client_sock = accept(server_sock, (struct sockaddr *) &addr, &sz);
+	client_sock = duk_accept_socket(server_sock, (struct sockaddr *) &addr, &sz);
 	if (client_sock < 0) {
 		fprintf(stderr, "%s: accept() failed, skip waiting for connection: %s\n", __FILE__, strerror(errno));
 		fflush(stderr);
@@ -105,14 +262,14 @@ void duk_trans_socket_waitconn(void) {
 	 */
 
 	if (server_sock >= 0) {
-		(void) close(server_sock);
+		duk_close_socket(server_sock);
 		server_sock = -1;
 	}
 	return;
 
  fail:
 	if (client_sock >= 0) {
-		(void) close(client_sock);
+		duk_close_socket(server_sock);
 		client_sock = -1;
 	}
 }
@@ -155,7 +312,7 @@ duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length
 	 * timeout here to recover from "black hole" disconnects.
 	 */
 
-	ret = read(client_sock, (void *) buffer, (size_t) length);
+	ret = duk_read_socket(client_sock, (void *)buffer, (size_t)length);
 	if (ret < 0) {
 		fprintf(stderr, "%s: debug read failed, errno %d, closing connection: %s\n", __FILE__, errno, strerror(errno));
 		fflush(stderr);
@@ -174,7 +331,7 @@ duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length
 
  fail:
 	if (client_sock >= 0) {
-		(void) close(client_sock);
+		duk_close_socket(client_sock);
 		client_sock = -1;
 	}
 	return 0;
@@ -214,7 +371,7 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 	 * timeout here to recover from "black hole" disconnects.
 	 */
 
-	ret = write(client_sock, (const void *) buffer, (size_t) length);
+	ret = duk_write_socket(client_sock, (const void *)buffer, (int)length);
 	if (ret <= 0 || ret > (ssize_t) length) {
 		fprintf(stderr, "%s: debug write failed, closing connection: %s\n", __FILE__, strerror(errno));
 		fflush(stderr);
@@ -225,7 +382,7 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 
  fail:
 	if (client_sock >= 0) {
-		(void) close(client_sock);
+		duk_close_socket(client_sock);
 		client_sock = -1;
 	}
 	return 0;
@@ -246,7 +403,7 @@ duk_size_t duk_trans_socket_peek_cb(void *udata) {
 	fds[0].events = POLLIN;
 	fds[0].revents = 0;
 
-	poll_rc = poll(fds, 1, 0);
+	poll_rc = duk_poll_socket(fds, 1, 0);
 	if (poll_rc < 0) {
 		fprintf(stderr, "%s: poll returned < 0, closing connection: %s\n", __FILE__, strerror(errno));
 		fflush(stderr);
@@ -263,7 +420,7 @@ duk_size_t duk_trans_socket_peek_cb(void *udata) {
 
  fail:
 	if (client_sock >= 0) {
-		(void) close(client_sock);
+		duk_close_socket(client_sock);
 		client_sock = -1;
 	}
 	return 0;

--- a/examples/debug-trans-socket/duk_trans_socket.c
+++ b/examples/debug-trans-socket/duk_trans_socket.c
@@ -73,7 +73,7 @@ int duk_open_socket(int af, int type, int proto)
 void duk_close_socket(int socket)
 {
 #ifdef WIN32
-	closesocket(socket);
+	closesocket((SOCKET)socket);
 #else
 	(void)close(socket);
 #endif
@@ -82,7 +82,7 @@ void duk_close_socket(int socket)
 int duk_accept_socket(int socket, struct sockaddr * addr, int* addrlen)
 {
 #ifdef _WIN32
-	SOCKET return_value = accept(socket, addr, addrlen);
+	SOCKET return_value = accept((SOCKET)socket, addr, addrlen);
 	if (return_value == INVALID_SOCKET) {
 		fprintf(stderr, "socket failed with error: %ld\n", WSAGetLastError());
 		WSACleanup();
@@ -146,20 +146,20 @@ win32RePoll:
 #endif
 }
 
-int duk_write_socket(SOCKET socket, const void* buffer, int length)
+int duk_write_socket(int socket, const void* buffer, int length)
 {
 #ifdef _WIN32
-	return send(socket, (char*)buffer, length, 0);
+	return send((SOCKET)socket, (char*)buffer, length, 0);
 #else
 	return write(client_sock, buffer, (size_t)length);
 #endif
 }
 
-SSIZE_T duk_read_socket(int socket, void *buf, size_t nbyte)
+ssize_t duk_read_socket(int socket, void *buf, size_t nbyte)
 {
 #ifdef _WIN32
-	int result = recv(socket, (char*)buf, (int)nbyte, 0);
-	return (SSIZE_T)result;
+	int result = recv((SOCKET)socket, (char*)buf, (int)nbyte, 0);
+	return (ssize_t)result;
 #else
 	return read(socket, (void *)buffer, (size_t)length);
 #endif

--- a/examples/debug-trans-socket/duk_trans_socket.h
+++ b/examples/debug-trans-socket/duk_trans_socket.h
@@ -4,6 +4,7 @@
 #include "duktape.h"
 
 void duk_trans_socket_init(void);
+void duk_trans_socket_finish(void);
 void duk_trans_socket_waitconn(void);
 duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length);
 duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t length);


### PR DESCRIPTION
This contains a few main additions for the duktape exaples.

1. Fixes the debug-trans-socket example to support windows. This has a few issues with the polling function, but other than that it is fully functional.
2. Updates to the duktape command line to reflect the changes shown in debug-trans-socket.
3. Custom C Object example that shows how to build custom objects in C that can be created using the "new" operator.