### PR TITLE
Implement debugger Detach notify

### DIFF
--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1325,6 +1325,31 @@ taken directly from the thrown object if it is an Error instance (after
 augmentation), otherwise these values are calculated from the bytecode
 executor state.
 
+Detaching notification (0x06)
+-----------------------------
+
+Format::
+
+    NFY <int: 6> <int: reason> [<str: msg>] EOM
+
+Example::
+
+    NFY 6 1 "error parsing dvalue" EOM
+
+Reason is one of:
+
+* 0x00: normal detach
+
+* 0x01: detaching due to stream error
+
+Duktape sends a Detaching notification when the debugger is detaching. If the
+target drops the transport without the client seeing this notification, it can
+assume the connection was lost and react accordingly (for example by trying to
+reestablish the link).
+
+``msg`` is an optional string elaborating on the reason for the detach. It may
+or may not be present depending on the nature of detachment.
+
 Commands sent by debug client
 =============================
 

--- a/src/duk_debugger.h
+++ b/src/duk_debugger.h
@@ -20,6 +20,7 @@
 #define DUK_DBG_CMD_ALERT         0x03
 #define DUK_DBG_CMD_LOG           0x04
 #define DUK_DBG_CMD_THROW         0x05
+#define DUK_DBG_CMD_DETACHING     0x06
 
 /* Initiated by debug client */
 #define DUK_DBG_CMD_BASICINFO     0x10

--- a/src/duk_heap.h
+++ b/src/duk_heap.h
@@ -434,6 +434,7 @@ struct duk_heap {
 	duk_bool_t dbg_paused;                  /* currently paused: talk with debug client until step/resume */
 	duk_bool_t dbg_state_dirty;             /* resend state next time executor is about to run */
 	duk_bool_t dbg_force_restart;           /* force executor restart to recheck breakpoints; used to handle function returns (see GH-303) */
+	duk_bool_t dbg_detaching;               /* debugger detaching; used to avoid calling detach handler recursively */
 	duk_small_uint_t dbg_step_type;         /* step type: none, step into, step over, step out */
 	duk_hthread *dbg_step_thread;           /* borrowed; NULL if no step state (NULLed in unwind) */
 	duk_size_t dbg_step_csindex;            /* callstack index */


### PR DESCRIPTION
This implements #423.

When debugger detach is initiated, a notify (`DUK_DBG_CMD_DETACHING = 0x06`) is sent out to let the client know the target is shutting down its end of the transport.  The notify includes an integer flag indicating the reason for the detach, 0 for an intentional detach (Detach command, heap destruction) or 1 for detach due to error (syntax error in debug message, read/write error, etc.).