### PR TITLE
Loosen rules for RegExp { } literals

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * Michael Drake (https://github.com/tlsa)
 * https://github.com/chris-y
 * Laurent Zubiaur (https://github.com/lzubiaur)
+* Julien Hamaide (https://github.com/crazyjul)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/config/config-options/DUK_USE_NONSTD_REGEXP_BRACES.yaml
+++ b/config/config-options/DUK_USE_NONSTD_REGEXP_BRACES.yaml
@@ -1,0 +1,10 @@
+define: DUK_USE_NONSTD_REGEXP_BRACES
+feature_enables: DUK_OPT_NONSTD_REGEXP_BRACES
+introduced: 1.3.2
+default: true
+tags:
+  - ecmascript
+description: >
+  Enable support for non-standard '{' literal. Ecmascript requires
+  curly braces to be escaped, but most regex engine support them
+  when they are not used in valid quantifier. This option is recommended.

--- a/tests/ecmascript/test-regexp-non-std-brace.js
+++ b/tests/ecmascript/test-regexp-non-std-brace.js
@@ -1,0 +1,75 @@
+var t;
+
+/*===
+a{abc}
+a{1b}
+a{2,b}
+===*/
+
+// Any non-valid character cancels quantifier parsing
+
+t = /a{.*}/.exec("aa{abc}");
+print(t[0]);
+t = /a{1.}/.exec("aa{1b}");
+print(t[0]);
+t = /a{2,.}/.exec("aa{2,b}");
+print(t[0]);
+
+/*===
+a{abc}
+===*/
+
+// Closing brace is allowed
+t = /a\{.*}/.exec("aa{abc}");
+print(t[0]);
+
+/*===
+a{1}
+a{1,2}
+===*/
+
+// Valid quantifier but for the closing brace
+t = /a{1\}/.exec("aa{1}");
+print(t[0]);
+t = /a{1,2\}/.exec("aa{1,2}");
+print(t[0]);
+
+/*===
+{1111111111111111111111111
+===*/
+
+// Do not fail on digits before , or }
+t = /{1111111111111111111111111/.exec('{1111111111111111111111111');
+print(t[0]);
+
+/*===
+a{}
+a{,}
+a{1,2,3}
+===*/
+
+//On parsing failure, treat as a brace
+
+t = /a{}/.exec('a{}');
+print(t[0]);
+
+t = /a{,}/.exec('a{,}');
+print(t[0]);
+
+t = /a{1,2,3}/.exec('a{1,2,3}');
+print(t[0]);
+
+
+/*===
+SyntaxError
+===*/
+
+// Current implementation does not allow all types of error
+
+// Too many numbers
+try {
+    eval("/{1111111111111111111111111}/.exec('foo');");
+    print("no exception");
+} catch (e) {
+    print(e.name);
+}


### PR DESCRIPTION
Check the regex for valid quantifier, if none found, suppose it's a character literal.

If } is encountered outside of quantifier parsing, it is treated as a literal

This MR fixes #142 and partial for #74