### PR TITLE
Avoid finalizer rerun unless object is rescued

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1220,6 +1220,20 @@ Planned
   function with a .fileName is found which improves error reporting for e.g.
   "[1,2,3].forEach(null)" (GH-455)
 
+* Provide a stronger finalizer re-entry guarantee than before: a finalizer
+  is called exactly once (at the latest in heap destruction) unless the
+  target object is rescued, in which case the finalizer is called once per
+  "rescue cycle" (GH-473)
+
+* Better finalizer behavior for heap destruction: finalized objects may
+  create new finalizable objects whose finalizers will also be called
+  (GH-473)
+
+* Add a second argument to finalizer calls, a boolean value which is true
+  when the finalizer is called during heap destruction as part of forced
+  finalization; the finalized object cannot be rescued by the finalizer
+  in such cases (GH-473)
+
 * Add a combined duktape.c without #line directives into the dist package,
   as it is a useful alternative in some environments (GH-363)
 

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -1122,21 +1122,23 @@ The following flags in the heap element header are used for controlling
 mark-and-sweep:
 
 * ``DUK_HEAPHDR_FLAG_REACHABLE``:
-  element is reachable through the reachability graph
+  element is reachable through the reachability graph.
 
 * ``DUK_HEAPHDR_FLAG_TEMPROOT``:
   element's reachability has been marked, but its children have not been
-  processed; this is required to limit the C recursion level
+  processed; this is required to limit the C recursion level.
 
 * ``DUK_HEAPHDR_FLAG_FINALIZABLE``:
   element is not reachable after the first marking pass (see algorithm),
   has a finalizer, and the finalizer has not been called in the previous
   mark-and-sweep round; object will be moved to the finalization work
-  list and will be considered (temporarily) a reachability root
+  list and will be considered (temporarily) a reachability root.
 
 * ``DUK_HEAPHDR_FLAG_FINALIZED``:
   element's finalizer has been executed, and if still unreachable, object
-  can be collected
+  can be collected.  The finalizer will not be called again until this
+  flag is cleared; this prevents accidental re-entry of the finalizer
+  until the object is explicitly rescued and this flag cleared.
 
 These are referred to as ``REACHABLE``, ``TEMPROOT``, ``FINALIZABLE``,
 and ``FINALIZED`` below for better readability.  All the flags are clear

--- a/doc/sandboxing.rst
+++ b/doc/sandboxing.rst
@@ -216,7 +216,9 @@ Suggestions for sandboxing:
   reference directly.
 
 * Write finalizers very carefully.  Make minimal assumptions on which
-  thread they run, i.e. which global object they see.
+  thread they run, i.e. which global object they see.  It's also best
+  practice to tolerate re-entry (although Duktape 1.4.0 and above has
+  a guarantee of no re-entry unless object is rescued).
 
 * For sandboxed environments it may be sensible to make all finalizers
   native code so that they can access the necessary thread contexts

--- a/src/duk_heap.h
+++ b/src/duk_heap.h
@@ -19,6 +19,7 @@
 #define DUK_HEAP_FLAG_REFZERO_FREE_RUNNING                     (1 << 2)  /* refcount code is processing refzero list */
 #define DUK_HEAP_FLAG_ERRHANDLER_RUNNING                       (1 << 3)  /* an error handler (user callback to augment/replace error) is running */
 #define DUK_HEAP_FLAG_INTERRUPT_RUNNING                        (1 << 4)  /* executor interrupt running (used to avoid nested interrupts) */
+#define DUK_HEAP_FLAG_FINALIZER_NORESCUE                       (1 << 5)  /* heap destruction ongoing, finalizer rescue no longer possible */
 
 #define DUK__HEAP_HAS_FLAGS(heap,bits)               ((heap)->flags & (bits))
 #define DUK__HEAP_SET_FLAGS(heap,bits)  do { \
@@ -33,18 +34,21 @@
 #define DUK_HEAP_HAS_REFZERO_FREE_RUNNING(heap)            DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_HAS_ERRHANDLER_RUNNING(heap)              DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_HAS_INTERRUPT_RUNNING(heap)               DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
