### PR TITLE
Add a combined source without #line directives into the dist package

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1155,6 +1155,9 @@ Planned
 * Allow debugger detached callback to call duk_debugger_attach(), previously
   this clobbered some internal state (GH-399)
 
+* Add a combined duktape.c without #line directives into the dist package,
+  as it is a useful alternative in some environments (GH-363)
+
 * Fix "debugger" statement line number off-by-one so that the debugger now
   correctly pauses on the debugger statement rather than after it (GH-347)
 

--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -61,6 +61,10 @@ This distributable contains:
 * ``src/``: main Duktape library in a "single source file" format (duktape.c,
   duktape.h, and duk_config.h).
 
+* ``src-noline/``: contains a variant of ``src/duktape.c`` with no ``#line``
+  directives which is preferable for some users.  See discussion in
+  https://github.com/svaarala/duktape/pull/363.
+
 * ``src-separate/``: main Duktape library in multiple files format.
 
 * ``config/``: genconfig utility for creating duk_config.h configuration

--- a/util/resolve_combined_lineno.py
+++ b/util/resolve_combined_lineno.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+#
+#  Resolve a line number in the combined source into an uncombined file/line
+#  using a dist/src/metadata.json file.
+#
+#  Usage: $ python resolve_combined_lineno.py dist/src/metadata.json 12345
+#
+
+import os
+import sys
+import json
+
+def main():
+	with open(sys.argv[1], 'rb') as f:
+		metadata = json.loads(f.read())
+	lineno = int(sys.argv[2])
+
+	for e in reversed(metadata['line_map']):
+		if lineno >= e['combined_line']:
+			orig_lineno = e['original_line'] + (lineno - e['combined_line'])
+			print('%s:%d -> %s:%d' % ('duktape.c', lineno,
+			                          e['original_file'], orig_lineno))
+			break
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Related to #362. Prototype how duktape.c would work without #line directives:

- [x] Add optparse to combine_src.py
- [x] Add a `--line-directives` option to combine_src.py
- [x] Emit a file/line metadata file into dist/src/metadata.json
- [x] Disable line directives in dist combine_src.py step
- [x] Add an utility to resolve a combined source line into original file/line using dist/src/metadata.json
- [x] Drop #line directives, or provide both combined source files? => include both, as both variants have relevant use cases
- [x] Dist documentation changes
- [x] Other documentation changes; website note and point to wiki?