### PR TITLE
Improve JSON.stringify() Proxy tests

### DIFF
--- a/doc/testcase-known-issues.yaml
+++ b/doc/testcase-known-issues.yaml
@@ -87,6 +87,9 @@
 -
   test: "test-bug-dataview-buffer-prop.js"
   knownissue: "DataView .buffer property misleading when DataView argument is not an ArrayBuffer (custom behavior)"
+-
+  test: "test-bi-json-enc-proxy.js"
+  knownissue: "JSON enumeration behavior for Proxy targets is incomplete and uses 'enumerate' trap instead of 'ownKeys' trap"
 
 # Ecmascript testcases that need special options or environment to work
 

--- a/src/duk_bi_object.c
+++ b/src/duk_bi_object.c
@@ -484,6 +484,12 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 		}
 	}
 
+	/* XXX: missing trap result validation for non-configurable target keys
+	 * (must be present), for non-extensible target all target keys must be
+	 * present and no extra keys can be present.
+	 * http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+	 */
+
 	/* XXX: for Object.keys() the [[OwnPropertyKeys]] result (trap result)
 	 * should be filtered so that only enumerable keys remain.  Enumerability
 	 * should be checked with [[GetOwnProperty]] on the original object

--- a/tests/ecmascript/test-bi-json-enc-proxy.js
+++ b/tests/ecmascript/test-bi-json-enc-proxy.js
@@ -7,7 +7,11 @@
 {"foo":345}
 ===*/
 
