### PR TITLE
Add hack "const" keyword support

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1141,6 +1141,10 @@ Planned
 1.4.0 (XXXX-XX-XX)
 ------------------
 
+* Add minimal support for "const" declarations with non-standard semantics,
+  intended mainly for minimal compatibility with existing code using "const"
+  (GH-360)
+
 * Add a debugger Throw notify for errors about to be thrown, and an option
   to automatically pause before an uncaught error is thrown (GH-286, GH-347)
 

--- a/src/duk_lexer.h
+++ b/src/duk_lexer.h
@@ -72,13 +72,13 @@ typedef void (*duk_re_range_callback)(void *user, duk_codepoint_t r1, duk_codepo
 #define DUK_TOK_TRY                               22
 #define DUK_TOK_TYPEOF                            23
 #define DUK_TOK_VAR                               24
-#define DUK_TOK_VOID                              25
-#define DUK_TOK_WHILE                             26
-#define DUK_TOK_WITH                              27
+#define DUK_TOK_CONST                             25
+#define DUK_TOK_VOID                              26
+#define DUK_TOK_WHILE                             27
+#define DUK_TOK_WITH                              28
 
 /* reserved words: future reserved words */
-#define DUK_TOK_CLASS                             28
-#define DUK_TOK_CONST                             29
+#define DUK_TOK_CLASS                             29
 #define DUK_TOK_ENUM                              30
 #define DUK_TOK_EXPORT                            31
 #define DUK_TOK_EXTENDS                           32

--- a/src/genstrings.py
+++ b/src/genstrings.py
@@ -801,6 +801,7 @@ standard_reserved_words_list = [
 	mkstr("try", reserved_word=True),
 	mkstr("typeof", reserved_word=True),
 	mkstr("var", reserved_word=True),
+	mkstr("const", reserved_word=True),
 	mkstr("void", reserved_word=True),
 	mkstr("while", reserved_word=True),
 	mkstr("with", reserved_word=True),
@@ -808,7 +809,7 @@ standard_reserved_words_list = [
 	# Future reserved word
 
 	mkstr("class", reserved_word=True, future_reserved_word=True),
-	mkstr("const", reserved_word=True, future_reserved_word=True),
+	# const is supported
 	mkstr("enum", reserved_word=True, future_reserved_word=True),
 	mkstr("export", reserved_word=True, future_reserved_word=True),
 	mkstr("extends", reserved_word=True, future_reserved_word=True),

--- a/tests/ecmascript/test-dev-minimal-const.js
+++ b/tests/ecmascript/test-dev-minimal-const.js
@@ -1,0 +1,92 @@
+/*
+ *  Minimal support for 'const'
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+123 234 357
+===*/
+
+/* Normal intended use. */
+
+function constBasicTest() {
+    const x = 123;
+    var y = 234;
+    print(x, y, x + y);
+}
+
+try {
+    constBasicTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+1000 234 1234
+===*/
+
+/* The minimal 'const' implementation treats a 'const' like 'var' so that the
+ * constant is actually a normal variable and thus writable.
+ */
+
+function constWriteTest() {
+    const x = 123;
+    var y = 234;
+    x = 1000;
+    print(x, y, x + y);
+}
+
+try {
+    constWriteTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+SyntaxError
+===*/
+
+/* The minimal 'const' implementation requires an initializer for 'const'
+ * (which is not required for 'var').
+ */
+
+function noConstInitializerTest() {
+    try {
+        eval('(function test() { const x; print(x); })')();
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    noConstInitializerTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+234
+===*/
+
+/* Re-declaring a 'const' as a 'var' is silently allowed because that's treated
+ * like re-declaring a variable.
+ */
+
+function redeclareConstAsVarTest() {
+    try {
+        eval('(function test() { const x = 123; var x = 234; print(x); })')();
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    redeclareConstAsVarTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/website/guide/custombehavior.html
+++ b/website/guide/custombehavior.html
@@ -22,6 +22,12 @@ use invalid UTF-8 (<code>0xFF</code> prefix byte).</p>
 <p>The <a href="#use-duk-notail">"use duk notail"</a> directive is non-standard.
 It prevents a function from being tail called.</p>
 
+<h2>"const" treated mostly like "var"</h2>
+
+<p>The <code>const</code> keyword is supported with minimal non-standard
+semantics (officially defined in Ecmascript 6).  See
+<a href="#es6-const">Const variables</a> for more detail.</p>
+
 <h2>The global require() function for module loading</h2>
 
 <p>The <code>require()</code> built-in is non-standard, and provided for

--- a/website/guide/es6features.html
+++ b/website/guide/es6features.html
@@ -5,6 +5,23 @@
 These features are not fully compliant; the intent is to minimize custom features
 and to align with the ES6 specification when possible.</p>
 
+<h2 id="es6-const">Const variables</h2>
+
+<p>Duktape has minimal support for
+<a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a>
+declarations to allow existing code using <code>const</code> to run.  However,
+<code>const</code> is mostly just an alias for <code>var</code> and currently has
+the following non-standard semantics:</p>
+<ul>
+<li>Unlike <code>var</code> declarations, <code>const</code> declarations are
+    required to have an initializer.</li>
+<li>Const variables are writable.  In ES6 <code>const</code> variables are
+    not writable.</li>
+<li>Const variables are function scoped and "hoisted" to the top of the
+    function like <code>var</code> declarations.  In ES6 <code>const</code>
+    has block scoping like <code>let</code>.
+</ul>
+
 <h2 id="es6-proto">Object.setPrototypeOf and Object.prototype.__proto__</h2>
 
 <p><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.setprototypeof">Object.setPrototypeOf</a>

--- a/website/guide/intro.html
+++ b/website/guide/intro.html
@@ -67,8 +67,8 @@ features (some are visible to applications, while others are internal):</p>
 <ul>
 <li>Khronos/ES6 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>
     and <a href="https://nodejs.org/docs/v0.12.1/api/buffer.html">Node.js Buffer</a> bindings</li>
-<li>Borrowed from ES6: <code>setPrototypeOf</code>/<code>__proto__</code>
-    and a subset of <code>Proxy</code> objects</li>
+<li>Borrowed from ES6: <code>setPrototypeOf</code>/<code>__proto__</code>,
+    a subset of <code>Proxy</code> objects, and minimal <code>const</code> support</li>
 <li>Borrowed from browsers: <code>print()</code> and <code>alert()</code></li>
 <li>Duktape specific built-ins: provided by the <code>Duktape</code> global object</li>
 <li>Extended types: custom "buffer" and "pointer" types, extended string type


### PR DESCRIPTION
Add a hack to support "const" so that it is treated exactly like "var". This is mainly useful for existing codebases, and a holdover until ES6 "const" is implemented.

- [x] Best solution for token numbers: `const` is an E5.1 reserved future keyword
- [x] Reject const without assignment (`const c;`)
- [x] Optional compilation => not implemented because const is part of ES6, and ES5.1 allows custom const semantics
- [x] Testcases
- [x] Documentation - website custom features / ES6 features, known limitations
- [x] Releases entry