### PR TITLE
Change Function .toString() output to be Emscripten compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,8 +678,8 @@ emscriptentest: emscripten duk
 	emscripten/emcc $(EMCCOPTS) tests/emscripten/helloworld.c -o /tmp/duk-emcc-test.js
 	cat /tmp/duk-emcc-test.js | $(PYTHON) util/fix_emscripten.py > /tmp/duk-emcc-test-fixed.js
 	@ls -l /tmp/duk-emcc-test*
-	./duk /tmp/duk-emcc-test-fixed.js
-	#./duk /tmp/duk-emcc-test.js
+	#./duk /tmp/duk-emcc-test-fixed.js
+	./duk /tmp/duk-emcc-test.js
 
 .PHONY: emscriptenmandeltest
 emscriptenmandeltest: emscripten duk
@@ -689,8 +689,8 @@ emscriptenmandeltest: emscripten duk
 	emscripten/emcc $(EMCCOPTS) tests/emscripten/mandelbrot.c -o /tmp/duk-emcc-test.js
 	cat /tmp/duk-emcc-test.js | $(PYTHON) util/fix_emscripten.py > /tmp/duk-emcc-test-fixed.js
 	@ls -l /tmp/duk-emcc-test*
-	./duk /tmp/duk-emcc-test-fixed.js
-	#./duk /tmp/duk-emcc-test.js
+	#./duk /tmp/duk-emcc-test-fixed.js
+	./duk /tmp/duk-emcc-test.js
 
 # Compile Duktape and hello.c using Emscripten and execute the result with
 # Duktape.
@@ -702,8 +702,8 @@ emscripteninceptiontest: emscripten dist duk
 	emscripten/emcc $(EMCCOPTS) -Idist/src dist/src/duktape.c dist/examples/hello/hello.c -o /tmp/duk-emcc-test.js
 	cat /tmp/duk-emcc-test.js | $(PYTHON) util/fix_emscripten.py > /tmp/duk-emcc-test-fixed.js
 	@ls -l /tmp/duk-emcc-test*
-	./duk /tmp/duk-emcc-test-fixed.js
-	#./duk /tmp/duk-emcc-test.js
+	#./duk /tmp/duk-emcc-test-fixed.js
+	./duk /tmp/duk-emcc-test.js
 
 # Compile Duktape with Emscripten and execute it with NodeJS:
 #   - --memory-init-file 0 to avoid a separate memory init file (this is
@@ -771,7 +771,8 @@ emscriptenluatest: emscripten duk lua-5.2.3
 	emscripten/emcc $(EMCCOPTS) -Ilua-5.2.3/src/ $(patsubst %,lua-5.2.3/src/%,$(LUASRC)) -o /tmp/duk-emcc-luatest.js
 	cat /tmp/duk-emcc-luatest.js | $(PYTHON) util/fix_emscripten.py > /tmp/duk-emcc-luatest-fixed.js
 	@ls -l /tmp/duk-emcc-luatest*
-	./duk /tmp/duk-emcc-luatest-fixed.js
+	#./duk /tmp/duk-emcc-luatest-fixed.js
+	./duk /tmp/duk-emcc-luatest.js
 
 JS-Interpreter:
 	# https://github.com/NeilFraser/JS-Interpreter

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1372,6 +1372,11 @@ Planned
   existing Javascript code which often assumes support for some non-standard
   regexp expressions (GH-142, GH-513, GH-547)
 
+* Change Function object .toString() output to be Emscripten compatible:
+  anonymous functions won't get an automatic "anon" name, and the function
+  type is indicated using a fake directive rather than a comment; for example,
+  'function () {"ecmascript"}' (GH-554)
+
 * Fix potentially memory unsafe behavior when a refcount-triggered finalizer
   function rescues an object; the memory unsafe behavior doesn't happen
   immediately which makes the cause of the unsafe behavior difficult to

--- a/doc/emscripten-status.rst
+++ b/doc/emscripten-status.rst
@@ -8,17 +8,11 @@ Hello world test
 Quick hello world test::
 
   $ ./emcc --memory-init-file 0 tests/hello_world.cpp -o /tmp/test.js
