### PR TITLE
Packed tvals are not possible on ppc64

### DIFF
--- a/config/header-snippets/packed_tval.h.in
+++ b/config/header-snippets/packed_tval.h.in
@@ -34,8 +34,8 @@
 #define DUK_USE_PACKED_TVAL_POSSIBLE
 #endif
 
-/* PPC: packed always possible */
-#if !defined(DUK_USE_PACKED_TVAL_POSSIBLE) && defined(DUK_F_PPC)
+/* PPC32: packed always possible */
+#if !defined(DUK_USE_PACKED_TVAL_POSSIBLE) && defined(DUK_F_PPC32)
 #define DUK_USE_PACKED_TVAL_POSSIBLE
 #endif
 

--- a/config/header-snippets/platform1.h.in
+++ b/config/header-snippets/platform1.h.in
@@ -76,6 +76,11 @@
 /* PowerPC */
 #if defined(__powerpc) || defined(__powerpc__) || defined(__PPC__)
 #define DUK_F_PPC
+#if defined(__PPC64__)
+#define DUK_F_PPC64
+#else
+#define DUK_F_PPC32
+#endif
 #endif
 
 /* Linux */


### PR DESCRIPTION
commit 422f66fb739734bd712de987ad9478c321e7b774 caused a regression for me using duktape on ps3 (ppc64). This patch fixes the problem.

