### PR TITLE
Avoid slow path GETVAR/CSVAR for function self-reference

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1266,6 +1266,12 @@ Planned
   by allowing indent value or gap string and by supporting JX/JC in the
   fast path (GH-445)
 
+1.5.0 (XXXX-XX-XX)
+------------------
+
+* Internal performance improvement: handle function self-reference specially
+  to avoid a slow path identifier lookup for self-recursive functions (GH-401)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/debugger/duk_opcodes.yaml
+++ b/debugger/duk_opcodes.yaml
@@ -434,7 +434,9 @@ extra:
   - name: ENDLABEL
     args:
       - BC_I
-  - name: EXTRA34
+  - name: LDCURRFN
+    args:
+      - BC_R
   - name: EXTRA35
   - name: EXTRA36
   - name: EXTRA37

--- a/src/duk_js_bytecode.h
+++ b/src/duk_js_bytecode.h
@@ -176,6 +176,7 @@ typedef duk_uint32_t duk_instr_t;
 #define DUK_EXTRAOP_IN              31
 #define DUK_EXTRAOP_LABEL           32
 #define DUK_EXTRAOP_ENDLABEL        33
+#define DUK_EXTRAOP_LDCURRFN        34
 
 /* DUK_OP_CALL flags in A */
 #define DUK_BC_CALL_FLAG_TAILCALL           (1 << 0)

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -4390,6 +4390,16 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 				break;
 			}
 
+			case DUK_EXTRAOP_LDCURRFN: {
+				duk_uint_fast_t bc = DUK_DEC_BC(ins);
+				duk_tval *tv1;
+
+				tv1 = DUK__REGP(bc);
+				DUK_ASSERT(DUK__FUN() != NULL);
+				DUK_TVAL_SET_OBJECT_UPDREF(thr, tv1, (duk_hobject *) DUK__FUN());
+				break;
+			}
+
 			default: {
 				DUK__INTERNAL_ERROR("invalid extra opcode");
 			}

--- a/tests/ecmascript/test-dev-func-self-ref.js
+++ b/tests/ecmascript/test-dev-func-self-ref.js
@@ -1,0 +1,105 @@
+/*
+ *  Function self-reference, compiles to specific bytecode for most self
+ *  recursive functions.
+ */
+
+/*===
+===*/
+
+/* Basic counter test, with a self-referencing recursive call. */
+
+function counterTest() {
+    function counter(n) {
+        print(n);
+        print(counter);  // self ref as a value (LDCURRFN)
+        print(typeof counter);  // FIXME: hard code result?
+        if (n > 0) { counter(n - 1); }  // self ref in a call (LDCURRFN + CSREG)
+    }
+
+    counter(5);
+}
+
+try {
+    print('counter test');
+    counterTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+===*/
+
+/* Self-reference captured by a 'with'. */
+
+function capturingWithTest() {
+    function counter(n) {
+        with ({ counter: function (x) { print('captured:', x); } }) {
+            if (n > 0) { counter(n - 1); }
+        }
+    }
+
+    counter(5);
+}
+
+try {
+    print('capturing with test');
+    capturingWithTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+===*/
+
+/* Self reference captured by 'catch'. */
+
+function capturingCatchTest() {
+    function counter(n) {
+        try {
+            throw function (x) { print('captured:', x); };
+        } catch (counter) {
+            if (n > 0) { counter(n - 1); }
+        }
+    }
+
+    counter(5);
+}
+
+try {
+    print('capturing catch test');
+    capturingCatchTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+===*/
+
+/* Write over a global binding during self-reference. */
+
+function mutationHelper(n) {
+    if (n == 3) {
+        this.counterAssignTest = function (n) {
+            print('captured by mutated counterAssignTest:', n);
+        };
+    }
+}
+
+function counterAssignTest(n) {
+    print(n);
+    mutationHelper(n);
+    if (n > 0) {
+        counterAssignTest(n - 1);
+    }
+}
+
+try {
+    // FIXME: check required semantics; V8 seems to allow first round
+    // to use original value (= self reference always sees the same
+    // original function), Rhino does not.
+    print('counter assign test');
+    counterAssignTest(5);  // on first round self refs allow counter to go through
+    counterAssignTest(5);  // on second round uses mutated value
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Currently a function self reference compiles to a slow path GETVAR. Avoid this slow path by detecting self reference at compile time and emit a LDCURRFN (load current function) when it's safe to do so.

I'm not sure if there are actually many safe situations, I'll need to check the semantics. For example, a global function declaration is writable so there's no guarantee that it won't be mutated during self recursion.

Tasks:

- [ ] Compiler changes
- [ ] Executor changes
- [ ] Debugger opcode definitions, check emitted output for call setup and normal read reference
- [ ] Check and document official semantics, compare to V8 and Rhino
- [ ] Test cases to cover emitted opcodes, with/catch capture cases, unsafe self references
- [ ] Releases entry