-  $ python $DUKTAPE/util/fix_emscripten.py < /tmp/test.js > /tmp/test-fixed.js
-  $ duk /tmp/test-fixed.js
+  $ duk /tmp/test.js
 
 Tweaks needed:
 
 * ``--memory-init-file 0``: don't use an external memory file.
-
-* Emscripten expects a function's ``.toString()`` to match a certain
-  pattern which is not guaranteed (and Duktape doesn't match), see
-  ``util/fix_emscripten.py``.  Since Duktape 1.5.0 non-standard regexp
-  fixes for unescaped curly braces are no longer needed.
 
 Normally this suffices.  If you're running Duktape with a small amount of
 memory (e.g. when running the Duktape command line tool with the ``-r``
@@ -31,9 +25,18 @@ following additional options:
 * ``-s TOTAL_STACK=524288``: reduce total stack size to fit it into the
   reduced memory size.
 
-Since Duktape 1.3 there is support for Khronos/ES6 TypedArrays which allow
-Emscripten to run better than with Duktape 1.2, and also allows use of
-Emscripten fastcomp.
+Changes in Duktape versions:
+
+* Since Duktape 1.3 there is support for Khronos/ES6 TypedArrays which allow
+  Emscripten to run better than with Duktape 1.2, and also allows use of
+  Emscripten fastcomp.
+
+* Since Duktape 1.5 no fixups are needed to run Emscripten-generated code:
+  Duktape now accepts non-standard unescaped curly braces in regexps, and
+  the Function ``.toString()`` output was changed to be acceptable to the
+  Emscripten regexps.  Earlier a fixup script was needed::
+
+      $ python $DUKTAPE/util/fix_emscripten.py < /tmp/test.js > /tmp/test-fixed.js
 
 Setting up fastcomp for Duktape
 ===============================

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -4505,7 +4505,7 @@ DUK_INTERNAL void duk_push_lightfunc_tostring(duk_context *ctx, duk_tval *tv) {
 
 	duk_push_string(ctx, "function ");
 	duk_push_lightfunc_name(ctx, tv);
-	duk_push_string(ctx, "() {/* light */}");
+	duk_push_string(ctx, "() {\"light\"}");
 	duk_concat(ctx, 3);
 }
 

--- a/src/duk_bi_error.c
+++ b/src/duk_bi_error.c
@@ -194,6 +194,8 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 					}
 				}
 
+				/* XXX: Change 'anon' handling here too, to use empty string for anonymous functions? */
+				/* XXX: Could be improved by coercing to a readable duk_tval (especially string escaping) */
 				h_name = duk_get_hstring(ctx, -2);  /* may be NULL */
 				funcname = (h_name == NULL || h_name == DUK_HTHREAD_STRING_EMPTY_STRING(thr)) ?
 				           "anon" : (const char *) DUK_HSTRING_GET_DATA(h_name);

--- a/src/duk_strings.c
+++ b/src/duk_strings.c
@@ -122,5 +122,4 @@ DUK_INTERNAL const char *duk_str_regexp_executor_recursion_limit = "regexp execu
 DUK_INTERNAL const char *duk_str_regexp_executor_step_limit = "regexp step limit";
 
 /* Misc */
-DUK_INTERNAL const char *duk_str_anon = "anon";
 DUK_INTERNAL const char *duk_str_realloc_failed = "realloc failed";

--- a/src/duk_strings.h
+++ b/src/duk_strings.h
@@ -263,7 +263,6 @@ DUK_INTERNAL_DECL const char *duk_str_regexp_executor_recursion_limit;
 DUK_INTERNAL_DECL const char *duk_str_regexp_executor_step_limit;
 #endif  /* !DUK_SINGLE_FILE */
 
-#define DUK_STR_ANON duk_str_anon
 #define DUK_STR_REALLOC_FAILED duk_str_realloc_failed
 
 #if !defined(DUK_SINGLE_FILE)

--- a/tests/api/test-dev-api-verbose-error-messages-gh441.c
+++ b/tests/api/test-dev-api-verbose-error-messages-gh441.c
@@ -120,14 +120,14 @@ TypeError: buffer required, found [object Function] (stack index -3)
 TypeError: pointer required, found [object Function] (stack index -3)
 test__c_function ok
 top: 1
