### PR TITLE
Add a few convenience flags to duk_def_prop()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1155,6 +1155,9 @@ Planned
 * Allow debugger detached callback to call duk_debugger_attach(), previously
   this clobbered some internal state (GH-399)
 
+* Add defines DUK_DEFPROP_{SET,CLEAR}_{WRITABLE,ENUMERABLE,CONFIGURABLE} for
+  duk_def_prop() to improve call site readability (GH-421)
+
 * Add a combined duktape.c without #line directives into the dist package,
   as it is a useful alternative in some environments (GH-363)
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -176,6 +176,12 @@ struct duk_number_list_entry {
 #define DUK_DEFPROP_HAVE_GETTER           (1 << 7)    /* set getter (given on value stack) */
 #define DUK_DEFPROP_HAVE_SETTER           (1 << 8)    /* set setter (given on value stack) */
 #define DUK_DEFPROP_FORCE                 (1 << 9)    /* force change if possible, may still fail for e.g. virtual properties */
+#define DUK_DEFPROP_SET_WRITABLE          (DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE)
+#define DUK_DEFPROP_CLEAR_WRITABLE        DUK_DEFPROP_HAVE_WRITABLE
+#define DUK_DEFPROP_SET_ENUMERABLE        (DUK_DEFPROP_HAVE_ENUMERABLE | DUK_DEFPROP_ENUMERABLE)
+#define DUK_DEFPROP_CLEAR_ENUMERABLE      DUK_DEFPROP_HAVE_ENUMERABLE
+#define DUK_DEFPROP_SET_CONFIGURABLE      (DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_CONFIGURABLE)
+#define DUK_DEFPROP_CLEAR_CONFIGURABLE    DUK_DEFPROP_HAVE_CONFIGURABLE
 
 /* Flags for duk_push_thread_raw() */
 #define DUK_THREAD_NEW_GLOBAL_ENV         (1 << 0)    /* create a new global environment */

--- a/tests/api/test-def-prop-convenience.c
+++ b/tests/api/test-def-prop-convenience.c
@@ -1,0 +1,65 @@
+/*
+ *  duk_def_prop() convenience flags, added in Duktape 1.4.0.
+ */
+
+/*===
+*** test_basic (duk_safe_call)
+{value:undefined,writable:true,enumerable:true,configurable:true}
+{value:undefined,writable:false,enumerable:true,configurable:true}
+{value:undefined,writable:false,enumerable:false,configurable:true}
+{value:undefined,writable:false,enumerable:false,configurable:false}
+{value:undefined,writable:false,enumerable:false,configurable:true}
+{value:undefined,writable:false,enumerable:true,configurable:true}
+{value:undefined,writable:true,enumerable:true,configurable:true}
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static void dump_prop(duk_context *ctx) {
+	duk_eval_string(ctx,
+		"(function (obj) {\n"
+		"    print(Duktape.enc('jx', Object.getOwnPropertyDescriptor(obj, 'prop')));\n"
+		"})");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+}
+
+static duk_ret_t test_basic(duk_context *ctx) {
+	duk_push_object(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_SET_WRITABLE | DUK_DEFPROP_SET_ENUMERABLE | DUK_DEFPROP_SET_CONFIGURABLE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_CLEAR_WRITABLE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_CLEAR_ENUMERABLE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_CLEAR_CONFIGURABLE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_SET_CONFIGURABLE | DUK_DEFPROP_FORCE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_SET_ENUMERABLE);
+	dump_prop(ctx);
+
+	duk_push_string(ctx, "prop");
+	duk_def_prop(ctx, -2, DUK_DEFPROP_SET_WRITABLE);
+	dump_prop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -151,6 +151,12 @@ typedef struct duk_number_list_entry duk_number_list_entry;
 #define DUK_DEFPROP_HAVE_GETTER           (1 &lt;&lt; 7)    /* set getter (given on value stack) */
 #define DUK_DEFPROP_HAVE_SETTER           (1 &lt;&lt; 8)    /* set setter (given on value stack) */
 #define DUK_DEFPROP_FORCE                 (1 &lt;&lt; 9)    /* force change if possible, may still fail for e.g. virtual properties */
+#define DUK_DEFPROP_SET_WRITABLE          (DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE)
+#define DUK_DEFPROP_CLEAR_WRITABLE        DUK_DEFPROP_HAVE_WRITABLE
+#define DUK_DEFPROP_SET_ENUMERABLE        (DUK_DEFPROP_HAVE_ENUMERABLE | DUK_DEFPROP_ENUMERABLE)
+#define DUK_DEFPROP_CLEAR_ENUMERABLE      DUK_DEFPROP_HAVE_ENUMERABLE
+#define DUK_DEFPROP_SET_CONFIGURABLE      (DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_CONFIGURABLE)
+#define DUK_DEFPROP_CLEAR_CONFIGURABLE    DUK_DEFPROP_HAVE_CONFIGURABLE
 </pre>
 
 <h2>Enumeration flags for duk_enum()</h2>

--- a/website/api/duk_def_prop.yaml
+++ b/website/api/duk_def_prop.yaml
@@ -52,6 +52,13 @@ summary: |
       new property value as a stack argument.</li>
   </ul>
 
+  <p>In Duktape 1.4.0 convenience flags for setting/clearing attributes were added:</p>
+  <ul>
+  <li><code>DUK_DEFPROP_SET_WRITABLE</code> / <code>DUK_DEFPROP_CLEAR_WRITABLE</code></li>
+  <li><code>DUK_DEFPROP_SET_ENUMERABLE</code> / <code>DUK_DEFPROP_CLEAR_ENUMERABLE</code></li>
+  <li><code>DUK_DEFPROP_SET_CONFIGURABLE</code> / <code>DUK_DEFPROP_CLEAR_CONFIGURABLE</code></li>
+  </ul>
+
   <p>This API call is useful for various things:</p>
   <ul>
   <li>To create properties with non-default attributes directly from C code.</li>
@@ -78,6 +85,19 @@ example: |
                DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE |
                DUK_DEFPROP_HAVE_ENUMERABLE | 0 |
                DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_CONFIGURABLE);
+
+  /* In Duktape 1.4.0 there are convenience defines to make the above
+   * more readable.
+   */
+
+  duk_push_string(ctx, "my_prop_1");
+  duk_push_int(ctx, 123);  /* prop value */
+  duk_def_prop(ctx,
+               obj_idx,
+               DUK_DEFPROP_HAVE_VALUE |
+               DUK_DEFPROP_SET_WRITABLE |
+               DUK_DEFPROP_CLEAR_ENUMERABLE |
+               DUK_DEFPROP_SET_CONFIGURABLE);
 
   /* Change the property value and make it non-writable.  Don't touch other
    * attributes.


### PR DESCRIPTION
Add convenience flags to set/clear writable, enumerable, and configurable. These defines make call sites a bit more readable:

```
duk_def_prop(ctx, -3, DUK_DEFPROP_SET_WRITABLE);
```

instead of:

```
duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE);
```