### PR TITLE
Minor base64 fast path improvement

### DIFF
--- a/tests/perf/test-base64-decode-whitespace.js
+++ b/tests/perf/test-base64-decode-whitespace.js
@@ -26,8 +26,10 @@ function test() {
 
     print(tmp2.length);
     print('run');
-    for (i = 0; i < 1000; i++) {
-        Duktape.dec('base64', tmp2);
+    for (i = 0; i < 2000; i++) {
+        // Assigning to 'res' avoids garbage collection of result; this is
+        // intentional to avoid mixing string intern performance to the test.
+        var res = Duktape.dec('base64', tmp2);
     }
 }
 

--- a/tests/perf/test-base64-decode-whitespace.py
+++ b/tests/perf/test-base64-decode-whitespace.py
@@ -23,7 +23,7 @@ def test():
 
 	print(len(tmp2))
 	print('run')
-	for i in xrange(1000):
-		ign = tmp2.decode('base64')
+	for i in xrange(2000):
+		res = tmp2.decode('base64')
 
 test()

--- a/tests/perf/test-base64-decode.js
+++ b/tests/perf/test-base64-decode.js
@@ -19,8 +19,10 @@ function test() {
 
     print(tmp2.length);
     print('run');
-    for (i = 0; i < 1000; i++) {
-        Duktape.dec('base64', tmp2);
+    for (i = 0; i < 2000; i++) {
+        // Assigning to 'res' avoids garbage collection of result; this is
+        // intentional to avoid mixing string intern performance to the test.
+        var res = Duktape.dec('base64', tmp2);
     }
 }
 

--- a/tests/perf/test-base64-decode.py
+++ b/tests/perf/test-base64-decode.py
@@ -16,7 +16,7 @@ def test():
 
 	print(len(tmp2))
 	print('run')
-	for i in xrange(1000):
-		ign = tmp2.decode('base64')
+	for i in xrange(2000):
+		res = tmp2.decode('base64')
 
 test()

--- a/tests/perf/test-base64-encode.js
+++ b/tests/perf/test-base64-encode.js
@@ -18,8 +18,10 @@ function test() {
 
     print(tmp2.length);
     print('run');
-    for (i = 0; i < 1000; i++) {
-        Duktape.enc('base64', tmp2);
+    for (i = 0; i < 2000; i++) {
+        // Assigning to 'res' avoids garbage collection of result; this is
+        // intentional to avoid mixing string intern performance to the test.
+        var res = Duktape.enc('base64', tmp2);
     }
 }
 

--- a/tests/perf/test-base64-encode.lua
+++ b/tests/perf/test-base64-encode.lua
@@ -1,0 +1,20 @@
+local function test()
+    local t1 = {}
+    local t2 = {}
+
+    for i=1,1024 do
+        t1[i] = string.char(math.floor(math.random(255)))
+    end
+    t1 = table.concat(t1)
+    for i=1,1024 do
+        t2[i] = t1
+    end
+    t2 = table.concat(t2)
+    print(#t2)
+
+    local base64 = require('base64')
+    for i=1,2000 do
+        local res = base64.encode(t2)
+    end
+end
+test()

--- a/tests/perf/test-base64-encode.py
+++ b/tests/perf/test-base64-encode.py
@@ -15,7 +15,7 @@ def test():
 
 	print(len(tmp2))
 	print('run')
-	for i in xrange(1000):
-		ign = tmp2.encode('base64')
+	for i in xrange(2000):
+		res = tmp2.encode('base64')
 
 test()

--- a/tests/perf/test-hex-decode.js
+++ b/tests/perf/test-hex-decode.js
@@ -18,7 +18,9 @@ function test() {
     print(tmp2.length);
     print('run');
     for (i = 0; i < 10000; i++) {
-        Duktape.dec('hex', tmp2);
+        // Assigning to 'res' avoids garbage collection of result; this is
+        // intentional to avoid mixing string intern performance to the test.
+        var res = Duktape.dec('hex', tmp2);
     }
 }
 

--- a/tests/perf/test-hex-decode.py
+++ b/tests/perf/test-hex-decode.py
@@ -16,6 +16,6 @@ def test():
 	print(len(tmp2))
 	print('run')
 	for i in xrange(10000):
-		ign = tmp2.decode('hex')
+		res = tmp2.decode('hex')
 
 test()

--- a/tests/perf/test-hex-encode.js
+++ b/tests/perf/test-hex-encode.js
@@ -19,7 +19,9 @@ function test() {
     print(tmp2.length);
     print('run');
     for (i = 0; i < 5000; i++) {
-        Duktape.enc('hex', tmp2);
+        // Assigning to 'res' avoids garbage collection of result; this is
+        // intentional to avoid mixing string intern performance to the test.
+        res = Duktape.enc('hex', tmp2);
     }
 }
 

--- a/tests/perf/test-hex-encode.py
+++ b/tests/perf/test-hex-encode.py
@@ -16,6 +16,6 @@ def test():
 	print(len(tmp2))
 	print('run')
 	for i in xrange(5000):
-		ign = tmp2.encode('hex')
+		res = tmp2.encode('hex')
 
 test()


### PR DESCRIPTION
Also fix test cases to avoid string interning every encode result so that the microbenchmark properly focuses on base64 only.