### PR TITLE
Add DUK_TVAL_SET_xxx_UPDREF() macros

### DIFF
--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -137,7 +137,9 @@ Checklist for ordinary releases
     resize algorithms (or similar) can lead to unbounded or suboptimal
     memory usage
 
-  - XXX: establish some baseline test
+  - Minimal manual refcount leak test:
+
+    - test-dev-refcount-leak-basic.js
 
 * Performance testing
 

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -763,6 +763,7 @@ int main(int argc, char *argv[]) {
 	int ajsheap_log = 0;
 	int debugger = 0;
 	int recreate_heap = 0;
+	int no_heap_destroy = 0;
 	int verbose = 0;
 	int run_stdin = 0;
 	const char *compile_filename = NULL;
@@ -872,6 +873,8 @@ int main(int argc, char *argv[]) {
 			debugger = 1;
 		} else if (strcmp(arg, "--recreate-heap") == 0) {
 			recreate_heap = 1;
+		} else if (strcmp(arg, "--no-heap-destroy") == 0) {
+			no_heap_destroy = 1;
 		} else if (strcmp(arg, "--verbose") == 0) {
 			verbose = 1;
 		} else if (strcmp(arg, "--run-stdin") == 0) {
@@ -995,7 +998,10 @@ int main(int argc, char *argv[]) {
 		fflush(stderr);
 	}
 
-	if (ctx) {
+	if (ctx && no_heap_destroy) {
+		duk_gc(ctx, 0);
+	}
+	if (ctx && !no_heap_destroy) {
 		destroy_duktape_heap(ctx, alloc_provider);
 	}
 	ctx = NULL;
@@ -1033,6 +1039,7 @@ int main(int argc, char *argv[]) {
 			"   --debugger         start example debugger\n"
 #endif
 			"   --recreate-heap    recreate heap after every file\n"
+			"   --no-heap-destroy  force GC, but don't destroy heap at end (leak testing)\n"
 	                "\n"
 	                "If <filename> is omitted, interactive mode is started automatically.\n");
 	fflush(stderr);

--- a/src/duk_api_heap.c
+++ b/src/duk_api_heap.c
@@ -82,6 +82,7 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 	 */
 
 	h_prev_glob = thr->builtins[DUK_BIDX_GLOBAL];
+	DUK_UNREF(h_prev_glob);
 	thr->builtins[DUK_BIDX_GLOBAL] = h_glob;
 	DUK_HOBJECT_INCREF(thr, h_glob);
 	DUK_HOBJECT_DECREF_ALLOWNULL(thr, h_prev_glob);  /* side effects, in theory (referenced by global env) */

--- a/src/duk_bi_thread.c
+++ b/src/duk_bi_thread.c
@@ -50,7 +50,6 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
 DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hthread *thr_resume;
-	duk_tval tv_tmp;
 	duk_tval *tv;
 	duk_hobject *func;
 	duk_hobject *caller_func;
@@ -165,17 +164,11 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 
 	/* lj value2: thread */
 	DUK_ASSERT(thr->valstack_bottom < thr->valstack_top);
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value2);
-	DUK_TVAL_SET_TVAL(&thr->heap->lj.value2, &thr->valstack_bottom[0]);
-	DUK_TVAL_INCREF(thr, &thr->heap->lj.value2);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
+	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value2, &thr->valstack_bottom[0]);  /* side effects */
 
 	/* lj value1: value */
 	DUK_ASSERT(thr->valstack_bottom + 1 < thr->valstack_top);
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-	DUK_TVAL_SET_TVAL(&thr->heap->lj.value1, &thr->valstack_bottom[1]);
-	DUK_TVAL_INCREF(thr, &thr->heap->lj.value1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
+	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value1, &thr->valstack_bottom[1]);  /* side effects */
 
 	thr->heap->lj.iserror = is_error;
 
@@ -209,7 +202,6 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 
 DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_tval tv_tmp;
 	duk_hobject *caller_func;
 	duk_small_int_t is_error;
 
@@ -292,10 +284,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 
 	/* lj value1: value */
 	DUK_ASSERT(thr->valstack_bottom < thr->valstack_top);
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-	DUK_TVAL_SET_TVAL(&thr->heap->lj.value1, &thr->valstack_bottom[0]);
-	DUK_TVAL_INCREF(thr, &thr->heap->lj.value1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
+	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value1, &thr->valstack_bottom[0]);  /* side effects */
 
 	thr->heap->lj.iserror = is_error;
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1885,6 +1885,7 @@ DUK_INTERNAL duk_bool_t duk_debug_remove_breakpoint(duk_hthread *thr, duk_small_
 	heap->dbg_breakpoints_active[0] = (duk_breakpoint *) NULL;
 
 	DUK_HSTRING_DECREF(thr, h);  /* side effects */
+	DUK_UNREF(h);  /* w/o refcounting */
 
 	/* Breakpoint entries above the used area are left as garbage. */
 

--- a/src/duk_error_misc.c
+++ b/src/duk_error_misc.c
@@ -71,8 +71,6 @@ DUK_INTERNAL duk_hobject *duk_error_prototype_from_code(duk_hthread *thr, duk_er
  */
 
 DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t lj_type) {
-	duk_tval tv_tmp;
-
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	/* If something is thrown with the debugger attached and nobody will
 	 * catch it, execution is paused before the longjmp, turning over
@@ -127,10 +125,7 @@ DUK_INTERNAL void duk_err_setup_heap_ljstate(duk_hthread *thr, duk_small_int_t l
 	thr->heap->lj.type = lj_type;
 
 	DUK_ASSERT(thr->valstack_top > thr->valstack);
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-	DUK_TVAL_SET_TVAL(&thr->heap->lj.value1, thr->valstack_top - 1);
-	DUK_TVAL_INCREF(thr, &thr->heap->lj.value1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
+	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value1, thr->valstack_top - 1);  /* side effects */
 
 	duk_pop((duk_context *) thr);
 }

--- a/src/duk_heap.h
+++ b/src/duk_heap.h
@@ -514,7 +514,9 @@ DUK_INTERNAL_DECL duk_hstring *duk_heap_string_lookup_u32(duk_heap *heap, duk_ui
 #endif
 DUK_INTERNAL_DECL duk_hstring *duk_heap_string_intern_u32(duk_heap *heap, duk_uint32_t val);
 DUK_INTERNAL_DECL duk_hstring *duk_heap_string_intern_u32_checked(duk_hthread *thr, duk_uint32_t val);
+#if defined(DUK_USE_REFERENCE_COUNTING)
 DUK_INTERNAL_DECL void duk_heap_string_remove(duk_heap *heap, duk_hstring *h);
+#endif
 #if defined(DUK_USE_MARK_AND_SWEEP) && defined(DUK_USE_MS_STRINGTABLE_RESIZE)
 DUK_INTERNAL_DECL void duk_heap_force_strtab_resize(duk_heap *heap);
 #endif

--- a/src/duk_heap_stringtable.c
+++ b/src/duk_heap_stringtable.c
@@ -974,6 +974,7 @@ DUK_INTERNAL duk_hstring *duk_heap_string_intern_u32_checked(duk_hthread *thr, d
 }
 
 /* find and remove string from stringtable; caller must free the string itself */
+#if defined(DUK_USE_REFERENCE_COUNTING)
 DUK_INTERNAL void duk_heap_string_remove(duk_heap *heap, duk_hstring *h) {
 	DUK_DDD(DUK_DDDPRINT("remove string from stringtable: %!O", (duk_heaphdr *) h));
 
@@ -992,6 +993,7 @@ DUK_INTERNAL void duk_heap_string_remove(duk_heap *heap, duk_hstring *h) {
 #error internal error, invalid strtab options
 #endif
 }
+#endif
 
 #if defined(DUK_USE_MARK_AND_SWEEP) && defined(DUK_USE_MS_STRINGTABLE_RESIZE)
 DUK_INTERNAL void duk_heap_force_strtab_resize(duk_heap *heap) {

--- a/src/duk_heaphdr.h
+++ b/src/duk_heaphdr.h
@@ -350,6 +350,250 @@ struct duk_heaphdr_string {
 		} \
 	} while (0)
 
+/*
+ *  Macros to set a duk_tval and update refcount of the target (decref the
+ *  old value and incref the new value if necessary).  This is both performance
+ *  and footprint critical; any changes made should be measured for size/speed.
+ */
+
+#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_UNDEFINED_ACTUAL(tv__dst); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_UNDEFINED_UNUSED(tv__dst); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_NULL_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_NULL(tv__dst); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_BOOLEAN(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_NUMBER_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_NUMBER(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#define DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_NUMBER_CHKFAST(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#define DUK_TVAL_SET_DOUBLE_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_DOUBLE(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#define DUK_TVAL_SET_NAN_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_NAN(tv__dst); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#if defined(DUK_USE_FASTINT)
+#define DUK_TVAL_SET_FASTINT_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_FASTINT(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_FASTINT_I32(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_FASTINT_U32(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+#endif  /* DUK_USE_FASTINT */
+
+#define DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0(thr,tvptr_dst,lf_v,lf_fp,lf_flags) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_LIGHTFUNC(tv__dst, (lf_v), (lf_fp), (lf_flags)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_STRING_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_STRING(tv__dst, (newval)); \
+		DUK_HSTRING_INCREF((thr), (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_OBJECT_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_OBJECT(tv__dst, (newval)); \
+		DUK_HOBJECT_INCREF((thr), (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_BUFFER_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_BUFFER(tv__dst, (newval)); \
+		DUK_HBUFFER_INCREF((thr), (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#define DUK_TVAL_SET_POINTER_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_POINTER(tv__dst, (newval)); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+/* DUK_TVAL_SET_TVAL_UPDREF() is used a lot in executor, property lookups,
+ * etc, so it's very important for performance.
+ *
+ * NOTE: the source and destination duk_tval pointers may be the same, and
+ * the macros MUST deal with that correctly.
+ */
+
+/* Original idiom used. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT0(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_tval tv__tmp; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+		DUK_TVAL_INCREF((thr), tv__src); \
+		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+#if 0  /* XXX: to optimize and measure */
+/* Original idiom but with forced fast refcount macros. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT0F(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_tval tv__tmp; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
+		DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+		DUK_TVAL_INCREF_FAST((thr), tv__src); \
+		DUK_TVAL_DECREF_FAST((thr), &tv__tmp);  /* side effects */ \
+	} while (0)
+
+/* Use 'h__obj' temporary to avoid a full duk_tval copy. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT1(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_heaphdr *h__obj; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		if (DUK_TVAL_IS_HEAP_ALLOCATED(tv__dst)) { \
+			h__obj = DUK_TVAL_GET_HEAPHDR(tv__dst); \
+			DUK_ASSERT(h__obj != NULL); \
+		} else { \
+			h__obj = NULL; \
+		} \
+		DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+		DUK_TVAL_INCREF((thr), tv__src); \
+		if (h__obj != NULL) { \
+			DUK_HEAPHDR_DECREF_FAST((thr), h__obj);  /* side effects */ \
+		} \
+	} while (0)
+
+/* Use 'h__obj' temporary to avoid a full duk_tval copy. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT1A(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_heaphdr *h__obj; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		if (DUK_UNLIKELY(DUK_TVAL_IS_HEAP_ALLOCATED(tv__dst))) { \
+			h__obj = DUK_TVAL_GET_HEAPHDR(tv__dst); \
+			DUK_ASSERT(h__obj != NULL); \
+		} else { \
+			h__obj = NULL; \
+		} \
+		DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+		DUK_TVAL_INCREF_FAST((thr), tv__src); \
+		if (DUK_UNLIKELY(h__obj != NULL)) { \
+			DUK_HEAPHDR_DECREF_FAST((thr), h__obj);  /* side effects */ \
+		} \
+	} while (0)
+
+/* Avoid rechecking 'h__obj'. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT2(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_heaphdr *h__obj; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		if (DUK_TVAL_IS_HEAP_ALLOCATED(tv__dst)) { \
+			h__obj = DUK_TVAL_GET_HEAPHDR(tv__dst); \
+			DUK_ASSERT(h__obj != NULL); \
+			DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+			DUK_TVAL_INCREF((thr), tv__src); \
+			DUK_HEAPHDR_DECREF_FAST((thr), h__obj);  /* side effects */ \
+		} else { \
+			DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+			DUK_TVAL_INCREF((thr), tv__src); \
+		} \
+	} while (0)
+
+/* Avoid rechecking 'h__obj'. */
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT3(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; duk_heaphdr *h__obj; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		if (DUK_UNLIKELY(DUK_TVAL_IS_HEAP_ALLOCATED(tv__dst))) { \
+			h__obj = DUK_TVAL_GET_HEAPHDR(tv__dst); \
+			DUK_ASSERT(h__obj != NULL); \
+			DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+			DUK_TVAL_INCREF_FAST((thr), tv__src); \
+			DUK_HEAPHDR_DECREF_FAST((thr), h__obj);  /* side effects */ \
+		} else { \
+			DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+			DUK_TVAL_INCREF_FAST((thr), tv__src); \
+		} \
+	} while (0)
+#endif
+
+/* XXX: no optimized variants yet */
+#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF  DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0
+#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF  DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0
+#define DUK_TVAL_SET_NULL_UPDREF              DUK_TVAL_SET_NULL_UPDREF_ALT0
+#define DUK_TVAL_SET_BOOLEAN_UPDREF           DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0
+#define DUK_TVAL_SET_NUMBER_UPDREF            DUK_TVAL_SET_NUMBER_UPDREF_ALT0
+#define DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF    DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF_ALT0
+#define DUK_TVAL_SET_DOUBLE_UPDREF            DUK_TVAL_SET_DOUBLE_UPDREF_ALT0
+#define DUK_TVAL_SET_NAN_UPDREF               DUK_TVAL_SET_NAN_UPDREF_ALT0
+#if defined(DUK_USE_FASTINT)
+#define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_FASTINT_UPDREF_ALT0
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0
+#endif  /* DUK_USE_FASTINT */
+#define DUK_TVAL_SET_LIGHTFUNC_UPDREF         DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0
+#define DUK_TVAL_SET_STRING_UPDREF            DUK_TVAL_SET_STRING_UPDREF_ALT0
+#define DUK_TVAL_SET_OBJECT_UPDREF            DUK_TVAL_SET_OBJECT_UPDREF_ALT0
+#define DUK_TVAL_SET_BUFFER_UPDREF            DUK_TVAL_SET_BUFFER_UPDREF_ALT0
+#define DUK_TVAL_SET_POINTER_UPDREF           DUK_TVAL_SET_POINTER_UPDREF_ALT0
+
+#if defined(DUK_USE_FAST_REFCOUNT_DEFAULT)
+/* Optimized for speed. */
+#define DUK_TVAL_SET_TVAL_UPDREF              DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_FAST         DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_SLOW         DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#else
+/* Optimized for size. */
+#define DUK_TVAL_SET_TVAL_UPDREF              DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_FAST         DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_SLOW         DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#endif
+
 #else  /* DUK_USE_REFERENCE_COUNTING */
 
 #define DUK_TVAL_INCREF_FAST(thr,v)            do {} while (0) /* nop */
@@ -380,6 +624,128 @@ struct duk_heaphdr_string {
 #define DUK_HTHREAD_DECREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HOBJECT_INCREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
+
+#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_UNDEFINED_ACTUAL(tv__dst); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_UNDEFINED_UNUSED(tv__dst); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_NULL_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_NULL(tv__dst); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_BOOLEAN(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_NUMBER_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_NUMBER(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#define DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_NUMBER_CHKFAST(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#define DUK_TVAL_SET_DOUBLE_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_DOUBLE(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#define DUK_TVAL_SET_NAN_UPDREF_ALT0(thr,tvptr_dst) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_NAN(tv__dst); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#if defined(DUK_USE_FASTINT)
+#define DUK_TVAL_SET_FASTINT_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_FASTINT(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_FASTINT_I32(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_FASTINT_U32(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+#endif  /* DUK_USE_FASTINT */
+
+#define DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0(thr,tvptr_dst,lf_v,lf_fp,lf_flags) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_LIGHTFUNC(tv__dst, (lf_v), (lf_fp), (lf_flags)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_STRING_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_STRING(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_OBJECT_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_OBJECT(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_BUFFER_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_BUFFER(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_POINTER_ALT0(thr,tvptr_dst,newval) do { \
+		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
+		DUK_TVAL_SET_POINTER(tv__dst, (newval)); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_TVAL_UPDREF_ALT0(thr,tvptr_dst,tvptr_src) do { \
+		duk_tval *tv__dst, *tv__src; \
+		tv__dst = (tvptr_dst); tv__src = (tvptr_src); \
+		DUK_TVAL_SET_TVAL(tv__dst, tv__src); \
+		DUK_UNREF((thr)); \
+	} while (0)
+
+#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF  DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0
+#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF  DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0
+#define DUK_TVAL_SET_NULL_UPDREF              DUK_TVAL_SET_NULL_UPDREF_ALT0
+#define DUK_TVAL_SET_BOOLEAN_UPDREF           DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0
+#define DUK_TVAL_SET_NUMBER_UPDREF            DUK_TVAL_SET_NUMBER_UPDREF_ALT0
+#define DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF    DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF_ALT0
+#define DUK_TVAL_SET_DOUBLE_UPDREF            DUK_TVAL_SET_DOUBLE_UPDREF_ALT0
+#define DUK_TVAL_SET_NAN_UPDREF               DUK_TVAL_SET_NAN_UPDREF_ALT0
+#if defined(DUK_USE_FASTINT)
+#define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_FASTINT_UPDREF_ALT0
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0
+#endif  /* DUK_USE_FASTINT */
+#define DUK_TVAL_SET_LIGHTFUNC_UPDREF         DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0
+#define DUK_TVAL_SET_STRING_UPDREF            DUK_TVAL_SET_STRING_UPDREF_ALT0
+#define DUK_TVAL_SET_OBJECT_UPDREF            DUK_TVAL_SET_OBJECT_UPDREF_ALT0
+#define DUK_TVAL_SET_BUFFER_UPDREF            DUK_TVAL_SET_BUFFER_UPDREF_ALT0
+#define DUK_TVAL_SET_POINTER_UPDREF           DUK_TVAL_SET_POINTER_UPDREF_ALT0
+
+#define DUK_TVAL_SET_TVAL_UPDREF              DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_FAST         DUK_TVAL_SET_TVAL_UPDREF_ALT0
+#define DUK_TVAL_SET_TVAL_UPDREF_SLOW         DUK_TVAL_SET_TVAL_UPDREF_ALT0
 
 #endif  /* DUK_USE_REFERENCE_COUNTING */
 

--- a/src/duk_hobject.h
+++ b/src/duk_hobject.h
@@ -614,7 +614,7 @@
 #endif
 
 /* note: this updates refcounts */
-#define DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr,h,p)       duk_hobject_set_prototype((thr), (h), (p))
+#define DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr,h,p)       duk_hobject_set_prototype_updref((thr), (h), (p))
 
 /*
  *  Resizing and hash behavior
@@ -902,7 +902,7 @@ DUK_INTERNAL_DECL duk_ret_t duk_hobject_get_enumerated_keys(duk_context *ctx, du
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t get_value);
 
 /* macros */
-DUK_INTERNAL_DECL void duk_hobject_set_prototype(duk_hthread *thr, duk_hobject *h, duk_hobject *p);
+DUK_INTERNAL_DECL void duk_hobject_set_prototype_updref(duk_hthread *thr, duk_hobject *h, duk_hobject *p);
 
 /* finalization */
 DUK_INTERNAL_DECL void duk_hobject_run_finalizer(duk_hthread *thr, duk_hobject *obj);

--- a/src/duk_hobject_misc.c
+++ b/src/duk_hobject_misc.c
@@ -30,7 +30,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_prototype_chain_contains(duk_hthread *thr, d
 	return 0;
 }
 
-DUK_INTERNAL void duk_hobject_set_prototype(duk_hthread *thr, duk_hobject *h, duk_hobject *p) {
+DUK_INTERNAL void duk_hobject_set_prototype_updref(duk_hthread *thr, duk_hobject *h, duk_hobject *p) {
 #ifdef DUK_USE_REFERENCE_COUNTING
 	duk_hobject *tmp;
 

--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -4173,8 +4173,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 			tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, desc.e_idx);
 			DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, tv);  /* side effects */
 		}
-#if 1  /* XXX: remove */
-		/* this is not strictly necessary because if key == NULL, value MUST be ignored */
+#if 0
+		/* These are not strictly necessary because if key == NULL, value
+		 * (including flags) MUST be ignored.
+		 */
 		DUK_HOBJECT_E_SET_FLAGS(thr->heap, obj, desc.e_idx, 0);
 		DUK_TVAL_SET_UNDEFINED_UNUSED(DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, desc.e_idx));
 #endif

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -845,7 +845,6 @@ duk_int_t duk_handle_call(duk_hthread *thr,
 	duk_activation *act;
 	duk_hobject *env;
 	duk_jmpbuf our_jmpbuf;
-	duk_tval tv_tmp;
 	duk_int_t retval = DUK_EXEC_ERROR;
 	duk_ret_t rc;
 
@@ -1582,13 +1581,8 @@ duk_int_t duk_handle_call(duk_hthread *thr,
 		 * runs etc capture even out-of-memory errors so nothing should
 		 * throw here.
 		 */
-		DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-		DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value1);
-		DUK_TVAL_DECREF(thr, &tv_tmp);
-
-		DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value2);
-		DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value2);
-		DUK_TVAL_DECREF(thr, &tv_tmp);
+		DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+		DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
 		DUK_DDD(DUK_DDDPRINT("setjmp catchpoint torn down"));
 	}
