### PR TITLE
Fix heap_allocated reinsertion for refzero finalizer rescued objects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * Michael Drake (https://github.com/tlsa)
 * https://github.com/chris-y
 * Laurent Zubiaur (https://github.com/lzubiaur)
+* Ole André Vadla Ravnås (https://github.com/oleavr)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1367,6 +1367,11 @@ Planned
 1.5.0 (XXXX-XX-XX)
 ------------------
 
+* Fix potentially memory unsafe behavior when a refcount-triggered finalizer
+  function rescues an object; the memory unsafe behavior doesn't happen
+  immediately which makes the cause of the unsafe behavior difficult to
+  diagnose (GH-531)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/src/duk_heap_markandsweep.c
+++ b/src/duk_heap_markandsweep.c
@@ -752,6 +752,7 @@ DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_int_t flags, duk_size_t *out_
 				DUK_HEAPHDR_SET_PREV(heap, curr, NULL);
 #endif
 				DUK_HEAPHDR_SET_NEXT(heap, curr, heap->finalize_list);
+				DUK_ASSERT_HEAPHDR_LINKS(heap, curr);
 				heap->finalize_list = curr;
 #ifdef DUK_USE_DEBUG
 				count_finalize++;
@@ -789,6 +790,8 @@ DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_int_t flags, duk_size_t *out_
 #ifdef DUK_USE_DOUBLE_LINKED_HEAP
 				DUK_HEAPHDR_SET_PREV(heap, curr, prev);
 #endif
+				DUK_ASSERT_HEAPHDR_LINKS(heap, prev);
+				DUK_ASSERT_HEAPHDR_LINKS(heap, curr);
 				prev = curr;
 			}
 
@@ -843,6 +846,7 @@ DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_int_t flags, duk_size_t *out_
 	if (prev) {
 		DUK_HEAPHDR_SET_NEXT(heap, prev, NULL);
 	}
+	DUK_ASSERT_HEAPHDR_LINKS(heap, prev);
 
 #ifdef DUK_USE_DEBUG
 	DUK_D(DUK_DPRINT("mark-and-sweep sweep objects (non-string): %ld freed, %ld kept, %ld rescued, %ld queued for finalization",

--- a/src/duk_heap_misc.c
+++ b/src/duk_heap_misc.c
@@ -21,6 +21,11 @@ DUK_INTERNAL void duk_heap_remove_any_from_heap_allocated(duk_heap *heap, duk_he
 	} else {
 		;
 	}
+
+	/* The prev/next pointers of the removed duk_heaphdr are left as garbage.
+	 * It's up to the caller to ensure they're written before inserting the
+	 * object back.
+	 */
 }
 #endif
 

--- a/src/duk_heap_refcount.c
+++ b/src/duk_heap_refcount.c
@@ -350,8 +350,12 @@ DUK_LOCAL void duk__refzero_free_pending(duk_hthread *thr) {
 			DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZABLE(h1));
 			DUK_ASSERT(DUK_HEAPHDR_HAS_FINALIZED(h1));
 			DUK_HEAPHDR_CLEAR_FINALIZED(h1);
+			h2 = heap->heap_allocated;
 			DUK_HEAPHDR_SET_PREV(heap, h1, NULL);
-			DUK_HEAPHDR_SET_NEXT(heap, h1, heap->heap_allocated);
+			if (h2) {
+				DUK_HEAPHDR_SET_PREV(heap, h2, h1);
+			}
+			DUK_HEAPHDR_SET_NEXT(heap, h1, h2);
 			heap->heap_allocated = h1;
 		} else {
 			/* no -> decref members, then free */

--- a/src/duk_heap_refcount.c
+++ b/src/duk_heap_refcount.c
@@ -27,11 +27,14 @@ DUK_LOCAL void duk__queue_refzero(duk_heap *heap, duk_heaphdr *hdr) {
 		DUK_HEAPHDR_SET_NEXT(heap, hdr, NULL);
 		DUK_HEAPHDR_SET_PREV(heap, hdr, hdr_prev);
 		DUK_HEAPHDR_SET_NEXT(heap, hdr_prev, hdr);
+		DUK_ASSERT_HEAPHDR_LINKS(heap, hdr);
+		DUK_ASSERT_HEAPHDR_LINKS(heap, hdr_prev);
 		heap->refzero_list_tail = hdr;
 	} else {
 		DUK_ASSERT(heap->refzero_list_tail == NULL);
 		DUK_HEAPHDR_SET_NEXT(heap, hdr, NULL);
 		DUK_HEAPHDR_SET_PREV(heap, hdr, NULL);
+		DUK_ASSERT_HEAPHDR_LINKS(heap, hdr);
 		heap->refzero_list = hdr;
 		heap->refzero_list_tail = hdr;
 	}
@@ -356,6 +359,8 @@ DUK_LOCAL void duk__refzero_free_pending(duk_hthread *thr) {
 				DUK_HEAPHDR_SET_PREV(heap, h2, h1);
 			}
 			DUK_HEAPHDR_SET_NEXT(heap, h1, h2);
+			DUK_ASSERT_HEAPHDR_LINKS(heap, h1);
+			DUK_ASSERT_HEAPHDR_LINKS(heap, h2);
 			heap->heap_allocated = h1;
 		} else {
 			/* no -> decref members, then free */

--- a/src/duk_heaphdr.h
+++ b/src/duk_heaphdr.h
@@ -232,6 +232,27 @@ struct duk_heaphdr_string {
 #define DUK_HEAPHDR_STRING_INIT_NULLS(h)  /* currently nop */
 
 /*
+ *  Assert helpers
+ */
+
+/* Check that prev/next links are consistent: if e.g. h->prev is != NULL,
+ * h->prev->next should point back to h.
+ */
+#if defined(DUK_USE_DOUBLE_LINKED_HEAP)
+#define DUK_ASSERT_HEAPHDR_LINKS(heap,h) do { \
+		if ((h) != NULL) { \
+			duk_heaphdr *h__prev, *h__next; \
+			h__prev = DUK_HEAPHDR_GET_PREV((heap), (h)); \
+			h__next = DUK_HEAPHDR_GET_NEXT((heap), (h)); \
+			DUK_ASSERT(h__prev == NULL || (DUK_HEAPHDR_GET_NEXT((heap), h__prev) == (h))); \
+			DUK_ASSERT(h__next == NULL || (DUK_HEAPHDR_GET_PREV((heap), h__next) == (h))); \
+		} \
+	} while (0)
+#else
+#define DUK_ASSERT_HEAPHDR_LINKS(heap,h) do {} while (0)
+#endif
+
+/*
  *  Reference counting helper macros.  The macros take a thread argument
  *  and must thus always be executed in a specific thread context.  The
  *  thread argument is needed for features like finalization.  Currently

--- a/src/duk_hobject_alloc.c
+++ b/src/duk_hobject_alloc.c
@@ -24,7 +24,8 @@ DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_hobject *obj, duk_uint
 	DUK_HEAPHDR_SET_PREV(heap, &obj->hdr, NULL);
 #endif
 #endif
-        DUK_HEAP_INSERT_INTO_HEAP_ALLOCATED(heap, &obj->hdr);
+	DUK_ASSERT_HEAPHDR_LINKS(heap, &obj->hdr);
+	DUK_HEAP_INSERT_INTO_HEAP_ALLOCATED(heap, &obj->hdr);
 
 	/*
 	 *  obj->props is intentionally left as NULL, and duk_hobject_props.c must deal

--- a/tests/api/test-bug-refzero-rescue-queue.c
+++ b/tests/api/test-bug-refzero-rescue-queue.c
@@ -1,0 +1,185 @@
+/*
+ *  Duktape 1.4.0 (and unpatched previous versions) had a bug in refcount
+ *  finalizer handling: when the rescued object was queued back into the
+ *  heap_allocated list, the "prev" pointer of the previous list head (which
+ *  becomes the "next" of the inserted object) was not updated.
+ *
+ *  The "prev" pointer will be NULL which, while incorrect, is not a memory
+ *  safety issue by itself.  However, when the object later participates in
+ *  heap linked list operations, the NULL pointer may cause an unrelated
+ *  object's "next" pointer to be left unupdated.  That "next" pointer may
+ *  then be a non-NULL dangling pointer pointing to an object already freed.
+ *
+ *  This issue often goes unnoticed (before this test was added no previous
+ *  finalizer test triggered any issues, even with valgrind enabled), but can
+ *  cause odd side effects much later after the finalizer rescue.  For example,
+ *  a previously freed object can be added back into the heap which then causes
+ *  a read/write-after-free detected by valgrind or ASAN.
+ *
+ *  This test case is a result of debugging an issue which occurred with
+ *  Frida Duktape integration.  https://github.com/oleavr was able to reduce
+ *  the original issue into an independent repro case ("dukrecycle") which was
+ *  then adapted into this test case.  The test case may seem a bit odd, but
+ *  several (seemingly unrelated) heap linked list operations are needed to
+ *  trigger the concrete memory safety issues caused by the bug.
+ *
+ *  The test case doesn't work without refcounts because it expects the
+ *  finalizer to run immediately and make the rescued object available
+ *  for reuse.
+ */
+
+/*===
+*** test_badgers (duk_safe_call)
+first call
+* pushing badger1
+> inspect_badger
+* pushing badger2
+* putting back badger2
+< inspect_badger
+* putting back badger1
+
+second call
+* pushing badger1
+> inspect_badger
+* pushing badger2
+* putting back badger2
+< inspect_badger
+* putting back badger1
+
+done
+final top: 0
+==> rc=0, result='undefined'
+* putting back badger1
+* putting back badger2
+===*/
+
+static void *create_badger(duk_context *ctx, const char *id);
+static void push_badger(duk_context *ctx);
+static duk_ret_t finalize_badger(duk_context *ctx);
+static duk_ret_t inspect_badger(duk_context *ctx);
+
+static void *cached_badger_1 = NULL;
+static void *cached_badger_2 = NULL;
+
+static duk_ret_t test_badgers(duk_context *ctx) {
+	cached_badger_1 = create_badger(ctx, "badger1");
+	cached_badger_2 = create_badger(ctx, "badger2");
+
+	printf("first call\n");
+
+	duk_push_c_function(ctx, inspect_badger, 1);
+	duk_push_object(ctx);
+	push_badger(ctx);
+	duk_put_prop_string(ctx, -2, "animal");
+
+	duk_pcall(ctx, 1);
+	duk_pop(ctx);
+
+	printf("\nsecond call\n");
+
+	duk_push_c_function(ctx, inspect_badger, 1);
+
+	duk_push_object(ctx);
+	push_badger(ctx);
+	duk_put_prop_string(ctx, -2, "animal");
+
+	duk_pcall(ctx, 1);
+	duk_pop(ctx);
+
+	printf("\ndone\n");
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static void *create_badger(duk_context *ctx, const char *id) {
+	void *result;
+
+	duk_push_object(ctx);
+
+	duk_push_string(ctx, id);
+	duk_put_prop_string(ctx, -2, "id");
+
+	duk_push_c_function(ctx, finalize_badger, 2);
+	duk_set_finalizer(ctx, -2);
+
+	result = duk_get_heapptr(ctx, -1);
+
+	duk_push_global_stash(ctx);
+	duk_dup(ctx, -2);
+	duk_put_prop_string(ctx, -2, id);
+
+	duk_pop_2(ctx);
+
+	return result;
+}
+
+static void push_badger(duk_context *ctx) {
+	void **cached_badger;
+
+	cached_badger = &cached_badger_1;
+	if (*cached_badger != NULL) {
+		printf("* pushing badger1\n");
+	} else {
+		cached_badger = &cached_badger_2;
+		printf("* pushing badger2\n");
+	}
+
+	if (*cached_badger != NULL) {
+		const char *id;
+
+		duk_push_heapptr(ctx, *cached_badger);
+		*cached_badger = NULL;
+
+		duk_get_prop_string(ctx, -1, "id");
+		id = duk_get_string(ctx, -1);
+
+		duk_push_global_stash(ctx);
+		duk_del_prop_string(ctx, -1, id);
+
+		duk_pop_2(ctx);
+
+		return;
+	}
+
+	printf("never here\n");
+}
+
+static duk_ret_t finalize_badger(duk_context *ctx) {
+	const char *id;
+
+	duk_get_prop_string(ctx, 0, "id");
+	id = duk_get_string(ctx, -1);
+
+	if (strcmp(id, "badger1") == 0) {
+		printf("* putting back badger1\n");
+		cached_badger_1 = duk_get_heapptr(ctx, 0);
+	} else if (strcmp(id, "badger2") == 0) {
+		printf("* putting back badger2\n");
+		cached_badger_2 = duk_get_heapptr(ctx, 0);
+	} else {
+		printf("never here\n");
+	}
+
+	duk_push_global_stash(ctx);
+	duk_dup(ctx, 0);
+	duk_put_prop_string(ctx, -2, id);
+
+	duk_pop_2(ctx);
+
+	return 0;
+}
+
+static duk_ret_t inspect_badger(duk_context *ctx) {
+	printf("> inspect_badger\n");
+
+	push_badger(ctx);
+	duk_pop(ctx);
+
+	printf("< inspect_badger\n");
+
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_badgers);
+}


### PR DESCRIPTION
Fix heap_allocated reinsertion bug which affected refzero finalizer rescued objects. See test case in: https://github.com/oleavr/dukrecycle/ (a bug test case will be adapted in this branch based on that).

- [x] Fix the re-queueing of refzero finalizer rescued objects
- [x] Adapt test case from dukrecycle, test that bug appears before and gets fixes by the diff
- [x] Add linked list consistency assertion helper which checks that prev/next and curr are linked correctly
- [x] Add more heap_allocated consistency asserts to linked list manipulation points, ensure assertion tests pass with them in place and that asserts would have caught the original bug
- [x] Releases entry
- [x] Schedule backports to 1.4.1, 1.3.3, and 1.2.6