-function jsonStringifyProxyTest() {
+/* Minimal case where Proxy has no traps that interfere with JSON
+ * stringification.
+ */
+
+function jsonStringifyNakedProxyTest() {
     var target, proxy, obj;
 
     // Here keys to be enumerated are from the target object.
@@ -23,37 +27,94 @@ function jsonStringifyProxyTest() {
     target.foo = 123;  // serialized
     proxy = new Proxy(target, { get: function () { return 345; } });
     print(JSON.stringify(proxy));
+}
+
+try {
+    jsonStringifyNakedProxyTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+ownKeys should be called
+{"foo":"key-foo","quux":"key-quux"}
+ownKeys should be called
+getOwnPropertyDescriptor for foo
+getOwnPropertyDescriptor for quux
+getOwnPropertyDescriptor for baz
+getOwnPropertyDescriptor for nonEnumerable
+{"foo":"key-foo","quux":"key-quux","baz":"key-baz"}
+===*/
+
+/* Proxy 'ownKeys' trap is consulted, 'enumerate' trap is NOT consulted.
+ * This has been verified to match Firefox behavior.
+ */
+
+function jsonStringifyOwnKeysProxyTest() {
+    var target, proxy, obj;
 
     // 'keys' trap is invoked to figure out keys to serialize
     // - JSON.stringify() calls internal function: http://www.ecma-international.org/ecma-262/6.0/#sec-serializejsonobject
     // - SerializeJSONObject() calls internal function: http://www.ecma-international.org/ecma-262/6.0/#sec-enumerableownnames
     // - EnumerableOwnNames() calls O.[[OwnPropertyKeys]]
     // - Proxy [[OwnPropertyKeys]] calls 'ownKeys' trap: http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
-    // - XXX: must go through the post-processing to ensure the testcase is correct
+    // - Assuming 'ownKeys' trap result validation succeeds, EnumerableOwnNames() filters out non-enumerable target properties;
+    //   the property descriptor is obtained using [[GetOwnProperty]] which may invoke further traps
+    // - EnumerableOwnNames() reorders the resulting keys to match [[Enumerate]] order
+    //   (not sure what to do with a trap result?)
 
-    /* XXX: this test is disabled until the proper expect string is in place
-
-    target = { foo: 123, bar: 234, quux: 345 };
+    target = { foo: 123, bar: 234, quux: 345, nonEnumerable: 456 };
+    Object.defineProperty(target, 'nonEnumerable', { enumerable: false });
     proxy = new Proxy(target, {
         get: function (targ, key, recv) {
             return 'key-' + key;
         },
         enumerate: function () {
             print('enumerate should not be called');
-            return [];
+            return [ 'quux' ];
         },
         ownKeys: function () {
-            // ownKeys is called to decide what properties to serialize
+            // ownKeys is called to decide what properties to serialize.
+            // Non-enumerable properties are filtered out from JSON result.
             print('ownKeys should be called');
-            return [ 'foo', 'quux', 'baz' ];
+            return [ 'foo', 'quux', 'baz', 'nonEnumerable' ];
         }
     });
     print(JSON.stringify(proxy));
-    */
+
+    // With 'getOwnPropertyDescriptor' present that gets consulted to figure
+    // out what 'ownKeys' result keys are enumerable.
+
+    target = { foo: 123, bar: 234, quux: 345, nonEnumerable: 456 };
+    proxy = new Proxy(target, {
+        getOwnPropertyDescriptor: function (targ, key) {
+            print('getOwnPropertyDescriptor for ' + key);
+            return {
+                value: 'key-' + key,
+                writable: false,
+                enumerable: (key === 'nonEnumerable' ? false : true),
+                configurable: true
+            };
+        },
+        get: function (targ, key, recv) {
+            return 'key-' + key;
+        },
+        enumerate: function () {
+            print('enumerate should not be called');
+            return [ 'quux' ];
+        },
+        ownKeys: function () {
+            // ownKeys is called to decide what properties to serialize.
+            // Non-enumerable properties are filtered out from JSON result.
+            print('ownKeys should be called');
+            return [ 'foo', 'quux', 'baz', 'nonEnumerable' ];
+        }
+    });
+    print(JSON.stringify(proxy));
 }
 
 try {
-    jsonStringifyProxyTest();
+    jsonStringifyOwnKeysProxyTest();
 } catch (e) {
     print(e.stack || e);
 }

--- a/website/guide/es6features.html
+++ b/website/guide/es6features.html
@@ -19,7 +19,7 @@ the following non-standard semantics:</p>
     not writable.</li>
 <li>Const variables are function scoped and "hoisted" to the top of the
     function like <code>var</code> declarations.  In ES6 <code>const</code>
-    has block scoping like <code>let</code>.
+    has block scoping like <code>let</code>.</li>
 </ul>
 
 <h2 id="es6-proto">Object.setPrototypeOf and Object.prototype.__proto__</h2>
@@ -60,7 +60,7 @@ ES6.  The following traps are implemented:</p>
 <tr><td class="propname">set</td><td>yes</td><td></td></tr>
 <tr><td class="propname">deleteProperty</td><td>yes</td><td></td></tr>
 <tr><td class="propname">enumerate</td><td>yes</td><td></td></tr>
-<tr><td class="propname">ownKeys</td><td>yes</td><td><code>Object.keys()</code> enumerability check limitation</td></tr>
+<tr><td class="propname">ownKeys</td><td>yes</td><td><code>Object.keys()</code> enumerability check limitation, trap result validation (non-configurable properties, non-extensible target) not done</td></tr>
 <tr><td class="propname">apply</td><td>no</td><td></td></tr>
 <tr><td class="propname">construct</td><td>no</td><td></td></tr>
 </tbody>
@@ -75,6 +75,10 @@ ES6.  The following traps are implemented:</p>
     by the trap are enumerable.  <code>Object.keys()</code> and <code>Object.getOwnPropertyNames()</code>
     thus currently return the same value for a proxy object implementing the <code>ownKeys</code>
     trap.</li>
+<li>Proxy trap results are not validated, e.g. <code>ownKeys</code> trap result validation
+    steps described in <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">[[OwnPropertyKeys]] ()</a>
+    for non-configurable target properties and/or non-extensible target object are not
+    yet implemented.</li>
 <li>Proxy revocation feature of ES6 is not supported.</li>
 <li>The target and handler objects given to <code>new Proxy()</code> cannot
     be proxy objects themselves.  ES6 poses no such limitation, but Duktape


### PR DESCRIPTION
Add basic tests to cover how a Proxy should be treated during JSON.stringify():

- The 'ownKeys' trap should be invoked (right now Duktape invokes 'enumerate' instead).
- The 'ownKeys' trap result is validated, non-enumerable keys are filtered (possibly invoking 'getOwnPropertyDescriptor' trap in the process)

Document known limitation for test case.

Fixes #328.