+#define DUK_HEAP_HAS_FINALIZER_NORESCUE(heap)              DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
 
 #define DUK_HEAP_SET_MARKANDSWEEP_RUNNING(heap)            DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING)
 #define DUK_HEAP_SET_MARKANDSWEEP_RECLIMIT_REACHED(heap)   DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED)
 #define DUK_HEAP_SET_REFZERO_FREE_RUNNING(heap)            DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_SET_ERRHANDLER_RUNNING(heap)              DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_SET_INTERRUPT_RUNNING(heap)               DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
+#define DUK_HEAP_SET_FINALIZER_NORESCUE(heap)              DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
 
 #define DUK_HEAP_CLEAR_MARKANDSWEEP_RUNNING(heap)          DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING)
 #define DUK_HEAP_CLEAR_MARKANDSWEEP_RECLIMIT_REACHED(heap) DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED)
 #define DUK_HEAP_CLEAR_REFZERO_FREE_RUNNING(heap)          DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_CLEAR_ERRHANDLER_RUNNING(heap)            DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_CLEAR_INTERRUPT_RUNNING(heap)             DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
+#define DUK_HEAP_CLEAR_FINALIZER_NORESCUE(heap)            DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
 
 /*
  *  Longjmp types, also double as identifying continuation type for a rethrow (in 'finally')
@@ -69,8 +73,9 @@
 
 #define DUK_MS_FLAG_EMERGENCY                (1 << 0)   /* emergency mode: try extra hard */
 #define DUK_MS_FLAG_NO_STRINGTABLE_RESIZE    (1 << 1)   /* don't resize stringtable (but may sweep it); needed during stringtable resize */
