### PR TITLE
Add a testcase for already fixed nested property assignment bug

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1159,6 +1159,8 @@ Planned
   value is a register-bound variable which is used and mutated in the rest
   of the expression (GH-381)
 
+* Fix nested property assignment handling (GH-427, GH-428)
+
 * Fix Unix local time offset handling which caused issues at least on RISC
   OS (GH-406, GH-407)
 

--- a/tests/ecmascript/test-bug-nested-property-assignment-gh427.js
+++ b/tests/ecmascript/test-bug-nested-property-assignment-gh427.js
@@ -1,0 +1,38 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/427
+ */
+
+/*===
+none true 0
+text true 1
+0 true none
+1 true text
+none true 0
+text true 1
+0 true none
+1 true text
+===*/
+
+// Original issue
+var obj1;
+(function (obj1) {
+    obj1[obj1["none"] = 0] = "none";
+    obj1[obj1["text"] = 1] = "text";
+})(obj1 || (obj1 = {}));
+
+[ 'none', 'text', 0, 1 ].forEach(function (k) {
+   print(k, k in obj1, obj1[k]);
+});
+
+// Slightly modified
+var obj2;
+(function (obj2) {
+    var t = '';
+    var i = 0;
+    obj2[obj2[t + "none"] = i + 0] = "none";
+    obj2[obj2[t + "text"] = i + 1] = "text";
+})(obj2 || (obj2 = {}));
+
+[ 'none', 'text', 0, 1 ].forEach(function (k) {
+   print(k, k in obj2, obj2[k]);
+});


### PR DESCRIPTION
Nested property assignment bug #427 happens in Duktape 1.3.0 but is already fixed in master. This pull provides a test case for the bug, which was probably fixed in #381.
