### PR TITLE
Improve JSON.stringify() slow path loop detection performance

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1224,8 +1224,8 @@ Planned
 * Internal performance improvement: optimize internal refcount handling
   macros (GH-394)
 
-* Internal performance improvement: improve JSON.stringify() default slow
-  path indent handling (GH-444)
+* Internal performance improvement: improve JSON.stringify() slow path
+  indentation and loop detection performance (GH-444, GH-446)
 
 * Internal performance improvement: improve JSON.stringify() fast path
   by allowing indent value or gap string and by supporting JX/JC in the

--- a/src/duk_json.h
+++ b/src/duk_json.h
@@ -17,10 +17,8 @@
 /* How much stack to require on entry to object/array decode */
 #define DUK_JSON_DEC_REQSTACK                 32
 
-/* How large a loop detection stack to use for fast path */
-#if defined(DUK_USE_JSON_STRINGIFY_FASTPATH)
+/* How large a loop detection stack to use */
 #define DUK_JSON_ENC_LOOPARRAY                64
-#endif
 
 /* Encoding state.  Heap object references are all borrowed. */
 typedef struct {
@@ -48,9 +46,7 @@ typedef struct {
 	duk_small_uint_t stridx_custom_posinf;
 	duk_small_uint_t stridx_custom_function;
 #endif
-#if defined(DUK_USE_JSON_STRINGIFY_FASTPATH)
 	duk_hobject *visiting[DUK_JSON_ENC_LOOPARRAY];  /* indexed by recursion_depth */
-#endif
 } duk_json_enc_ctx;
 
 typedef struct {

--- a/tests/ecmascript/test-bi-json-enc-slowpath-loopdetect.js
+++ b/tests/ecmascript/test-bi-json-enc-slowpath-loopdetect.js
@@ -1,0 +1,281 @@
+/*
+ *  Loop detection in slow path uses a hybrid approach since Duktape 1.4.0,
+ *  exercise its corner cases using loops of different depth.
+ */
+
+/*===
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+78
+85
+92
+99
+106
+113
+120
+127
+134
+141
+148
+155
+162
+169
+176
+183
+190
+197
+204
+211
+218
+225
+232
+239
+246
+253
+260
+267
+274
+281
+288
+295
+302
+309
+316
+323
+330
+337
+344
+351
+358
+365
+372
+379
+386
+393
+400
+407
+414
+421
+428
+435
+442
+449
+456
+463
+470
+477
+484
+491
+498
+505
+512
+519
+526
+533
+540
+547
+554
+561
+568
+575
+582
+589
+596
+603
+610
+617
+624
+631
+638
+645
+652
+659
+666
+673
+680
+687
+694
+701
+708
+715
+722
+729
+736
+743
+750
+757
+764
+771
+778
+785
+792
+799
+806
+813
+820
+827
+834
+841
+848
+855
+862
+869
+876
+883
+890
+897
+904
+911
+918
+925
+932
+939
+946
+953
+960
+967
+974
+981
+988
+995
+expected errors: 3117
+===*/
+
+// identity replacer to forcibly avoid fast path
+function id(k, v) {
+    return v;
+}
+
+function mkloop(depth, loopDepth) {
+    var objects = [];
+    var i;
+
+    for (i = 0; i < depth; i++) {
+        objects.push({ myDepth: i });
+    }
+
+    // Link objects linearly.
+    for (i = 0; i < depth - 1; i++) {
+        objects[i].ref = objects[i + 1];
+    }
+
+    // Add loop link to specified object.
+    objects[depth - 1].loopRef = objects[loopDepth];
+
+    return objects[0];
+}
+
+function test() {
+    var i, j, j_step;
+    var obj;
+    var match = 0;
+
+    for (i = 1; i < 1000;) {
+        print(i);
+
+        // visiting[] is now 64 entries, so go over that a bit densely,
+        // then skip.
+        j_step = (i <= 70 ? 1 : i >>> 2);
+
+        for (j = 0; j < i; j += j_step) {
+            obj = mkloop(i, j);
+
+            try {
+                print(JSON.stringify(obj, id, 4));
+            } catch (e) {
+                if (e.name === 'TypeError' &&
+                    (e.message.toLowerCase().indexOf('cyclic') >= 0 ||
+                     e.message.toLowerCase().indexOf('circular') >= 0)) {
+                    match++;
+                } else {
+                    print(e.stack);
+                    throw new Error('no cyclic error, i=' + i + ', j=' + j + ': ' + e);
+                }
+            }
+        }
+
+        // Sample i densely over the visiting[] size, then skip.
+        if (i <= 70) {
+            i++;
+        } else {
+            i += 7;
+        }
+    }
+
+    print('expected errors: ' + match);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-json-serialize-fastpath-loop.js
+++ b/tests/perf/test-json-serialize-fastpath-loop.js
@@ -1,0 +1,47 @@
+/*
+ *  Loop detection in fast path.
+ */
+
+function mkloop(depth) {
+    var objects = [];
+    var i;
+
+    for (i = 0; i < depth; i++) {
+        objects.push({ myDepth: i });
+    }
+
+    // Link objects linearly.
+    for (i = 0; i < depth - 1; i++) {
+        objects[i].ref = objects[i + 1];
+    }
+
+    // No loop here, because a loop causes a fallback to slow path.
+
+    return objects[0];
+}
+
+function test() {
+    var i, j, k;
+    var obj;
+
+    // Limit to depth 64, size of visiting[] at the moment.
+    for (i = 1; i <= 64; i++) {
+        for (j = 0; j < i; j++) {
+            obj = mkloop(i, j);
+
+            for (k = 0; k < 100; k++) {
+                try {
+                    void JSON.stringify(obj, null, 4);
+                } catch (e) {
+                }
+            }
+        }
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-json-serialize-nofrac.js
+++ b/tests/perf/test-json-serialize-nofrac.js
@@ -1,0 +1,33 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function build() {
+    var obj = {};
+
+    obj.key1 = 'foo';
+    obj.key2 = 'bar';
+    obj.key3 = 'quux';
+    obj.key4 = 'baz';
+    obj.key5 = 'quuux';
+    obj.key6 = [ 'foo', 'bar', 'quux', 'baz', 'quuux' ];
+    obj.key7 = [ undefined, null, true, 123, -234, {}, {}, {} ];
+
+    return obj;
+}
+
+function test() {
+    var obj;
+    var i;
+    var ignore;
+
+    obj = build();
+    for (i = 0; i < 4e5; i++) {
+        ignore = JSON.stringify(obj);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-json-serialize-slowpath-loop.js
+++ b/tests/perf/test-json-serialize-slowpath-loop.js
@@ -1,0 +1,60 @@
+/*
+ *  Loop detection in slow path.
+ */
+
+// identity replacer to forcibly avoid fast path
+function id(k, v) {
+    return v;
+}
+
+function mkloop(depth, loopDepth) {
+    var objects = [];
+    var i;
+
+    for (i = 0; i < depth; i++) {
+        objects.push({ myDepth: i });
+    }
+
+    // Link objects linearly.
+    for (i = 0; i < depth - 1; i++) {
+        objects[i].ref = objects[i + 1];
+    }
+
+    // Add loop link to specified object.
+    objects[depth - 1].loopRef = objects[loopDepth];
+
+    return objects[0];
+}
+
+function test() {
+    var i, j, j_step, k;
+    var obj;
+
+    for (i = 1; i < 100;) {
+        j_step = (i <= 40 ? 1 : i >>> 2);
+
+        for (j = 0; j < i; j += j_step) {
+            obj = mkloop(i, j);
+
+            for (k = 0; k < 100; k++) {
+                try {
+                    void JSON.stringify(obj, id, 4);
+                } catch (e) {
+                }
+            }
+        }
+
+        if (i <= 40) {
+            i++;
+        } else {
+            i += 11;
+        }
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/util/time_multi.py
+++ b/util/time_multi.py
@@ -15,6 +15,7 @@ def main():
 	parser.add_option('--mode', dest='mode', default='min')
 	parser.add_option('--sleep', type='float', dest='sleep', default=0.0)
 	parser.add_option('--sleep-factor', type='float', dest='sleep_factor', default=0.0)
+	parser.add_option('--rerun-limit', type='int', dest='rerun_limit', default=30)
 	parser.add_option('--verbose', action='store_true', dest='verbose', default=False)
 	(opts, args) = parser.parse_args()
 
@@ -71,11 +72,16 @@ def main():
 		# Sleep time dependent on test time is useful for thermal throttling.
 		time.sleep(opts.sleep_factor * time_this)
 
+		# If run takes too long, there's no point in trying to get an accurate
+		# estimate.
+		if time_this >= opts.rerun_limit:
+			break
+
 	if opts.verbose:
 		sys.stderr.write('\n')
 		sys.stderr.flush()
 
-	time_avg = time_sum / float(opts.count)
+	time_avg = time_sum / float(len(time_list))
 
 	# /usr/bin/time has only two digits of resolution
 	if opts.mode == 'min':
@@ -86,7 +92,7 @@ def main():
 		print('%.02f' % time_avg)
 	elif opts.mode == 'all':
 		print('min=%.02f, max=%.02f, avg=%0.2f, count=%d: %r' % \
-		      (time_min, time_max, time_avg, opts.count, time_list))
+		      (time_min, time_max, time_avg, len(time_list), time_list))
 	else:
 		print('invalid mode: %r' % opts.mode)
 


### PR DESCRIPTION
Improve loop detection performance by using a hybrid approach where a `visiting[]` array (shared with fast path) is used up to a certain depth, large enough for most practical code, and only after that a tracking object is taken into use.

- [x] Review loop detection code
- [x] Assertion run
- [x] Perftest run
- [x] Releases