### PR TITLE
Minimal support for debugger web UI bytecode "current PC" highlight

### DIFF
--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -1403,6 +1403,7 @@ Debugger.prototype.sendGetBytecodeRequest = function () {
         var bcode;
         var preformatted;
         var ret;
+        var idxPreformattedInstructions;
 
         //console.log(JSON.stringify(msg));
 
@@ -1432,6 +1433,7 @@ Debugger.prototype.sendGetBytecodeRequest = function () {
             preformatted.push('; c' + i + ' ' + JSON.stringify(v));
         });
         preformatted.push('');
+        idxPreformattedInstructions = preformatted.length;
         bcode.forEach(function (v) {
             preformatted.push(v.str);
         });
@@ -1441,7 +1443,8 @@ Debugger.prototype.sendGetBytecodeRequest = function () {
             constants: consts,
             functions: funcs,
             bytecode: bcode,
-            preformatted: preformatted
+            preformatted: preformatted,
+            idxPreformattedInstructions: idxPreformattedInstructions
         };
 
         return ret;

--- a/debugger/static/style.css
+++ b/debugger/static/style.css
@@ -358,8 +358,12 @@
 	margin: 10px 0 10px 0;
 }
 #bytecode-dialog pre {
-	font: 14pt monospace;
+	font: 10pt monospace;
 	color: #000000;
+}
+#bytecode-dialog div.highlight {
+	background: #888888;
+	color: #ffffff;
 }
 
 #eval {


### PR DESCRIPTION
Current limitations:

- Doesn't scroll
- Automatic reload for bytecode when changing active function is not 100% as it's based on function name only (proper heap references would be needed to implement properly)