### PR TITLE
Add a separate marker tag for 'unused' values

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1171,6 +1171,9 @@ Planned
   so that values above current value stack top are set to "undefined" instead
   of "unused" to improve call performance (GH-389)
 
+* Internal performance improvement: use a separate 'unused' tag instead of a
+  sub-type of 'undefined' to e.g. mark gaps in arrays (GH-396)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -685,9 +685,10 @@ some cases:
 |                       |           | length in network order and buffer    |
 |                       |           | data follows initial byte             |
 +-----------------------+-----------+---------------------------------------+
-| 0x15                  | unused    | Represents the internal "undefined    |
-|                       |           | unused" type which used to e.g. mark  |
-|                       |           | unused (unmapped) array entries       |
+| 0x15                  | unused    | Represents an unused/none value, used |
+|                       |           | internally to mark unmapped array     |
+|                       |           | entries and in the debugger protocol  |
+|                       |           | to indicate a "none" result           |
 +-----------------------+-----------+---------------------------------------+
 | 0x16                  | undefined | Ecmascript "undefined"                |
 +-----------------------+-----------+---------------------------------------+
@@ -809,6 +810,14 @@ Notes:
   (Duktape.Buffer, Node.js Buffer, ArrayBuffer, DataView, and TypedArray
   views) are represented as objects.  This means that their contents are
   not transmitted, only their heap pointer and a class number.
+
+* The "unused" value is special: it's used internally by Duktape to mark
+  unmapped array entries, but is not intended to be used for actual values
+  (entries on the value stack, property values, etc).  The "unused" value
+  is used in the debugger protocol to denote a missing/none value in some
+  command replies.  It's not used in requests, so the debug client should
+  never send an "unused" dvalue in a request (e.g. PutVar); Duktape will
+  reject such a request as having a format error.
 
 Endianness
 ----------

--- a/doc/fastint.rst
+++ b/doc/fastint.rst
@@ -179,8 +179,8 @@ necessary information (in a highly fragile manner though).  For instance,
 you can use something like::
 
   /* Fastint tag depends on duk_tval packing */
