### PR TITLE
Add fastint downgrade check for yield/resume values

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1243,6 +1243,8 @@ Planned
   DUK_OPT_REGEXP_CANON_WORKAROUND or DUK_USE_REGEXP_CANON_WORKAROUND if
   editing duk_config.h directly (GH-411)
 
+* Add a fastint downgrade check for yield/resume values (GH-482)
+
 * Fix a segfault (and assertion error) caused by compiler intermediate value
   handling bug; the bug was triggered when a temporary register was required
   by the compiler, but an existing "intermediate value" referred to a const

--- a/doc/fastint.rst
+++ b/doc/fastint.rst
@@ -27,12 +27,15 @@ only applied in specific situations.  Currently:
 * All function return values are automatically downgraded to fastints if
   possible.
 
+* Thread yield/resume values are automatically downgraded to fastints if
+  possible.
+
 Fastints don't affect Ecmascript semantics and are completely transparent
 to user C and Ecmascript code: all conversions are automatic.
 
-To enable fastint support, simply define the feature option:
+To enable fastint support, simply define:
 
-* ``DUK_OPT_FASTINT``
+* ``DUK_OPT_FASTINT`` / ``DUK_USE_FASTINT``
 
 You should measure the impact of enabling fastint support for your target
 platform and Ecmascript code base.  Fastint support is not an automatic

--- a/src/duk_bi_thread.c
+++ b/src/duk_bi_thread.c
@@ -169,6 +169,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	/* lj value1: value */
 	DUK_ASSERT(thr->valstack_bottom + 1 < thr->valstack_top);
 	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value1, &thr->valstack_bottom[1]);  /* side effects */
+	DUK_TVAL_CHKFAST_INPLACE(&thr->heap->lj.value1);
 
 	thr->heap->lj.iserror = is_error;
 
@@ -285,6 +286,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	/* lj value1: value */
 	DUK_ASSERT(thr->valstack_bottom < thr->valstack_top);
 	DUK_TVAL_SET_TVAL_UPDREF(thr, &thr->heap->lj.value1, &thr->valstack_bottom[0]);  /* side effects */
+	DUK_TVAL_CHKFAST_INPLACE(&thr->heap->lj.value1);
 
 	thr->heap->lj.iserror = is_error;
 

--- a/tests/ecmascript/test-dev-fastint-basic.js
+++ b/tests/ecmascript/test-dev-fastint-basic.js
@@ -1713,7 +1713,7 @@ return value downgrade test
 
 function retvalDowngradeTest() {
     // All function return values (both Ecmascript and C) are automatically
-    // double-to-fastint downgraded
+    // double-to-fastint downgraded.
 
     function myfunc() {
         var x = 123.0;
@@ -1725,6 +1725,49 @@ function retvalDowngradeTest() {
     printFastint(Math.floor(123.1));
     printFastint('foo'.charCodeAt(1));
     printFastint(myfunc());
+}
+
+/*===
+yield/resume value downgrade test
+x before initial resume
+123 7b
+arg in thread
+123 7b fastint
+x before initial yield
+123 7b
+yield value
+123 7b fastint
+===*/
+
+function yieldResumeDowngradeTest() {
+    // All yielded values are automatically double-to-fastint downgraded.
+    // All resume values are automatically double-to-fastint downgraded.
+
+    print('yield/resume value downgrade test');
+
+    function myThread(arg) {
+        print('arg in thread');
+        printFastint(arg);
+
+        var x = 123.0;
+        x += 0.5; x -= 0.5;
+        print('x before initial yield');
+        printFastint(x);
+        var resumeValue = Duktape.Thread.yield(x);
+
+        print('resume value');
+        printFastint(resumeValue);
+    }
+
+    var t = new Duktape.Thread(myThread);
+
+    var x = 123.0;
+    x += 0.5; x -= 0.5;
+    print('x before initial resume');
+    printFastint(x);
+    var yieldValue = Duktape.Thread.resume(t, x);
+    print('yield value');
+    printFastint(yieldValue);
 }
 
 /*===
@@ -3090,6 +3133,7 @@ try {
     unaryBitopsBrute();
     negativeZeroTest();
     retvalDowngradeTest();
+    yieldResumeDowngradeTest();
     unaryPlusDowngradeTest();
     downgradeSanityTest();
 } catch (e) {


### PR DESCRIPTION
Add fastint downgrade check for yield/resume values, which should intuitively match function return value behavior.