### PR TITLE
Clarify debugger documentation for callbacks calling back into Duktape

### DIFF
--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -256,7 +256,8 @@ debug command (see "Custom requests and notifications"), use instead::
                                my_udata);                /* debug udata */
 
 When called, Duktape will enter debug mode, pause execution, and wait for
-further instructions from the debug client.
+further instructions from the debug client.  If Duktape debugger support is
+not enabled, an error is thrown.
 
 The transport callbacks are given as part of the start request.  Duktape
 expects a new virtual stream for every debug start/stop cycle, and will
@@ -267,7 +268,14 @@ The detached callback is called when the debugger becomes detached.  This
 can happen due to an explicit request (``duk_debugger_detach()``), a debug
 message/transport error, or Duktape heap destruction.
 
-If Duktape debugger support is not enabled, an error is thrown.
+Unless explicitly mentioned in the API documentation, none of the callbacks
+are allowed to call into the Duktape API (this is also the reason why they
+mostly don't get a ``ctx`` argument); doing so may cause memory unsafe
+behavior.  As a concrete example, if a user read callback calls into the
+Duktape API during a read operation, the API call may trigger garbage
+collection.  Because garbage collection may have arbitrary side effects,
+the debugger command in progress (implemented in ``src/duk_debugger.c``)
+may then break in a very confusing manner.
 
 duk_debugger_detach()
 ---------------------

--- a/website/api/duk_debugger_attach.yaml
+++ b/website/api/duk_debugger_attach.yaml
@@ -22,18 +22,24 @@ summary: |
   <code>read_flush_cb</code> and <code>write_flush_cb</code> callbacks are
   optional.  Unimplemented callbacks are indicated using a <code>NULL</code>.</p>
 
+  <p><b>Important:</b> The callbacks are not allowed to call any Duktape API
+  functions (doing so may cause memory unsafe behavior) except for the following:</p>
+  <ul>
+  <li>The <code>request_cb</code> AppRequest callback (given in the extended
+      <code><a href="#duk_debugger_attach_custom">duk_debugger_attach_custom()</a></code>
+      API call) may use the value stack within the guidelines described in
+      <a href="https://github.com/svaarala/duktape/blob/master/doc/debugger.rst">debugger.rst</a>.</li>
+  <li>Since Duktape 1.4.0 the debugger detached callback is allowed to call
+      <code><a href="#duk_debugger_attach">duk_debugger_attach()</a></code>
+      to immediately reattach the debugger.  In Duktape 1.3.0 and before the
+      immediate reattach potentially caused
+      <a href="https://github.com/svaarala/duktape/pull/399">some issues</a>.</li>
+  </ul>
+
   <div class="note">
   The <code><a href="#duk_debugger_attach_custom">duk_debugger_attach_custom()</a></code>
   variant accepts an additional callback to support application specific commands
   (AppRequest).  These two calls will be merged in Duktape 2.x.
-  </div>
-
-  <div class="note">
-  Since Duktape 1.4.0 the debugger detached callback is allowed to call
-  <code><a href="#duk_debugger_attach">duk_debugger_attach()</a></code>
-  to immediately reattach the debugger.  In Duktape 1.3.0 and before the
-  immediate reattach potentially caused
-  <a href="https://github.com/svaarala/duktape/pull/399">some issues</a>.
   </div>
 
 example: |


### PR DESCRIPTION
- [x] Add note to `duk_debugger_attach()` API doc
- [x] Add note to debugger doc