### PR TITLE
Rework BREAK and CONTINUE opcode handling to avoid longjmp entirely

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1151,6 +1151,10 @@ Planned
   longjmp() calls, improving performance slightly on ordinary platforms and
   significantly on Emscripten (GH-342, GH-345)
 
+* Internal performance improvement: rework BREAK and CONTINUE opcode handling
+  to avoid longjmp() calls, improving performance slightly on ordinary
+  platforms and significantly on Emscripten (GH-348)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/src/duk_heap.h
+++ b/src/duk_heap.h
@@ -52,12 +52,12 @@
 
 #define DUK_LJ_TYPE_UNKNOWN      0    /* unused */
 #define DUK_LJ_TYPE_THROW        1    /* value1 -> error object */
-#define DUK_LJ_TYPE_BREAK        2    /* value1 -> label number */
-#define DUK_LJ_TYPE_CONTINUE     3    /* value1 -> label number */
-#define DUK_LJ_TYPE_YIELD        4    /* value1 -> yield value, iserror -> error / normal */
-#define DUK_LJ_TYPE_RESUME       5    /* value1 -> resume value, value2 -> resumee thread, iserror -> error/normal */
-#define DUK_LJ_TYPE_NORMAL       6    /* pseudo-type to indicate a normal continuation (for 'finally') */
-#define DUK_LJ_TYPE_RETURN       7    /* pseudo-type to indicate a return continuation (for 'finally') */
+#define DUK_LJ_TYPE_YIELD        2    /* value1 -> yield value, iserror -> error / normal */
+#define DUK_LJ_TYPE_RESUME       3    /* value1 -> resume value, value2 -> resumee thread, iserror -> error/normal */
+#define DUK_LJ_TYPE_BREAK        4    /* value1 -> label number, pseudo-type to indicate a break continuation (for ENDFIN) */
+#define DUK_LJ_TYPE_CONTINUE     5    /* value1 -> label number, pseudo-type to indicate a continue continuation (for ENDFIN) */
+#define DUK_LJ_TYPE_RETURN       6    /* value1 -> return value, pseudo-type to indicate a return continuation (for ENDFIN) */
+#define DUK_LJ_TYPE_NORMAL       7    /* no value, pseudo-type to indicate a normal continuation (for ENDFIN) */
 
 /*
  *  Mark-and-sweep flags

--- a/tests/ecmascript/test-dev-break-continue-cases.js
+++ b/tests/ecmascript/test-dev-break-continue-cases.js
@@ -1,0 +1,353 @@
+/*
+ *  Exercise various code paths related to break/continue handling.
+ */
+
+/*===
+testBreak1
+0
+testContinue1
+0
+1
+2
+testMultiLevelBreak1
+0 0
+testMultiLevelContinue1
+0 0
+1 0
+2 0
+testBreakThroughFinally1
+start of outer 0
+0 0
+finally
+end of function
+testContinueThroughFinally1
+start of outer 0
+0 0
+finally
+start of outer 1
+1 0
+finally
+start of outer 2
+2 0
+finally
+end of function
+testBreakCapturesFinally1
+start of outer 0
+0 0
+finally
+Error: dummy
+end of function
+testContinueCapturesFinally1
+start of outer 0
+0 0
+finally
+Error: dummy
+end of function
+testBreakThroughMultipleFinally1
+start of outer 0
+0 0
+finally 1
+finally 2
+end of function
+testContinueThroughMultipleFinally1
+start of outer 0
+0 0
+finally 1
+finally 2
+start of outer 1
+1 0
+finally 1
+finally 2
+start of outer 2
+2 0
+finally 1
+finally 2
+end of function
+testBreakConvertedToReturn1
+start of outer 0
+0 0
+finally
+123
+testContinueConvertedToReturn1
+start of outer 0
+0 0
+finally
+123
+===*/
+
+/* Basic single level break/continue.  Current compiler turns these into
+ * JUMP opcodes.
+ */
+
+function testBreak1() {
+    for (var i = 0; i < 3; i++) {
+        print(i);
+        break;
+    }
+}
+function testContinue1() {
+    for (var i = 0; i < 3; i++) {
+        print(i);
+        continue;
+    }
+}
+
+/* Basic multilevel break/continue.  These are compiled into an actual BREAK
+ * or CONTINUE opcode now.
+ */
+
+function testMultiLevelBreak1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        for (var j = 0; j < 3; j++) {
+            print(i, j);
+            break label;
+        }
+    }
+}
+
+function testMultiLevelContinue1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        for (var j = 0; j < 3; j++) {
+            print(i, j);
+            continue label;
+        }
+    }
+}
+
+/* Break through a finally, finally doesn't change completion. */
+
+function testBreakThroughFinally1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            for (var j = 0; j < 3; j++) {
+                print(i, j);
+                break label;
+            }
+        } finally {
+            print('finally');
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+/* Continue through a finally, finally doesn't change completion. */
+
+function testContinueThroughFinally1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            for (var j = 0; j < 3; j++) {
+                print(i, j);
+                continue label;
+            }
+        } finally {
+            print('finally');
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+/* Break captured by finally. */
+
+function testBreakCapturesFinally1() {
+    try {
+     label:
+        for (var i = 0; i < 3; i++) {
+            print('start of outer', i);
+
+            try {
+                for (var j = 0; j < 3; j++) {
+                    print(i, j);
+                    break label;
+                }
+            } finally {
+                print('finally');
+                throw new Error('dummy');
+            }
+
+            print('end of outer', i);
+        }
+    } catch (e) {
+        print(e);
+    }
+
+    print('end of function');
+}
+
+/* Continue captured by finally. */
+
+function testContinueCapturesFinally1() {
+    try {
+     label:
+        for (var i = 0; i < 3; i++) {
+            print('start of outer', i);
+
+            try {
+                for (var j = 0; j < 3; j++) {
+                    print(i, j);
+                    continue label;
+                }
+            } finally {
+                print('finally');
+                throw new Error('dummy');
+            }
+
+            print('end of outer', i);
+        }
+    } catch (e) {
+        print(e);
+    }
+
+    print('end of function');
+}
+
+/* Break through multiple finally parts, finally doesn't change completion. */
+
+function testBreakThroughMultipleFinally1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            try {
+                for (var j = 0; j < 3; j++) {
+                    print(i, j);
+                    break label;
+                }
+            } finally {
+                print('finally 1');
+            }
+        } finally {
+            print('finally 2');
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+/* Continue through multiple finally parts, finally doesn't change completion. */
+
+function testContinueThroughMultipleFinally1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            try {
+                for (var j = 0; j < 3; j++) {
+                    print(i, j);
+                    continue label;
+                }
+            } finally {
+                print('finally 1');
+            }
+        } finally {
+            print('finally 2');
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+/* Break captured by a finally and converted into a return. */
+
+function testBreakConvertedToReturn1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            for (var j = 0; j < 3; j++) {
+                print(i, j);
+                break label;
+            }
+        } finally {
+            print('finally');
+            return 123;
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+/* Continue captured by a finally and converted into a return. */
+
+function testContinueConvertedToReturn1() {
+ label:
+    for (var i = 0; i < 3; i++) {
+        print('start of outer', i);
+
+        try {
+            for (var j = 0; j < 3; j++) {
+                print(i, j);
+                continue label;
+            }
+        } finally {
+            print('finally');
+            return 123;
+        }
+
+        print('end of outer', i);
+    }
+
+    print('end of function');
+}
+
+try {
+    print('testBreak1');
+    testBreak1();
+
+    print('testContinue1');
+    testContinue1();
+
+    print('testMultiLevelBreak1');
+    testMultiLevelBreak1();
+
+    print('testMultiLevelContinue1');
+    testMultiLevelContinue1();
+
+    print('testBreakThroughFinally1');
+    testBreakThroughFinally1();
+
+    print('testContinueThroughFinally1');
+    testContinueThroughFinally1();
+
+    print('testBreakCapturesFinally1');
+    testBreakCapturesFinally1();
+
+    print('testContinueCapturesFinally1');
+    testContinueCapturesFinally1();
+
+    print('testBreakThroughMultipleFinally1');
+    testBreakThroughMultipleFinally1();
+
+    print('testContinueThroughMultipleFinally1');
+    testContinueThroughMultipleFinally1();
+
+    print('testBreakConvertedToReturn1');
+    print(testBreakConvertedToReturn1());
+
+    print('testContinueConvertedToReturn1');
+    print(testContinueConvertedToReturn1());
+} catch (e) {
+    print(e);
+}

--- a/tests/ecmascript/test-dev-finally-catch-clobber.js
+++ b/tests/ecmascript/test-dev-finally-catch-clobber.js
@@ -1,0 +1,39 @@
+/*
+ *  Specific test that when an error is propagating through a
+ *  'finally' block, a try-catch with error caught doesn't
+ *  affect the propagated value once finally is finished.
+ *  Also checks that both the register and envrec binding for
+ *  the catch variable is correct.
+ */
+
+/*===
+finally
+ignore quux
+Error: foo
+Error: foo
+Error: bar
+===*/
+
+function test() {
+    try {
+        // this error really doesn't affect the test
+        throw new Error('foo');
+    } catch (e) {
+        try {
+            throw new Error('bar');
+        } finally {
+            print('finally');
+            try { throw new Error('quux'); } catch (e) { print('ignore quux'); }
+
+            print(e);
+            eval('print(e)');
+            // continue propagating original error ('bar')
+        }
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e);
+}

--- a/tests/perf/test-break-fast.js
+++ b/tests/perf/test-break-fast.js
@@ -1,0 +1,15 @@
+function test() {
+    var i;
+    for (i = 0; i < 1e8; i++) {
+        do {
+            break;
+        } while (0);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-break-slow.js
+++ b/tests/perf/test-break-slow.js
@@ -1,0 +1,18 @@
+function test() {
+    var i;
+    for (i = 0; i < 1e8; i++) {
+        do {
+            try {
+                break;
+            } finally {
+            }
+        } while (0);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
The compiler emits a "fast break/continue", which is just a plain JUMP, in common situations but falls back to a "slow break/continue" in other situations. A slow break/continue means emitting a BREAK or CONTINUE opcode, and the executor then using a longjmp() to propagate the break/continue outwards. Note that a finally block may capture and even cancel a break/continue - uncommon, but required functionality.

At the moment a slow break is emitted when there are any try-catch sites between the break/continue source and target, but also if the break/continue breaks out more than one level. See the compiler source for the exact conditions.

Implement changes to avoid longjmp() entirely in BREAK and CONTINUE (= slow break/continue) handling. While longjmp() is slower than ordinary code in desktop platforms, there's an enormous different for Emscripten-compiled Duktape executed using e.g. Chrome or Firefox.

- [x] Refactor current `DUK_LJ_TYPE_BREAK` and `DUK_LJ_TYPE_CONTINUE` handler into a non-longjmp-bound handler.
- [x] Use the new handler from BREAK/CONTINUE directly.
- [x] Also use the new handler from ENDFIN, in case a break/continue will propagate outwards after a finally block finishes without affecting the completion being propagated.
- [x] Check debug log levels, resolve FIXMEs
- [x] Cleanup up both RETURN, BREAK/CONTINUE handling
- [x] Documentation updates
- [x] Test case updates, add a test case covering all direct and ENDFIN control paths
- [x] Add perf testcase for fast and slow break/continue
- [x] Check Github issues for fast/slow break/continue references and update
- [x] Performance measurement, both desktop and Emscripten
- [x] Assert and torture runs
- [x] Test without fastints
- [x] Release notes

This will be merged after #345 (rebase after merging).