### PR TITLE
Reorder detach cleanup and detach callback

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1145,12 +1145,15 @@ Planned
   intended mainly for minimal compatibility with existing code using "const"
   (GH-360)
 
-* Add a debugger Throw notify for errors about to be thrown, and an option
-  to automatically pause before an uncaught error is thrown (GH-286, GH-347)
-
 * Add a human readable summary of object/key for rejected property operations
   to make error messages more useful for operations like "null.foo = 123;"
   (GH-210, GH-405)
+
+* Add a debugger Throw notify for errors about to be thrown, and an option
+  to automatically pause before an uncaught error is thrown (GH-286, GH-347)
+
+* Allow debugger detached callback to call duk_debugger_attach(), previously
+  this clobbered some internal state (GH-399)
 
 * Fix "debugger" statement line number off-by-one so that the debugger now
   correctly pauses on the debugger statement rather than after it (GH-347)

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -593,8 +593,26 @@ static int handle_interactive(duk_context *ctx) {
 
 #ifdef DUK_CMDLINE_DEBUGGER_SUPPORT
 static void debugger_detached(void *udata) {
+	duk_context *ctx = (duk_context *) udata;
+	(void) ctx;
 	fprintf(stderr, "Debugger detached, udata: %p\n", (void *) udata);
 	fflush(stderr);
+
+#if 0  /* For manual auto-reattach test */
+	duk_trans_socket_finish();
+	duk_trans_socket_init();
+	duk_trans_socket_waitconn();
+	fprintf(stderr, "Debugger connected, call duk_debugger_attach() and then execute requested file(s)/eval\n");
+	fflush(stderr);
+	duk_debugger_attach(ctx,
+	                    duk_trans_socket_read_cb,
+	                    duk_trans_socket_write_cb,
+	                    duk_trans_socket_peek_cb,
+	                    duk_trans_socket_read_flush_cb,
+	                    duk_trans_socket_write_flush_cb,
+	                    debugger_detached,
+	                    (void *) ctx);
+#endif
 }
 #endif
 
@@ -706,7 +724,7 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 		                    duk_trans_socket_read_flush_cb,
 		                    duk_trans_socket_write_flush_cb,
 		                    debugger_detached,
-		                    (void *) 0xbeef1234);
+		                    (void *) ctx);
 #else
 		fprintf(stderr, "Warning: option --debugger ignored, no debugger support\n");
 		fflush(stderr);

--- a/examples/debug-trans-socket/duk_trans_socket.c
+++ b/examples/debug-trans-socket/duk_trans_socket.c
@@ -29,7 +29,7 @@ static int server_sock = -1;
 static int client_sock = -1;
 
 /*
- *  Transport init
+ *  Transport init and finish
  */
 
 void duk_trans_socket_init(void) {
@@ -65,6 +65,17 @@ void duk_trans_socket_init(void) {
 	return;
 
  fail:
+	if (server_sock >= 0) {
+		(void) close(server_sock);
+		server_sock = -1;
+	}
+}
+
+void duk_trans_socket_finish(void) {
+	if (client_sock >= 0) {
+		(void) close(client_sock);
+		client_sock = -1;
+	}
 	if (server_sock >= 0) {
 		(void) close(server_sock);
 		server_sock = -1;

--- a/examples/debug-trans-socket/duk_trans_socket.h
+++ b/examples/debug-trans-socket/duk_trans_socket.h
@@ -4,6 +4,7 @@
 #include "duktape.h"
 
 void duk_trans_socket_init(void);
+void duk_trans_socket_finish(void);
 void duk_trans_socket_waitconn(void);
 duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length);
 duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t length);

--- a/src/duk_api_debug.c
+++ b/src/duk_api_debug.c
@@ -53,6 +53,10 @@ DUK_EXTERNAL void duk_debugger_attach(duk_context *ctx,
 	const char *str;
 	duk_size_t len;
 
+	/* XXX: should there be an error or an automatic detach if
+	 * already attached?
+	 */
+
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(read_cb != NULL);
 	DUK_ASSERT(write_cb != NULL);
@@ -104,7 +108,7 @@ DUK_EXTERNAL void duk_debugger_detach(duk_context *ctx) {
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(thr->heap != NULL);
 
-	/* Can be called muliple times with no harm. */
+	/* Can be called multiple times with no harm. */
 	duk_debug_do_detach(thr->heap);
 }
 

--- a/website/api/duk_debugger_attach.yaml
+++ b/website/api/duk_debugger_attach.yaml
@@ -21,6 +21,14 @@ summary: |
   <code>read_flush_cb</code> and <code>write_flush_cb</code> callbacks are
   optional.  Unimplemented callbacks are indicated using a <code>NULL</code>.</p>
 
+  <div class="note">
+  Since Duktape 1.4.0 the debugger detached callback is allowed to call
+  <code><a href="#duk_debugger_attach">duk_debugger_attach()</a></code>
+  to immediately reattach the debugger.  In Duktape 1.3.0 and before the
+  immediate reattach potentially caused
+  <a href="https://github.com/svaarala/duktape/pull/399">some issues</a>.
+  </div>
+
 example: |
   duk_debugger_attach(ctx,
                       my_read_cb,


### PR DESCRIPTION
This should make it easier to allow a detached callback to reattach immediately without leaving the debugger state inconsistent.

Tasks:

- [x] Check that the detached -> attach sequence works in practice (multiple times)
- [x] Document that the detached callback may reattach immediately
- [x] Delay detached callback to message handling loop so that it's called between two full messages (this avoids accidentally e.g. skipping to EOM or writing to the new connection in handling code dealing with data from the previous connection)
- [x] Releases entry