-  var fastintTag = (Duktape.info(true)[1] === 0xfff4 ?
-                   0xfff1 /* tag for packed duk_tval) :
+  var fastintTag = (Duktape.info(true)[1] === 0xfff5 ?
+                   0xfff2 /* tag for packed duk_tval) :
                    1 /* tag for unpacked duk_tval */ );
 
   function isFastint(x) {

--- a/doc/hobject-alg-getprop.rst
+++ b/doc/hobject-alg-getprop.rst
@@ -489,10 +489,10 @@ Some notes:
 
 * A certain key in the array can be defined even if the value is ``undefined``.
   The check is whether the key has been defined, i.e. ``[[HasProperty]]``
-  would be true.  Internally, the value "undefined unused" is used to denote
-  unused entries with unused keys, while the value "undefined actual"
-  represents an undefined value with a defined key.  For instance, the
-  following defines an array key::
+  would be true.  Internally, the value "unused" is used to denote unused
+  entries with unused keys, while the value "undefined" represents an
+  undefined value with a defined key.  For instance, the following defines
+  an array key::
 
     var a = [];
     a[10] = undefined;  // "10" will now enumerate

--- a/doc/hobject-design.rst
+++ b/doc/hobject-design.rst
@@ -936,8 +936,8 @@ The array part simply contains a sequence of tagged values::
   | value 0 |  Represents the array:
   | UNUSED  |    { "0": (value 0), "2": (value 2) }
   | value 2 |
-  | UNUSED  |  UNUSED = duk_tval 'undefined unused' value
-  | UNUSED  |           (DUK_TVAL_IS_UNDEFINED_UNUSED(tv))
+  | UNUSED  |  UNUSED = duk_tval 'unused' marker value
+  | UNUSED  |           (DUK_TVAL_IS_UNUSED(tv))
   +---------+
 
   Here, a_size = 5.
@@ -960,9 +960,8 @@ and moved to the entry part to maintain E5 semantics.
 
 All array entries are always reachable from a GC perspective, up to
 the allocated size, ``a_size``.  Unused values are marked with the special
-"undefined unused" value, set using the
-``DUK_TVAL_SET_UNDEFINED_UNUSED`` macro.  Any other entries, including
-"undefined actual" values, set using the ``DUK_TVAL_SET_UNDEFINED_ACTUAL``
+"unused" value, set using the ``DUK_TVAL_SET_UNUSED`` macro.  Any other
+entries, including "undefined" values, set using the ``DUK_TVAL_SET_UNDEFINED``
 macro, are considered to be in use, and their corresponding key is
 considered to exist in the object, and they are thus visible to enumeration.
 In the illustration above, values at indices "0" and "2" are considered used,

--- a/polyfills/duktape-isfastint.js
+++ b/polyfills/duktape-isfastint.js
@@ -16,7 +16,7 @@ if (typeof Duktape === 'object') {
     if (typeof Duktape.fastintTag === 'undefined') {
         Object.defineProperty(Duktape, 'fastintTag', {
             /* Tag number depends on duk_tval packing. */
-            value: (Duktape.info(true)[1] === 0xfff4) ?
+            value: (Duktape.info(true)[1] >= 0xfff0) ?
                     0xfff1 /* tag for packed duk_tval */ :
                     1 /* tag for unpacked duk_tval */,
             writable: false,

--- a/src/duk_api_internal.h
+++ b/src/duk_api_internal.h
@@ -124,9 +124,6 @@ DUK_INTERNAL_DECL duk_hnativefunction *duk_require_hnativefunction(duk_context *
 DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx_t index);
 DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t index);
 
-#if defined(DUK_USE_DEBUGGER_SUPPORT)
-DUK_INTERNAL_DECL void duk_push_unused(duk_context *ctx);
-#endif
 DUK_INTERNAL_DECL void duk_push_hstring(duk_context *ctx, duk_hstring *h);
 DUK_INTERNAL_DECL void duk_push_hstring_stridx(duk_context *ctx, duk_small_int_t stridx);
 DUK_INTERNAL_DECL void duk_push_hobject(duk_context *ctx, duk_hobject *h);

--- a/src/duk_bi_json.c
+++ b/src/duk_bi_json.c
@@ -2012,6 +2012,8 @@ DUK_LOCAL void duk__enc_value2(duk_json_enc_ctx *js_ctx) {
 #endif
 	default: {
 		/* number */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
+		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		/* XXX: A fast path for usual integers would be useful when
 		 * fastint support is not enabled.
 		 */
@@ -2258,7 +2260,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 
 				tv_val = DUK_HOBJECT_A_GET_VALUE_PTR(js_ctx->thr->heap, obj, i);
 
-				if (DUK_UNLIKELY(DUK_TVAL_IS_UNDEFINED_UNUSED(tv_val))) {
+				if (DUK_UNLIKELY(DUK_TVAL_IS_UNUSED(tv_val))) {
 					/* Gap in array; check for inherited property,
 					 * bail out if one exists.  This should be enough
 					 * to support gappy arrays for all practical code.
@@ -2360,6 +2362,9 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		/* XXX: A fast path for usual integers would be useful when
 		 * fastint support is not enabled.
 		 */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
+		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
+
 		/* XXX: Stack discipline is annoying, could be changed in numconv. */
 		duk_push_tval((duk_context *) js_ctx->thr, tv);
 		duk__enc_double(js_ctx);

--- a/src/duk_debug_vsnprintf.c
+++ b/src/duk_debug_vsnprintf.c
@@ -388,7 +388,7 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 			/* leave out trailing 'unused' elements */
 			while (a_limit > 0) {
 				tv = DUK_HOBJECT_A_GET_VALUE_PTR(NULL, h, a_limit - 1);
-				if (!DUK_TVAL_IS_UNDEFINED_UNUSED(tv)) {
+				if (!DUK_TVAL_IS_UNUSED(tv)) {
 					break;
 				}
 				a_limit--;
@@ -717,11 +717,11 @@ DUK_LOCAL void duk__print_tval(duk__dprint_state *st, duk_tval *tv) {
 	}
 	switch (DUK_TVAL_GET_TAG(tv)) {
 	case DUK_TAG_UNDEFINED: {
-		if (DUK_TVAL_IS_UNDEFINED_UNUSED(tv)) {
-			duk_fb_put_cstring(fb, "unused");
-		} else {
-			duk_fb_put_cstring(fb, "undefined");
-		}
+		duk_fb_put_cstring(fb, "undefined");
+		break;
+	}
+	case DUK_TAG_UNUSED: {
+		duk_fb_put_cstring(fb, "unused");
 		break;
 	}
 	case DUK_TAG_NULL: {
@@ -764,6 +764,7 @@ DUK_LOCAL void duk__print_tval(duk__dprint_state *st, duk_tval *tv) {
 #endif
 	default: {
 		/* IEEE double is approximately 16 decimal digits; print a couple extra */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		duk_fb_sprintf(fb, "%.18g", (double) DUK_TVAL_GET_NUMBER(tv));
 		break;

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -399,9 +399,6 @@ DUK_INTERNAL void duk_debug_read_tval(duk_hthread *thr) {
 		len = duk__debug_read_uint16_raw(thr);
 		duk__debug_read_hbuffer_raw(thr, len);
 		break;
-	case 0x15:
-		duk_push_unused(ctx);
-		break;
 	case 0x16:
 		duk_push_undefined(ctx);
 		break;
@@ -440,6 +437,7 @@ DUK_INTERNAL void duk_debug_read_tval(duk_hthread *thr) {
 		duk_push_heapptr(thr, (void *) h);
 		break;
 	}
+	case 0x15:  /* unused: not accepted in inbound messages */
 	default:
 		goto fail;
 	}
@@ -689,8 +687,10 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
 	case DUK_TAG_UNDEFINED:
-		duk_debug_write_byte(thr,
-		                     DUK_TVAL_IS_UNDEFINED_UNUSED(tv) ? 0x15 : 0x16);
+		duk_debug_write_byte(thr, 0x16);
+		break;
+	case DUK_TAG_UNUSED:
+		duk_debug_write_byte(thr, 0x15);
 		break;
 	case DUK_TAG_NULL:
 		duk_debug_write_byte(thr, 0x17);
@@ -726,6 +726,7 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 #endif
 	default:
 		/* Numbers are normalized to big (network) endian. */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		du.d = DUK_TVAL_GET_NUMBER(tv);
 		DUK_DBLUNION_DOUBLE_HTON(&du);

--- a/src/duk_heap_alloc.c
+++ b/src/duk_heap_alloc.c
@@ -777,8 +777,8 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 #endif
 	DUK_ASSERT(res->lj.type == DUK_LJ_TYPE_UNKNOWN);  /* zero */
 
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&res->lj.value1);
-	DUK_TVAL_SET_UNDEFINED_UNUSED(&res->lj.value2);
+	DUK_TVAL_SET_UNDEFINED(&res->lj.value1);
+	DUK_TVAL_SET_UNDEFINED(&res->lj.value2);
 
 #if (DUK_STRTAB_INITIAL_SIZE < DUK_UTIL_MIN_HASH_PRIME)
 #error initial heap stringtable size is defined incorrectly

--- a/src/duk_heaphdr.h
+++ b/src/duk_heaphdr.h
@@ -356,17 +356,17 @@ struct duk_heaphdr_string {
  *  and footprint critical; any changes made should be measured for size/speed.
  */
 
-#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0(thr,tvptr_dst) do { \
+#define DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0(thr,tvptr_dst) do { \
 		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
 		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
-		DUK_TVAL_SET_UNDEFINED_ACTUAL(tv__dst); \
+		DUK_TVAL_SET_UNDEFINED(tv__dst); \
 		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
 	} while (0)
 
-#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
+#define DUK_TVAL_SET_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
 		duk_tval *tv__dst; duk_tval tv__tmp; tv__dst = (tvptr_dst); \
 		DUK_TVAL_SET_TVAL(&tv__tmp, tv__dst); \
-		DUK_TVAL_SET_UNDEFINED_UNUSED(tv__dst); \
+		DUK_TVAL_SET_UNUSED(tv__dst); \
 		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
 	} while (0)
 
@@ -563,8 +563,8 @@ struct duk_heaphdr_string {
 #endif
 
 /* XXX: no optimized variants yet */
-#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF  DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0
-#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF  DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0
+#define DUK_TVAL_SET_UNDEFINED_UPDREF         DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0
+#define DUK_TVAL_SET_UNUSED_UPDREF            DUK_TVAL_SET_UNUSED_UPDREF_ALT0
 #define DUK_TVAL_SET_NULL_UPDREF              DUK_TVAL_SET_NULL_UPDREF_ALT0
 #define DUK_TVAL_SET_BOOLEAN_UPDREF           DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0
 #define DUK_TVAL_SET_NUMBER_UPDREF            DUK_TVAL_SET_NUMBER_UPDREF_ALT0
@@ -625,15 +625,15 @@ struct duk_heaphdr_string {
 #define DUK_HOBJECT_INCREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 
-#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0(thr,tvptr_dst) do { \
+#define DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0(thr,tvptr_dst) do { \
 		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
-		DUK_TVAL_SET_UNDEFINED_ACTUAL(tv__dst); \
+		DUK_TVAL_SET_UNDEFINED(tv__dst); \
 		DUK_UNREF((thr)); \
 	} while (0)
 
-#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
+#define DUK_TVAL_SET_UNUSED_UPDREF_ALT0(thr,tvptr_dst) do { \
 		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
-		DUK_TVAL_SET_UNDEFINED_UNUSED(tv__dst); \
+		DUK_TVAL_SET_UNUSED(tv__dst); \
 		DUK_UNREF((thr)); \
 	} while (0)
 
@@ -724,8 +724,8 @@ struct duk_heaphdr_string {
 		DUK_UNREF((thr)); \
 	} while (0)
 
-#define DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF  DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF_ALT0
-#define DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF  DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF_ALT0
+#define DUK_TVAL_SET_UNDEFINED_UPDREF         DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0
+#define DUK_TVAL_SET_UNUSED_UPDREF            DUK_TVAL_SET_UNUSED_UPDREF_ALT0
 #define DUK_TVAL_SET_NULL_UPDREF              DUK_TVAL_SET_NULL_UPDREF_ALT0
 #define DUK_TVAL_SET_BOOLEAN_UPDREF           DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0
 #define DUK_TVAL_SET_NUMBER_UPDREF            DUK_TVAL_SET_NUMBER_UPDREF_ALT0

--- a/src/duk_hobject_enum.c
+++ b/src/duk_hobject_enum.c
@@ -379,7 +379,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 			duk_tval *tv;
 
 			tv = DUK_HOBJECT_A_GET_VALUE_PTR(thr->heap, curr, i);
-			if (DUK_TVAL_IS_UNDEFINED_UNUSED(tv)) {
+			if (DUK_TVAL_IS_UNUSED(tv)) {
 				continue;
 			}
 			k = duk_heap_string_intern_u32_checked(thr, i);
@@ -419,7 +419,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 			}
 
 			DUK_ASSERT(DUK_HOBJECT_E_SLOT_IS_ACCESSOR(thr->heap, curr, i) ||
-			           !DUK_TVAL_IS_UNDEFINED_UNUSED(&DUK_HOBJECT_E_GET_VALUE_PTR(thr->heap, curr, i)->v));
+			           !DUK_TVAL_IS_UNUSED(&DUK_HOBJECT_E_GET_VALUE_PTR(thr->heap, curr, i)->v));
 
 			duk_push_hstring(ctx, k);
 			duk_push_true(ctx);
@@ -536,7 +536,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 		k = DUK_HOBJECT_E_GET_KEY(thr->heap, e, idx);
 		DUK_ASSERT(k != NULL);
 		DUK_ASSERT(!DUK_HOBJECT_E_SLOT_IS_ACCESSOR(thr->heap, e, idx));
-		DUK_ASSERT(!DUK_TVAL_IS_UNDEFINED_UNUSED(&DUK_HOBJECT_E_GET_VALUE(thr->heap, e, idx).v));
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(&DUK_HOBJECT_E_GET_VALUE(thr->heap, e, idx).v));
 
 		idx++;
 

--- a/src/duk_hthread_alloc.c
+++ b/src/duk_hthread_alloc.c
@@ -38,7 +38,7 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	thr->valstack_top = thr->valstack;
 
 	for (i = 0; i < DUK_VALSTACK_INITIAL_SIZE; i++) {
-		DUK_TVAL_SET_UNDEFINED_ACTUAL(&thr->valstack[i]);
+		DUK_TVAL_SET_UNDEFINED(&thr->valstack[i]);
 	}
 
 	/* callstack */

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -1586,8 +1586,8 @@ duk_int_t duk_handle_call(duk_hthread *thr,
 		 * runs etc capture even out-of-memory errors so nothing should
 		 * throw here.
 		 */
-		DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
-		DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
+		DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+		DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
 		DUK_DDD(DUK_DDDPRINT("setjmp catchpoint torn down"));
 	}
@@ -1972,8 +1972,8 @@ duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	 * runs etc capture even out-of-memory errors so nothing should
 	 * throw here.
 	 */
-	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
-	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
 	DUK_DDD(DUK_DDDPRINT("setjmp catchpoint torn down"));
 

--- a/src/duk_js_compiler.c
+++ b/src/duk_js_compiler.c
@@ -611,9 +611,9 @@ DUK_LOCAL duk_int_t duk__cleanup_varmap(duk_compiler_ctx *comp_ctx) {
 		tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, h_varmap, i);
 		if (!DUK_TVAL_IS_NUMBER(tv)) {
 			DUK_ASSERT(!DUK_TVAL_IS_HEAP_ALLOCATED(tv));
-			DUK_TVAL_SET_UNDEFINED_UNUSED(tv);
 			DUK_HOBJECT_E_SET_KEY(thr->heap, h_varmap, i, NULL);
 			DUK_HSTRING_DECREF(thr, h_key);
+			/* when key is NULL, value is garbage so no need to set */
 		} else {
 			ret++;
 		}
@@ -2047,6 +2047,7 @@ duk_regconst_t duk__ispec_toregconst_raw(duk_compiler_ctx *comp_ctx,
 			duk_double_t dval;
 			duk_int32_t ival;
 
+			DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 			dval = DUK_TVAL_GET_NUMBER(tv);
 

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -1201,8 +1201,8 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 	thr->heap->lj.type = DUK_LJ_TYPE_UNKNOWN;
 	thr->heap->lj.iserror = 0;
 
-	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
-	DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
 
  just_return:
 	return retval;
@@ -2269,7 +2269,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			duk_tval *tv;
 			tv = thr->valstack_top;
 			while (tv != thr->valstack_end) {
-				DUK_ASSERT(DUK_TVAL_IS_UNDEFINED_ACTUAL(tv));
+				DUK_ASSERT(DUK_TVAL_IS_UNDEFINED(tv));
 				tv++;
 			}
 		}
@@ -3769,7 +3769,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 				duk_tval *tv1;
 
 				tv1 = DUK__REGP(bc);
-				DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
+				DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv1);  /* side effects */
 				break;
 			}
 
@@ -4025,7 +4025,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
+					DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv1);  /* side effects */
 					tv1 = NULL;
 
 					tv1 = thr->valstack + cat->idx_base + 1;
@@ -4083,7 +4083,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-					DUK_TVAL_SET_UNDEFINED_ACTUAL_UPDREF(thr, tv1);  /* side effects */
+					DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv1);  /* side effects */
 					tv1 = NULL;
 
 					tv1 = thr->valstack + cat->idx_base + 1;

--- a/src/duk_js_ops.c
+++ b/src/duk_js_ops.c
@@ -102,6 +102,7 @@ DUK_INTERNAL duk_bool_t duk_js_toboolean(duk_tval *tv) {
 		/* number */
 		duk_double_t d;
 		int c;
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_DOUBLE(tv));
 		d = DUK_TVAL_GET_DOUBLE(tv);
 		c = DUK_FPCLASSIFY((double) d);
@@ -240,6 +241,7 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 #endif
 	default: {
 		/* number */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_DOUBLE(tv));
 		return DUK_TVAL_GET_DOUBLE(tv);
 	}
@@ -637,6 +639,8 @@ DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, d
 		case DUK_TAG_FASTINT:
 #endif
 		default: {
+			DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv_x));
+			DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv_y));
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv_x));
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv_y));
 			DUK_UNREACHABLE();
