### PR TITLE
Better error .fileName and .lineNumber default

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1194,6 +1194,11 @@ Planned
 * Improve error message verbosity for API index check calls, duk_require_xxx()
   calls, and Array iterator calls (GH-441)
 
+* Improve error object .fileName and .lineNumber attribution: if a callstack
+  function is missing a .fileName property, scan the callstack until a
+  function with a .fileName is found which improves error reporting for e.g.
+  "[1,2,3].forEach(null)" (GH-455)
+
 * Add a combined duktape.c without #line directives into the dist package,
   as it is a useful alternative in some environments (GH-363)
 
@@ -1215,6 +1220,11 @@ Planned
 
 * Fix Unix local time offset handling which caused issues at least on RISC
   OS (GH-406, GH-407)
+
+* Fix a bug in stack trace ellipsis ("[...]") handling: previously the
+  ellipsis might be emitted up to 2 callstack levels too early because
+  the presence of a compilation error and/or a C call site was not taken
+  into account in stack trace creation (GH-455)
 
 * Remove octal autodetection in parseInt(), also fixes incorrect octal
   autodetection in e.g. "parseInt('00e1', 16)" (GH-413, GH-414)

--- a/config/config-options/DUK_USE_TRACEBACK_DEPTH.yaml
+++ b/config/config-options/DUK_USE_TRACEBACK_DEPTH.yaml
@@ -13,3 +13,7 @@ description: >
   Define traceback collection depth.  A large number causes tracedata to be
   larger, taking more time to create and consuming more memory.  A small
   number makes tracebacks less useful.
+
+  When tracebacks are disabled this option affects .fileName and .lineNumber
+  blaming.  Error augmentation code won't look deeper than this value to find
+  a function to blame for error .fileName / .lineNumber.

--- a/config/header-snippets/unsorted_flags.h.in
+++ b/config/header-snippets/unsorted_flags.h.in
@@ -130,12 +130,10 @@
 #undef DUK_USE_VERBOSE_ERRORS
 #endif
 
-#if defined(DUK_USE_TRACEBACKS)
 #if defined(DUK_OPT_TRACEBACK_DEPTH)
 #define DUK_USE_TRACEBACK_DEPTH  DUK_OPT_TRACEBACK_DEPTH
 #else
 #define DUK_USE_TRACEBACK_DEPTH  10
-#endif
 #endif
 
 /* Include messages in executor internal errors. */

--- a/misc/preproc_compare1.c
+++ b/misc/preproc_compare1.c
@@ -1,0 +1,17 @@
+/*
+ *  Preprocessor compare with right part undefined.
+ */
+
+#include <stdio.h>
+
+#define FOO 123
+#undef BAR
+
+int main(int argc, char *argv[]) {
+#if defined(FOO) && defined(BAR) && (FOO == BAR)
+	printf("FOO == BAR\n");
+#else
+	printf("FOO != BAR\n");
+#endif
+	return 0;
+}

--- a/misc/preproc_compare2.c
+++ b/misc/preproc_compare2.c
@@ -1,0 +1,17 @@
+/*
+ *  Preprocessor compare with left part undefined.
+ */
+
+#include <stdio.h>
+
+#define FOO 123
+#undef BAR
+
+int main(int argc, char *argv[]) {
+#if defined(FOO) && defined(BAR) && (BAR == FOO)
+	printf("FOO == BAR\n");
+#else
+	printf("FOO != BAR\n");
+#endif
+	return 0;
+}

--- a/misc/preproc_compare3.c
+++ b/misc/preproc_compare3.c
@@ -1,0 +1,17 @@
+/*
+ *  Preprocessor compare with right part defined to empty.
+ */
+
+#include <stdio.h>
+
+#define FOO 123
+#define BAR
+
+int main(int argc, char *argv[]) {
+#if defined(FOO) && defined(BAR) && (FOO == BAR)
+	printf("FOO == BAR\n");
+#else
+	printf("FOO != BAR\n");
+#endif
+	return 0;
+}

