### PR TITLE
Add duk_is_xxx_error() convenience calls

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1158,6 +1158,9 @@ Planned
 * Add defines DUK_DEFPROP_{SET,CLEAR}_{WRITABLE,ENUMERABLE,CONFIGURABLE} for
   duk_def_prop() to improve call site readability (GH-421)
 
+* Add convenience API calls to detect specific error subtypes, e.g.
+  duk_is_eval_error() (GH-340, GH-433)
+
 * Add a combined duktape.c without #line directives into the dist package,
   as it is a useful alternative in some environments (GH-363)
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -523,6 +523,18 @@ DUK_EXTERNAL_DECL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t 
 DUK_EXTERNAL_DECL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t index);
 #define duk_is_error(ctx,index) \
 	(duk_get_error_code((ctx), (index)) != 0)
+#define duk_is_eval_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_EVAL_ERROR)
+#define duk_is_range_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_RANGE_ERROR)
+#define duk_is_reference_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_REFERENCE_ERROR)
+#define duk_is_syntax_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_SYNTAX_ERROR)
+#define duk_is_type_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_TYPE_ERROR)
+#define duk_is_uri_error(ctx,index) \
+	(duk_get_error_code((ctx), (index)) == DUK_ERR_URI_ERROR)
 
 /*
  *  Get operations: no coercion, returns default value for invalid

--- a/tests/api/test-get-error-code-is-error.c
+++ b/tests/api/test-get-error-code-is-error.c
@@ -4,35 +4,35 @@
 
 /*===
 *** test_basic (duk_safe_call)
-index 0: type=1 errcode=0 is_error=0
-index 1: type=2 errcode=0 is_error=0
-index 2: type=3 errcode=0 is_error=0
-index 3: type=3 errcode=0 is_error=0
-index 4: type=4 errcode=0 is_error=0
-index 5: type=4 errcode=0 is_error=0
-index 6: type=4 errcode=0 is_error=0
-index 7: type=4 errcode=0 is_error=0
-index 8: type=5 errcode=0 is_error=0
-index 9: type=5 errcode=0 is_error=0
-index 10: type=6 errcode=0 is_error=0
-index 11: type=6 errcode=0 is_error=0
-index 12: type=7 errcode=0 is_error=0
-index 13: type=7 errcode=0 is_error=0
-index 14: type=7 errcode=0 is_error=0
-index 15: type=7 errcode=0 is_error=0
-index 16: type=8 errcode=0 is_error=0
-index 17: type=8 errcode=0 is_error=0
-index 18: type=6 errcode=100 is_error=1
-index 19: type=6 errcode=101 is_error=1
-index 20: type=6 errcode=102 is_error=1
-index 21: type=6 errcode=103 is_error=1
-index 22: type=6 errcode=104 is_error=1
-index 23: type=6 errcode=105 is_error=1
-index 24: type=6 errcode=106 is_error=1
-index 25: type=6 errcode=106 is_error=1
-index 26: type=6 errcode=100 is_error=1
-index 27: type=6 errcode=100 is_error=1
-index 28: type=6 errcode=100 is_error=1
+index 0: type=1 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 1: type=2 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 2: type=3 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 3: type=3 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 4: type=4 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 5: type=4 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 6: type=4 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 7: type=4 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 8: type=5 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 9: type=5 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 10: type=6 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 11: type=6 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 12: type=7 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 13: type=7 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 14: type=7 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 15: type=7 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 16: type=8 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 17: type=8 errcode=0 is_error=0 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 18: type=6 errcode=100 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 19: type=6 errcode=101 is_error=1 eval=1 range=0 reference=0 syntax=0 type=0 uri=0
+index 20: type=6 errcode=102 is_error=1 eval=0 range=1 reference=0 syntax=0 type=0 uri=0
+index 21: type=6 errcode=103 is_error=1 eval=0 range=0 reference=1 syntax=0 type=0 uri=0
+index 22: type=6 errcode=104 is_error=1 eval=0 range=0 reference=0 syntax=1 type=0 uri=0
+index 23: type=6 errcode=105 is_error=1 eval=0 range=0 reference=0 syntax=0 type=1 uri=0
+index 24: type=6 errcode=106 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=1
+index 25: type=6 errcode=106 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=1
+index 26: type=6 errcode=100 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 27: type=6 errcode=100 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
+index 28: type=6 errcode=100 is_error=1 eval=0 range=0 reference=0 syntax=0 type=0 uri=0
 final top: 29
 ==> rc=0, result='undefined'
 *** test_protoloop_code (duk_safe_call)
@@ -95,9 +95,17 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	duk_pcall(ctx, 0);
 
 	for (n = duk_get_top(ctx), i = 0; i < n; i++) {
-		printf("index %ld: type=%ld errcode=%ld is_error=%ld\n",
-		       (long) i, (long) duk_get_type(ctx, i),
-		       (long) duk_get_error_code(ctx, i), (long) duk_is_error(ctx, i));
+		printf("index %ld: type=%ld errcode=%ld is_error=%ld eval=%ld range=%ld reference=%ld syntax=%ld type=%ld uri=%ld\n",
+		       (long) i,
+		       (long) duk_get_type(ctx, i),
+		       (long) duk_get_error_code(ctx, i),
+		       (long) duk_is_error(ctx, i),
+		       (long) duk_is_eval_error(ctx, i),
+		       (long) duk_is_range_error(ctx, i),
+		       (long) duk_is_reference_error(ctx, i),
+		       (long) duk_is_syntax_error(ctx, i),
+		       (long) duk_is_type_error(ctx, i),
+		       (long) duk_is_uri_error(ctx, i));
 	}
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));

--- a/website/api/duk_is_eval_error.yaml
+++ b/website/api/duk_is_eval_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_eval_error
+
+proto: |
+  duk_bool_t duk_is_eval_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>EvalError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_EVAL_ERROR</code>.</p>
+
+example: |
+  if (duk_is_eval_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0

--- a/website/api/duk_is_range_error.yaml
+++ b/website/api/duk_is_range_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_range_error
+
+proto: |
+  duk_bool_t duk_is_range_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>RangeError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_RANGE_ERROR</code>.</p>
+
+example: |
+  if (duk_is_range_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0

--- a/website/api/duk_is_reference_error.yaml
+++ b/website/api/duk_is_reference_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_reference_error
+
+proto: |
+  duk_bool_t duk_is_reference_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>ReferenceError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_REFERENCE_ERROR</code>.</p>
+
+example: |
+  if (duk_is_reference_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0

--- a/website/api/duk_is_syntax_error.yaml
+++ b/website/api/duk_is_syntax_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_syntax_error
+
+proto: |
+  duk_bool_t duk_is_syntax_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>SyntaxError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_SYNTAX_ERROR</code>.</p>
+
+example: |
+  if (duk_is_syntax_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0

--- a/website/api/duk_is_type_error.yaml
+++ b/website/api/duk_is_type_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_type_error
+
+proto: |
+  duk_bool_t duk_is_type_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>TypeError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_TYPE_ERROR</code>.</p>
+
+example: |
+  if (duk_is_type_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0

--- a/website/api/duk_is_uri_error.yaml
+++ b/website/api/duk_is_uri_error.yaml
@@ -1,0 +1,24 @@
+name: duk_is_uri_error
+
+proto: |
+  duk_bool_t duk_is_uri_error(duk_context *ctx, duk_idx_t index);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>index</code> inherits from <code>URIError</code>,
+  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  a convenience call for using
+  <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_URI_ERROR</code>.</p>
+
+example: |
+  if (duk_is_uri_error(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - error
+
+introduced: 1.4.0


### PR DESCRIPTION
Currently to detect e.g. a URI error:

```c
if (duk_get_error_code(ctx, -3) == DUK_ERR_URI_ERROR) {
    /* ... */
}
```

Using the convenience calls:

```c
if (duk_is_uri_error(ctx, -3)) {
    /* ... */
}
```

Fixes #340.