### PR TITLE
Improve string intern computation of UTF-8 character length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1200,7 +1200,7 @@ TIME=python util/time_multi.py --count 5 --sleep 10 --mode min # Take minimum ti
 # other JIT engines.
 perftest: duk duk.O2 duk.O3 duk.O4
 	for i in tests/perf/*.js; do \
-		printf '%-30s:' "`basename $$i`"; \
+		printf '%-32s:' "`basename $$i`"; \
 		printf ' duk.Os %5s' "`$(TIME) ./duk $$i`"; \
 		printf ' duk.O2 %5s' "`$(TIME) ./duk.O2 $$i`"; \
 		printf ' duk.O3 %5s' "`$(TIME) ./duk.O3 $$i`"; \
@@ -1224,7 +1224,7 @@ perftest: duk duk.O2 duk.O3 duk.O4
 	done
 perftestduk: duk duk.O2
 	for i in tests/perf/*.js; do \
-		printf '%-30s:' "`basename $$i`"; \
+		printf '%-32s:' "`basename $$i`"; \
 		printf ' duk.Os %5s' "`$(TIME) ./duk $$i`"; \
 		printf ' duk.O2 %5s' "`$(TIME) ./duk.O2 $$i`"; \
 		printf ' |'; \
@@ -1236,7 +1236,7 @@ perftestduk: duk duk.O2
 	done
 perftestduk3: duk.O2
 	for i in tests/perf/*.js; do \
-		printf '%-30s:' "`basename $$i`"; \
+		printf '%-32s:' "`basename $$i`"; \
 		printf ' duk.O2'; \
 		printf ' %5s' "`$(TIME) ./duk.O2 $$i`"; \
 		printf ' %5s' "`$(TIME) ./duk.O2 $$i`"; \

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1194,6 +1194,9 @@ Planned
 * Internal performance improvement: improve duk_push_this() performance by
   direct value stack access (GH-403)
 
+* Internal performance improvement: faster computation of string UTF-8
+  character length in string interning (GH-422)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/src/duk_heap_stringcache.c
+++ b/src/duk_heap_stringcache.c
@@ -36,6 +36,10 @@ DUK_INTERNAL void duk_heap_strcache_string_remove(duk_heap *heap, duk_hstring *h
 
 /*
  *  String scanning helpers
+ *
+ *  All bytes other than UTF-8 continuation bytes ([0x80,0xbf]) are
+ *  considered to contribute a character.  This must match how string
+ *  character length is computed.
  */
 
 DUK_LOCAL duk_uint8_t *duk__scan_forwards(duk_uint8_t *p, duk_uint8_t *q, duk_uint_fast32_t n) {

--- a/src/duk_unicode_support.c
+++ b/src/duk_unicode_support.c
@@ -257,258 +257,75 @@ DUK_INTERNAL duk_ucodepoint_t duk_unicode_decode_xutf8_checked(duk_hthread *thr,
 /* Compute (extended) utf-8 length without codepoint encoding validation,
  * used for string interning.
  *
- * NOTE: This algorithm is performance critical (more so than string hashing
- * in some cases): it is needed when interning a string and it needs to scan
+ * NOTE: This algorithm is performance critical, more so than string hashing
+ * in some cases.  It is needed when interning a string and needs to scan
  * every byte of the string with no skipping.  Having an ASCII fast path
- * would be useful (if possible in the algorithm).  Several variants are
- * left below, commented out; the active algorithm was chosen on x64 based
- * on gcc -O2 testing.
+ * is useful if possible in the algorithm.  The current algorithms were
+ * chosen from several variants, based on x64 gcc -O2 testing.  See:
+ * https://github.com/svaarala/duktape/pull/422
  */
 
-const duk_uint8_t duk__ncont_incr[256] = {
-	/* 10xxxxxx = continuation chars (0x80...0xbf), above
-	 * and below that initial bytes.
-	 */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-
-const duk_uint8_t duk__nchar_incr[256] = {
-	/* 10xxxxxx = continuation chars (0x80...0xbf), above
-	 * and below that initial bytes.
-	 */
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-};
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_simple1(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p;
-	const duk_uint8_t *p_end;
-	duk_size_t clen;
-
-	p = data;
-	p_end = data + blen;
-	clen = 0;
-	while (p != p_end) {
-		duk_uint8_t x = *p++;
-		if (DUK_LIKELY(x < 0x80 || x >= 0xc0)) {
-			/* 10xxxxxx = continuation chars (0x80...0xbf), above
-			 * and below that initial bytes.
-			 */
-			clen++;
-		}
-	}
-
-	return clen;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_simple2(const duk_uint8_t *data, duk_size_t blen) {
+#if defined(DUK_USE_PREFER_SIZE)
+/* Small variant; roughly 150 bytes smaller than the fast variant. */
+DUK_INTERNAL duk_size_t duk_unicode_unvalidated_utf8_length(const duk_uint8_t *data, duk_size_t blen) {
 	const duk_uint8_t *p;
 	const duk_uint8_t *p_end;
 	duk_size_t ncont;
+	duk_size_t clen;
 
 	p = data;
 	p_end = data + blen;
 	ncont = 0;
 	while (p != p_end) {
-		duk_uint8_t x = *p++;
+		duk_uint8_t x;
+		x = *p++;
 		if (DUK_UNLIKELY(x >= 0x80 && x <= 0xbf)) {
 			ncont++;
 		}
 	}
 
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_simple3(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont;
-
-	p = data;
-	p_end = data + blen;
-	ncont = 0;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		ncont += ((x & 0xc0) == 0x80) ? 1 : 0;
-	}
-
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_simple4(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont;
-
-	p = data;
-	p_end = data + blen;
-	ncont = 0;
-	while (p != p_end) {
-		/* Bit trick:
-		 *     10xxxxxx ^ 01000000 =   11xxxxxx (and other bit patterns are 10xxxxxx or less)
-		 *              + 01000000 = 1 00xxxxxx (and other bit patterns won't overflow to 9 bits)
-		 *              >>> 8      = 1
-		 */
-		duk_small_uint_t x;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-	}
-
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_lookup1(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p;
-	const duk_uint8_t *p_end;
-	duk_size_t clen;
-
-	p = data;
-	p_end = data + blen;
-	clen = 0;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		clen += duk__nchar_incr[x];
-	}
-
+	DUK_ASSERT(ncont <= blen);
+	clen = blen - ncont;
+	DUK_ASSERT(clen <= blen);
 	return clen;
 }
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_lookup2(const duk_uint8_t *data, duk_size_t blen) {
+#else  /* DUK_USE_PREFER_SIZE */
+/* This seems like a good overall approach.  Fast path for ASCII in 4 byte
+ * blocks.
+ */
+DUK_INTERNAL duk_size_t duk_unicode_unvalidated_utf8_length(const duk_uint8_t *data, duk_size_t blen) {
 	const duk_uint8_t *p;
 	const duk_uint8_t *p_end;
+	const duk_uint32_t *p32_end;
+	const duk_uint32_t *p32;
 	duk_size_t ncont;
+	duk_size_t clen;
 
+	ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
 	p = data;
 	p_end = data + blen;
-	ncont = 0;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-	}
-
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll1(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-	const duk_uint32_t *p32;
-
 	if (blen < 16) {
 		goto skip_fastpath;
 	}
-	/* Align 'p' to 4. */
-	while (((duk_small_uint_t) (duk_uintptr_t) (void *) p) & 0x03) {
+
+	/* Align 'p' to 4; the input data may have arbitrary alignment.
+	 * End of string check not needed because blen >= 16.
+	 */
+	while (((duk_small_uint_t) (duk_uintptr_t) (const void *) p) & 0x03) {
 		duk_uint8_t x;
 		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
+		if (DUK_UNLIKELY(x >= 0x80 && x <= 0xbf)) {
 			ncont++;
 		}
 	}
+
 	/* Full, aligned 4-byte reads. */
-	p_end = data + blen;
-	p_end = p + ((duk_size_t) (p_end - p) & (duk_size_t) (~0x03));
+	p32_end = (const duk_uint32_t *) (p + ((duk_size_t) (p_end - p) & (duk_size_t) (~0x03)));
 	p32 = (const duk_uint32_t *) p;
-	while (p32 != (const duk_uint32_t *) p_end) {
+	while (p32 != (const duk_uint32_t *) p32_end) {
 		duk_uint32_t x;
 		x = *p32++;
-		if ((x & 0x80808080UL) == 0) {
-			;  /* ASCII fast path */
-		} else {
-			if ((x & 0xc0000000UL) == 0x80000000UL) {
-				ncont++;
-			}
-			if ((x & 0x00c00000UL) == 0x00800000UL) {
-				ncont++;
-			}
-			if ((x & 0x0000c000UL) == 0x00008000UL) {
-				ncont++;
-			}
-			if ((x & 0x000000c0UL) == 0x00000080UL) {
-				ncont++;
-			}
-		}
-	}
-	p = (const duk_uint8_t *) p32;
-	/* Fall through to handle the rest. */
- skip_fastpath:
-	p_end = data + blen;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll2(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-	const duk_uint32_t *p32;
-
-	if (blen < 16) {
-		goto skip_fastpath;
-	}
-	/* Align 'p' to 4. */
-	while (((duk_small_uint_t) (duk_uintptr_t) (void *) p) & 0x03) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-	/* Full, aligned 4-byte reads. */
-	p_end = data + blen;
-	p_end = p + ((duk_size_t) (p_end - p) & (duk_size_t) (~0x03));
-	p32 = (const duk_uint32_t *) p;
-	while (p32 != (const duk_uint32_t *) p_end) {
-		duk_uint32_t x;
-		x = *p32++;
-		if ((x & 0x80808080UL) == 0) {
+		if (DUK_LIKELY((x & 0x80808080UL) == 0)) {
 			;  /* ASCII fast path */
 		} else {
 			/* Flip highest bit of each byte which changes
@@ -516,260 +333,38 @@ DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll2(const duk_uint8_t *data, duk_
 			 * allows an easy bit mask test.
 			 */
 			x ^= 0x80808080UL;
-			if (!(x & 0xc0000000UL)) {
+			if (DUK_UNLIKELY(!(x & 0xc0000000UL))) {
 				ncont++;
 			}
-			if (!(x & 0x00c00000UL)) {
+			if (DUK_UNLIKELY(!(x & 0x00c00000UL))) {
 				ncont++;
 			}
-			if (!(x & 0x0000c000UL)) {
+			if (DUK_UNLIKELY(!(x & 0x0000c000UL))) {
 				ncont++;
 			}
-			if (!(x & 0x000000c0UL)) {
+			if (DUK_UNLIKELY(!(x & 0x000000c0UL))) {
 				ncont++;
 			}
 		}
 	}
 	p = (const duk_uint8_t *) p32;
 	/* Fall through to handle the rest. */
+
  skip_fastpath:
-	p_end = data + blen;
 	while (p != p_end) {
 		duk_uint8_t x;
 		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
+		if (DUK_UNLIKELY(x >= 0x80 && x <= 0xbf)) {
 			ncont++;
 		}
 	}
 
 	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll3(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-	const duk_uint32_t *p32;
-
-	if (blen < 16) {
-		goto skip_fastpath;
-	}
-	/* Align 'p' to 4. */
-	while (((duk_small_uint_t) (duk_uintptr_t) (void *) p) & 0x03) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-	/* Full, aligned 4-byte reads. */
-	p_end = data + blen;
-	p_end = p + ((duk_size_t) (p_end - p) & (duk_size_t) (~0x03));
-	p32 = (const duk_uint32_t *) p;
-	while (p32 != (const duk_uint32_t *) p_end) {
-		/* Bit tricks to work 4 bytes at a time, similar to the bit trick below.
-		 *
-		 *                 10xxxxxx 10xxxxxx 10xxxxxxx 10xxxxxx
-		 *  ^ 0x40404040   11xxxxxx 11xxxxxx 11xxxxxxx 11xxxxxx
-		 *  >> 6           00000011 00000011 000000011 00000011
-		 *  + 0x01010101   00000100 00000100 000000100 00000100
-		 *                      ^        ^         ^        ^
-		 *                      `--------+---------+--------+---- carry if cont byte [+]
-		 */
-		duk_uint32_t x;
-		x = *p32++;
-		x = ((x ^ 0x40404040UL) >> 6) + 0x01010101UL;
-		x &= 0x04040404UL;
-		x = (x & 0xffffUL) + (x >> 16);  /* two step sum of carries */
-		x = (x & 0xffUL) + (x >> 8);
-		ncont += x >> 2;
-	}
-	/* Fall through to handle the rest. */
- skip_fastpath:
-	p_end = data + blen;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll4(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-
-	p_end = data + (blen & ((duk_size_t) (~0x03)));
-	while (p < p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-	p_end = data + blen;
-	while (p < p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		if (x < 0x80 || x >= 0xc0) {
-			;
-		} else {
-			ncont++;
-		}
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll5(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-
-	p_end = data + (blen & ((duk_size_t) (~0x03)));
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-	}
-
-	p_end = data + blen;
-	while (p != p_end) {
-		duk_uint8_t x;
-		x = *p++;
-		ncont += duk__ncont_incr[x];
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll6(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-
-	p_end = data + (blen & ((duk_size_t) (~0x03)));
-	while (p != p_end) {
-		duk_small_uint_t x;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-	}
-	p_end = data + blen;
-	while (p != p_end) {
-		duk_small_uint_t x;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_LOCAL duk_size_t duk__unicode_utf8clen_unroll7(const duk_uint8_t *data, duk_size_t blen) {
-	const duk_uint8_t *p = data;
-	const duk_uint8_t *p_end;
-	duk_size_t ncont = 0;  /* number of continuation (non-initial) bytes in [0x80,0xbf] */
-
-	p_end = data + (blen & ((duk_size_t) (~0x03)));
-	while (p != p_end) {
-		/* Similar bit trick as above, but postpone the shift.
-		 * This means we need to avoid overflows from the lower
-		 * bits and need the "x & 0xc0".
-		 */
-		duk_small_uint_t x;
-		duk_small_uint_t tmp = 0;
-		x = *p++;
-		tmp += ((x & 0xc0) ^ 0x40) + 0x40;
-		x = *p++;
-		tmp += ((x & 0xc0) ^ 0x40) + 0x40;
-		x = *p++;
-		tmp += ((x & 0xc0) ^ 0x40) + 0x40;
-		x = *p++;
-		tmp += ((x & 0xc0) ^ 0x40) + 0x40;
-		ncont += tmp;
-	}
-	p_end = data + blen;
-	while (p != p_end) {
-		duk_small_uint_t x;
-		x = *p++;
-		ncont += ((x ^ 0x40) + 0x40) >> 8;
-	}
-
-	DUK_ASSERT(ncont <= blen);
-	return blen - ncont;
-}
-
-DUK_INTERNAL duk_size_t duk_unicode_unvalidated_utf8_length(const duk_uint8_t *data, duk_size_t blen) {
-	duk_size_t clen;
-
-#if 0
-	clen = duk__unicode_utf8clen_simple1(data, blen);
-	clen = duk__unicode_utf8clen_simple2(data, blen);
-	clen = duk__unicode_utf8clen_simple3(data, blen);
-	clen = duk__unicode_utf8clen_simple4(data, blen);
-
-	clen = duk__unicode_utf8clen_lookup1(data, blen);
-	clen = duk__unicode_utf8clen_lookup2(data, blen);
-
-	clen = duk__unicode_utf8clen_unroll1(data, blen);
-	clen = duk__unicode_utf8clen_unroll2(data, blen);
-	clen = duk__unicode_utf8clen_unroll3(data, blen);
-	clen = duk__unicode_utf8clen_unroll4(data, blen);
-	clen = duk__unicode_utf8clen_unroll5(data, blen);
-	clen = duk__unicode_utf8clen_unroll6(data, blen);
-	clen = duk__unicode_utf8clen_unroll7(data, blen);
-#endif
-
-	clen = duk__unicode_utf8clen_unroll1(data, blen);
+	clen = blen - ncont;
 	DUK_ASSERT(clen <= blen);
 	return clen;
 }
+#endif  /* DUK_USE_PREFER_SIZE */
 
 /*
  *  Unicode range matcher

--- a/tests/ecmascript/test-dev-string-charlen-correctness.js
+++ b/tests/ecmascript/test-dev-string-charlen-correctness.js
@@ -1,0 +1,71 @@
+/*
+ *  Ensure string character length calculation is correct even for invalid
+ *  UTF-8 and various string lengths.
+ *
+ *  The character length calculation is important for performance and the
+ *  algorithm has optimizations which deal with e.g. different string lengths
+ *  using separate code paths.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+done
+===*/
+
+function testOne(blen) {
+    var buf, str;
+    var i;
+    var clen;
+
+    buf = new Duktape.Buffer(blen);
+    for (i = 0; i < blen; i++) {
+        buf[i] = Math.random() * 256;
+    }
+
+    // Expected character length computed using Ecmascript:
+    // all bytes outside of [0x80,0xbf] (UTF-8 continuation
+    // bytes) contribute +1 to character length.
+    clen = 0;
+    for (i = 0; i < blen; i++) {
+        if (buf[i] < 0x80 || buf[i] >= 0xc0) {
+            clen++;
+        }
+    }
+
+    str = String(buf);
+    if (str.length != clen) {
+        throw new Error('mismatch: ' + str.length + ' vs ' + clen);
+    }
+}
+
+function test() {
+    var i, j;
+    var blen;
+
+    // Strings up to 256 bytes, a few times each
+    for (i = 0; i <= 256; i++) {
+        for (j = 0; j < 100; j++) {
+            testOne(i);
+        }
+    }
+
+    // Random strings up to 64kB, favor shorter strings
+    // Math.exp(0) - 1 = 0
+    // Math.exp(11.1) - 1 ~= 66170
+    for (i = 0; i < 1000; i++) {
+        blen = Math.max(Math.min(Math.floor(Math.exp(Math.random() * 11.1) - 1), 65536), 0);
+        testOne(blen);
+    }
+}
+
+try {
+    test();
+    print('done');
+} catch (e) {
+    print(e.stack);
+}

--- a/tests/perf/test-string-charlen-ascii.js
+++ b/tests/perf/test-string-charlen-ascii.js
@@ -1,0 +1,27 @@
+/*
+ *  Important fast path: character length for pure ASCII strings.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var str;
+    var i, n;
+
+    str = 'aAbBcCdDeEfFgGhH';
+    while (str.length < 65536) {
+        str = str + str;
+    }
+    print(str.length);
+
+    for (i = 0; i < 1e5; i++) {
+        void (str + 'x').length;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-string-charlen-nonascii.js
+++ b/tests/perf/test-string-charlen-nonascii.js
@@ -1,0 +1,27 @@
+/*
+ *  Character length for non-ASCII strings.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var str;
+    var i, n;
+
+    str = '\u1234\u2345\u3456\u4567\u5678\u6789\u789a\u89ab\u9abc\uabcd\ubcde\ucdef\udef0\uef01\uf012\u0123';
+    while (str.length < 16384) {
+        str = str + str;
+    }
+    print(str.length);
+
+    for (i = 0; i < 1e5; i++) {
+        void (str + 'x').length;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-string-intern-match.js
+++ b/tests/perf/test-string-intern-match.js
@@ -8,11 +8,13 @@ if (typeof print !== 'function') { print = console.log; }
 
 function test() {
     var buf = Duktape.Buffer(2048);
+    var ref;
     var i;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;
     }
+    ref = String(buf);
 
     for (i = 0; i < 1e6; i++) {
         void String(buf);


### PR DESCRIPTION
When a new string is interned its character length in UTF-8 codepoints is computed and stored in the `duk_hstring` struct. Unlike string hashing, the character length computation must go through all the string bytes, so the algorithm has a significant performance impact for code dealing with a lot of strings. The algorithm is simple and also handles invalid UTF-8: every byte outside the range `[0x80,0xbf]` (UTF-8 continuation bytes) contribute +1 to character length while continuation bytes contribute +0.

The existing implementation is a simple loop. This pull provides a faster implementation based on measurement on x64.

Tasks:

- [x] Select the best variant, inspect assembly to see if there's room for improvement
- [x] Remove unnecessary variants
- [x] If there's a significant memory/speed tradeoff, ensure low memory config options exist for low footprint => conditional to `DUK_USE_PREFER_SIZE`
- [x] Perf test for large pure/mostly ASCII strings, perf test for Unicode strings
- [x] Test x64, x86, and callgrind
- [x] Test x64/x86 with unaligned fast loop (removes need to align first) => difference is insignificant
- [x] Correctness test for random strings, comparison value computed using pure Ecmascript
- [x] Releases entry