--- a/misc/preproc_compare4.c
+++ b/misc/preproc_compare4.c
@@ -1,0 +1,17 @@
+/*
+ *  Preprocessor compare with left part defined to empty.
+ */
+
+#include <stdio.h>
+
+#define FOO 123
+#define BAR
+
+int main(int argc, char *argv[]) {
+#if defined(FOO) && defined(BAR) && (BAR == FOO)
+	printf("FOO == BAR\n");
+#else
+	printf("FOO != BAR\n");
+#endif
+	return 0;
+}

--- a/src/duk_bi_error.c
+++ b/src/duk_bi_error.c
@@ -119,6 +119,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 	duk_idx_t idx_td;
 	duk_small_int_t i;  /* traceback depth fits into 16 bits */
 	duk_small_int_t t;  /* stack type fits into 16 bits */
+	duk_small_int_t count_func = 0;  /* traceback depth ensures fits into 16 bits */
 	const char *str_tailcalled = " tailcalled";
 	const char *str_strict = " strict";
 	const char *str_construct = " construct";
@@ -163,6 +164,8 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 				/*
 				 *  Ecmascript/native function call or lightfunc call
 				 */
+
+				count_func++;
 
 				/* [ ... v1(func) v2(pc+flags) ] */
 
@@ -262,7 +265,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 			}
 		}
 
