### PR TITLE
Fix feature option defaults when already provided

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1381,6 +1381,10 @@ Planned
   exotic pointer models by avoiding arithmetic and binary operations on
   (u)intptr_t values (GH-530, GH-539)
 
+* Fix a genconfig legacy feature option bug in Duktape 1.4.0 which caused
+  DUK_USE_PACKED_TVAL to default to false unless forced using
+  DUK_OPT_PACKED_TVAL (GH-550)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/config/config-options/DUK_USE_ALIGN_BY.yaml
+++ b/config/config-options/DUK_USE_ALIGN_BY.yaml
@@ -1,5 +1,4 @@
 define: DUK_USE_ALIGN_BY
-# FIXME: resolve wrapper
 feature_snippet: |
   #if !defined(DUK_USE_ALIGN_BY)
   #if defined(DUK_OPT_FORCE_ALIGN)
@@ -8,6 +7,7 @@ feature_snippet: |
   #define DUK_USE_ALIGN_BY 8
   #endif
   #endif
+feature_no_default: true  # provided by architecture unless forced
 introduced: 1.3.0
 default: 8
 tags:

--- a/config/config-options/DUK_USE_EXAMPLE.yaml
+++ b/config/config-options/DUK_USE_EXAMPLE.yaml
@@ -30,6 +30,12 @@ related_feature_defines:
 #   #endif
 #   #endif
 
+# Feature default value is provided by platform, compiler, or architecture.
+# DUK_OPT_xxx handling can force the value if explicitly requested by
+# DUK_OPT_XXX or DUK_OPT_NO_xxx, but if neither is given, don't emit a
+# default.
+#feature_no_default: true
+
 # Duktape version number where this option was first introduced.
 introduced: 1.1.0
 

--- a/config/config-options/DUK_USE_PACKED_TVAL.yaml
+++ b/config/config-options/DUK_USE_PACKED_TVAL.yaml
@@ -1,9 +1,6 @@
 define: DUK_USE_PACKED_TVAL
 feature_enables: DUK_OPT_PACKED_TVAL
-# FIXME: current snippet is actually:
-#if defined(DUK_USE_PACKED_TVAL_POSSIBLE) && !defined(DUK_OPT_NO_PACKED_TVAL)
-#define DUK_USE_PACKED_TVAL
-#endif
+feature_no_default: true  # provided by architecture unless forced
 introduced: 1.0.0
 default: false
 tags:

--- a/config/config-options/DUK_USE_SETJMP.yaml
+++ b/config/config-options/DUK_USE_SETJMP.yaml
@@ -1,5 +1,6 @@
 define: DUK_USE_SETJMP
 feature_enables: DUK_OPT_SETJMP
+feature_no_default: true  # provided by platform unless forced
 introduced: 1.1.0
 default: true
 tags:

--- a/config/config-options/DUK_USE_SIGSETJMP.yaml
+++ b/config/config-options/DUK_USE_SIGSETJMP.yaml
@@ -1,5 +1,6 @@
 define: DUK_USE_SIGSETJMP
 feature_enables: DUK_OPT_SIGSETJMP
+feature_no_default: true  # provided by platform unless forced
 introduced: 1.1.0
 default: false
 tags:

--- a/config/config-options/DUK_USE_UNDERSCORE_SETJMP.yaml
+++ b/config/config-options/DUK_USE_UNDERSCORE_SETJMP.yaml
@@ -1,5 +1,6 @@
 define: DUK_USE_UNDERSCORE_SETJMP
 feature_enables: DUK_OPT_UNDERSCORE_SETJMP
+feature_no_default: true  # provided by platform unless forced
 introduced: 1.1.0
 default: false
 tags:


### PR DESCRIPTION
This caused an issue with a few config options when feature option support (DUK_OPT_xxx) was enabled.  For example, DUK_USE_PACKED_TVAL is provided by platform detection; if neither DUK_OPT_PACKED_TVAL nor DUK_OPT_NO_PACKED_TVAL was defined, the default clause would #undef DUK_USE_PACKED_TVAL instead of keeping the platform detected value. Workaround is to use `-DDUK_OPT_PACKED_TVAL`.

Affected config options:

- DUK_USE_PACKED_TVAL
- DUK_USE_SETJMP
- DUK_USE_UNDERSCORE_SETJMP