@@ -1749,7 +1743,6 @@ duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	duk_instr_t **entry_ptr_curr_pc;
 	duk_jmpbuf *old_jmpbuf_ptr = NULL;
 	duk_jmpbuf our_jmpbuf;
-	duk_tval tv_tmp;
 	duk_idx_t idx_retbase;
 	duk_int_t retval;
 	duk_ret_t rc;
@@ -1974,13 +1967,8 @@ duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	 * runs etc capture even out-of-memory errors so nothing should
 	 * throw here.
 	 */
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
-
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value2);
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value2);
-	DUK_TVAL_DECREF(thr, &tv_tmp);
+	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
 	DUK_DDD(DUK_DDDPRINT("setjmp catchpoint torn down"));
 
@@ -2219,7 +2207,6 @@ duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 
 	if (use_tailcall) {
 		duk_tval *tv1, *tv2;
-		duk_tval tv_tmp;
 		duk_size_t cs_index;
 		duk_int_t i_stk;  /* must be signed for loop structure */
 		duk_idx_t i_arg;
@@ -2324,10 +2311,7 @@ duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		tv2 = thr->valstack_bottom + idx_func + 1;
 		DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);  /* tv1 is -below- valstack_bottom */
 		DUK_ASSERT(tv2 >= thr->valstack_bottom && tv2 < thr->valstack_top);
