### PR TITLE
Use an outer setjmp wrapper for duk_handle_call() and duk_handle_safe_call()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1305,9 +1305,10 @@ Planned
   assignment statements with an identifier left-hand-side value, especially
   when the assignment is a top level expression like "x = y + z;" (GH-380)
 
-* Internal performance improvement: split bytecode executor into an inner and
-  outer function, with the outer function containing a setjmp/longjmp catch
-  point and the inner function free of setjmp/longjmp (GH-369, GH-370)
+* Internal performance improvement: split bytecode executor and call handling
+  into an inner and outer function, with the outer function containing a
+  setjmp/longjmp catch point and the inner function free of setjmp/longjmp
+  (GH-369, GH-370, GH-498)
 
 * Internal performance improvement: change value stack initialization policy
   so that values above current value stack top are set to "undefined" instead

--- a/src/duk_api_call.c
+++ b/src/duk_api_call.c
@@ -39,7 +39,6 @@ DUK_EXTERNAL void duk_call(duk_context *ctx, duk_idx_t nargs) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_small_uint_t call_flags;
 	duk_idx_t idx_func;
-	duk_int_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
@@ -58,17 +57,15 @@ DUK_EXTERNAL void duk_call(duk_context *ctx, duk_idx_t nargs) {
 
 	call_flags = 0;  /* not protected, respect reclimit, not constructor */
 
-	rc = duk_handle_call(thr,           /* thread */
-	                     nargs,         /* num_stack_args */
-	                     call_flags);   /* call_flags */
-	DUK_UNREF(rc);
+	duk_handle_call_unprotected(thr,           /* thread */
+	                            nargs,         /* num_stack_args */
+	                            call_flags);   /* call_flags */
 }
 
 DUK_EXTERNAL void duk_call_method(duk_context *ctx, duk_idx_t nargs) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_small_uint_t call_flags;
 	duk_idx_t idx_func;
-	duk_int_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
@@ -81,10 +78,9 @@ DUK_EXTERNAL void duk_call_method(duk_context *ctx, duk_idx_t nargs) {
 
 	call_flags = 0;  /* not protected, respect reclimit, not constructor */
 
-	rc = duk_handle_call(thr,           /* thread */
-	                     nargs,         /* num_stack_args */
-	                     call_flags);   /* call_flags */
-	DUK_UNREF(rc);
+	duk_handle_call_unprotected(thr,           /* thread */
+	                            nargs,         /* num_stack_args */
+	                            call_flags);   /* call_flags */
 }
 
 DUK_EXTERNAL void duk_call_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs) {
@@ -133,11 +129,11 @@ DUK_EXTERNAL duk_int_t duk_pcall(duk_context *ctx, duk_idx_t nargs) {
 	duk_push_undefined(ctx);
 	duk_insert(ctx, idx_func + 1);
 
-	call_flags = DUK_CALL_FLAG_PROTECTED;  /* protected, respect reclimit, not constructor */
+	call_flags = 0;  /* respect reclimit, not constructor */
 
-	rc = duk_handle_call(thr,           /* thread */
-	                     nargs,         /* num_stack_args */
-	                     call_flags);   /* call_flags */
+	rc = duk_handle_call_protected(thr,           /* thread */
+	                               nargs,         /* num_stack_args */
+	                               call_flags);   /* call_flags */
 
 	return rc;
 }
@@ -158,11 +154,11 @@ DUK_EXTERNAL duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs) {
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
 
-	call_flags = DUK_CALL_FLAG_PROTECTED;  /* protected, respect reclimit, not constructor */
+	call_flags = 0;  /* respect reclimit, not constructor */
 
-	rc = duk_handle_call(thr,           /* thread */
-	                     nargs,         /* num_stack_args */
-	                     call_flags);   /* call_flags */
+	rc = duk_handle_call_protected(thr,           /* thread */
+	                               nargs,         /* num_stack_args */
+	                               call_flags);   /* call_flags */
 
 	return rc;
 }
@@ -271,7 +267,6 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 	duk_hobject *fallback;
 	duk_idx_t idx_cons;
 	duk_small_uint_t call_flags;
-	duk_int_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -365,15 +360,13 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 
 	call_flags = DUK_CALL_FLAG_CONSTRUCTOR_CALL;  /* not protected, respect reclimit, is a constructor call */
 
-	rc = duk_handle_call(thr,           /* thread */
-	                     nargs,         /* num_stack_args */
-	                     call_flags);   /* call_flags */
-	DUK_UNREF(rc);
+	duk_handle_call_unprotected(thr,           /* thread */
+	                            nargs,         /* num_stack_args */
+	                            call_flags);   /* call_flags */
 
 	/* [... fallback retval] */
 
