### PR TITLE
Avoid rdflib in non-official dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1016,7 +1016,7 @@ cloc:	dist cloc-1.60.pl
 # XXX: make prints a harmless warning related to the sub-make.
 dist:
 	@make codepolicycheck
-	if [ -f compiler.jar ]; then sh util/make_dist.sh --minify closure; else sh util/make_dist.sh --minify none; fi
+	if [ -f compiler.jar ]; then sh util/make_dist.sh --minify closure --create-spdx; else sh util/make_dist.sh --minify none --create-spdx; fi
 
 .PHONY:	dist-src
 dist-src:	dist

--- a/util/make_dist.sh
+++ b/util/make_dist.sh
@@ -22,9 +22,11 @@
 set -e  # exit on errors
 
 INITJS_MINIFY=closure
+CREATE_SPDX=0
 while [ $# -gt 0 ]; do
 	case "$1" in
 		--minify) INITJS_MINIFY="$2"; shift;;
+		--create-spdx) CREATE_SPDX=1; break;;
 		--) shift; break;;
 		*) break;;
 	esac
@@ -826,4 +828,8 @@ python util/combine_src.py $DISTSRCSEP $DISTSRCCOM/duktape.c \
 rm $DIST/*.tmp
 
 # Create SPDX license once all other files are in place (and cleaned)
-python util/create_spdx_license.py `pwd`/dist/license.spdx
+if [ x"$CREATE_SPDX" = "x1" ]; then
+	python util/create_spdx_license.py `pwd`/dist/license.spdx
+else
+	echo "Skip SPDX license creation"
+fi


### PR DESCRIPTION
This removes one more dependency for making a development dist. Might matter to e.g. Windows users; rdflib is not a common dependency and is only used for SPDX license creation.