-		if (i >= DUK_USE_TRACEBACK_DEPTH * 2) {
+		if (count_func >= DUK_USE_TRACEBACK_DEPTH) {
 			/* Possibly truncated; there is no explicit truncation
 			 * marker so this is the best we can do.
 			 */

--- a/src/duk_bi_error.c
+++ b/src/duk_bi_error.c
@@ -179,11 +179,16 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 
 				/* [ ... v1 v2 name filename ] */
 
-				if (output_type == DUK__OUTPUT_TYPE_FILENAME) {
-					return 1;
-				} else if (output_type == DUK__OUTPUT_TYPE_LINENUMBER) {
-					duk_push_int(ctx, line);
-					return 1;
+				/* When looking for .fileName/.lineNumber, blame first
+				 * function which has a .fileName.
+				 */
+				if (duk_is_string(ctx, -1)) {
+					if (output_type == DUK__OUTPUT_TYPE_FILENAME) {
+						return 1;
+					} else if (output_type == DUK__OUTPUT_TYPE_LINENUMBER) {
+						duk_push_int(ctx, line);
+						return 1;
+					}
 				}
 
 				h_name = duk_get_hstring(ctx, -2);  /* may be NULL */
@@ -233,6 +238,9 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 
 				/* [ ... v1(filename) v2(line+flags) ] */
 
+				/* When looking for .fileName/.lineNumber, blame compilation
+				 * or C call site unless flagged not to do so.
+				 */
 				if (!(flags & DUK_TB_FLAG_NOBLAME_FILELINE)) {
 					if (output_type == DUK__OUTPUT_TYPE_FILENAME) {
 						duk_pop(ctx);

--- a/tests/api/test-dev-error-fileline-blame-gh455.c
+++ b/tests/api/test-dev-error-fileline-blame-gh455.c
@@ -1,0 +1,573 @@
+/*
+ *  Test error .fileName / .lineNumber blaming.
+ *
+ *  Try to cover all the C code paths.  Must test with and without tracebacks
+ *  separately, as the code paths are different.
+ */
+
+/*===
+*** test_empty_1 (duk_safe_call)
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_empty_2 (duk_safe_call)
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_empty_3 (duk_safe_call)
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_empty_4 (duk_safe_call)
+undefined undefined
+final top: 1
+==> rc=0, result='undefined'
+*** test_nofile_1 (duk_safe_call)
+delete: true
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_nofile_2 (duk_safe_call)
+delete: true
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_nofile_3 (duk_safe_call)
+delete: true
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_nofile_4 (duk_safe_call)
+delete: true
+undefined undefined
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile1_1 (duk_safe_call)
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile1_2 (duk_safe_call)
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile1_3 (duk_safe_call)
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile1_4 (duk_safe_call)
+dummy_filename.js 2
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile2_1 (duk_safe_call)
+delete: true
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile2_2 (duk_safe_call)
+delete: true
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile2_3 (duk_safe_call)
+delete: true
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_havefile2_4 (duk_safe_call)
+delete: true
+dummy_filename.c 0
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_1a (duk_safe_call)
+delete: true
+target depth: 9
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_1b (duk_safe_call)
+delete: true
+target depth: 10
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_1c (duk_safe_call)
+delete: true
+target depth: 11
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_1d (duk_safe_call)
+delete: true
+target depth: 50
+dummy_source.js 4
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_2a (duk_safe_call)
+delete: true
+target depth: 9
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_2b (duk_safe_call)
+delete: true
+target depth: 10
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_2c (duk_safe_call)
+delete: true
+target depth: 11
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_2d (duk_safe_call)
+delete: true
+target depth: 50
+dummy.c 1234
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_3a (duk_safe_call)
+delete: true
+target depth: 9
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_3b (duk_safe_call)
+delete: true
+target depth: 10
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_3c (duk_safe_call)
+delete: true
+target depth: 11
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_3d (duk_safe_call)
+delete: true
+target depth: 50
+dummy.c 2345
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_4a (duk_safe_call)
+delete: true
+target depth: 9
+outer_limits.c 0
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_4b (duk_safe_call)
+delete: true
+target depth: 10
+outer_limits.c 0
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_4c (duk_safe_call)
+delete: true
+target depth: 11
+undefined undefined
+final top: 1
+==> rc=0, result='undefined'
+*** test_deep_4d (duk_safe_call)
+delete: true
+target depth: 50
+undefined undefined
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+/*
+ *  Helpers
+ */
+
+static duk_c_function target_func_hack;
+static int depth_hack;
+
+static duk_ret_t my_thrower_1(duk_context *ctx) {
+	/* When an error is thrown during compilation, the source file/line
+	 * is always blamed.
+	 */
+	duk_push_string(ctx, "\n\n\nfoo=");
+	duk_push_string(ctx, "dummy_source.js");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+	return 0;
+}
+
+static duk_ret_t my_thrower_2(duk_context *ctx) {
+	/* When an error is thrown using duk_error(), the __FILE__ and __LINE__
+	 * of the throw site gets blamed for the error w.r.t. to .fileName and
+	 * .lineNumber.
+	 */
+#line 1234 "dummy.c"
+	duk_error(ctx, DUK_ERR_RANGE_ERROR, "user error");
+	return 0;
+}
+
+static duk_ret_t my_thrower_3(duk_context *ctx) {
+	/* When an error is constructed using duk_push_error_object() and then
+	 * thrown, the same thing happens as with duk_error().
+	 */
+#line 2345 "dummy.c"
+	duk_push_error_object(ctx, DUK_ERR_RANGE_ERROR, "user error");
+	duk_throw(ctx);
+	return 0;
+}
+
+static duk_ret_t my_thrower_4(duk_context *ctx) {
+	/* When an error is thrown from inside Duktape (which is always
+	 * considered "infrastructure code") the __FILE__ and __LINE__
+	 * are recorded in the traceback but not blamed as file/line.
+	 */
+	duk_push_undefined(ctx);
+	duk_require_string(ctx, -1);
+	return 0;
+}
+
+/*
+ *  Empty callstack
+ */
+
+static duk_ret_t empty_helper(duk_context *ctx, duk_c_function target_func) {
+	duk_int_t rc;
+
+	rc = duk_safe_call(ctx, target_func, 0, 1);
+	(void) rc;
+
+	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_empty_1(duk_context *ctx) {
+	return empty_helper(ctx, my_thrower_1);
+}
+
+static duk_ret_t test_empty_2(duk_context *ctx) {
+	return empty_helper(ctx, my_thrower_2);
+}
+
+static duk_ret_t test_empty_3(duk_context *ctx) {
+	return empty_helper(ctx, my_thrower_3);
+}
+
+static duk_ret_t test_empty_4(duk_context *ctx) {
+	return empty_helper(ctx, my_thrower_4);
+}
+
+/*
+ *  Callstack has entries but nothing with a .fileName.
+ */
+
+static duk_ret_t nofile_helper_2(duk_context *ctx) {
+	duk_push_string(ctx,
+		"(function () {\n"
+		"    var fn = function noFileName(v) { v(); return 123; };\n"
+		"    print('delete: ' + delete fn.fileName);\n"
+		"    return fn;\n"
+		"})()");
+	duk_push_string(ctx, "dummy_filename.js");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+
+	duk_push_c_function(ctx, target_func_hack, 0);
+	duk_call(ctx, 1);
+	return 0;
+}
+
+static duk_ret_t nofile_helper(duk_context *ctx, duk_c_function target_func) {
+	duk_int_t rc;
+
+	target_func_hack = target_func;
+	duk_push_c_function(ctx, nofile_helper_2, 0);  /* Duktape/C func with no .fileName */
+	duk_pcall(ctx, 0);
+	(void) rc;
+
+	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nofile_1(duk_context *ctx) {
+	return nofile_helper(ctx, my_thrower_1);
+}
+
+static duk_ret_t test_nofile_2(duk_context *ctx) {
+	return nofile_helper(ctx, my_thrower_2);
+}
+
+static duk_ret_t test_nofile_3(duk_context *ctx) {
+	return nofile_helper(ctx, my_thrower_3);
+}
+
+static duk_ret_t test_nofile_4(duk_context *ctx) {
+	return nofile_helper(ctx, my_thrower_4);
+}
+
+/*
+ *  Callstack has entries with .fileName, but the innermost function
+ *  does not have a filename.
+ */
+
+static duk_ret_t havefile1_helper_2(duk_context *ctx) {
+	duk_push_string(ctx,
+		"(function () {\n"
+		"    var fn = function haveFileName(v) { v(); return 123; };\n"
+		"    return fn;\n"
+		"})()");
+	duk_push_string(ctx, "dummy_filename.js");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+
+	duk_push_c_function(ctx, target_func_hack, 0);
+	duk_call(ctx, 1);
+	return 0;
+}
+
+static duk_ret_t havefile1_helper(duk_context *ctx, duk_c_function target_func) {
+	duk_int_t rc;
+
+	target_func_hack = target_func;
+	duk_push_c_function(ctx, havefile1_helper_2, 0);  /* Duktape/C func with no .fileName */
+	duk_pcall(ctx, 0);
+	(void) rc;
+
+	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_havefile1_1(duk_context *ctx) {
+	return havefile1_helper(ctx, my_thrower_1);
+}
+
+static duk_ret_t test_havefile1_2(duk_context *ctx) {
+	return havefile1_helper(ctx, my_thrower_2);
+}
+
+static duk_ret_t test_havefile1_3(duk_context *ctx) {
+	return havefile1_helper(ctx, my_thrower_3);
+}
+
+static duk_ret_t test_havefile1_4(duk_context *ctx) {
+	return havefile1_helper(ctx, my_thrower_4);
+}
+
+/*
+ *  Callstack has entries with .fileName, and the innermost function
+ *  also has a filename.
+ */
+
+static duk_ret_t havefile2_helper_2(duk_context *ctx) {
+	duk_push_string(ctx,
+		"(function () {\n"
+		"    var fn = function noFileName(v) { v(); return 123; };\n"
+		"    print('delete: ' + delete fn.fileName);\n"
+		"    return fn;\n"
+		"})()");
+	duk_push_string(ctx, "dummy_filename.js");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+
+	duk_push_c_function(ctx, target_func_hack, 0);
+	duk_push_string(ctx, "fileName");
+	duk_push_string(ctx, "dummy_filename.c");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_SET_WRITABLE | DUK_DEFPROP_SET_CONFIGURABLE);
+	duk_call(ctx, 1);
+	return 0;
+}
+
+static duk_ret_t havefile2_helper(duk_context *ctx, duk_c_function target_func) {
+	duk_int_t rc;
+
+	target_func_hack = target_func;
+	duk_push_c_function(ctx, havefile2_helper_2, 0);  /* Duktape/C func with no .fileName */
+	duk_pcall(ctx, 0);
+	(void) rc;
+
+	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_havefile2_1(duk_context *ctx) {
+	return havefile2_helper(ctx, my_thrower_1);
+}
+
+static duk_ret_t test_havefile2_2(duk_context *ctx) {
+	return havefile2_helper(ctx, my_thrower_2);
+}
+
+static duk_ret_t test_havefile2_3(duk_context *ctx) {
+	return havefile2_helper(ctx, my_thrower_3);
+}
+
+static duk_ret_t test_havefile2_4(duk_context *ctx) {
+	return havefile2_helper(ctx, my_thrower_4);
+}
+
+/*
+ *  Callstack has entries with .fileName but those entries are deeper than
+ *  the traceback depth so that they don't get blamed.
+ *
+ *  The default callstack depth is 10, so test boundary values 9, 10, 11,
+ *  and a much deeper 50.
+ */
+
+static duk_ret_t deep_helper_2(duk_context *ctx) {
+	duk_push_string(ctx,
+		"(function () {\n"
+		"    var fn = function noFileName(n, v) { if (n > 0) { noFileName(n - 1, v); } else { v(); } return 123; };\n"
+		"    print('delete: ' + delete fn.fileName);\n"
+		"    return fn;\n"
+		"})()");
+	duk_push_string(ctx, "dummy_filename.js");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+
+	printf("target depth: %d\n", (int) depth_hack);
+	duk_push_int(ctx, depth_hack - 3);  /* account for: one func already in callstack; first call into the helper; final call to target */
+	duk_push_c_function(ctx, target_func_hack, 0);
+	duk_call(ctx, 2);
+	return 0;
+}
+
+static duk_ret_t deep_helper(duk_context *ctx, duk_c_function target_func, int depth) {
+	duk_int_t rc;
+
+	target_func_hack = target_func;
+	depth_hack = depth;
+	duk_push_c_function(ctx, deep_helper_2, 0);  /* Duktape/C func with .fileName */
+	duk_push_string(ctx, "fileName");
+	duk_push_string(ctx, "outer_limits.c");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_SET_WRITABLE | DUK_DEFPROP_SET_CONFIGURABLE);
+	duk_pcall(ctx, 0);
+	(void) rc;
+
+	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_deep_1a(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_1, 9);
+}
+static duk_ret_t test_deep_1b(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_1, 10);
+}
+static duk_ret_t test_deep_1c(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_1, 11);
+}
+static duk_ret_t test_deep_1d(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_1, 50);
+}
+
+static duk_ret_t test_deep_2a(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_2, 9);
+}
+static duk_ret_t test_deep_2b(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_2, 10);
+}
+static duk_ret_t test_deep_2c(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_2, 11);
+}
+static duk_ret_t test_deep_2d(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_2, 50);
+}
+
+static duk_ret_t test_deep_3a(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_3, 9);
+}
+static duk_ret_t test_deep_3b(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_3, 10);
+}
+static duk_ret_t test_deep_3c(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_3, 11);
+}
+static duk_ret_t test_deep_3d(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_3, 50);
+}
+
+static duk_ret_t test_deep_4a(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_4, 9);
+}
+static duk_ret_t test_deep_4b(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_4, 10);
+}
+static duk_ret_t test_deep_4c(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_4, 11);
+}
+static duk_ret_t test_deep_4d(duk_context *ctx) {
+	return deep_helper(ctx, my_thrower_4, 50);
+}
+
+/*
+ *  User code can set an explicit .fileName and .lineNumber on the error
+ *  object to avoid this default blaming.
+ */
+
+void test(duk_context *ctx) {
+	/* For manual testing: */
+#if 0
+	duk_eval_string_noresult(ctx, "this.PRINT_STACK = true;");
+#else
+	duk_eval_string_noresult(ctx, "this.PRINT_STACK = false;");
+#endif
+
+	TEST_SAFE_CALL(test_empty_1);
+	TEST_SAFE_CALL(test_empty_2);
+	TEST_SAFE_CALL(test_empty_3);
+	TEST_SAFE_CALL(test_empty_4);
+
+	TEST_SAFE_CALL(test_nofile_1);
+	TEST_SAFE_CALL(test_nofile_2);
+	TEST_SAFE_CALL(test_nofile_3);
+	TEST_SAFE_CALL(test_nofile_4);
+
+	TEST_SAFE_CALL(test_havefile1_1);
+	TEST_SAFE_CALL(test_havefile1_2);
+	TEST_SAFE_CALL(test_havefile1_3);
+	TEST_SAFE_CALL(test_havefile1_4);
+
+	TEST_SAFE_CALL(test_havefile2_1);
+	TEST_SAFE_CALL(test_havefile2_2);
+	TEST_SAFE_CALL(test_havefile2_3);
+	TEST_SAFE_CALL(test_havefile2_4);
+
+	TEST_SAFE_CALL(test_deep_1a);
+	TEST_SAFE_CALL(test_deep_1b);
+	TEST_SAFE_CALL(test_deep_1c);
+	TEST_SAFE_CALL(test_deep_1d);
+	TEST_SAFE_CALL(test_deep_2a);
+	TEST_SAFE_CALL(test_deep_2b);
+	TEST_SAFE_CALL(test_deep_2c);
+	TEST_SAFE_CALL(test_deep_2d);
+	TEST_SAFE_CALL(test_deep_3a);
+	TEST_SAFE_CALL(test_deep_3b);
+	TEST_SAFE_CALL(test_deep_3c);
+	TEST_SAFE_CALL(test_deep_3d);
+	TEST_SAFE_CALL(test_deep_4a);
+	TEST_SAFE_CALL(test_deep_4b);
+	TEST_SAFE_CALL(test_deep_4c);
+	TEST_SAFE_CALL(test_deep_4d);
+}

