### PR TITLE
Avoid fmin/fmax on Atari Mint

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1385,6 +1385,8 @@ Planned
   DUK_USE_PACKED_TVAL to default to false unless forced using
   DUK_OPT_PACKED_TVAL (GH-550)
 
+* Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -261,6 +261,8 @@ typedef FILE duk_file;
 /* uclibc may be missing these */
 #elif defined(DUK_F_AMIGAOS) && defined(DUK_F_VBCC)
 /* vbcc + AmigaOS may be missing these */
+#elif defined(DUK_F_MINT)
+/* mint clib is missing these */
 #elif !defined(DUK_F_C99) && !defined(DUK_F_CPP11)
 /* build is not C99 or C++11, play it safe */
 #else

--- a/config/helper-snippets/DUK_F_MINT.h.in
+++ b/config/helper-snippets/DUK_F_MINT.h.in
@@ -1,0 +1,4 @@
+/* Atari Mint */
+#if defined(__MINT__)
+#define DUK_F_MINT
+#endif


### PR DESCRIPTION
Fix needed in NetSurf: http://source.netsurf-browser.org/netsurf.git/commit/javascript/duktape/duk_config.h?id=c2bd86ca9644734ad87b560757251e26fde666b7
