### PR TITLE
Fix property access handling of inner expression mutating a register-bound variable holding the base value

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1218,6 +1218,10 @@ Planned
 
 * Fix nested property assignment handling (GH-427, GH-428)
 
+* Fix property access expression handling when a variable holding the base
+  value is mutated by other parts of the expression, in both LHS and RHS
+  positions (GH-429)
+
 * Fix Unix local time offset handling which caused issues at least on RISC
   OS (GH-406, GH-407)
 

--- a/src/duk_js_compiler.c
+++ b/src/duk_js_compiler.c
@@ -3792,9 +3792,17 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 	case DUK_TOK_PERIOD: {
 		/* Property access expressions are critical for correct LHS ordering,
 		 * see comments in duk__expr()!
+		 *
+		 * A conservative approach would be to use duk__ivalue_totempconst()
+		 * for 'left'.  However, allowing a reg-bound variable seems safe here
+		 * and is nice because "foo.bar" is a common expression.  If the ivalue
+		 * is used in an expression a GETPROP will occur before any changes to
+		 * the base value can occur.  If the ivalue is used as an assignment
+		 * LHS, the assignment code will ensure the base value is safe from
+		 * RHS mutation.
 		 */
 
-		/* XXX: this now coerces an identifier into a GETVAR to a temp, which
+		/* XXX: This now coerces an identifier into a GETVAR to a temp, which
 		 * causes an extra LDREG in call setup.  It's sufficient to coerce to a
 		 * unary ivalue?
 		 */
@@ -3825,13 +3833,22 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 		/* XXX: optimize temp reg use */
 		/* XXX: similar coercion issue as in DUK_TOK_PERIOD */
-
 		/* XXX: coerce to regs? it might be better for enumeration use, where the
 		 * same PROP ivalue is used multiple times.  Or perhaps coerce PROP further
 		 * there?
 		 */
+		/* XXX: for simple cases like x['y'] an unnecessary LDREG is
+		 * emitted for the base value; could avoid it if we knew that
+		 * the key expression is safe (e.g. just a single literal).
+		 */
 
-		duk__ivalue_toplain(comp_ctx, left);
+		/* The 'left' value must not be a register bound variable
+		 * because it may be mutated during the rest of the expression
+		 * and E5.1 Section 11.2.1 specifies the order of evaluation
+		 * so that the base value is evaluated first.
+		 * See: test-bug-nested-prop-mutate.js.
+		 */
+		duk__ivalue_totempconst(comp_ctx, left);
 		duk__expr_toplain(comp_ctx, res, DUK__BP_FOR_EXPR /*rbp_flags*/);  /* Expression, ']' terminates */
 		duk__advance_expect(comp_ctx, DUK_TOK_RBRACKET);
 

--- a/tests/ecmascript/test-bug-nested-prop-mutate.js
+++ b/tests/ecmascript/test-bug-nested-prop-mutate.js
@@ -1,0 +1,101 @@
+/*
+ *  Property assignment expression cases where the key expression mutates
+ *  the variable holding the base value.
+ */
+
+/*===
+setter called: bar
+name,foo,redirect,bar
+name
+name,foo,bar
+name
+name,bar
+name
+name,bar
+name
+foo
+bar
+===*/
+
+function test1() {
+    var obj1 = { name: 'obj1' };
+    var obj2 = { name: 'obj2' };
+    var obj1orig = obj1;
+
+    // Accessor in property key swaps reference in outer scope.
+    // Works incorrectly in Duktape 1.3.0.
+    Object.defineProperty(obj1, 'foo', {
+        set: function (v) {
+            print('setter called:', v);
+            obj1.redirect = v;
+            obj1 = obj2;
+        }
+    });
+
+    // The outermost 'obj1' must be evaluated to an immutable value (temporary
+    // or constant) before evaluating the rest, because it may get assigned to.
+    obj1[obj1['foo'] = 'bar'] = 'quux';
+
+    print(Object.getOwnPropertyNames(obj1orig));
+    print(Object.getOwnPropertyNames(obj2));
+}
+
+function test2() {
+    var obj1 = { name: 'obj1' };
+    var obj2 = { name: 'obj2' };
+    var obj1orig = obj1;
+
+    // Same effect using comma expression.
+    // Works incorrectly in Duktape 1.3.0.
+    obj1[(obj1['foo'] = 'bar'), (obj1 = obj2), 'bar'] = 'quux';
+
+    print(Object.getOwnPropertyNames(obj1orig));
+    print(Object.getOwnPropertyNames(obj2));
+}
+
+function test3() {
+    var obj1 = { name: 'obj1' };
+    var obj2 = { name: 'obj2' };
+    var obj1orig = obj1;
+
+    // Same effect using comma expression on the RHS.  Works correctly
+    // in Duktape 1.3.0.
+    obj1.bar = ((obj1 = obj2), 'quux');
+
+    print(Object.getOwnPropertyNames(obj1orig));
+    print(Object.getOwnPropertyNames(obj2));
+}
+
+function test4() {
+    var obj1 = { name: 'obj1' };
+    var obj2 = { name: 'obj2' };
+    var obj1orig = obj1;
+
+    // Same effect using comma expression on the RHS, but using a different
+    // property access syntax.  Works correctly in Duktape 1.3.0.
+    obj1['bar'] = ((obj1 = obj2), 'quux');
+
+    print(Object.getOwnPropertyNames(obj1orig));
+    print(Object.getOwnPropertyNames(obj2));
+}
+
+function test5() {
+    var obj1 = { name: 'obj1' };
+
+    // Avoiding an explicit copy from a reg-bound variable to a temporary
+    // would be nice for at least these common cases.
+    obj1.name = 'foo';
+    print(obj1.name);
+    obj1['name'] = 'bar';
+    print(obj1.name);
+}
+
+try {
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bug-propread-mutate.js
+++ b/tests/ecmascript/test-bug-propread-mutate.js
@@ -1,0 +1,30 @@
+/*
+ *  For a property access the base value must be evaluated first to a safe
+ *  temporary/constant which won't be changed if code in the key expression
+ *  assigns to the variable holding the base value.
+ */
+
+/*===
+obj1
+obj1
+obj1
+===*/
+
+function test() {
+    var obj1 = { name: 'obj1' };
+    var obj2 = { name: 'obj2' };
+
+    // For these it'd be nice to avoid an explicit bytecode copy, because
+    // the key won't mutate any state.
+    print(obj1.name);
+    print(obj1['name']);
+
+    // Here a copy must be made.
+    print(obj1[(obj1 = obj2), 'name']);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-mutate-propaccess-in-expr.js
+++ b/tests/ecmascript/test-dev-mutate-propaccess-in-expr.js
@@ -1,0 +1,30 @@
+/*
+ *  Mutate a property access as part of an expression.  Conceptually the lookup
+ *  must happen before proceeding with the expression.
+ */
+
+/*===
+1123
+1123
+===*/
+
+function test1() {
+    var obj = { foo: 123 };
+    var alt = { foo: 234 };
+
+    print(obj.foo + (obj = alt, 1000));
+}
+
+function test2() {
+    var obj = { foo: 123 };
+    var alt = { foo: 234 };
+
+    print(obj['foo'] + (obj = alt, 1000));
+}
+
+try {
+    test1();
+    test2();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-mutate-propaccess-in-rhs.js
+++ b/tests/ecmascript/test-dev-mutate-propaccess-in-rhs.js
@@ -1,0 +1,39 @@
+/*
+ *  Mutate an LHS property access in the RHS.
+ */
+
+/*===
+{"foo":234,"bar":345}
+{"foo":234}
+{"foo":234,"bar":345}
+{"foo":234}
+===*/
+
+function test1() {
+    var alt1 = { foo: 234 };
+    var alt2 = { foo: 234 };
+    var obj;
+
+    obj = alt1;
+    obj.bar = (obj = alt2, 345);
+    print(JSON.stringify(alt1));
+    print(JSON.stringify(alt2));
+}
+
+function test2() {
+    var alt1 = { foo: 234 };
+    var alt2 = { foo: 234 };
+    var obj;
+
+    obj = alt1;
+    obj['bar'] = (obj = alt2, 345);
+    print(JSON.stringify(alt1));
+    print(JSON.stringify(alt2));
+}
+
+try {
+    test1();
+    test2();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-assign-proplhs-reg.js
+++ b/tests/perf/test-assign-proplhs-reg.js
@@ -1,0 +1,140 @@
+/*
+ *  Loading register to property write LHS.
+ */
+
+if (typeof print !== 'function') { prinobj.foo = console.log; }
+
+function test() {
+    var i;
+    var t;
+    var r0 = 123.0;
+    var r1 = 123.1;
+    var r2 = 123.2;
+    var r3 = 123.3;
+    var r4 = 123.4;
+    var r5 = 123.5;
+    var r6 = 123.6;
+    var r7 = 123.7;
+    var r8 = 123.8;
+    var r9 = 123.9;
+    var obj = {};
+
+    for (i = 0; i < 1e6; i++) {
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+
+        obj.foo = r0;
+        obj.foo = r1;
+        obj.foo = r2;
+        obj.foo = r3;
+        obj.foo = r4;
+        obj.foo = r5;
+        obj.foo = r6;
+        obj.foo = r7;
+        obj.foo = r8;
+        obj.foo = r9;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-assign-proprhs.js
+++ b/tests/perf/test-assign-proprhs.js
@@ -1,0 +1,130 @@
+/*
+ *  Loading property read to register.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+    var t;
+    var obj = { foo: 123 };
+
+    for (i = 0; i < 1e6; i++) {
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+        t = obj.foo;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-assign-reg.js
+++ b/tests/perf/test-assign-reg.js
@@ -1,5 +1,5 @@
 /*
- *  Loading constant to register.
+ *  Loading register to register.
  */
 
 if (typeof print !== 'function') { print = console.log; }


### PR DESCRIPTION
A property assignment LHS base value must be evaluated before the rest of the expression, and the expression (e.g. the key of the LHS) may mutate a variable containing the base value. The test case illustrates this best.

This is relatively uncommon in actual code but worth fixing. The fix is to coerce the base value to "temp or const" instead of just "plain" which also allows a register-bound variable (which can then get mutated).

Tasks:

- [x] Add testcase
- [x] Add initial fix
- [x] Assert testcase run
- [x] Perf test run
- [x] Releases entry (bug present in 1.3.0 too)