-		DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-		DUK_TVAL_SET_TVAL(tv1, tv2);
-		DUK_TVAL_INCREF(thr, tv1);
-		DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+		DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv2);  /* side effects */
 
 		for (i_arg = 0; i_arg < idx_args; i_arg++) {
 			/* XXX: block removal API primitive */

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -72,7 +72,6 @@ DUK_LOCAL void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_
 	if (DUK_TVAL_IS_FASTINT(tv_x) && DUK_TVAL_IS_FASTINT(tv_y)) {
 		duk_int64_t v1, v2, v3;
 		duk_int32_t v3_hi;
-		duk_tval tv_tmp;
 		duk_tval *tv_z;
 
 		/* Input values are signed 48-bit so we can detect overflow
@@ -85,10 +84,7 @@ DUK_LOCAL void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_
 		v3_hi = (duk_int32_t) (v3 >> 32);
 		if (DUK_LIKELY(v3_hi >= -0x8000LL && v3_hi <= 0x7fffLL)) {
 			tv_z = thr->valstack_bottom + idx_z;
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-			DUK_TVAL_SET_FASTINT(tv_z, v3);
-			DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-			DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+			DUK_TVAL_SET_FASTINT_UPDREF(thr, tv_z, v3);  /* side effects */
 			return;
 		} else {
 			/* overflow, fall through */
@@ -98,7 +94,6 @@ DUK_LOCAL void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_
 #endif  /* DUK_USE_FASTINT */
 
 	if (DUK_TVAL_IS_NUMBER(tv_x) && DUK_TVAL_IS_NUMBER(tv_y)) {
-		duk_tval tv_tmp;
 		duk_tval *tv_z;
 
 		du.d = DUK_TVAL_GET_NUMBER(tv_x) + DUK_TVAL_GET_NUMBER(tv_y);
@@ -106,10 +101,7 @@ DUK_LOCAL void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_
 		DUK_ASSERT(DUK_DBLUNION_IS_NORMALIZED(&du));
 
 		tv_z = thr->valstack_bottom + idx_z;
-		DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-		DUK_TVAL_SET_NUMBER(tv_z, du.d);
-		DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-		DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+		DUK_TVAL_SET_NUMBER_UPDREF(thr, tv_z, du.d);  /* side effects */
 		return;
 	}
 
@@ -162,7 +154,6 @@ DUK_LOCAL void duk__vm_arith_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tva
 	 */
 
 	duk_context *ctx = (duk_context *) thr;
-	duk_tval tv_tmp;
 	duk_tval *tv_z;
 	duk_double_t d1, d2;
 	duk_double_union du;
@@ -239,10 +230,7 @@ DUK_LOCAL void duk__vm_arith_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tva
 		v3_hi = (duk_int32_t) (v3 >> 32);
 		if (DUK_LIKELY(v3_hi >= -0x8000LL && v3_hi <= 0x7fffLL)) {
 			tv_z = thr->valstack_bottom + idx_z;
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-			DUK_TVAL_SET_FASTINT(tv_z, v3);
-			DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-			DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+			DUK_TVAL_SET_FASTINT_UPDREF(thr, tv_z, v3);  /* side effects */
 			return;
 		}
 		/* fall through if overflow etc */
@@ -295,10 +283,7 @@ DUK_LOCAL void duk__vm_arith_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tva
 	DUK_ASSERT(DUK_DBLUNION_IS_NORMALIZED(&du));
 
 	tv_z = thr->valstack_bottom + idx_z;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_NUMBER(tv_z, du.d);
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv_z, du.d);  /* side effects */
 }
 
 DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_fast_t idx_z, duk_small_uint_fast_t opcode) {
@@ -313,7 +298,6 @@ DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_t
 	 */
 
 	duk_context *ctx = (duk_context *) thr;
-	duk_tval tv_tmp;
 	duk_tval *tv_z;
 	duk_int32_t i1, i2, i3;
 	duk_uint32_t u1, u2, u3;
@@ -408,10 +392,7 @@ DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_t
 
  fastint_result_set:
 	tv_z = thr->valstack_bottom + idx_z;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_FASTINT(tv_z, fi3);
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+	DUK_TVAL_SET_FASTINT_UPDREF(thr, tv_z, fi3);  /* side effects */
 #else
 	d3 = (duk_double_t) i3;
 
@@ -420,10 +401,7 @@ DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_t
 	DUK_ASSERT_DOUBLE_IS_NORMALIZED(d3);   /* always normalized */
 
 	tv_z = thr->valstack_bottom + idx_z;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_NUMBER(tv_z, d3);
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv_z, d3);  /* side effects */
 #endif
 }
 
