### PR TITLE
Add mergeready tag to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ To make a code contribution to Duktape
   - If test case status changes (tests are broken / fixed, test cases
     themselves needed fixing, test cases were added, etc), mention that.
 
+* A pull request can be created before you think your changes are finished.
+  When the changes are finished, add the tag `mergeready` to the pull
+  request to indicate you're no longer making any changes.
+
 To report bugs or request features
 ----------------------------------
 


### PR DESCRIPTION
Using a mergeready tag tells others (repo owner in particular) that the changes are finished and are ready to be merged to master.  Without this indication it may be unclear whether changes should be merged or if more work or fixes are coming.