### PR TITLE
Add property multi get/put API calls

### DIFF
--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -654,6 +654,9 @@ DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
 DUK_EXTERNAL_DECL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t flags);
 
+/* FIXME: naming; constants for characters */
+DUK_EXTERNAL_DECL void duk_get_prop_multi(duk_context *ctx, duk_idx_t index, const char *fmt, ...);
+
 DUK_EXTERNAL_DECL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key);
 

--- a/tests/api/test-get-prop-multi.c
+++ b/tests/api/test-get-prop-multi.c
@@ -1,0 +1,31 @@
+/*
+ *  duk_get_prop_multi()
+ */
+
+static duk_ret_t test_basic(duk_context *ctx) {
+	duk_int_t my_int;
+
+	duk_eval_string(ctx, "({ undefinedValue: void 0, \n"
+	                     "   nullValue: null, \n"
+	                     "   falseValue: false, \n"
+	                     "   trueValue: true, \n"
+	                     "   integerValue: -321, \n"
+	                     "   numberValue: 123.4, \n"
+	                     "   stringValue: 'foo bar' })");
+
+	my_int = 123;
+	duk_get_prop_multi(ctx, -1, "integerValue:d", &my_int);
+	printf("my_int: %ld\n", (long) my_int);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/* FIXME: missing property */
+/* FIXME: NULL value pointer */
+/* FIXME: invalid character */
+/* FIXME: missing colon */
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}


### PR DESCRIPTION
For now this is a quick prototype branch for adding property multi get/put API calls, so that there's something concrete to reflect on.

Issues:

- [ ] Jansson API provides keys as va_args too (e.g. "s:s" -> key string, value string) which is more flexible but less literal
- [ ] What should be the "get" operation: should it be a "duk_to_int" vs. "duk_get_int" for integers, for example? Lowercase for "get", uppercase for "to"?
- [ ] Characters for all relevant types
- [ ] Ability to specify property attributes (would be useful for internals where attributes are often important)
- [ ] Finalize get and put operations
- [ ] Find at least a few internal call sites for each
- [ ] API documentation, link to wiki examples
- [ ] API testcases
- [ ] Releases entry