### PR TITLE
Change error accessor properties to make .fileName, .lineNumber, and .stack normally writable

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1185,6 +1185,10 @@ Planned
 * Add convenience API calls to detect specific error subtypes, e.g.
   duk_is_eval_error() (GH-340, GH-433)
 
+* Make Error instance .filename, .lineNumber, and .stack directly writable
+  to match V8 and Spidermonkey behavior; the previous behavior is provided
+  by polyfills/duktape-error-setter-nonwritable.js (GH-390)
+
 * Add a combined duktape.c without #line directives into the dist package,
   as it is a useful alternative in some environments (GH-363)
 

--- a/polyfills/duktape-error-setter-nonwritable.js
+++ b/polyfills/duktape-error-setter-nonwritable.js
@@ -1,0 +1,20 @@
+/*
+ *  Ensure Error .fileName, .lineNumber, and .stack are not directly writable,
+ *  but can be written using Object.defineProperty().  This matches Duktape
+ *  1.3.0 and prior.
+ *
+ *  See: https://github.com/svaarala/duktape/pull/390.
+ */
+
+(function () {
+    var err = new Error('test');
+    err.fileName = 999;
+    if (err.fileName !== 999) { return; }  // already non-writable
+
+    var fn = new Function('');  // nop
+    Object.defineProperties(Error.prototype, {
+        fileName: { set: fn },
+        lineNumber: { set: fn },
+        stack: { set: fn }
+    });
+})();

--- a/polyfills/duktape-error-setter-writable.js
+++ b/polyfills/duktape-error-setter-writable.js
@@ -1,0 +1,19 @@
+/*
+ *  Ensure Error .fileName, .lineNumber, and .stack are directly writable
+ *  without having to use Object.defineProperty().  This matches Duktape
+ *  1.4.0 behavior.
+ *
+ *  See: https://github.com/svaarala/duktape/pull/390.
+ */
+
+(function () {
+    var err = new Error('test');
+    err.fileName = 999;
+    if (err.fileName === 999) { return; }  // already writable
+
+    Object.defineProperties(Error.prototype, {
+        fileName: { set: new Function('v', 'Object.defineProperty(this, "fileName", { value: v, writable: true, enumerable: false, configurable: true });') },
+        lineNumber: { set: new Function('v', 'Object.defineProperty(this, "lineNumber", { value: v, writable: true, enumerable: false, configurable: true });') },
+        stack: { set: new Function('v', 'Object.defineProperty(this, "stack", { value: v, writable: true, enumerable: false, configurable: true });') },
+    });
+})();

--- a/src/duk_bi_error.c
+++ b/src/duk_bi_error.c
@@ -93,7 +93,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx) {
 	return 1;
 }
 
-#ifdef DUK_USE_TRACEBACKS
+#if defined(DUK_USE_TRACEBACKS)
 
 /*
  *  Traceback handling
@@ -114,7 +114,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx) {
 #define DUK__OUTPUT_TYPE_FILENAME    0
 #define DUK__OUTPUT_TYPE_LINENUMBER  1
 
-DUK_LOCAL duk_ret_t duk__traceback_getter_helper(duk_context *ctx, duk_small_int_t output_type) {
+DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t output_type) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_idx_t idx_td;
 	duk_small_int_t i;  /* traceback depth fits into 16 bits */
@@ -277,20 +277,20 @@ DUK_LOCAL duk_ret_t duk__traceback_getter_helper(duk_context *ctx, duk_small_int
 	}
 }
 
