### PR TITLE
Fix incorrect debugger eval-related assert

### DIFF
--- a/src/duk_bi_global.c
+++ b/src/duk_bi_global.c
@@ -431,7 +431,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 	duk_small_uint_t comp_flags;
 	duk_int_t level = -2;
 
-	DUK_ASSERT_TOP(ctx, 1);
+	DUK_ASSERT(duk_get_top(ctx) == 1 || duk_get_top(ctx) == 2);  /* 2 when called by debugger */
 	DUK_ASSERT(thr->callstack_top >= 1);  /* at least this function exists */
 	DUK_ASSERT(((thr->callstack + thr->callstack_top - 1)->flags & DUK_ACT_FLAG_DIRECT_EVAL) == 0 || /* indirect eval */
 	           (thr->callstack_top >= 2));  /* if direct eval, calling activation must exist */


### PR DESCRIPTION
Debugger Eval caused an assertion failure with asserts enabled. The failing assert was `DUK_ASSERT_TOP(ctx, 1)` in the `duk_bi_global.c` `eval()` function. That assert is incorrect when the debugger calls `eval()`; in that case top will be 2.