### PR TITLE
Don't "require" debugger support for debugger opts

### DIFF
--- a/config/config-options/DUK_USE_DEBUGGER_DUMPHEAP.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_DUMPHEAP.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DEBUGGER_DUMPHEAP
 feature_enables: DUK_OPT_DEBUGGER_DUMPHEAP
 introduced: 1.2.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 default: false
 tags:
   - debugger

--- a/config/config-options/DUK_USE_DEBUGGER_FWD_LOGGING.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_FWD_LOGGING.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DEBUGGER_FWD_LOGGING
 feature_enables: DUK_OPT_DEBUGGER_FWD_LOGGING
 introduced: 1.2.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 default: false
 tags:
   - debugger

--- a/config/config-options/DUK_USE_DEBUGGER_FWD_PRINTALERT.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_FWD_PRINTALERT.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DEBUGGER_FWD_PRINTALERT
 feature_enables: DUK_OPT_DEBUGGER_FWD_PRINTALERT
 introduced: 1.2.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 default: false
 tags:
   - debugger

--- a/config/config-options/DUK_USE_DEBUGGER_PAUSE_UNCAUGHT.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_PAUSE_UNCAUGHT.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DEBUGGER_PAUSE_UNCAUGHT
 feature_enables: DUK_OPT_DEBUGGER_PAUSE_UNCAUGHT
 introduced: 1.4.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 related:
   - DUK_USE_DEBUGGER_THROW_NOTIFY
 default: false

--- a/config/config-options/DUK_USE_DEBUGGER_THROW_NOTIFY.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_THROW_NOTIFY.yaml
@@ -1,11 +1,12 @@
 define: DUK_USE_DEBUGGER_THROW_NOTIFY
 feature_enables: DUK_OPT_DEBUGGER_THROW_NOTIFY
 introduced: 1.4.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 related:
   - DUK_USE_DEBUGGER_PAUSE_UNCAUGHT
-default: false
+default: true
 tags:
   - debugger
 description: >

--- a/config/config-options/DUK_USE_DEBUGGER_TRANSPORT_TORTURE.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_TRANSPORT_TORTURE.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DEBUGGER_TRANSPORT_TORTURE
 feature_enables: DUK_OPT_DEBUGGER_TRANSPORT_TORTURE
 introduced: 1.2.0
-requires:
-  - DUK_USE_DEBUGGER_SUPPORT
+# Option is ignored unless debugger support is enabled.
+#requires:
+#  - DUK_USE_DEBUGGER_SUPPORT
 default: false
 tags:
   - debugger


### PR DESCRIPTION
DUK_USE_DEBUGGER_THROW_NOTIFY default is "true".  If the option "requires" DUK_USE_DEBUGGER_SUPPORT (which defaults to "false") the option configuraiton would be inconsistent and rejected by default.

Remove the "required" metadata for debugger options: the options don't really require debugger support.  Instead, if debugger support is disabled, the debugger config options are just ignored without causing a build error.