-#define DUK_MS_FLAG_NO_FINALIZERS            (1 << 2)   /* don't run finalizers (which may have arbitrary side effects) */
-#define DUK_MS_FLAG_NO_OBJECT_COMPACTION     (1 << 3)   /* don't compact objects; needed during object property allocation resize */
+#define DUK_MS_FLAG_NO_OBJECT_COMPACTION     (1 << 2)   /* don't compact objects; needed during object property allocation resize */
+#define DUK_MS_FLAG_NO_FINALIZERS            (1 << 3)   /* don't run finalizers; leave finalizable objects in finalize_list for next round */
+#define DUK_MS_FLAG_SKIP_FINALIZERS          (1 << 4)   /* don't run finalizers; queue finalizable objects back to heap_allocated */
 
 /*
  *  Thread switching

--- a/tests/api/test-dev-finalizer-rerun.c
+++ b/tests/api/test-dev-finalizer-rerun.c
@@ -1,0 +1,111 @@
+/*
+ *  A finalizer shouldn't be re-entered unless the finalizer explicitly
+ *  rescued the object.
+ */
+
+/*===
+*** test_heap_destruction (duk_safe_call)
+creating heap
+heap created
+object 1 finalizer
+destroying heap
+heap destroyed
+==> rc=0, result='undefined'
+===*/
+
+/* Create an object, force one round of GC and destroy heap immediately.
+ * Object has been finalized but not yet rescued, and should not be
+ * finalized again on destruction.
+ */
+static duk_ret_t test_heap_destruction(duk_context *ignored_ctx) {
+	duk_context *my_ctx;
+
+	printf("creating heap\n"); fflush(stdout);
+	my_ctx = duk_create_heap_default();
+	if (!my_ctx) {
+		printf("failed to create heap\n"); fflush(stdout);
+		return 0;
+	}
+	printf("heap created\n"); fflush(stdout);
+
+	duk_eval_string_noresult(my_ctx,
+		"(function () {\n"
+		"    var obj1 = {}; var obj2 = {};\n"
+		"    obj1.ref = obj2; obj2.ref = obj1;\n"
+		"    Duktape.fin(obj1, function obj1fin() { print('object 1 finalizer'); });\n"
+		"    obj1 = obj2 = null;\n"
+		"    Duktape.gc();\n"
+		"})()");
+
+	printf("destroying heap\n"); fflush(stdout);
+	duk_destroy_heap(my_ctx);
+	printf("heap destroyed\n"); fflush(stdout);
+
+	return 0;
+}
+
+#if 0  /* Disabled: this is too fragile because it relies on dangling references;
+        * unfortunately the potential re-run scenario is difficult to confirm
+        * otherwise.
+        */
+/* Create a circular reference with a finalizer, force a GC run which runs the
+ * finalizer.  Use a dangling (!) C heaphdr reference to break the loop so that
+ * refzero code processes the object again.  Finalization should not happen again
+ * in the refcount path.
+ */
+static duk_ret_t test_markandsweep_finalize_then_refzero(duk_context *ignored_ctx) {
+	duk_context *my_ctx;
+	void *ptr;
+
+	printf("creating heap\n"); fflush(stdout);
+	my_ctx = duk_create_heap_default();
+	if (!my_ctx) {
+		printf("failed to create heap\n"); fflush(stdout);
+		return 0;
+	}
+	printf("heap created\n"); fflush(stdout);
+
+	duk_eval_string(my_ctx,
+		"(function () {\n"
+		"    var obj1 = {}; var obj2 = {};\n"
+		"    obj1.ref = obj2; obj2.ref = obj1;\n"
+		"    Duktape.fin(obj1, function obj1fin() { print('object 1 finalizer'); });\n"
+		"    return obj1;\n"
+		"})()");
+
+	ptr = duk_get_heapptr(my_ctx, -1);
+	duk_pop(my_ctx);
+	if (!ptr) {
+		printf("heap ptr was NULL\n"); fflush(stdout);
+	} else {
+		printf("forcing gc\n"); fflush(stdout);
+		duk_gc(my_ctx, 0);
+		printf("gc done\n"); fflush(stdout);
+
+		/* Because 'ptr' has a finalizer it's been finalized but would
+		 * require a second round of mark-and-sweep the be actually freed.
+		 * So 'ptr' is reachable but technically dangling so this is not
+		 * fully safe.  But it's safe enough to break the circular reference
+		 * unless something else triggers GC before that.
+		 */
+		duk_push_heapptr(my_ctx, ptr);
+		duk_del_prop_string(my_ctx, -1, "ref");
+		printf("popping final reference after breaking cycle\n"); fflush(stdout);
+		duk_pop(my_ctx);
+		printf("pop completed\n"); fflush(stdout);
+	}
+
+	printf("destroying heap\n"); fflush(stdout);
+	duk_destroy_heap(my_ctx);
+	printf("heap destroyed\n"); fflush(stdout);
+
+	return 0;
+}
+#endif  /* 0 */
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_heap_destruction);
+#if 0
+	TEST_SAFE_CALL(test_markandsweep_finalize_then_refzero);
+#endif
+}

--- a/tests/ecmascript/test-dev-finalizer-heapdestruct-argument.js
+++ b/tests/ecmascript/test-dev-finalizer-heapdestruct-argument.js
@@ -1,0 +1,30 @@
+/*
+ *  Test the second finalizer argument, a boolean which is true if we're in
+ *  heap destruction and cannot rescue the object.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+finalizer 2: object boolean false
+finalizer 1: object boolean true
+===*/
+
+var obj1 = {};
+Duktape.fin(obj1, function myFinalizer(o, heapDestruct) {
+    print('finalizer 1:', typeof o, typeof heapDestruct, heapDestruct);
+});
+
+var obj2 = {};
+Duktape.fin(obj2, function myFinalizer(o, heapDestruct) {
+    print('finalizer 2:', typeof o, typeof heapDestruct, heapDestruct);
+});
+
+obj2 = null;
+Duktape.gc();  // Force obj2 collection before heap destruct
+
+// Let heap destruction handle obj1.

