### PR TITLE
Missing parameter in the API doc example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * https://github.com/sstruchtrup
 * Michael Drake (https://github.com/tlsa)
 * https://github.com/chris-y
+* Laurent Zubiaur (https://github.com/lzubiaur)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/website/api/duk_push_error_object_va.yaml
+++ b/website/api/duk_push_error_object_va.yaml
@@ -16,7 +16,7 @@ example: |
       duk_idx_t err_idx;
 
       va_start(ap, fmt);
-      err_idx = duk_push_error_object_va(ctx, fmt, ap);
+      err_idx = duk_push_error_object_va(ctx, DUK_ERR_TYPE_ERROR, fmt, ap);
       va_end(ap);
 
       return err_idx;


### PR DESCRIPTION
Parameter `err_code` is missing when calling `duk_push_error_object_va` in the example.