### PR TITLE
Fix debugger eval locking

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1394,6 +1394,10 @@ Planned
   DUK_USE_PACKED_TVAL to default to false unless forced using
   DUK_OPT_PACKED_TVAL (GH-550)
 
+* Fix debugger Eval handling issue where an uncaught error during Eval
+  command (with "pause on uncaught" option enabled) would cause a recursive
+  attempt to halt execution (GH-558, GH-562)
+
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 
 * Change OS string (visible in Duktape.env) from "ios" to "osx" for non-phone

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1877,6 +1877,7 @@ DUK_INTERNAL duk_bool_t duk_debug_process_messages(duk_hthread *thr, duk_bool_t 
 	DUK_UNREF(ctx);
 	DUK_ASSERT(thr->heap != NULL);
 	DUK_ASSERT(DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap));
+	DUK_ASSERT(thr->heap->dbg_processing == 1);  /* caller ensures */
 #if defined(DUK_USE_ASSERTIONS)
 	entry_top = duk_get_top(ctx);
 #endif


### PR DESCRIPTION
`heap->dbg_processing` was not set to 1 when debugger message loop was entered from the bytecode executor. When the debugger Eval command was then used it was possible for error handling code to send Throw notifys while running the eval code; more seriously, if "pause on uncaught" was enabled the debugger might try to halt while already halted.

Fixing `dbg_processing` flag fixes the uncaught error bug. As a side effect there won't be Throw notifys during debugger Eval.

Fixes #558.