@@ -1286,6 +1290,7 @@ DUK_INTERNAL duk_hstring *duk_js_typeof(duk_hthread *thr, duk_tval *tv_x) {
 #endif
 	default: {
 		/* number */
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv_x));
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv_x));
 		stridx = DUK_STRIDX_LC_NUMBER;
 		break;

--- a/src/duk_js_var.c
+++ b/src/duk_js_var.c
@@ -1698,7 +1698,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 				DUK_UNREF(tmp);
 			} else {
 				tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, holder, e_idx);
-				DUK_TVAL_SET_UNDEFINED_UNUSED_UPDREF(thr, tv);
+				DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv);
 			}
 
 			/* Here val would be potentially invalid if we didn't make

--- a/tests/api/test-dump-load-fastint.c
+++ b/tests/api/test-dump-load-fastint.c
@@ -23,7 +23,7 @@ static duk_ret_t test_1(duk_context *ctx) {
 	duk_eval_string_noresult(ctx,
 		"Object.defineProperty(Duktape, 'fastintTag', {\n"
 		"    /* Tag number depends on duk_tval packing. */\n"
-		"    value: (Duktape.info(true)[1] === 0xfff4) ?\n"
+		"    value: (Duktape.info(true)[1] >= 0xfff0) ?\n"
 		"            0xfff1 /* tag for packed duk_tval */ :\n"
 		"            1 /* tag for unpacked duk_tval */,\n"
 		"    writable: false,\n"

