### PR TITLE
Minor fixes to debugger throw notify

### DIFF
--- a/src/duk_error_misc.c
+++ b/src/duk_error_misc.c
@@ -84,15 +84,14 @@ DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t l
 	if (DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap) && lj_type == DUK_LJ_TYPE_THROW) {
 		duk_context *ctx = (duk_context *) thr;
 		duk_bool_t fatal;
-		duk_bool_t is_syntax_err;
-		duk_hobject *hobj;
+		duk_hobject *h_obj;
 
 		/* Don't intercept a DoubleError, we may have caused the initial double
 		 * fault and attempting to intercept it will cause us to be called
 		 * recursively and exhaust the C stack.
 		 */
-		hobj = duk_get_hobject(ctx, -1);
-		if (hobj == thr->builtins[DUK_BIDX_DOUBLE_ERROR]) {
+		h_obj = duk_get_hobject(ctx, -1);
+		if (h_obj == thr->builtins[DUK_BIDX_DOUBLE_ERROR]) {
 			DUK_D(DUK_DPRINT("built-in DoubleError instance thrown, not intercepting"));
 			goto skip_throw_intercept;
 		}
@@ -104,9 +103,9 @@ DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t l
 		/* Report it to the debug client */
 		duk_debug_send_throw(thr, fatal);
 
-		if (fatal && !is_syntax_err) {
+		if (fatal) {
 			DUK_D(DUK_DPRINT("throw will be fatal, halt before longjmp"));
-			duk_debug_halt_execution(thr, 1 /* use_prev_pc */);
+			duk_debug_halt_execution(thr, 1 /*use_prev_pc*/);
 		}
 	}
 


### PR DESCRIPTION
- Fix compile warnings and incorrect condition for halting.

- Fix debugger act->func refs for lightfuncs, use act->tv_func instead.  This was previously never a problem because debug messages were only processed when the topmost activation was an Ecmascript function.  Now with pause-on-uncaught-throw the topmost function may be native and debugger code must tolerate that.

- Formatting trivia.