### PR TITLE
Remove unnecessary volatile attributes in call handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1296,9 +1296,6 @@ Planned
 * Fix base64 decode reject for whitespace between padding characters
   (e.g. "Zm= =") (GH-465)
 
-* Fix a (possibly incorrect) setjmp-related warning by adding "volatile" to
-  call handling "idx_func" variable (GH-497)
-
 * Improve error message for source code UTF-8 decode error (GH-504, GH-506)
 
 * Internal performance improvement: rework RETURN opcode handling to avoid

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -982,10 +982,10 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	duk_uint_fast8_t entry_thread_state;
 	duk_instr_t **entry_ptr_curr_pc;
 #if !defined(DUK_USE_CPP_EXCEPTIONS)
-	duk_jmpbuf * volatile old_jmpbuf_ptr = NULL;    /* ptr is volatile (not the target) */
+	duk_jmpbuf *old_jmpbuf_ptr = NULL;
 	duk_jmpbuf our_jmpbuf;
 #endif
-	volatile duk_idx_t idx_func;         /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
+	duk_idx_t idx_func;  /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
 
 	/* XXX: Multiple tv_func lookups are now avoided by making a local
 	 * copy of tv_func.  Another approach would be to compute an offset


### PR DESCRIPTION
These have been unnecessary even before, but they caused seemingly bogus warnings with some compilers.  Now that the setjmp() functions are much smaller, these are hopefully no longer an issue.