@@ -504,7 +482,6 @@ DUK_LOCAL void duk__vm_bitwise_not(duk_hthread *thr, duk_tval *tv_x, duk_small_u
 	 */
 
 	duk_context *ctx = (duk_context *) thr;
-	duk_tval tv_tmp;
 	duk_tval *tv_z;
 	duk_int32_t i1, i2;
 #if !defined(DUK_USE_FASTINT)
@@ -534,10 +511,7 @@ DUK_LOCAL void duk__vm_bitwise_not(duk_hthread *thr, duk_tval *tv_x, duk_small_u
 #if defined(DUK_USE_FASTINT)
 	/* Result is always fastint compatible. */
 	tv_z = thr->valstack_bottom + idx_z;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_FASTINT_I32(tv_z, i2);
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+	DUK_TVAL_SET_FASTINT_I32_UPDREF(thr, tv_z, i2);  /* side effects */
 #else
 	d2 = (duk_double_t) i2;
 
@@ -545,10 +519,7 @@ DUK_LOCAL void duk__vm_bitwise_not(duk_hthread *thr, duk_tval *tv_x, duk_small_u
 	DUK_ASSERT_DOUBLE_IS_NORMALIZED(d2);   /* always normalized */
 
 	tv_z = thr->valstack_bottom + idx_z;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_NUMBER(tv_z, d2);
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv_z));  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);   /* side effects */
+	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv_z, d2);  /* side effects */
 #endif
 }
 
@@ -557,7 +528,6 @@ DUK_LOCAL void duk__vm_logical_not(duk_hthread *thr, duk_tval *tv_x, duk_tval *t
 	 *  E5 Section 11.4.9
 	 */
 
-	duk_tval tv_tmp;
 	duk_bool_t res;
 
 	DUK_ASSERT(thr != NULL);
@@ -573,9 +543,7 @@ DUK_LOCAL void duk__vm_logical_not(duk_hthread *thr, duk_tval *tv_x, duk_tval *t
 	res = duk_js_toboolean(tv_x);  /* does not modify tv_x */
 	DUK_ASSERT(res == 0 || res == 1);
 	res ^= 1;
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv_z);
-	DUK_TVAL_SET_BOOLEAN(tv_z, res);  /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+	DUK_TVAL_SET_BOOLEAN_UPDREF(thr, tv_z, res);  /* side effects */
 }
 
 /*
@@ -672,7 +640,6 @@ DUK_LOCAL void duk__reconfig_valstack_ecma_catcher(duk_hthread *thr, duk_size_t 
 
 /* Set catcher regs: idx_base+0 = value, idx_base+1 = lj_type. */
 DUK_LOCAL void duk__set_catcher_regs(duk_hthread *thr, duk_size_t cat_idx, duk_tval *tv_val_unstable, duk_small_uint_t lj_type) {
-	duk_tval tv_tmp;
 	duk_tval *tv1;
 
 	DUK_ASSERT(thr != NULL);
@@ -680,21 +647,16 @@ DUK_LOCAL void duk__set_catcher_regs(duk_hthread *thr, duk_size_t cat_idx, duk_t
 
 	tv1 = thr->valstack + thr->catchstack[cat_idx].idx_base;
 	DUK_ASSERT(tv1 < thr->valstack_top);
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-	DUK_TVAL_SET_TVAL(tv1, tv_val_unstable);
-	DUK_TVAL_INCREF(thr, tv1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+	DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv_val_unstable);  /* side effects */
 
 	tv1 = thr->valstack + thr->catchstack[cat_idx].idx_base + 1;
 	DUK_ASSERT(tv1 < thr->valstack_top);
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
+
 #if defined(DUK_USE_FASTINT)
-	DUK_TVAL_SET_FASTINT_U32(tv1, (duk_uint32_t) lj_type);
+	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) lj_type);  /* side effects */
 #else
