### PR TITLE
Fix debugger "lockout" in interrupt handling for better performance

### DIFF
--- a/config/config-options/DUK_USE_INTERRUPT_DEBUG_FIXUP.yaml
+++ b/config/config-options/DUK_USE_INTERRUPT_DEBUG_FIXUP.yaml
@@ -1,0 +1,10 @@
+define: DUK_USE_INTERRUPT_DEBUG_FIXUP
+introduced: 1.4.0
+default: false
+tags:
+  - development
+description: >
+  For Duktape development only: enable "interrupt fixup" in call handling
+  so that heap->inst_count_exec and heap->inst_count_interrupt can be
+  manually checked to match.  Only useful when debugging and/or asserts
+  are enabled.

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1700,6 +1700,7 @@ DUK_INTERNAL void duk_debug_halt_execution(duk_hthread *thr, duk_bool_t use_prev
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(thr->heap != NULL);
 	DUK_ASSERT(DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap));
+	DUK_ASSERT(thr->heap->dbg_processing == 0);
 
 	DUK_HEAP_SET_PAUSED(thr->heap);
 

--- a/src/duk_error_misc.c
+++ b/src/duk_error_misc.c
@@ -74,8 +74,9 @@ DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t l
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	/* If something is thrown with the debugger attached and nobody will
 	 * catch it, execution is paused before the longjmp, turning over
-	 * control to the debug client. This allows local state to be examined
-	 * before the stack is unwound.
+	 * control to the debug client.  This allows local state to be examined
+	 * before the stack is unwound.  Errors are not intercepted when debug
+	 * message loop is active (e.g. for Eval).
 	 */
 
 	/* XXX: Allow customizing the pause and notify behavior at runtime
@@ -83,7 +84,9 @@ DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t l
 	 * config options.
 	 */
 #if defined(DUK_USE_DEBUGGER_THROW_NOTIFY) || defined(DUK_USE_DEBUGGER_PAUSE_UNCAUGHT)
-	if (DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap) && lj_type == DUK_LJ_TYPE_THROW) {
+	if (DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap) &&
+	    !thr->heap->dbg_processing &&
+	    lj_type == DUK_LJ_TYPE_THROW) {
 		duk_context *ctx = (duk_context *) thr;
 		duk_bool_t fatal;
 		duk_hobject *h_obj;

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -29,7 +29,7 @@ DUK_LOCAL void duk__interrupt_fixup(duk_hthread *thr, duk_hthread *entry_curr_th
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(thr->heap != NULL);
 
-#if 0
+#if defined(DUK_USE_INTERRUPT_DEBUG_FIXUP)
 	if (entry_curr_thread == NULL) {
 		thr->interrupt_init = thr->interrupt_init - thr->interrupt_counter;
 		thr->heap->inst_count_interrupt += thr->interrupt_init;


### PR DESCRIPTION
The executor must prevent interrupt handling when (1) interrupt handling is *not* active but (2) debug handling is active. This may now happen at any time because we can call into the debugger message loop from anywhere.

The current check is in the executor hot path and is executed for every instruction dispatched. This shows up as a performance degradation from 1.3.0. It also makes the "opcodes executed" and "cumulative interrupt counter" numbers diverge in these special cases.

Fix so that the debugger-message-loop-in-progress check happens inside the interrupt-counter-zero handling, same as how nested interrupts are detected. This should also fix the interrupt counter issue (it needs manual verification).

Tasks:

- [x] Reimplement "lockout"
- [x] Test interrupt executor count match manually
- [x] Add explicit config option for debug/assert of executor count
- [x] Fix double executor halt issue in debugger Eval