-	DUK_DDD(DUK_DDDPRINT("constructor call finished, rc=%ld, fallback=%!iT, retval=%!iT",
-	                     (long) rc,
+	DUK_DDD(DUK_DDDPRINT("constructor call finished, fallback=%!iT, retval=%!iT",
 	                     (duk_tval *) duk_get_tval(ctx, -2),
 	                     (duk_tval *) duk_get_tval(ctx, -1)));
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1397,7 +1397,7 @@ DUK_LOCAL void duk__debug_handle_eval(duk_hthread *thr, duk_heap *heap) {
 
 	/* [ ... eval "eval" eval_input level ] */
 
-	call_flags = DUK_CALL_FLAG_PROTECTED;
+	call_flags = 0;
 	if (thr->callstack_top >= (duk_size_t) -level) {
 		duk_activation *act;
 		duk_hobject *fun;
@@ -1414,7 +1414,7 @@ DUK_LOCAL void duk__debug_handle_eval(duk_hthread *thr, duk_heap *heap) {
 		}
 	}
 
-	call_ret = duk_handle_call(thr, 2 /*num_stack_args*/, call_flags);
+	call_ret = duk_handle_call_protected(thr, 2 /*num_stack_args*/, call_flags);
 
 	if (call_ret == DUK_EXEC_SUCCESS) {
 		eval_err = 0;

--- a/src/duk_error_augment.c
+++ b/src/duk_error_augment.c
@@ -136,12 +136,11 @@ DUK_LOCAL void duk__err_augment_user(duk_hthread *thr, duk_small_uint_t stridx_c
 	DUK_ASSERT(!DUK_HEAP_HAS_ERRHANDLER_RUNNING(thr->heap));  /* since no recursive error handler calls */
 	DUK_HEAP_SET_ERRHANDLER_RUNNING(thr->heap);
 
-	call_flags = DUK_CALL_FLAG_PROTECTED |
-	             DUK_CALL_FLAG_IGNORE_RECLIMIT;  /* protected, ignore reclimit, not constructor */
+	call_flags = DUK_CALL_FLAG_IGNORE_RECLIMIT;  /* ignore reclimit, not constructor */
 
-	rc = duk_handle_call(thr,
-	                     1,            /* num args */
-	                     call_flags);  /* call_flags */
+	rc = duk_handle_call_protected(thr,
+	                               1,            /* num args */
+	                               call_flags);  /* call_flags */
 	DUK_UNREF(rc);  /* no need to check now: both success and error are OK */
 
 	DUK_ASSERT(DUK_HEAP_HAS_ERRHANDLER_RUNNING(thr->heap));

--- a/src/duk_js.h
+++ b/src/duk_js.h
@@ -6,12 +6,11 @@
 #define DUK_JS_H_INCLUDED
 
 /* Flags for call handling. */
-#define DUK_CALL_FLAG_PROTECTED              (1 << 0)  /* duk_handle_call: call is protected */
-#define DUK_CALL_FLAG_IGNORE_RECLIMIT        (1 << 1)  /* duk_handle_call: call ignores C recursion limit (for errhandler calls) */
-#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 2)  /* duk_handle_call: constructor call (i.e. called as 'new Foo()') */
-#define DUK_CALL_FLAG_IS_RESUME              (1 << 3)  /* duk_handle_ecma_call_setup: setup for a resume() */
-#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 4)  /* duk_handle_ecma_call_setup: setup for a tail call */
-#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 5)  /* call is a direct eval call */
+#define DUK_CALL_FLAG_IGNORE_RECLIMIT        (1 << 0)  /* duk_handle_call_xxx: call ignores C recursion limit (for errhandler calls) */
+#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 1)  /* duk_handle_call_xxx: constructor call (i.e. called as 'new Foo()') */
+#define DUK_CALL_FLAG_IS_RESUME              (1 << 2)  /* duk_handle_ecma_call_setup: setup for a resume() */
+#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 3)  /* duk_handle_ecma_call_setup: setup for a tail call */
+#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 4)  /* call is a direct eval call */
 
 /* Flags for duk_js_equals_helper(). */
 #define DUK_EQUALS_FLAG_SAMEVALUE            (1 << 0)  /* use SameValue instead of non-strict equality */
@@ -88,7 +87,8 @@ void duk_js_push_closure(duk_hthread *thr,
                          duk_hobject *outer_lex_env);
 
 /* call handling */
-DUK_INTERNAL_DECL duk_int_t duk_handle_call(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL void duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
 DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 


### PR DESCRIPTION
- [x] Move setjmp and error handling to an outer function and provide separate `duk_handle_call_unprotected()` and `duk_handle_call_protected()` calls
- [x] Split success and error paths from `duk_handle_safe_call()` into local helpers to also reduce the size of the function containing `DUK_SETJMP()`
- [x] Rework `DUK_SETJMP()` call sites so that success case is always the first clause (the "then" part); this is more compatible with using C++ try-catch later
- [x] Review call handling and compare to previous
- [x] Performance test => no measurable change
- [x] Assertion runs
- [x] Test262
- [x] Compilation test on Linux and Windows