-	DUK_TVAL_SET_NUMBER(tv1, (duk_double_t) lj_type);
+	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) lj_type);  /* side effects */
 #endif
-	DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv1));   /* no need to incref */
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
 }
 
 DUK_LOCAL void duk__handle_catch(duk_hthread *thr, duk_size_t cat_idx, duk_tval *tv_val_unstable, duk_small_uint_t lj_type) {
@@ -849,7 +811,6 @@ DUK_LOCAL void duk__handle_label(duk_hthread *thr, duk_size_t cat_idx, duk_small
  * when a RETURN opcode terminates a thread and yields to the resumer.
  */
 DUK_LOCAL void duk__handle_yield(duk_hthread *thr, duk_hthread *resumer, duk_size_t act_idx, duk_tval *tv_val_unstable) {
-	duk_tval tv_tmp;
 	duk_tval *tv1;
 
 	DUK_ASSERT(thr != NULL);
@@ -859,10 +820,7 @@ DUK_LOCAL void duk__handle_yield(duk_hthread *thr, duk_hthread *resumer, duk_siz
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPILEDFUNCTION(DUK_ACT_GET_FUNC(resumer->callstack + act_idx)));  /* resume caller must be an ecmascript func */
 
 	tv1 = resumer->valstack + resumer->callstack[act_idx].idx_retval;  /* return value from Duktape.Thread.resume() */
-	DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-	DUK_TVAL_SET_TVAL(tv1, tv_val_unstable);
-	DUK_TVAL_INCREF(thr, tv1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+	DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv_val_unstable);  /* side effects */
 
 	duk_hthread_callstack_unwind(resumer, act_idx + 1);  /* unwind to 'resume' caller */
 
@@ -876,7 +834,6 @@ DUK_LOCAL
 duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
                                      duk_hthread *entry_thread,
                                      duk_size_t entry_callstack_top) {
-	duk_tval tv_tmp;
 	duk_size_t entry_callstack_index;
 	duk_small_uint_t retval = DUK__LONGJMP_RESTART;
 
@@ -994,10 +951,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 			tv = resumee->valstack + resumee->callstack[act_idx].idx_retval;  /* return value from Duktape.Thread.yield() */
 			DUK_ASSERT(tv >= resumee->valstack && tv < resumee->valstack_top);
 			tv2 = &thr->heap->lj.value1;
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv);
-			DUK_TVAL_SET_TVAL(tv, tv2);
-			DUK_TVAL_INCREF(thr, tv);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_TVAL_UPDREF(thr, tv, tv2);  /* side effects */
 
 			duk_hthread_callstack_unwind(resumee, act_idx + 1);  /* unwind to 'yield' caller */
 
@@ -1247,13 +1201,8 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 	thr->heap->lj.type = DUK_LJ_TYPE_UNKNOWN;
 	thr->heap->lj.iserror = 0;
 
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value1);
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value1);
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
-
-	DUK_TVAL_SET_TVAL(&tv_tmp, &thr->heap->lj.value2);
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&thr->heap->lj.value2);
-	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
  just_return:
 	return retval;
@@ -1352,7 +1301,6 @@ DUK_LOCAL void duk__handle_break_or_continue(duk_hthread *thr,
 DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr,
                                               duk_hthread *entry_thread,
                                               duk_size_t entry_callstack_top) {
-	duk_tval tv_tmp;
 	duk_tval *tv1;
 	duk_tval *tv2;
 	duk_hthread *resumer;
@@ -1450,10 +1398,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr,
 		tv1 = thr->valstack + (thr->callstack + thr->callstack_top - 2)->idx_retval;
 		DUK_ASSERT(thr->valstack_top - 1 >= thr->valstack_bottom);
 		tv2 = thr->valstack_top - 1;
-		DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-		DUK_TVAL_SET_TVAL(tv1, tv2);
-		DUK_TVAL_INCREF(thr, tv2);  /* == tv1 */
-		DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+		DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv2);  /* side effects */
 
 		DUK_DDD(DUK_DDDPRINT("return value at idx_retval=%ld is %!T",
 		                     (long) (thr->callstack + thr->callstack_top - 2)->idx_retval,
@@ -2355,52 +2300,39 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 		case DUK_OP_LDREG: {
 			duk_small_uint_fast_t a;
 			duk_uint_fast_t bc;
-			duk_tval tv_tmp;
 			duk_tval *tv1, *tv2;
 
 			a = DUK_DEC_A(ins); tv1 = DUK__REGP(a);
 			bc = DUK_DEC_BC(ins); tv2 = DUK__REGP(bc);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-			DUK_TVAL_SET_TVAL(tv1, tv2);
-			DUK_TVAL_INCREF(thr, tv1);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_TVAL_UPDREF_FAST(thr, tv1, tv2);  /* side effects */
 			break;
 		}
 
 		case DUK_OP_STREG: {
 			duk_small_uint_fast_t a;
 			duk_uint_fast_t bc;
-			duk_tval tv_tmp;
 			duk_tval *tv1, *tv2;
 
 			a = DUK_DEC_A(ins); tv1 = DUK__REGP(a);
 			bc = DUK_DEC_BC(ins); tv2 = DUK__REGP(bc);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv2);
-			DUK_TVAL_SET_TVAL(tv2, tv1);
-			DUK_TVAL_INCREF(thr, tv2);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_TVAL_UPDREF_FAST(thr, tv2, tv1);  /* side effects */
 			break;
 		}
 
 		case DUK_OP_LDCONST: {
 			duk_small_uint_fast_t a;
 			duk_uint_fast_t bc;
-			duk_tval tv_tmp;
 			duk_tval *tv1, *tv2;
 
 			a = DUK_DEC_A(ins); tv1 = DUK__REGP(a);
 			bc = DUK_DEC_BC(ins); tv2 = DUK__CONSTP(bc);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-			DUK_TVAL_SET_TVAL(tv1, tv2);
-			DUK_TVAL_INCREF(thr, tv2);  /* may be e.g. string */
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_TVAL_UPDREF_FAST(thr, tv1, tv2);  /* side effects */
 			break;
 		}
 
 		case DUK_OP_LDINT: {
 			duk_small_uint_fast_t a;
 			duk_int_fast_t bc;
-			duk_tval tv_tmp;
 			duk_tval *tv1;
 #if defined(DUK_USE_FASTINT)
 			duk_int32_t val;
@@ -2411,15 +2343,11 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 #if defined(DUK_USE_FASTINT)
 			a = DUK_DEC_A(ins); tv1 = DUK__REGP(a);
 			bc = DUK_DEC_BC(ins); val = (duk_int32_t) (bc - DUK_BC_LDINT_BIAS);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-			DUK_TVAL_SET_FASTINT_I32(tv1, val);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_FASTINT_I32_UPDREF(thr, tv1, val);  /* side effects */
 #else
 			a = DUK_DEC_A(ins); tv1 = DUK__REGP(a);
 			bc = DUK_DEC_BC(ins); val = (duk_double_t) (bc - DUK_BC_LDINT_BIAS);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-			DUK_TVAL_SET_NUMBER(tv1, val);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, val);  /* side effects */
 #endif
 			break;
 		}
@@ -3581,7 +3509,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 				DUK_ASSERT(new_env != NULL);
 
 				act = thr->callstack + thr->callstack_top - 1;  /* relookup (side effects) */
