### PR TITLE
Minor debugger (and other) cleanups

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1152,6 +1152,9 @@ Planned
 * Add a debugger Throw notify for errors about to be thrown, and an option
   to automatically pause before an uncaught error is thrown (GH-286, GH-347)
 
+* Add a debugger Detaching notify which informs a debug client of an orderly
+  (or non-orderly) pending detach (GH-423, GH-430, GH-434)
+
 * Allow debugger detached callback to call duk_debugger_attach(), previously
   this clobbered some internal state (GH-399)
 

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -10,7 +10,7 @@ Overview
 
 Duktape provides the following basic debugging features:
 
-* Execution status: running/paused at file/line, call stack, local variables
+* Execution status: running/paused at file/line, callstack, local variables
 
 * Execution control: pause, resume, step over, step into, step out
 
@@ -1320,7 +1320,7 @@ Fatal is one of:
 Duktape sends a Throw notification whenever an error is thrown, either by
 Duktape due to a runtime error or directly by Ecmascript code.
 
-msg is the string-coerced value being thrown. Filename and line number are
+msg is the string-coerced value being thrown.  Filename and line number are
 taken directly from the thrown object if it is an Error instance (after
 augmentation), otherwise these values are calculated from the bytecode
 executor state.
@@ -1342,12 +1342,12 @@ Reason is one of:
 
 * 0x01: detaching due to stream error
 
-Duktape sends a Detaching notification when the debugger is detaching. If the
+Duktape sends a Detaching notification when the debugger is detaching.  If the
 target drops the transport without the client seeing this notification, it can
 assume the connection was lost and react accordingly (for example by trying to
 reestablish the link).
 
-``msg`` is an optional string elaborating on the reason for the detach. It may
+``msg`` is an optional string elaborating on the reason for the detach.  It may
 or may not be present depending on the nature of detachment.
 
 Commands sent by debug client
@@ -1546,7 +1546,7 @@ Example::
     REP 1 "myValue" EOM
 
 Level specifies the callstack depth, where -1 is the topmost (current) function,
--2 is the calling function, etc. If not provided, the topmost function will be
+-2 is the calling function, etc.  If not provided, the topmost function will be
 used.
 
 PutVar request (0x1b)
@@ -1563,7 +1563,7 @@ Example::
     REP EOM
 
 Level specifies the callstack depth, where -1 is the topmost (current) function,
--2 is the calling function, etc. If not provided, the topmost function will be
+-2 is the calling function, etc.  If not provided, the topmost function will be
 used.
 
 GetCallStack request (0x1c)
@@ -1578,6 +1578,8 @@ Example::
 
     REQ 28 EOM
     REP "foo.js" "doStuff" 100 317 "bar.js" "doOtherStuff" 210 880 EOM
+
+List callstack entries from top to bottom.
 
 GetLocals request (0x1d)
 ------------------------
@@ -1594,7 +1596,7 @@ Example::
 
 List local variable names from specified activation (the internal ``_Varmap``).
 Level specifies the callstack depth, where -1 is the topmost (current) function,
--2 is the calling function, etc. If not provided, the topmost function will be
+-2 is the calling function, etc.  If not provided, the topmost function will be
 used.
 
 The result includes only local variables declared with ``var`` and locally
@@ -1620,11 +1622,10 @@ Example::
     REP 0 3 EOM
 
 Level specifies the callstack depth, where -1 is the topmost (current) function,
--2 is the calling function, etc. If not provided, the topmost function will be
-used (as with a real ``eval()``).
-
-Note that the full callstack will be visible to, e.g. ``Duktape.act()`` called
-from the Eval'd code, regardless of the callstack index provided.
+-2 is the calling function, etc.  If not provided, the topmost function will be
+used (as with a real ``eval()``).  The level affects only the lexical scope of
+the code evaluated.  The callstack will be intact, and will be visible in e.g.
+stack traces and ``Duktape.act()``.
 
 The eval expression is evaluated as if a "direct call" to eval was executed
 in the position where execution has paused, in the lexical scope specified by
@@ -1746,7 +1747,7 @@ Ecmascript has a debugger statement::
 The E5 specification states that:
 
     Evaluating the DebuggerStatement production may allow an implementation
-    to cause a breakpoint when run under a debugger. If a debugger is not
+    to cause a breakpoint when run under a debugger.  If a debugger is not
     present or active this statement has no observable effect.
 
 Other Ecmascript engines typically treat a debugger statement as a breakpoint:
@@ -2024,7 +2025,7 @@ The step state is rather tricky:
   not matter).  Execute in normal mode (unless there are breakpoints, of course).
   If the activation is unwound for any reason, enter paused mode.  This means
   that if an error is thrown, we resume execution in the catcher.  Step out
-  handling is concretely implemented as part of call stack unwinding, which
+  handling is concretely implemented as part of callstack unwinding, which
   differs completely from how other step commands are implemented.
 
   A coroutine yield does not trigger a "step out" because the callstack is not