--- a/tests/ecmascript/test-dev-finalizer-heapdestruct-rescue.js
+++ b/tests/ecmascript/test-dev-finalizer-heapdestruct-rescue.js
@@ -1,0 +1,52 @@
+/*
+ *  An object rescued just before heap destruction will get its finalizer
+ *  executed once more in forced finalization.  This is easy to get wrong
+ *  because an object may have FINALIZED flag set, but not yet be rescued
+ *  (by another mark-and-sweep round).  User code would then expect the
+ *  finalizer to run once more - but the FINALIZED flag would prevent it.
+ */
+
+/*===
+created object 1
+object 1 finalized before heap destruction, create new object, rescue current
+created object 2
+object 2 finalized before heap destruction, create new object, rescue current
+created object 3
+object 3 finalized during heap destruction, don't create another object
+object 2 finalized during heap destruction, don't create another object
+object 1 finalized during heap destruction, don't create another object
+===*/
+
+var objCount = 0;
+var rescued = [];
+
+function mkObj() {
+    var obj = {};
+    var other = {};
+    obj.ref = other; other.ref = obj; other = null;  // ensure cycle -> mark-and-sweep
+    var myCount = ++objCount;
+
+    print('created object', myCount);
+    Duktape.fin(obj, function finalize(o, heapDestruct) {
+        if (heapDestruct) {
+            print('object', myCount, 'finalized during heap destruction, don\'t create another object');
+        } else {
+            print('object', myCount, 'finalized before heap destruction, create new object, rescue current');
+            rescued.push(o);
+            void mkObj();
+        }
+    });
+}
+
+void mkObj();
+
+// Begin heap destruction
+
+// At the moment object 2 will be finalized on the last normal forced GC round
+// and will then be rescued and re-finalized in forced finalization as required
+// by finalizer guarantees: the 'heapDestruct' flag is false when the finalizer
+// runs for the first time so rescuing is allowed.
+//
+// Object 3 is first finalized during forced finalization, so that its finalizer
+// only runs once.  This is correct: the 'heapDestruct' flag is true when the
+// finalizer runs, so rescuing is not supported.

--- a/tests/ecmascript/test-dev-finalizer-heapdestruct-runonce.js
+++ b/tests/ecmascript/test-dev-finalizer-heapdestruct-runonce.js
@@ -1,0 +1,47 @@
+/*
+ *  A finalizer won't be re-executed by heap destruction if the object is
+ *  still in the heap when forced finalizer execution begins.
+ *
+ *  This is a bit difficult to arrange: heap destruction begins with a few
+ *  normal GC rounds so normal unreachable objects will be finalized on the
+ *  first round and the second round frees them.  What we need is for the last
+ *  normal GC round to run a finalizer, but with the object still sitting
+ *  uncollected in the heap.   We arrange this by creating a new finalizable
+ *  object on every finalizer run, so that there will always be a finalized
+ *  but uncollected object by the time forced finalization begins.
+ *
+ *  In Duktape 1.3.0 and prior, the finalizer of at least one object would
+ *  run twice.
+ */
+
+/*===
+created object 1
+object 1 finalized before heap destruction, create new object
+created object 2
+object 2 finalized before heap destruction, create new object
+created object 3
+object 3 finalized during heap destruction, don't create another object
+===*/
+
+var objCount = 0;
+
+function mkObj() {
+    var obj = {};
+    var other = {};
+    obj.ref = other; other.ref = obj; other = null;  // ensure cycle -> mark-and-sweep
+    var myCount = ++objCount;
+
+    print('created object', myCount);
+    Duktape.fin(obj, function finalize(o, heapDestruct) {
+        if (heapDestruct) {
+            print('object', myCount, 'finalized during heap destruction, don\'t create another object');
+        } else {
+            print('object', myCount, 'finalized before heap destruction, create new object');
+            void mkObj();
+        }
+    });
+}
+
+void mkObj();
+
+// Begin heap destruction