--- a/website/guide/errorobjects.html
+++ b/website/guide/errorobjects.html
@@ -23,6 +23,12 @@ of error objects is minimized to keep error objects as small as possible.</p>
 </tbody>
 </table>
 
+<div class="note">
+Assigning the most useful <code>fileName</code> and <code>lineNumber</code> is
+somewhat complicated.  The related issues and current behavior are described in:
+<a href="https://github.com/svaarala/duktape/blob/master/doc/error-objects.rst">error-objects.rst</a>.
+</div>
+
 <p>If Duktape is compiled with traceback support:</p>
 
 <ul>


### PR DESCRIPTION
Use the first traceback entry which actually has a `.fileName` to provide virtual `.fileName` and `.lineNumber`. See #454.

This works better for expressions such as `Duktape.enc(123)` which currently get `undefined` as `.fileName`: the value comes from the `Duktape.enc()` function, which has no `.fileName` property.

Tasks:

- [x] New behavior for traceback-based `.fileName` and `.lineNumber` getters
- [x] New behavior for error augmentation when tracebacks are disabled
- [x] Fix stack trace summarization: previously Duktape would print `[...]` before traceback depth was reached (code didn't account for compilation error or C call site)
- [x] Testcases and test case fixes
- [x] Testcase for empty callstack case
- [x] Testcase for the case where a callstack has entries but none has `.fileName`
- [x] Testcase for the case where a callstack has entries both with and without `.fileName`
- [x] Assert testcase run, with and without tracebacks
- [x] Final code review
- [x] Document the "error file/line attribution" issue in internal error document
- [x] Review and cleanup the internal error document
- [x] Code issues notes on preprocessor defines (somewhat unrelated to this issue)
- [x] Documentation changes (internal docs, website), if necessary
- [x] Releases entry