### PR TITLE
Add "make emduk" target

### DIFF
--- a/util/emduk_wrapper.sh
+++ b/util/emduk_wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+node WORKDIR/emduk.js "$@"


### PR DESCRIPTION
- Add `--run-stdin` option to `duk`, execute stdin like a file so that all lines are compiled as a single unit (instead of line by line).

- Add `make emduk` target for Emscripten compiled `duk` command line tool, useful for performance testing.  Emduk executes `emduk.js` using Node.js.

The interactive mode of `emduk` works but has some limitations: the prompt is not shown normally but you can evaluate code normally otherwise.

File I/O does not work so you can't execute code from a file, but you can use stdin and the `--run-stdin` option:

```
$ cat mandel.js | ./emduk --run-stdin
```

This works only for small files, up to 256 bytes. Emscripten stdin behaves very oddly when executed using Node.js: instead of an EOF, the input loops. The command line tool was modified to detect the smallest loop and cut off the input source. This is quite ugly but enabled only for Emscripten and makes it possible to run performance tests (Node.js + Emscripten roughly simulates browser performance).

`emduk.js` can also be executed using Duktape but since Duktape has very limited file I/O you can't actually provide code for it to execute.