--- a/tests/ecmascript/test-dev-finalizer-heapdestruct-spawn1.js
+++ b/tests/ecmascript/test-dev-finalizer-heapdestruct-spawn1.js
@@ -1,0 +1,52 @@
+/*
+ *  Test heap destruction finalizer sanity limit for "runaway finalizers".
+ *  Here, test a finalizer which spawns one new finalizable object which
+ *  does the same.
+ *
+ *  This testcase is fragile: the number of finalizations depends on internal
+ *  parameters which may be changed without breaking compatibility promises.
+ *  The important thing is that the process terminates in a reasonable time.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+===*/
+
+function mkObj() {
+    var obj = {};
+    Duktape.fin(obj, function myFinalizer(o, heapDestruct) {
+        print(typeof o, heapDestruct);
+        var dummy = mkObj();
+    });
+    return obj;
+}
+
+var ref = mkObj();
+
+// Let heap destruction handle the finalizable objects.

--- a/tests/ecmascript/test-dev-finalizer-heapdestruct-spawn2.js
+++ b/tests/ecmascript/test-dev-finalizer-heapdestruct-spawn2.js
@@ -1,0 +1,287 @@
+/*
+ *  Test heap destruction finalizer sanity limit for "runaway finalizers".
+ *  Here, test a finalizer which spawns two new finalizable objects which
+ *  do the same.
+ *
+ *  This testcase is fragile: the number of finalizations depends on internal
+ *  parameters which may be changed without breaking compatibility promises.
+ *  The important thing is that the process terminates in a reasonable time.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+object true
+===*/
+
+function mkObj() {
+    var obj = {};
+    Duktape.fin(obj, function myFinalizer(o, heapDestruct) {
+        print(typeof o, heapDestruct);
+        var dummy1 = mkObj();
+        var dummy2 = mkObj();
+    });
+    return obj;
+}
+
+var ref = mkObj();
+
+// Let heap destruction handle the finalizable objects.