-				DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, new_env, act->lex_env);
+				DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, new_env, act->lex_env);  /* side effects */
 
 				act = thr->callstack + thr->callstack_top - 1;  /* relookup (side effects) */
 				act->lex_env = new_env;
@@ -3629,7 +3557,6 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			duk_small_uint_fast_t a = DUK_DEC_A(ins);
 			duk_uint_fast_t bc = DUK_DEC_BC(ins);
 			duk_tval *tv1, *tv2;
-			duk_tval tv_tmp;
 			duk_double_t x, y, z;
 
 			/* Two lowest bits of opcode are used to distinguish
@@ -3660,10 +3587,8 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 				DUK_TVAL_SET_FASTINT(tv1, y_fi);  /* no need for refcount update */
 
 				tv2 = DUK__REGP(a);
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv2);
 				z_fi = (ins & DUK_ENC_OP(0x02)) ? x_fi : y_fi;
-				DUK_TVAL_SET_FASTINT(tv2, z_fi);    /* no need for incref */
-				DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+				DUK_TVAL_SET_FASTINT_UPDREF(thr, tv2, z_fi);  /* side effects */
 				break;
 			}
 		 skip_fastint:
@@ -3695,10 +3620,8 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			}
 
 			tv2 = DUK__REGP(a);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv2);
 			z = (ins & DUK_ENC_OP(0x02)) ? x : y;
-			DUK_TVAL_SET_NUMBER(tv2, z);    /* no need for incref */
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+			DUK_TVAL_SET_NUMBER_UPDREF(thr, tv2, z);  /* side effects */
 			break;
 		}
 
@@ -3830,7 +3753,6 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			case DUK_EXTRAOP_LDTHIS: {
 				/* Note: 'this' may be bound to any value, not just an object */
 				duk_uint_fast_t bc = DUK_DEC_BC(ins);
-				duk_tval tv_tmp;
 				duk_tval *tv1, *tv2;
 
 				tv1 = DUK__REGP(bc);
@@ -3839,48 +3761,36 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 				DUK_DDD(DUK_DDDPRINT("LDTHIS: %!T to r%ld", (duk_tval *) tv2, (long) bc));
 
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-				DUK_TVAL_SET_TVAL(tv1, tv2);
-				DUK_TVAL_INCREF(thr, tv1);
-				DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+				DUK_TVAL_SET_TVAL_UPDREF_FAST(thr, tv1, tv2);  /* side effects */
 				break;
 			}
 
 			case DUK_EXTRAOP_LDUNDEF: {
 				duk_uint_fast_t bc = DUK_DEC_BC(ins);
-				duk_tval tv_tmp;
 				duk_tval *tv1;
 
 				tv1 = DUK__REGP(bc);
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-				DUK_TVAL_SET_UNDEFINED_ACTUAL(tv1);
-				DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+				DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
 				break;
 			}
 
 			case DUK_EXTRAOP_LDNULL: {
 				duk_uint_fast_t bc = DUK_DEC_BC(ins);
-				duk_tval tv_tmp;
 				duk_tval *tv1;
 
 				tv1 = DUK__REGP(bc);
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-				DUK_TVAL_SET_NULL(tv1);
-				DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+				DUK_TVAL_SET_NULL_UPDREF(thr, tv1);  /* side effects */
 				break;
 			}
 
 			case DUK_EXTRAOP_LDTRUE:
 			case DUK_EXTRAOP_LDFALSE: {
 				duk_uint_fast_t bc = DUK_DEC_BC(ins);
-				duk_tval tv_tmp;
 				duk_tval *tv1;
 				duk_small_uint_fast_t bval = (extraop == DUK_EXTRAOP_LDTRUE ? 1 : 0);
 
 				tv1 = DUK__REGP(bc);
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-				DUK_TVAL_SET_BOOLEAN(tv1, bval);
-				DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
+				DUK_TVAL_SET_BOOLEAN_UPDREF(thr, tv1, bval);  /* side effects */
 				break;
 			}
 
