### PR TITLE
Simplify JSON.stringify() slow path indent handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1224,6 +1224,9 @@ Planned
 * Internal performance improvement: optimize internal refcount handling
   macros (GH-394)
 
+* Internal performance improvement: improve JSON.stringify() default slow
+  path indent handling (GH-444)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/src/duk_json.h
+++ b/src/duk_json.h
@@ -28,7 +28,6 @@ typedef struct {
 	duk_bufwriter_ctx bw;        /* output bufwriter */
 	duk_hobject *h_replacer;     /* replacer function */
 	duk_hstring *h_gap;          /* gap (if empty string, NULL) */
-	duk_hstring *h_indent;       /* current indent (if gap is NULL, this is NULL) */
 	duk_idx_t idx_proplist;      /* explicit PropertyList */
 	duk_idx_t idx_loop;          /* valstack index of loop detection object */
 	duk_small_uint_t flags;

--- a/tests/ecmascript/test-bi-json-enc-indents.js
+++ b/tests/ecmascript/test-bi-json-enc-indents.js
@@ -1,0 +1,999 @@
+/*
+ *  Exercise indent depths with spaces and string gap.  Ensures optimized
+ *  indent handling works correctly for all code paths.
+ */
+
+/*===
+{
+  "foo": "bar"
+}
+{
+    "foo": "bar"
+}
+{
+<abcdefghi"foo": "bar"
+}
+{
+  "foo": {
+    "foo": "bar"
+  }
+}
+{
+    "foo": {
+        "foo": "bar"
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": "bar"
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": "bar"
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": "bar"
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": "bar"
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": "bar"
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": "bar"
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": "bar"
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": "bar"
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": "bar"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": "bar"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": "bar"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": "bar"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": "bar"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": "bar"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": "bar"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": "bar"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": "bar"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": "bar"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": "bar"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": "bar"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": {
+                          "foo": "bar"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": {
+                                                    "foo": "bar"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": {
+                          "foo": {
+                            "foo": "bar"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": {
+                                                    "foo": {
+                                                        "foo": "bar"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": {
+                          "foo": {
+                            "foo": {
+                              "foo": "bar"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": {
+                                                    "foo": {
+                                                        "foo": {
+                                                            "foo": "bar"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": {
+                          "foo": {
+                            "foo": {
+                              "foo": {
+                                "foo": "bar"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": {
+                                                    "foo": {
+                                                        "foo": {
+                                                            "foo": {
+                                                                "foo": "bar"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+{
+  "foo": {
+    "foo": {
+      "foo": {
+        "foo": {
+          "foo": {
+            "foo": {
+              "foo": {
+                "foo": {
+                  "foo": {
+                    "foo": {
+                      "foo": {
+                        "foo": {
+                          "foo": {
+                            "foo": {
+                              "foo": {
+                                "foo": {
+                                  "foo": "bar"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+{
+    "foo": {
+        "foo": {
+            "foo": {
+                "foo": {
+                    "foo": {
+                        "foo": {
+                            "foo": {
+                                "foo": {
+                                    "foo": {
+                                        "foo": {
+                                            "foo": {
+                                                "foo": {
+                                                    "foo": {
+                                                        "foo": {
+                                                            "foo": {
+                                                                "foo": {
+                                                                    "foo": "bar"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+{
+<abcdefghi"foo": {
+<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": {
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi"foo": "bar"
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi<abcdefghi}
+<abcdefghi<abcdefghi}
+<abcdefghi}
+}
+===*/
+
+function mkobj(n) {
+    var obj = { foo: 'bar' };
+    while (n-- > 0) {
+        obj = { foo: obj };
+    }
+    return obj;
+}
+
+function test() {
+    // 0...16 should exercise current code paths sufficiently
+    for (var i = 0; i <= 16; i++) {
+        print(JSON.stringify(mkobj(i), null, 2));
+        print(JSON.stringify(mkobj(i), null, 4));
+        print(JSON.stringify(mkobj(i), null, '<abcdefghijklmnopq>'));  // intentionally >10 chars, will be truncated to 10
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-json-enc-nul-in-gap.js
+++ b/tests/ecmascript/test-bi-json-enc-nul-in-gap.js
@@ -1,0 +1,32 @@
+/*
+ *  Ensure gap/indent handling deals with NUL codepoints correctly.
+ */
+
+/*===
+{
+--<NUL>-->"foo": 1,
+--<NUL>-->"bar": 2,
+--<NUL>-->"quux": 3,
+--<NUL>-->"baz": [
+--<NUL>-->--<NUL>-->1,
+--<NUL>-->--<NUL>-->2,
+--<NUL>-->--<NUL>-->3
+--<NUL>-->]
+}
+===*/
+
+function nulInGapTest() {
+    var obj = { foo: 1, bar: 2, quux: 3, baz: [ 1, 2, 3 ] };
+    var res;
+
+    // NUL in the middle of gap should not be an issue.
+    res = JSON.stringify(obj, null, '--\u0000-->');
+
+    print(res.replace(/\u0000/g, '<NUL>'));
+}
+
+try {
+    nulInGapTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-json-serialize-indented-deep100.js
+++ b/tests/perf/test-json-serialize-indented-deep100.js
@@ -1,0 +1,39 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function build() {
+    var obj = {};
+
+    // "fast" leaf values only, this test is just for indentation handling
+    obj.key1 = 'foo';
+    obj.key2 = 'bar';
+    obj.key3 = 'quux';
+    obj.key4 = 'baz';
+    obj.key5 = 'quuux';
+    obj.key6 = [ 'foo', 'bar', 'quux', 'baz', 'quuux' ];
+    obj.key7 = [ undefined, null, true, 123, {}, {}, {} ];
+
+    for (var i = 0; i < 100; i++) {
+        obj = { foo: obj };
+    }
+
+    return obj;
+}
+
+function test() {
+    var obj;
+    var i;
+    var ignore;
+
+    obj = build();
+    for (i = 0; i < 1e4; i++) {
+        ignore = JSON.stringify(obj, null, 4);
+    }
+    //print(ignore);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-json-serialize-indented-deep500.js
+++ b/tests/perf/test-json-serialize-indented-deep500.js
@@ -1,0 +1,39 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function build() {
+    var obj = {};
+
+    // "fast" leaf values only, this test is just for indentation handling
+    obj.key1 = 'foo';
+    obj.key2 = 'bar';
+    obj.key3 = 'quux';
+    obj.key4 = 'baz';
+    obj.key5 = 'quuux';
+    obj.key6 = [ 'foo', 'bar', 'quux', 'baz', 'quuux' ];
+    obj.key7 = [ undefined, null, true, 123, {}, {}, {} ];
+
+    for (var i = 0; i < 500; i++) {
+        obj = { foo: obj };
+    }
+
+    return obj;
+}
+
+function test() {
+    var obj;
+    var i;
+    var ignore;
+
+    obj = build();
+    for (i = 0; i < 1e3; i++) {
+        ignore = JSON.stringify(obj, null, 4);
+    }
+    //print(ignore);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-json-serialize-indented.js
+++ b/tests/perf/test-json-serialize-indented.js
@@ -1,0 +1,47 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function build() {
+    var obj = {};
+
+    // "fast" leaf values only, this test is just for indentation handling
+    obj.key1 = 'foo';
+    obj.key2 = 'bar';
+    obj.key3 = 'quux';
+    obj.key4 = 'baz';
+    obj.key5 = 'quuux';
+    obj.key6 = [ 'foo', 'bar', 'quux', 'baz', 'quuux' ];
+    obj.key7 = [ undefined, null, true, 123, {}, {}, {} ];
+
+    return {
+        foo: [
+            obj
+        ],
+        bar: {
+            quux: {
+                baz: obj,
+                quuux: {
+                    quuuux: obj
+                }
+            }
+        }
+    };
+}
+
+function test() {
+    var obj;
+    var i;
+    var ignore;
+
+    obj = build();
+    for (i = 0; i < 1e5; i++) {
+        ignore = JSON.stringify(obj, null, 4);
+    }
+    //print(ignore);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
Current implementation uses explicit dynamic `h_indent` but for most inputs it's better to copy `h_gap` N times in a loop. This avoids string table churn for the dynamic indent strings and works better for fast path pull later on. The resulting code is a bit smaller and a bit faster for indent handling.

- [x] Finalize change, compare to specification gap/stepback handling
- [x] Trivial indent helper variant for size optimized build (loop and emit hstring)
- [x] Assert test runs
- [x] Performance test run
- [x] Releases