### PR TITLE
Remove /tmp assumption from runtests.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,40 +486,40 @@ RUNTESTSOPTS=--prep-test-path util/prep_test.py --minify-uglifyjs2 UglifyJS2/bin
 ecmatest: runtestsdeps duk
 ifeq ($(VALGRIND_WRAP),1)
 	@echo "### ecmatest (valgrind)"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk.raw --report-diff-to-other --valgrind --run-nodejs --run-rhino --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk.raw --report-diff-to-other --valgrind --run-nodejs --run-rhino --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
 else
 	@echo "### ecmatest"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk --report-diff-to-other --run-nodejs --run-rhino --num-threads 8 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk --report-diff-to-other --run-nodejs --run-rhino --num-threads 8 --log-file=/tmp/duk-test.log tests/ecmascript/
 endif
 
 .PHONY:	ecmatestd
 ecmatestd: runtestsdeps dukd
 ifeq ($(VALGRIND_WRAP),1)
 	@echo "### ecmatestd (valgrind)"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd.raw --report-diff-to-other --valgrind --run-nodejs --run-rhino --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd.raw --report-diff-to-other --valgrind --run-nodejs --run-rhino --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
 else
 	@echo "### ecmatestd"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd --report-diff-to-other --run-nodejs --run-rhino --num-threads 8 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd --report-diff-to-other --run-nodejs --run-rhino --num-threads 8 --log-file=/tmp/duk-test.log tests/ecmascript/
 endif
 
 .PHONY:	qecmatest
 qecmatest: runtestsdeps duk
 ifeq ($(VALGRIND_WRAP),1)
 	@echo "### qecmatest (valgrind)"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk.raw --valgrind --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk.raw --valgrind --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
 else
 	@echo "### qecmatest"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk --num-threads 16 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/duk --num-threads 16 --log-file=/tmp/duk-test.log tests/ecmascript/
 endif
 
 .PHONY:	qecmatestd
 qecmatestd: runtestsdeps dukd
 ifeq ($(VALGRIND_WRAP),1)
 	@echo "### qecmatestd (valgrind)"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd.raw --valgrind --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd.raw --valgrind --num-threads 1 --log-file=/tmp/duk-test.log tests/ecmascript/
 else
 	@echo "### qecmatestd"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd --num-threads 16 --log-file=/tmp/duk-test.log tests/ecmascript/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --run-duk --cmd-duk=$(shell pwd)/dukd --num-threads 16 --log-file=/tmp/duk-test.log tests/ecmascript/
 endif
 
 # Separate target because it's also convenient to run manually.
@@ -530,10 +530,10 @@ apiprep: runtestsdeps libduktape.so.1.0.0
 apitest: apiprep
 ifeq ($(VALGRIND_WRAP),1)
 	@echo "### apitest (valgrind)"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --num-threads 1 --valgrind --log-file=/tmp/duk-api-test.log tests/api/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --num-threads 1 --valgrind --log-file=/tmp/duk-api-test.log tests/api/
 else
 	@echo "### apitest"
-	$(NODE) runtests/runtests.js $(RUNTESTSOPTS) --num-threads 1 --log-file=/tmp/duk-api-test.log tests/api/
+	"$(NODE)" runtests/runtests.js $(RUNTESTSOPTS) --num-threads 1 --log-file=/tmp/duk-api-test.log tests/api/
 endif
 
 .PHONY: matrix10
@@ -714,11 +714,11 @@ emscriptenduktest: emscripten dist
 	@echo "### emscriptenduktest"
 	@rm -f /tmp/duk-emcc-duktest.js
 	emscripten/emcc $(EMCCOPTS_DUKVM) -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -Idist/src/ dist/src/duktape.c dist/examples/eval/eval.c -o /tmp/duk-emcc-duktest.js
-	$(NODE) /tmp/duk-emcc-duktest.js \
+	"$(NODE)" /tmp/duk-emcc-duktest.js \
 		'print("Hello from Duktape running inside Emscripten/NodeJS");' \
 		'print(Duktape.version, Duktape.env);' \
 		'for(i=0;i++<100;)print((i%3?"":"Fizz")+(i%5?"":"Buzz")||i)'
-	$(NODE) /tmp/duk-emcc-duktest.js "eval(''+Duktape.dec('base64', '$(MAND_BASE64)'))"
+	"$(NODE)" /tmp/duk-emcc-duktest.js "eval(''+Duktape.dec('base64', '$(MAND_BASE64)'))"
 
 # This is a prototype of running Duktape in a web environment with Emscripten,
 # and providing an eval() facility from both sides.  This is a placeholder now

--- a/runtests/package.json
+++ b/runtests/package.json
@@ -7,12 +7,12 @@
         "email": "sami.vaarala@iki.fi"
     },
     "dependencies": {
-        "optimist": "~0.3.5",
-        "async": "~0.2.4",
-        "xml2js": "~0.2.4",
         "MD5": "~1.0.0",
+        "async": "~0.2.4",
+        "optimist": "~0.3.5",
+        "tmp": "0.0.27",
+        "xml2js": "~0.2.4",
         "yamljs": "~0.2.1"
     },
     "main": "runtests.js"
 }
-

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -8,7 +8,7 @@
 
 var fs = require('fs'),
     path = require('path'),
-//    temp = require('temp'),
+    tmp = require('tmp'),
     child_process = require('child_process'),
     async = require('async'),
     xml2js = require('xml2js'),
@@ -33,12 +33,12 @@ var knownIssues;
  *  Utils.
  */
 
-// FIXME: placeholder; for some reason 'temp' didn't work
-var tmpCount = 0;
-var tmpUniq = process.pid || Math.floor(Math.random() * 1e6);
-
+// Generate temporary filename, file will be autodeleted on exit unless
+// deleted explicitly.  See: https://www.npmjs.com/package/tmp
 function mkTempName(ext) {
-    return '/tmp/runtests-' + tmpUniq + '-' + (++tmpCount) + (ext !== undefined ? ext : '');
+    var fn = tmp.tmpNameSync({ keep: false, prefix: 'tmp-runtests-' });
+    console.log('mkTempName -> ' + fn);
+    return fn;
 }
 
 function safeUnlinkSync(filePath) {

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -37,7 +37,7 @@ var knownIssues;
 // deleted explicitly.  See: https://www.npmjs.com/package/tmp
 function mkTempName(ext) {
     var fn = tmp.tmpNameSync({ keep: false, prefix: 'tmp-runtests-', postfix: (typeof ext === 'undefined' ? '' : '' + ext) });
-    console.log('mkTempName -> ' + fn);
+    //console.log('mkTempName -> ' + fn);
     return fn;
 }
 

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -36,7 +36,7 @@ var knownIssues;
 // Generate temporary filename, file will be autodeleted on exit unless
 // deleted explicitly.  See: https://www.npmjs.com/package/tmp
 function mkTempName(ext) {
-    var fn = tmp.tmpNameSync({ keep: false, prefix: 'tmp-runtests-' });
+    var fn = tmp.tmpNameSync({ keep: false, prefix: 'tmp-runtests-', postfix: (typeof ext === 'undefined' ? '' : '' + ext) });
     console.log('mkTempName -> ' + fn);
     return fn;
 }


### PR DESCRIPTION
- [x] Use 'tmp' package for auto-deleting temporary filenames.  This should be portable to e.g. Windows, and obeys `TMP` on Unix which is preferable.
- [x] Figure out Python error on Windows => skipped