--- a/tests/ecmascript/test-dev-finalizer-skip.js
+++ b/tests/ecmascript/test-dev-finalizer-skip.js
@@ -30,17 +30,17 @@ function createGarbage() {
 try {
     // Forced GC to ensure GC is "in sync"
     print('gc before creating garbage');
-    Duktape.gc(4);
+    Duktape.gc(8);
 
     createGarbage();
 
-    // Mark-and-sweep without finalizers.  (1 << 2) = 4 is a flag from
+    // Mark-and-sweep without finalizers.  (1 << 3) = 8 is a flag from
     // duk_heap.h (this is a fragile dependency):
     //
-    // #define DUK_MS_FLAG_NO_FINALIZERS            (1 << 2)   /* don't run finalizers (which may have arbitrary side effects) */
+    // #define DUK_MS_FLAG_NO_FINALIZERS            (1 << 3)   /* don't run finalizers; leave finalizable objects in finalize_list for next round */
 
     print('gc without finalizers');
-    Duktape.gc(4);
+    Duktape.gc(8);
 
     // Mark-and-sweep with finalizers, should run the pending finalizers.
 

--- a/website/guide/duktapebuiltins.html
+++ b/website/guide/duktapebuiltins.html
@@ -501,7 +501,7 @@ The properties provided for call stack entries may change between versions.
 this call is a no-op.</p>
 
 <!-- Return value is undocumented for now, which is probably good for now.
-     Not sure what the best return value would be.
+     Not sure what the best return value would be.  Arguments are undocumented.
 -->
 
 <h3 id="builtin-duktape-compact">compact()</h3>

--- a/website/guide/finalization.html
+++ b/website/guide/finalization.html
@@ -1,36 +1,118 @@
 <h1 id="finalization">Finalization</h1>
 
+<h2>Overview</h2>
+
 <p>Duktape supports object finalization as a custom feature.  A finalizer
 is called when an object is about to be freed, so that application code
-can e.g. free native resources associated with an object.</p>
-
-<p>An object which has an internal finalizer property in its prototype
-chain (or in the object itself) is subject to finalization before being
-freed.  The internal finalizer property is set using the <code>Duktape.fin()</code>
-method with the object and the finalizer function as call arguments.
-The current finalizer is read back by calling <code>Duktape.fin()</code>
-with only the object as a call argument.  A finalizer can also be set/get from
-C code using the <code>duk_get_finalizer()</code> and <code>duk_set_finalizer()</code>
-API calls.  A finalizer can be either an Ecmascript function or a Duktape/C function.</p>
-
-<p>A finalizer is triggered when an unreachable object is detected by
-reference counting or mark-and-sweep.  Finalizers are also executed for all
-remaining objects (regardless of their reachability status) when a heap is destroyed.
-This guarantees that a finalizer gets executed at some point before a heap
-is destroyed, which allows native resources (such as sockets and files) to
-be freed reliably.</p>
-
-<p>The finalizer function is called with the target object as its sole
-argument.  The finalizer may rescue the object by creating a live reference
-to the object before returning.  The return value is ignored, and any errors
-thrown by the finalizer are silently ignored.  A finalizer may be called
-multiple times (this may happen in special cases even when the object is not
-rescued by the finalizer).  A finalizer should be careful to avoid e.g.
-freeing a native resource twice in such cases.</p>
-
-<p>Finalizers cannot currently yield.  The context executing the finalization
-can currently be any coroutine in the heap.  (This will be fixed in the future.)
-</p>
+can e.g. free native resources associated with the object.  The finalizer
+can be either an Ecmascript function or a Duktape/C function.  However,
+Ecmascript finalizers may interact badly with script timeouts, see below.</p>
 
 <p>See <a href="http://wiki.duktape.org/HowtoFinalization.html">How to use finalization</a>
 for examples.</p>
+
+<h2>Getting and setting the current finalizer</h2>
+
+<p>An object which has an internal <code>_Finalizer</code> property in its
+prototype chain (or in the object itself) is subject to finalization before
+being freed.  The internal property should not be accessed directly, but can
+be read/written using the following:</p>
+<ul>
+<li><code>Duktape.fin(obj)</code> (Ecmascript) or
+    <code>duk_get_finalizer()</code> (C)
+    gets the current finalizer.</li>
+<li><code>Duktape.fin(obj, fn)</code> (Ecmascript) or
+    <code>duk_set_finalizer()</code> (C)
+    sets the current finalizer.</li>
+</ul>
+
+<h2>Finalizer function arguments and return value</h2>
+
+<p>The finalizer function is called with two arguments:</p>
+<ul>
+<li>The object being finalized.</li>
+<li>A boolean flag indicating if the object is being forcibly freed as part
+    of heap destruction.  This argument was added in Duktape 1.4.0:
+    <ul>
+    <li>If <code>false</code> (normal case), the finalizer may rescue the object
+        by creating a live reference to the object before returning and the
+        finalizer is guaranteed to be called again later (heap destruction at
+        the latest).</li>
+    <li>If <code>true</code> (forced finalization in heap destruction), the
+        object cannot be rescued and will be forcibly freed after the finalizer
+        finishes.  Native resources should be freed without expecting any further
+        calls into the finalizer.</li>
+    </ul>
+    </li>
+</ul>
+
+<p>The return value of a finalizer is ignored.  Any errors thrown by the
+finalizer are also silently ignored.</p>
+
+<h2>Finalizer execution guarantees</h2>
+
+<p>The main finalizer guarantees are:</p>
+<ul>
+<li>Finalizers are executed for unreachable objects detected by reference
+    counting or mark-and-sweep.  The finalizer may not execute immediately,
+    however, not even when reference counting detects that the object became
+    unreachable.</li>
+<li>Finalizers are also executed for all remaining objects, regardless of
+    their reachability status, when a Duktape heap is destroyed.</li>
+<li>A finalizer is called exactly once, at the latest when the heap is
+    destroyed, unless the object is rescued by the finalizer by making
+    it reachable again.  An object may be rescued an arbitrary number of
+    times; the finalizer is called exactly once for each "rescue cycle".
+    Even with this guarantee in place, it's best practice for a finalizer
+    to be re-entrant and carefully avoid e.g. freeing a native resource
+    multiple times if re-entered.</li>
+<li>A finalizer is not executed for a Proxy object, but is executed for
+    the plain target object.  This ensures that a finalizer isn't executed
+    multiple times when Proxy objects are created.</li>
+</ul>
+
+<p>Together these guarantee that a finalizer gets executed at some point
+before a heap is destroyed, which allows native resources (such as sockets
+and files) to be freed reliably.  There are two exceptions to this guarantee,
+see below for more discussion:</p>
+<ul>
+<li>Heap destruction finalizer sanity limit may cause a finalizer not to
+    be executed.</li>
+<li>When a script timeout is being propagated out of the current callstack,
+    Ecmascript finalizers will immediately rethrow the script timeout error.
+    Duktape/C finalizers will execute normally.</li>
+</ul>
+
+<p>When the Duktape heap is being destroyed there are a few limitations for
+finalizer behavior:</p>
+<ul>
+<li>Finalizers are executed for all finalizable objects in the heap,
+    including reachable objects.</li>
+<li>Finalizers cannot rescue objects; the semantics for a "rescue" would be
+    ambiguous.  The finalizer's second argument is <code>true</code> when
+    called during heap destruction to indicate rescue is not possible.</li>
+<li>A finalizer can create new finalizable objects and these objects will also
+    be finalized.  For example, a finalizer may post a HTTP notification of
+    an object destruction which may use native network resources with their
+    own finalizers.  However, there's a sanity limit to this process to ensure
+    runaway finalizers cannot prevent a heap from being destroyed.</li>
+<li>The finalizer sanity algorithm is version specific, see
+    <a href="http://wiki.duktape.org/HowtoFinalization.html">How to use finalization</a>.
+    The algorithm allows the number of finalizable objects to grow initially,
+    but it must decrease in a reasonable time or the finalization process is
+    aborted, which may cause some native resource leaks.</li>
+</ul>
+
+<h2>Other current limitations</h2>
+
+<ul>
+<li>When script execution timeout
+(<code>DUK_OPT_EXEC_TIMEOUT_CHECK</code> / <code>DUK_USE_EXEC_TIMEOUT_CHECK</code>)
+is used and a timeout occurs, it's possible for an Ecmascript finalizer to start
+running but immediately fail due to a script timeout.  If this is a concrete
+concern, use a Duktape/C native finalizer instead which will run normally even
+when propagating a timeout.</li>
+<li>The context (Duktape thread) executing the finalizer can currently be any
+    coroutine in the heap.  This must be taken into account in sandboxing.</li>
+<li>Finalizers cannot currently yield.</li>
+</ul>


### PR DESCRIPTION
Change `duk_hobject_run_finalizer()` so that:

- If `DUK_HEAPHDR_FLAG_FINALIZED` is already set, do nothing.
- Set `DUK_HEAPHDR_FLAG_FINALIZED` just before running finalizer.

This should guarantee the semantics described in #109 (= at most one finalizer call per rescue cycle) because:

- The only place where a finalizer is called is `duk_hobject_run_finalizer()`.
- The `FINALIZED` flag is only cleared by an explicit rescue, detected by either mark-and-sweep or refcounting. 

Other changes:

- Heap destruction finalizer behavior changes: allow finalizers to create new finalizable objects whose finalizers are also executed, sanity limit.
- Explicit Proxy check, don't call finalizer on a Proxy object.

Tasks:

- [x] Review changes
- [x] Try to come up with a repro case for finalizer re-run, most obvious cases are already fixed
- [x] Test case for runaway finalizer which spawns 1 or 2 new objects per finalization
- [x] Test case for new finalizer argument
- [x] Ensure "mark-and-sweep running" is checked even when mark-and-sweep not enabled
- [x] Website changes for new guarantee
- [x] Internal doc changes for new guarantee
- [x] Add second parameter to finalizer indicating if rescue is possible or not (true: heap being destroyed, can't rescue; false: normal rescue possible)
- [x] Finalizer documentation changes for new 2nd argument
- [x] Run heap destruction finalizers in a loop to allow any new finalizable objects created by previous finalizers to also be finalized
- [x] Add a sanity limit to the finalization loop
- [x] Releases
- [x] Assert run with mark-and-sweep + refcounting
- [x] Assert run with mark-and-sweep only
- [x] Assert run with refcounting only

Fixes #109. See #108.