-/* XXX: output type could be encoded into native function 'magic' value to
- * save space.
+/* XXX: Output type could be encoded into native function 'magic' value to
+ * save space.  For setters the stridx could be encoded into 'magic'.
  */
 
 DUK_INTERNAL duk_ret_t duk_bi_error_prototype_stack_getter(duk_context *ctx) {
-	return duk__traceback_getter_helper(ctx, DUK__OUTPUT_TYPE_TRACEBACK);
+	return duk__error_getter_helper(ctx, DUK__OUTPUT_TYPE_TRACEBACK);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_error_prototype_filename_getter(duk_context *ctx) {
-	return duk__traceback_getter_helper(ctx, DUK__OUTPUT_TYPE_FILENAME);
+	return duk__error_getter_helper(ctx, DUK__OUTPUT_TYPE_FILENAME);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_error_prototype_linenumber_getter(duk_context *ctx) {
-	return duk__traceback_getter_helper(ctx, DUK__OUTPUT_TYPE_LINENUMBER);
+	return duk__error_getter_helper(ctx, DUK__OUTPUT_TYPE_LINENUMBER);
 }
 
 #undef DUK__OUTPUT_TYPE_TRACEBACK
@@ -330,11 +330,40 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_linenumber_getter(duk_context *ctx
 
 #endif  /* DUK_USE_TRACEBACKS */
 
-DUK_INTERNAL duk_ret_t duk_bi_error_prototype_nop_setter(duk_context *ctx) {
-	/* Attempt to write 'stack', 'fileName', 'lineNumber' is a silent no-op.
-	 * User can use Object.defineProperty() to override this behavior.
+DUK_LOCAL duk_ret_t duk__error_setter_helper(duk_context *ctx, duk_small_uint_t stridx_key) {
+	/* Attempt to write 'stack', 'fileName', 'lineNumber' works as if
+	 * user code called Object.defineProperty() to create an overriding
+	 * own property.  This allows user code to overwrite .fileName etc
+	 * intuitively as e.g. "err.fileName = 'dummy'" as one might expect.
+	 * See https://github.com/svaarala/duktape/issues/387.
 	 */
-	DUK_ASSERT_TOP(ctx, 1);  /* fixed arg count */
-	DUK_UNREF(ctx);
+
+	DUK_ASSERT_TOP(ctx, 1);  /* fixed arg count: value */
+
+	duk_push_this(ctx);
+	duk_push_hstring_stridx(ctx, (duk_small_int_t) stridx_key);
+	duk_dup(ctx, 0);
+
+	/* [ ... obj key value ] */
+
+	DUK_DD(DUK_DDPRINT("error setter: %!T %!T %!T",
+	                   duk_get_tval(ctx, -3), duk_get_tval(ctx, -2), duk_get_tval(ctx, -1)));
+
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE |
+	                      DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE |
+	                      DUK_DEFPROP_HAVE_ENUMERABLE | /*not enumerable*/
+	                      DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_CONFIGURABLE);
 	return 0;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_error_prototype_stack_setter(duk_context *ctx) {
+	return duk__error_setter_helper(ctx, DUK_STRIDX_STACK);
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_error_prototype_filename_setter(duk_context *ctx) {
+	return duk__error_setter_helper(ctx, DUK_STRIDX_FILE_NAME);
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_error_prototype_linenumber_setter(duk_context *ctx) {
+	return duk__error_setter_helper(ctx, DUK_STRIDX_LINE_NUMBER);
 }

--- a/src/duk_bi_protos.h
+++ b/src/duk_bi_protos.h
@@ -97,7 +97,9 @@ DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx);
 DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_stack_getter(duk_context *ctx);
 DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_filename_getter(duk_context *ctx);
 DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_linenumber_getter(duk_context *ctx);
-DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_nop_setter(duk_context *ctx);
+DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_stack_setter(duk_context *ctx);
+DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_filename_setter(duk_context *ctx);
+DUK_INTERNAL_DECL duk_ret_t duk_bi_error_prototype_linenumber_setter(duk_context *ctx);
 
 DUK_INTERNAL_DECL duk_ret_t duk_bi_function_constructor(duk_context *ctx);
 DUK_INTERNAL_DECL duk_ret_t duk_bi_function_prototype(duk_context *ctx);

--- a/src/duk_hthread_builtins.c
+++ b/src/duk_hthread_builtins.c
@@ -330,9 +330,6 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 				duk_c_function c_func_getter;
 				duk_c_function c_func_setter;
 
-				/* XXX: this is a bit awkward because there is no exposed helper
-				 * in the API style, only this internal helper.
-				 */
 				DUK_DDD(DUK_DDDPRINT("built-in accessor property: objidx=%ld, stridx=%ld, getteridx=%ld, setteridx=%ld, flags=0x%04lx",
 				                     (long) i, (long) stridx, (long) natidx_getter, (long) natidx_setter, (unsigned long) prop_flags));
 
@@ -341,7 +338,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 				duk_push_c_function_noconstruct_noexotic(ctx, c_func_getter, 0);  /* always 0 args */
 				duk_push_c_function_noconstruct_noexotic(ctx, c_func_setter, 1);  /* always 1 arg */
 
-				/* XXX: magic for getter/setter? */
+				/* XXX: magic for getter/setter? use duk_def_prop()? */
 
 				prop_flags |= DUK_PROPDESC_FLAG_ACCESSOR;  /* accessor flag not encoded explicitly */
 				duk_hobject_define_accessor_internal(thr,

--- a/src/genbuiltins.py
+++ b/src/genbuiltins.py
@@ -852,13 +852,13 @@ bi_error_prototype = {
 
 		{ 'name': 'stack',
 		  'getter': 'duk_bi_error_prototype_stack_getter',
-		  'setter': 'duk_bi_error_prototype_nop_setter' },
+		  'setter': 'duk_bi_error_prototype_stack_setter' },
 		{ 'name': 'fileName',
 		  'getter': 'duk_bi_error_prototype_filename_getter',
-		  'setter': 'duk_bi_error_prototype_nop_setter' },
+		  'setter': 'duk_bi_error_prototype_filename_setter' },
 		{ 'name': 'lineNumber',
 		  'getter': 'duk_bi_error_prototype_linenumber_getter',
-		  'setter': 'duk_bi_error_prototype_nop_setter' },
+		  'setter': 'duk_bi_error_prototype_linenumber_setter' },
 	],
 	'functions': [
 		{ 'name': 'toString',			'native': 'duk_bi_error_prototype_to_string',		'length': 0 },
@@ -2008,6 +2008,11 @@ class GenBuiltins:
 					#print(v, '->', i)
 					return i
 			raise Exception('invalid builtin index for magic: ' % repr(v))
+		elif elem['type'] == 'stridx':
+			v = self.gs.stringToIndex(valspec['name'])
+			if not (v >= -0x8000 and v <= 0x7fff):
+				raise Exception('invalid stridx value for magic: %s' % repr(v))
+			return v & 0xffff
 		elif elem['type'] == 'plain':
 			v = elem['value']
 			if not (v >= -0x8000 and v <= 0x7fff):

--- a/tests/ecmascript/test-dev-writable-error-filename-gh387.js
+++ b/tests/ecmascript/test-dev-writable-error-filename-gh387.js
@@ -1,0 +1,95 @@
+/*
+ *  Test that error .fileName, .lineNumber, and .stack are all writable.
+ *
+ *  These properties are not part of E5, but they are present in e.g. V8.
+ *  Before Duktape 1.4.0 the properties were not directly writable, but you
+ *  could use Object.defineProperty() to overwrite them.  This was changed
+ *  in Duktape 1.4.0 to match V8 and Spidermonkey behavior.
+ *
+ *  Also when Duktape 1.3.0 and prior was compiled without tracebacks,
+ *  .fileName and .lineNumber were writable, so the change in Duktape 1.4.0
+ *  makes traceback-enabled behavior more consistent.
+ *
+ *  https://github.com/svaarala/duktape/issues/387
+ */
+
+/*===
+["message"]
+dummy
+99999
+Foo
+	bar
+	quux
+["message","fileName","lineNumber","stack"]
+true true true
+false false false
+{get:{_func:true},set:{_func:true},enumerable:false,configurable:true}
+true true true
+true true true
+===*/
+
+function test() {
+    var err = new Error('aiee');
+    var pd;
+
+    // By default an Error instance only has a .message property; the rest
+    // of the properties are provided by inherited accessors based on an
+    // internal _Tracedata property.
+    print(JSON.stringify(Object.getOwnPropertyNames(err)));
+
+    // .fileName is writable
+    err.fileName = 'dummy';
+    print(err.fileName);
+
+    // .lineNumber is writable
+    err.lineNumber = 99999;
+    print(err.lineNumber);
+
+    // Note that the stacktrace uses file/line information from the call
+    // stack functions and will ignore the .fileName and .lineNumber "own"
+    // properties.
+
+    //print(err.stack)
+
+    // .stack is also writable
+    err.stack = 'Foo\n\tbar\n\tquux';
+    print(err.stack);
+
+    // All of the overwritten values appear as own properties which will
+    // shadow the default accessors.
+    print(JSON.stringify(Object.getOwnPropertyNames(err)));
+
+    function writabilityTest() {
+        err = new Error('zork');
+        var origFileName = err.fileName;
+        var origLineNumber = err.lineNumber;
+        var origStack = err.stack;
+        print(err.fileName === origFileName, err.lineNumber === origLineNumber, err.stack === origStack);
+        err.fileName = 'dummy';
+        err.lineNumber = 99999;
+        err.stack = 'Foo\nBar';
+        print(err.fileName === origFileName, err.lineNumber === origLineNumber, err.stack === origStack);
+    }
+
+    // If you prefer the Duktape 1.3.0 behavior, you can edit the inherited
+    // accessors.  For example, if the setter is made a no-op, Duktape 1.3.0
+    // behavior is restored.
+
+    writabilityTest();  // writable
+
+    pd = Object.getOwnPropertyDescriptor(Error.prototype, 'fileName');
+    print(Duktape.enc('jx', pd));
+    Object.defineProperties(Error.prototype, {
+        fileName: { set: function nop() {} },
+        lineNumber: { set: function nop() {} },
+        stack: { set: function nop() {} }
+    });
+
+    writabilityTest();  // not writable, Duktape 1.3.0 behavior
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/util/make_dist.sh
+++ b/util/make_dist.sh
@@ -261,6 +261,8 @@ for i in \
 	object-assign.js \
 	performance-now.js \
 	duktape-isfastint.js \
+	duktape-error-setter-writable.js \
+	duktape-error-setter-nonwritable.js \
 	; do
 	cp polyfills/$i $DIST/polyfills/
 done

--- a/website/guide/errorobjects.html
+++ b/website/guide/errorobjects.html
@@ -26,10 +26,14 @@ of error objects is minimized to keep error objects as small as possible.</p>
 <p>If Duktape is compiled with traceback support:</p>
 
 <ul>
-<li><code>stack</code>, <code>fileName</code>, and <code>lineNumber</code> are accessor
-    properties inherited from <code>Error.prototype</code>.</li>
+<li><code>stack</code>, <code>fileName</code>, and <code>lineNumber</code> are
+    accessor properties inherited from <code>Error.prototype</code>.  You can
+    override the properties by simply assigning over them: an inherited setter
+    will capture the write but will create an own property as if a normal
+    assignment was done.  This behavior was changed in Duktape 1.4.0 to better
+    match other engines.</li>
 <li>The raw traceback data needed by the accessor properties is stored in an internal
-    property (<code>\xFFtracedata</code>) which is not normally accessible from
+    property (<code>\xFFTracedata</code>) which is not normally accessible from
     Ecmascript code.</li>
 </ul>
 
@@ -37,9 +41,9 @@ of error objects is minimized to keep error objects as small as possible.</p>
 <ul>
 <li>The <code>stack</code> accessor will be equivalent to
     <code>Error.prototype.toString()</code>, so that printing the stacktrace
-    always produces a useful result.</li>
-<li><code>fileName</code> and <code>lineNumber</code> will be own properties of the
-    Error object.</li>
+    always produces a useful, human readable result.</li>
+<li><code>fileName</code> and <code>lineNumber</code> will be own properties
+    of the Error object.  You can override the properties using assignment.</li>
 </ul>
 
 <p>When error objects are created using the Duktape API from C code and the
@@ -66,7 +70,7 @@ Traceback data is automatically collected and added to an object:</p>
 </ul>
 
 <p>The data used to create the traceback is stored in an internal property
-(<code>\xFFtracedata</code>), in an internal and version-dependent format
+(<code>\xFFTracedata</code>), in an internal and version-dependent format
 described
 <a href="https://github.com/svaarala/duktape/blob/master/doc/error-objects.rst">error-objects.rst</a>.
 You shouldn't access the traceback data directly.</p>


### PR DESCRIPTION
In Duktape 1.3.0 you can't simply overwrite an error instance's `.fileName`, `.lineNumber`, or `.stack`. The write will be captured by an inherited setter (whose getter counterpart virtualizes these property reads) which ignores the write:

```
$ ./duk.O2.130
((o) Duktape 1.3.0 (v1.2.0-614-g57bdc8c)
duk> err = new Error('aiee'); err.fileName = 'dummy.js';
= dummy.js
duk> print(err.fileName);
input
= undefined
```

You could still set "own properties" overwriting these properties using Object.defineProperty:

```
$ ./duk.O2.130
((o) Duktape 1.3.0 (v1.2.0-614-g57bdc8c)
duk> err = new Error('aiee'); Object.defineProperty(err, 'fileName', {value:'dummy.js',writable:true,configurable:true});
= Error: aiee
duk> err.fileName
= dummy.js
```

This pull changes the inherited setter so that it automatically invokes a `duk_def_prop()` call to allow ordinary property assignment to work as expected.

Note, however, that fileName/lineNumber values in a `.stack` dump are based entirely on the internal `_Tracedata` so that overwriting `.fileName` and `.lineNumber` won't change them in the stack trace.

Tasks:

- [x] Finalize change
- [x] Finalize testcase
- [x] Polyfill to restore 1.3.0 behavior
- [x] Polyfill to ensure 1.4.0 behavior
- [x] Website error description update
- [x] Releases entry

Fixes #387.