--- a/src/duk_bi_global.c
+++ b/src/duk_bi_global.c
@@ -450,14 +450,14 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 	}
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-	/*  NOTE: level is used only by the debugger and should never be present
-	 *  for an Ecmascript eval().
+	/* NOTE: level is used only by the debugger and should never be present
+	 * for an Ecmascript eval().
 	 */
-	level = -2;  /* by default, use caller's environment */
+	DUK_ASSERT(level == -2);  /* by default, use caller's environment */
 	if (duk_get_top(ctx) >= 2 && duk_is_number(ctx, 1)) {
 		level = duk_get_int(ctx, 1);
 	}
-	DUK_ASSERT(level <= -2);
+	DUK_ASSERT(level <= -2);  /* This is guaranteed by debugger code. */
 #endif
 
 	/* [ source ] */

--- a/src/duk_debug.h
+++ b/src/duk_debug.h
@@ -173,7 +173,7 @@ DUK_INTERNAL_DECL duk_small_int_t duk_debug_level_stash;
 DUK_INTERNAL_DECL void duk_debug_log(const char *fmt, ...);
 #endif  /* DUK_USE_VARIADIC_MACROS */
 
-DUK_INTERNAL_DECL void duk_fb_put_bytes(duk_fixedbuffer *fb, duk_uint8_t *buffer, duk_size_t length);
+DUK_INTERNAL_DECL void duk_fb_put_bytes(duk_fixedbuffer *fb, const duk_uint8_t *buffer, duk_size_t length);
 DUK_INTERNAL_DECL void duk_fb_put_byte(duk_fixedbuffer *fb, duk_uint8_t x);
 DUK_INTERNAL_DECL void duk_fb_put_cstring(duk_fixedbuffer *fb, const char *x);
 DUK_INTERNAL_DECL void duk_fb_sprintf(duk_fixedbuffer *fb, const char *fmt, ...);

--- a/src/duk_debug_fixedbuffer.c
+++ b/src/duk_debug_fixedbuffer.c
@@ -7,7 +7,7 @@
 
 #ifdef DUK_USE_DEBUG
 
-DUK_INTERNAL void duk_fb_put_bytes(duk_fixedbuffer *fb, duk_uint8_t *buffer, duk_size_t length) {
+DUK_INTERNAL void duk_fb_put_bytes(duk_fixedbuffer *fb, const duk_uint8_t *buffer, duk_size_t length) {
 	duk_size_t avail;
 	duk_size_t copylen;
 
@@ -23,11 +23,11 @@ DUK_INTERNAL void duk_fb_put_bytes(duk_fixedbuffer *fb, duk_uint8_t *buffer, duk
 }
 
 DUK_INTERNAL void duk_fb_put_byte(duk_fixedbuffer *fb, duk_uint8_t x) {
-	duk_fb_put_bytes(fb, &x, 1);
+	duk_fb_put_bytes(fb, (const duk_uint8_t *) &x, 1);
 }
 
 DUK_INTERNAL void duk_fb_put_cstring(duk_fixedbuffer *fb, const char *x) {
-	duk_fb_put_bytes(fb, (duk_uint8_t *) x, (duk_size_t) DUK_STRLEN(x));
+	duk_fb_put_bytes(fb, (const duk_uint8_t *) x, (duk_size_t) DUK_STRLEN(x));
 }
 
 DUK_INTERNAL void duk_fb_sprintf(duk_fixedbuffer *fb, const char *fmt, ...) {

--- a/src/duk_util.h
+++ b/src/duk_util.h
@@ -475,7 +475,9 @@ DUK_INTERNAL_DECL duk_uint8_t duk_util_probe_steps[32];
 #endif  /* !DUK_SINGLE_FILE */
 #endif
 
+#if defined(DUK_USE_STRHASH_DENSE)
 DUK_INTERNAL_DECL duk_uint32_t duk_util_hashbytes(const duk_uint8_t *data, duk_size_t len, duk_uint32_t seed);
+#endif
 
 #if defined(DUK_USE_HOBJECT_HASH_PART) || defined(DUK_USE_STRTAB_PROBE)
 DUK_INTERNAL_DECL duk_uint32_t duk_util_get_hash_prime(duk_uint32_t size);


### PR DESCRIPTION
Summary of changes:
- Debugger cleanups for callstack level changes, add ability to test callstack level using JSON proxy
- Debugger cleanups for Detaching notify
- String hash declaration warning fix (declared but not defined when dense string hash not in used)
- -Wcast-qual fix for duk_debug_fixedbuffer.c
- Releases entry for Detaching notify

Tasks:
- [x] Review changes
- [x] Decide whether to implement callstack level support into debugger web UI in this pull => separate pull
- [x] Rename is_err to reason in detach macro, change typing