-TypeError: undefined required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: null required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: boolean required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: number required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: string required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: buffer required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: pointer required, found function LFUNC() {/= light =/} (stack index -3)
-TypeError: nativefunction required, found function LFUNC() {/= light =/} (stack index -3)
+TypeError: undefined required, found function LFUNC() {"light"} (stack index -3)
+TypeError: null required, found function LFUNC() {"light"} (stack index -3)
+TypeError: boolean required, found function LFUNC() {"light"} (stack index -3)
+TypeError: number required, found function LFUNC() {"light"} (stack index -3)
+TypeError: string required, found function LFUNC() {"light"} (stack index -3)
+TypeError: buffer required, found function LFUNC() {"light"} (stack index -3)
+TypeError: pointer required, found function LFUNC() {"light"} (stack index -3)
+TypeError: nativefunction required, found function LFUNC() {"light"} (stack index -3)
 top: 1
 TypeError: undefined required, found [object Function] (stack index -3)
 TypeError: null required, found [object Function] (stack index -3)
@@ -212,8 +212,7 @@ static duk_ret_t test__c_function(duk_context *ctx) {
 		rc = duk_safe_call(ctx, (fn), 3, 3); \
 		if (rc != 0) { \
 			duk_eval_string(ctx, "(function (v) { print(String(v).replace(/\\(0x.*?\\)/g, '(PTR)')" \
-			                     ".replace(/light_[0-9a-fA-F_]+/g, 'LFUNC')" \
-			                     ".replace(/\\*/g, '=')); })"); \
+			                     ".replace(/light_[0-9a-fA-F_]+/g, 'LFUNC')); })"); \
 			duk_dup(ctx, -4); \
 			duk_call(ctx, 1); \
 		} else { \

--- a/tests/api/test-dev-func-tostring.c
+++ b/tests/api/test-dev-func-tostring.c
@@ -1,0 +1,52 @@
+/*
+ *  Test the updated Function .toString() format in Duktape 1.5.0.
+ *
+ *  Cover a few cases which cannot be exercised using Ecmascript code alone.
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+function light_PTR() {"light"}
+function dummy {() {"native"}
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t dummy_func(duk_context *ctx) {
+	(void) ctx;
+	return 0;
+}
+
+static duk_ret_t test_1(duk_context *ctx) {
+	/* Lightfunc, must sanitize the address for the expect string. */
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    print(String(v).replace(/light_[0-9a-fA-f_]+/, 'light_PTR'));\n"
+		"})");
+	duk_push_c_lightfunc(ctx, dummy_func, 0 /*nargs*/, 0 /*length*/, 0 /*magic*/);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	/* Function with a .name containing invalid characters.
+	 *
+	 * This is not currently handled very well: the .toString() output
+	 * uses the name as is, which can make the output technically
+	 * incorrect because it won't parse as a function.  However, the
+	 * only way to create such functions is from C code so this is a
+	 * minor issue.
+	 */
+
+	duk_push_c_function(ctx, dummy_func, 0 /*nargs*/);
+	duk_push_string(ctx, "name");
+	duk_push_string(ctx, "dummy {");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_FORCE);
+	printf("%s\n", duk_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/tests/api/test-dev-lightfunc.c
+++ b/tests/api/test-dev-lightfunc.c
@@ -906,7 +906,7 @@ static duk_ret_t test_to_object(duk_context *ctx) {
 
 /*===
 *** test_to_buffer (duk_safe_call)
-function light_PTR_4232() {(* light *)}
+function light_PTR_4232() {"light"}
 final top: 1
 ==> rc=0, result='undefined'
 ===*/

--- a/tests/ecmascript/test-conv-tostring.js
+++ b/tests/ecmascript/test-conv-tostring.js
@@ -18,7 +18,7 @@
 3 string false
 4 string 123
 5 string foo
-6 string function myfunc() {|* ecmascript *|}
+6 string function myfunc() {"ecmascript"}
 7 string [object Object]
 8 TypeError
 9 string foo
@@ -49,7 +49,7 @@ function test() {
         try {
             var t = String(v);
             if (typeof v === 'function' && typeof t === 'string') {
-                // expect string hack
+                // expect string hack (no longer needed in Duktape 1.5.0)
                 t = t.replace(/\//g, '|');
             }
             print(i, typeof t, t);

--- a/tests/ecmascript/test-dev-func-tostring.js
+++ b/tests/ecmascript/test-dev-func-tostring.js
@@ -1,0 +1,40 @@
+/*
+ *  Test the updated Function .toString() format in Duktape 1.5.0.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+function () {"ecmascript"}
+function foo() {"ecmascript"}
+function cos() {"native"}
+===*/
+
+function test() {
+    var fn;
+
+    // Anonymous function
+    fn = function (){};
+    print(fn);
+
+    // Named function
+    fn = function foo(){};
+    print(fn);
+
+    // Native function
+    fn = Math.cos;
+    print(fn);
+
+    // Lightfunc and some other cases are covered by
+    // tests/api/test-dev-func-tostring.c.
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-primary-identifier.js
+++ b/tests/ecmascript/test-dev-primary-identifier.js
@@ -6,10 +6,10 @@
 foo
 foo
 234
-function inner() {|* ecmascript *|}
+function inner() {"ecmascript"}
 123
 234
-function inner() {|* ecmascript *|}
+function inner() {"ecmascript"}
 123
 ===*/
 
@@ -30,12 +30,12 @@ function test(arg) {
 
     // fast path local variable, local function, local argument
     print(x);
-    print(String(inner).replace(/\//g, '|'));
+    print(String(inner));
     print(arg);
 
     // same through slow path eval
     eval('print(x);');
-    eval('print(String(inner).replace(/\\//g, "|"));');
+    eval('print(String(inner));');
     eval('print(arg);');
 }
 

--- a/website/guide/compatibility.html
+++ b/website/guide/compatibility.html
@@ -93,19 +93,13 @@ support yet, no "heap object" can be provided.</p>
 <h2 id="compatibility-emscripten">Emscripten</h2>
 
 <p><a href="https://github.com/kripken/emscripten">Emscripten</a> compiles
-C/C++ into Javascript.  Duktape is currently Emscripten compatible except
-for an assumption about the format of a function's <code>toString()</code>
-output, see:
-<a href="https://github.com/svaarala/duktape/blob/master/util/fix_emscripten.py">fix_emscripten.py</a>.
-Since Duktape 1.5.0 fixes for non-standard regexps are no longer needed.
-</p>
+C/C++ into Javascript.  Duktape is currently (as of Duktape 1.5.0) Emscripten
+compatible and supports Khronos/ES6 TypedArray which allows Emscripten fastcomp
+to be used.</p>
 
-<p>As of Duktape 1.3 there is support for Khronos/ES6 TypedArray which improves
-Emscripten performance over Duktape 1.2 and allows the Emscripten fastcomp
-to be used.  Duktape can now also execute larger Emscripten-compiled programs
-and can e.g. run both Emscripten-compiled Lua and Duktape.  Large programs may
-still fail due to Duktape compiler running out of virtual registers, and
-performance is somewhat limited as Duktape is an interpreted engine.  See
+<p>Large programs may fail due to Duktape compiler running out of virtual
+registers, and performance is somewhat limited as Duktape is an interpreted
+engine.  See
 <a href="https://github.com/svaarala/duktape/blob/master/doc/emscripten-status.rst">emscripten-status.rst</a>
 for current compatibility status.</p>
 


### PR DESCRIPTION
Change Function `.toString()` output in two minor ways to make it Emscripten compatible without the need for fixups:

- If the function is anonymous, don't use a dummy `"anon"` name for it. For example, instead of `function anon() {...}` output `function () {}`.
- Use a string literal (similar to a directive) instead of a comment to indicate function type. For example, instead of `function foo() {/*ecmascript*/}` output `function foo() {"ecmascript"}`

While both the old and new formats are equally valid from a compliance perspective, it'd be nice if no Emscripten fixups were needed. The anonymous function behavior is, in my opinion, an improvement; the function type indication is more a matter of style.

Tasks:
- [x] Finalize change
- [x] Fix breaking testcases
- [x] Add a dev testcase for new format with explanation
- [x] Internal documentation, esp. Emscripten status
- [x] Website/wiki update for Emscripten status
- [x] Update `fix_emscripten.py` to indicate it's no longer required (at least with current Duktape and Emscripten versions)
- [x] Update Makefile to avoid the hopefully unnecessary fixups
- [x] Releases entry