### PR TITLE
Add some NORZ (no-refzero free) refcount macros

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1961,7 +1961,7 @@ Planned
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for
   Array .length coercion (GH-862); value stack operation optimization
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
-  opcode handler optimizations (GH-903)
+  opcode handler optimizations (GH-903); refcount optimizations (GH-443)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -414,15 +414,19 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t idx) {
 		/* Stack size decreases. */
 #if defined(DUK_USE_REFERENCE_COUNTING)
 		duk_uidx_t count;
+		duk_tval *tv_end;
 
 		count = vs_size - uidx;
 		DUK_ASSERT(count > 0);
-		while (count > 0) {
-			count--;
-			tv = --thr->valstack_top;  /* tv -> value just before prev top value; must relookup */
+		tv_end = thr->valstack_top - count;
+		tv = thr->valstack_top;
+		do {
+			tv--;
 			DUK_ASSERT(tv >= thr->valstack_bottom);
-			DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv);  /* side effects */
-		}
+			DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, tv);
+		} while (tv != tv_end);
+		thr->valstack_top = tv_end;
+		DUK_REFZERO_CHECK(thr);
 #else  /* DUK_USE_REFERENCE_COUNTING */
 		duk_uidx_t count;
 		duk_tval *tv_end;

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -569,6 +569,7 @@ DUK_INTERNAL_DECL void *duk_heap_mem_realloc_indirect(duk_heap *heap, duk_mem_ge
 DUK_INTERNAL_DECL void duk_heap_mem_free(duk_heap *heap, void *ptr);
 
 #ifdef DUK_USE_REFERENCE_COUNTING
+DUK_INTERNAL_DECL void duk_refzero_free_pending(duk_hthread *thr);
 #if !defined(DUK_USE_FAST_REFCOUNT_DEFAULT)
 DUK_INTERNAL_DECL void duk_tval_incref(duk_tval *tv);
 #endif
@@ -576,6 +577,7 @@ DUK_INTERNAL_DECL void duk_tval_incref(duk_tval *tv);
 DUK_INTERNAL_DECL void duk_tval_incref_allownull(duk_tval *tv);
 #endif
 DUK_INTERNAL_DECL void duk_tval_decref(duk_hthread *thr, duk_tval *tv);
+DUK_INTERNAL_DECL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv);
 #if 0  /* unused */
 DUK_INTERNAL_DECL void duk_tval_decref_allownull(duk_hthread *thr, duk_tval *tv);
 #endif
@@ -586,8 +588,12 @@ DUK_INTERNAL_DECL void duk_heaphdr_incref(duk_heaphdr *h);
 DUK_INTERNAL_DECL void duk_heaphdr_incref_allownull(duk_heaphdr *h);
 #endif
 DUK_INTERNAL_DECL void duk_heaphdr_decref(duk_hthread *thr, duk_heaphdr *h);
+#if 0  /* unused */
+DUK_INTERNAL_DECL void duk_heaphdr_decref_norz(duk_hthread *thr, duk_heaphdr *h);
+#endif
 DUK_INTERNAL_DECL void duk_heaphdr_decref_allownull(duk_hthread *thr, duk_heaphdr *h);
 DUK_INTERNAL_DECL void duk_heaphdr_refzero(duk_hthread *thr, duk_heaphdr *h);
+DUK_INTERNAL_DECL void duk_heaphdr_refzero_norz(duk_hthread *thr, duk_heaphdr *h);
 DUK_INTERNAL_DECL void duk_heaphdr_refcount_finalize(duk_hthread *thr, duk_heaphdr *hdr);
 #else
 /* no refcounting */

--- a/tests/perf/test-object-garbage-2.js
+++ b/tests/perf/test-object-garbage-2.js
@@ -1,0 +1,33 @@
+function test() {
+    var i;
+    var t;
+
+    for (i = 0; i < 2e5; i++) {
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+        t = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, quuuux: 6, quuuuux: 7, quuuuuux: 8, quuuuuuux: 9, quuuuuuuux: 10 };
+        t = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Add some "no-refzero free" refcount macros. The macros will decref the target value normally, and if the refcount becomes zero, queue the object for refzero handling. However, the refzero queue won't be processed so there are no side effects. This allows multiple refcount operations to be done without potentially invalidating pointers in the middle due to side effects.

- [x] Clean up changes
- [x] Prototype usage in a few locations for perf impact
- [x] Releases entry