--- a/tests/ecmascript/test-dev-fastint-basic.js
+++ b/tests/ecmascript/test-dev-fastint-basic.js
@@ -90,7 +90,7 @@ function printFastint(v) {
 
     if (typeof Duktape !== 'object') {
         isfast = ' NOT-DUKTAPE';
-    } else if (Duktape.info(true)[1] === 0xfff4) {
+    } else if (Duktape.info(true)[1] >= 0xfff0) {
         // packed duk_tval
         if (Duktape.info(v)[1] === 0xfff1) {
             isfast = ' fastint';


### PR DESCRIPTION
In Duktape 1.3.0 the 'undefined' value had a single internal tag value and two sub-types:

- "undefined unused" denoted an unused value, and was used to e.g. indicate missing array elements
- "undefined actual" denoted the Ecmascript `undefined` value

The sub-type was indicated in a field separate from the tag type field (similar to how booleans are handled).

Add a separate 'unused' tag type so that 'undefined' tag is only used for Ecmascript `undefined`. This improves performance with both packed and unpacked `duk_tval`:

- With packed `duk_tval` a 16-bit write can be used instead of a 32-bit write (may not be faster on all platforms in practice)
- With unpacked `duk_tval` one field write instead of two field writes

Also ensure that `unused` is not actually used anywhere in the code base other than to mark missing array elements. This means that the new marker tag doesn't need to be added to every type switch-case. Instead, add assertions to switch-cases so that the default clause only catches numbers, not 'unused' values.

The debugger protocol has a dvalue for `unused` values. Such values shouldn't be accepted as inputs (erroring on them should be fine; they didn't do anything useful before the change). They are currently sent as outputs in certain cases, check if they should be replaced with "undefined" (arguably a breaking change).

Tasks:

- [x] Duk_tval change
- [x] Change call sites for renamed macros
- [x] Go through every tag switch case and fix
- [x] Remove `duk_push_unused()` to avoid pushing unused values on the value stack
- [x] Debugger protocol exposes the "unused" type, figure out what to do with it
- [x] Fix "isFastint" polyfill for new tag numbers if necessary, test for both packed and unpacked
- [x] Internal documentation
- [x] Test on x64 (unpacked) and x86 (packed)
- [x] Assertion tests
- [x] Releases entry