@@ -4100,7 +4010,6 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 			case DUK_EXTRAOP_ENDTRY: {
 				duk_catcher *cat;
-				duk_tval tv_tmp;
 				duk_tval *tv1;
 
 				DUK_ASSERT(thr->catchstack_top >= 1);
@@ -4117,16 +4026,16 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-					DUK_TVAL_SET_UNDEFINED_ACTUAL(tv1);
-					DUK_TVAL_DECREF(thr, &tv_tmp);     /* side effects */
+					DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
 					tv1 = NULL;
 
 					tv1 = thr->valstack + cat->idx_base + 1;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-					DUK_TVAL_SET_NUMBER(tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* XXX: set int */
-					DUK_TVAL_DECREF(thr, &tv_tmp);     /* side effects */
+#if defined(DUK_USE_FASTINT)
+					DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
+#else
+					DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
+#endif
 					tv1 = NULL;
 
 					DUK_CAT_CLEAR_FINALLY_ENABLED(cat);
@@ -4143,7 +4052,6 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			case DUK_EXTRAOP_ENDCATCH: {
 				duk_activation *act;
 				duk_catcher *cat;
-				duk_tval tv_tmp;
 				duk_tval *tv1;
 
 				DUK_ASSERT(thr->catchstack_top >= 1);
@@ -4176,16 +4084,16 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-					DUK_TVAL_SET_UNDEFINED_ACTUAL(tv1);
-					DUK_TVAL_DECREF(thr, &tv_tmp);     /* side effects */
+					DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
 					tv1 = NULL;
 
 					tv1 = thr->valstack + cat->idx_base + 1;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_TVAL(&tv_tmp, tv1);
-					DUK_TVAL_SET_NUMBER(tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* XXX: set int */
-					DUK_TVAL_DECREF(thr, &tv_tmp);     /* side effects */
+#if defined(DUK_USE_FASTINT)
+					DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
+#else
+					DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
+#endif
 					tv1 = NULL;
 
 					DUK_CAT_CLEAR_FINALLY_ENABLED(cat);

--- a/src/duk_js_var.c
+++ b/src/duk_js_var.c
@@ -1348,17 +1348,13 @@ void duk__putvar_helper(duk_hthread *thr,
 			 * (immutable binding), use duk_hobject_putprop() which
 			 * will respect mutability.
 			 */
-			duk_tval tv_tmp;
 			duk_tval *tv_val;
 
 			DUK_ASSERT(ref.this_binding == NULL);  /* always for register bindings */
 
 			tv_val = ref.value;
 			DUK_ASSERT(tv_val != NULL);
-			DUK_TVAL_SET_TVAL(&tv_tmp, tv_val);
-			DUK_TVAL_SET_TVAL(tv_val, val);
-			DUK_TVAL_INCREF(thr, val);
-			DUK_TVAL_DECREF(thr, &tv_tmp);  /* must be last */
+			DUK_TVAL_SET_TVAL_UPDREF(thr, tv_val, val);  /* side effects */
 
 			/* ref.value and ref.this_binding invalidated here */
 		} else {
@@ -1701,12 +1697,8 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 				DUK_HOBJECT_DECREF_ALLOWNULL(thr, tmp);
 				DUK_UNREF(tmp);
 			} else {
-				duk_tval tv_tmp;
-
 				tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, holder, e_idx);
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv);
-				DUK_TVAL_SET_UNDEFINED_UNUSED(tv);
-				DUK_TVAL_DECREF(thr, &tv_tmp);
+				DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, tv);
 			}
 
 			/* Here val would be potentially invalid if we didn't make

--- a/tests/ecmascript/test-dev-refcount-leak-basic.js
+++ b/tests/ecmascript/test-dev-refcount-leak-basic.js
@@ -1,0 +1,379 @@
+/*
+ *  Basic regression harness for refcount leaks
+ *
+ *  Execute this test manually:
+ *
+ *      # Execute main test
+ *      $ valgrind ./duk --no-heap-destroy test-dev-refcount-leak-basic.js
+ *
+ *      # Set LOOP_COUNT to 1 manually and re-run the test
+ *      $ valgrind ./duk --no-heap-destroy test-dev-refcount-leak-basic.js
+ *
+ *  Inspect the final "still allocated" to ensure that in botj cases we arrive at
+ *  the same baseline allocation at the end.  There's a large loop count in this
+ *  test to magnify any leaks.  Using LOOP_COUNT 0 is OK but there may be small
+ *  differences due to the value stack and/or call stack having a different size
+ *  (which manifests as a final leak difference of ~100-1000 bytes).
+ *
+ *  You can also compare to "hello world"; it won't be an exact match if
+ *  mark-and-sweep is disabled, but close:
+ *
+ *      # Compare to 'hello world'
+ *      $ valgrind ./duk --no-heap-destroy test-dev-hello-world.js
+ *
+ *  The test function tries to exercise all places in code where refcounts
+ *  are increased/decreased.  It's not 100%, but together with other tests
+ *  should provide a reasonable regression harness.  The basic coverage here
+ *  is based on:
+ *
+ *      $ cd src/; grep DECREF UPDREF *.c > /tmp/worklist
+ *
+ *  Run the test with and without fastint support because that affects the
+ *  code paths executed.  It's best to test with mark-and-sweep disabled so
+ *  that garbage with broken refcounts won't get collected.
+ *
+ *  NOTE! To avoid circular references, all functions are made cycle free by
+ *  forcing .prototype to null.  If this is not done, and mark-and-sweep is
+ *  disabled, all functions will be leaks.
+ *
+ *  NOTE! Leaving function instances (even cycle free ones) in the function
+ *  registers when the function exits leads to a circular reference: the
+ *  environment will be closed which creates an environment object referring
+ *  to the function instance, and the function instance refers back to the
+ *  environment.  The testcases nullify locals on exit to avoid this issue
+ *  (not a bug but affects refcount testing).
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+exiting
+===*/
+
+this.T = {};
+this.T.LOOP_COUNT = 10000;  // <== EDIT MANUALLY between 10000 and 1
+
+this.T.executorTest = function executorTest() {
+    /*
+     *  duk_js_executor.c
+     */
+
+    var x, y, z;
+
+    // Catch variable
+    try { throw new Error('aiee'); } catch (e) { void e; }
+
+    // Finally catch register slots
+    do { try { break; } finally { void 0; } } while (0);
+    do { try { continue; } finally { void 0; } } while (0);
+    do { try { try { throw new Error('aiee'); } finally { void 0; } } catch (e) { void e; } } while (0);
+    do { try { try { return 'aiee'; } finally { throw new Error('cancel return'); } } catch (e) { void e; } } while (0);
+
+    // Return value handling
+    x = function () { return 123; }; x.prototype = null; z = {}; z = x();
+    x = function () { return 123; }; x.prototype = null;
+    y = function () { return x(); }; y.prototype = null;  // tail call
+    z = {}; z = y();
+    z = {}; z = Math.min(123, 234);
+
+    // Resume and yield
+    x = function () { Duktape.Thread.yield(new Date()); }; x.prototype = null;
+    y = new Duktape.Thread(x);
+    z = {}; z = Duktape.Thread.resume(y);
+
+    // With binding
+    with({ foo: 'bar' }) { void foo; }
+
+    // Addition fastint/number fast path; slow path
+    z = {}; x = 10; y = 20; z = x + y;
+    z = {}; x = 10.1; y = 20.1; z = x + y;
+    z = {}; x = ''; y = 20; z = x + y;
+
+    // Binary arithematic fastint/number fast path; slow path
+    z = {}; x = 10; y = 20; z = x - y;
+    z = {}; x = 10; y = 20; z = x * y;
+    z = {}; x = 10; y = 20; z = x / y;
+    z = {}; x = 10; y = 20; z = x % y;
+    z = {}; x = 10.1; y = 20.1; z = x - y;
+    z = {}; x = 10.1; y = 20.1; z = x * y;
+    z = {}; x = 10.1; y = 20.1; z = x / y;
+    z = {}; x = 10.1; y = 20.1; z = x % y;
+    z = {}; x = '100'; y = 20.1; z = x - y;
+    z = {}; x = '100'; y = 20.1; z = x * y;
+    z = {}; x = '100'; y = 20.1; z = x / y;
+    z = {}; x = '100'; y = 20.1; z = x % y;
+
+    // Bitwise binary ops
+    z = {}; x = 10; y = 20; z = x & y;
+    z = {}; x = 10; y = 20; z = x | y;
+    z = {}; x = 10; y = 20; z = x ^ y;
+    z = {}; x = 10; y = 20; z = x << y;
+    z = {}; x = 10; y = 20; z = x >> y;
+    z = {}; x = 10; y = 20; z = x >>> y;
+    z = {}; x = 10.1; y = 20.1; z = x & y;
+    z = {}; x = 10.1; y = 20.1; z = x | y;
+    z = {}; x = 10.1; y = 20.1; z = x ^ y;
+    z = {}; x = 10.1; y = 20.1; z = x << y;
+    z = {}; x = 10.1; y = 20.1; z = x >> y;
+    z = {}; x = 10.1; y = 20.1; z = x >>> y;
+    z = {}; x = '10.1'; y = 20.1; z = x & y;
+    z = {}; x = '10.1'; y = 20.1; z = x | y;
+    z = {}; x = '10.1'; y = 20.1; z = x ^ y;
+    z = {}; x = '10.1'; y = 20.1; z = x << y;
+    z = {}; x = '10.1'; y = 20.1; z = x >> y;
+    z = {}; x = '10.1'; y = 20.1; z = x >>> y;
+
+    // Unary arithmetic
+    z = {}; x = 10; z = +x;
+    z = {}; x = 10; z = -x;
+    z = {}; x = 10.1; z = +x;
+    z = {}; x = 10.1; z = -x;
+    z = {}; x = '100'; z = +x;
+    z = {}; x = '100'; z = -x;
+
+    // Bitwise unary op(s)
+    z = {}; x = 10; z = ~x;
+    z = {}; x = 10.1; z = ~x;
+    z = {}; x = '100'; z = ~x;
+
+    // Pre/post inc/dec
+    x = {}; z = x++;
+    x = {}; z = x--;
+    x = {}; z = ++x;
+    x = {}; z = --x;
+
+    // Misc opcode exercises
+    x = 123.1; z = {}; z = x;  // LDCONST, LDREG
+    x = 123; z = {}; z = x;    // LDINT, LDREG
+    z = {}; z = this;          // LDTHIS
+    z = {}; z = void 0;        // LDUNDEF
+    z = {}; z = null;          // LDNULL
+    z = {}; z = true;          // LDTRUE
+    z = {}; z = false;         // LDFALSE
+    z = []; z = {};            // NEWOBJ
+    z = {}; z = [];            // NEWARR
+    z = [1,2,3,,,,];           // SETALEN
+
+    // Without this any functions left behind will be copied into the
+    // final environment record.  The functions will then be in a circular
+    // reference with their environment and uncollectable.  This is not an
+    // actual leak; break the loop here for measurement.
+
+    x = y = z = null;
+};
+this.T.executorTest.prototype = null;  // break circular ref
+
+this.T.objectMiscTest = function objectMiscTest() {
+    var x, y, z;
+    var setter, getter;
+
+    // duk_hobject_props.c: array write shallow fast path
+    x = [ {}, {} ];
+    x[0] = {};
+    x[1] = 123;
+
+    // duk_hobject_props.c: make array shorter, fast path array part
+    x = [ {}, {}, {}, {} ];
+    x.length = 2;
+
+    // duk_hobject_props.c: make array shorter, abandoned array
+    x = [ {}, {}, {}, {} ];
+    x[1000] = {};
+    x.length = 2;
+
+    // duk_hobject_props.c: overwrite a data property (own or inherited)
+    x = { prop: {} }; y = { inherit: {} };
+    Object.setPrototypeOf(x, y);
+    x.prop = {};
+    x.inherit = {};
+
+    // duk_hobject_misc.c: duk_hobject_set_prototype()
+    x = {};
+    Object.setPrototypeOf(x, {});
+    Object.setPrototypeOf(x, {});
+
+    // duk_hobject_props.c: duk__realloc_props() abandon array
+    a = [{}, {}, {}];
+    a[1000] = {};
+
+    // duk_hobject_props.c: duk_hobject_delprop_raw() delete array elem
+    x = [ {}, {} ];
+    delete x[0];
+    delete x[1];
+
+    // duk_hobject_props.c: duk_hobject_delprop_raw() delete array elem, abandoned array
+    x = [ {}, {} ];
+    x[1000] = {};
+    delete x[0];
+    delete x[1];
+
+    // duk_hobject_props.c: duk_hobject_delprop_raw() delete accessor
+    x = {};
+    setter = function setter() {}; setter.prototype = null;
+    getter = function getter() {}; getter.prototype = null;
+
+    Object.defineProperty(x, 'prop', {
+        set: setter, get: getter, configurable: true
+    });
+    delete x.prop;
+
+    // duk_hobject_props.c: duk_hobject_delprop_raw() delete normal
+    x = {};
+    x.prop = {};
+    delete x.prop;
+
+    // duk_hobject_props.c: duk_hobject_define_property_helper,
+    // overwrite data property
+    x = {};
+    x.prop = {};
+    Object.defineProperty(x, 'prop', { value: {} });
+
+    // duk_hobject_props.c: duk_hobject_define_property_helper,
+    // overwrite accessor property
+    x = {};
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'prop', {
+        set: setter, get: getter, configurable: true
+    });
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'prop', {
+        set: setter, get: getter, configurable: true
+    });
+
+    // duk_hobject_props.c: duk_hobject_define_property_helper,
+    // convert data property to accessor
+    x = {};
+    x.prop = {};
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'prop', {
+        set: setter, get: getter, configurable: true
+    });
+
+    // duk_hobject_props.c: duk_hobject_define_property_helper,
+    // convert accessor to data property
+    x = {};
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'prop', {
+        set: setter, get: getter, configurable: true
+    });
+    Object.defineProperty(x, 'prop', { value: {} });
+
+    // Constructor calls
+    x = function () {}; x.prototype = { foo: 123 };  // constructor
+    y = new x();
+
+    // Avoid closure circular ref
+    x = y = z = setter = getter = null;
+};
+this.T.objectMiscTest.prototype = null;  // break circular ref
+
+this.T.miscTest = function miscTest() {
+    var x, y, z;
+
+    // duk_hobject_misc.c: duk_hobject_set_prototype()
+    x = {};
+    Object.setPrototypeOf(x, {});
+    Object.setPrototypeOf(x, {});
+
+    // DECLVAR over a data property
+    x = {}; eval('var x = {};');
+    with ({ foo: {} }) { eval('var foo = {};'); }
+
+    // DECLVAR over an accessor property
+    x = {};
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'foo', { set: setter, get: getter, configurable: true });
+    with (x) { eval('var foo = {};'); }
+
+    // PUTVAR (slow path) to a data property
+    x = {}; eval('x = {};');
+    with ({ foo: {} }) { eval('foo = {};'); }
+
+    // PUTVAR (slow path) to an accessor property
+    x = {};
+    setter = function () {}; setter.prototype = null;
+    getter = function () {}; getter.prototype = null;
+    Object.defineProperty(x, 'foo', { set: setter, get: getter, configurable: true });
+    with (x) { eval('foo = {};'); }
+
+    // TypedArray .slice() prototype updref
+    x = new Uint8Array(16);
+    y = x.subarray(4, 7);
+
+    // RegExp creation
+    x = /foo/g;
+
+    // Avoid closure circular ref
+    x = y = z = setter = getter = null;
+};
+this.T.miscTest.prototype = null;  // break circular ref
+
+this.T.test = function test() {
+    for (var i = 0; i < T.LOOP_COUNT; i++) {
+        T.executorTest();
+        T.objectMiscTest();
+        T.miscTest();
+
+        /* XXX: missing coverage:
+         *
+         *   - duk_api_heap.c: duk_set_global_object()
+         *   - duk_debugger.c: duk_debug_remove_breakpoint()
+         *   - duk_hthread_stacks.c: duk_hthread_callstack_unwind, .caller unwind
+         *   - duk_api_bytecode.c: prototype updref
+         *   - duk_api_stack.c: duk_push_buffer_object()
+         *   - duk_regexp_compiler.c: regexp prototype (refcount never reaches zero
+         *     because there's a built-in reference, so can't detect leaks)
+         *   - duk_hthread_builtins.c: built-in property references in general
+         *     (refcount never reaches zero so can't detect leaks)
+         *
+         * XXX: missing explicit coverage (but have indirect coverage most likely):
+         *
+         *   - duk_api_stack.c: duk_replace()
+         *   - duk_api_stack.c: duk_remove()
+         *   - duk_api_stack.c: integer coercions
+         *   - duk_api_stack.c: duk_set_top(), duk_pop(), duk_pop_n()
+         *   - duk_api_stack.c: duk_copy(), duk_to_undefined(), duk_to_null(),
+         *                      duk_to_boolean(), duk_to_number()
+         *   - duk_hthread_stacks.c: duk_hthread_callstack_unwind, decrefs for
+         *                           lex_env, var_env, func
+         *   - duk_js_call.c: thr->heap->lj.value1/2 decrefs
+         *   - duk_js_call.c: tailcall 'this' binding copy
+         *   - duk_js_compiler.c: varmap cleanup
+         *   - duk_hobject_props.c: duk_hobject_define_property_internal()
+         *   - duk_hobject_props.c: duk_hobject_define_property_internal_arridx()
+         */
+    }
+};
+this.T.test.prototype = null;  // break circular ref
+
+try {
+    T.test();
+
+    // Delete bindings and compact global object.  Important to delete
+    // and not just set to null.
+    delete T;
+
+    // Compact the global object to match test-dev-hello-world.js;
+    // built-ins including global object are compacted on creation
+    // so the result should be the same.
+    Duktape.compact(this);
+
+    // Global object should now be in its original state.
+
+    // *DO NOT* run mark-and-sweep here: if you do, garbage with broken
+    // refcounts will be collected which we don't want!  It's best to
+    // test with mark-and-sweep disabled.
+    //print(Object.getOwnPropertyNames(this));
+    print('exiting');
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Current idiom for overwriting a `duk_tval` with another is:

    duk_tval tv_tmp;
    DUK_TVAL_SET_TVAL(&tv_tmp, tv_dst);
    DUK_TVAL_SET_TVAL(tv_dst, tv_src);
    DUK_TVAL_INCREF(thr, tv_src);
    DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */

Provide a macro to make this shorter:

    DUK_TVAL_SET_TVAL_UPDREF(thr, tv_dst, tv_src);  /* side effects */

This can then be more easily optimized for performance; it appears in a lot of hot paths like LDREG, LDCONST, etc. Also add similar macros for other setters, e.g. `DUK_TVAL_SET_NULL_UPDREF()` which can avoid an unnecessary INCREF. Optimization will be done in a separate pull.

Tasks:

- [x] Write the basic macros
- [x] Convert call sites throughout
- [x] Test build with refcounting, without fastints
- [x] Test build with refcounting, with fastints
- [x] Test build without refcounting, without fastints
- [x] Test build without refcounting, with fastints
- [x] Test -Os size against master, shouldn't change much (--no-heap-destroy affects; Makefile.eval build result is smaller due to removed object prop code)
- [x] Add refcount leak regression test (manual)
- [x] Releases entry => no need as the pull has no outward results for now (optimization in separate branch)