### PR TITLE
Add support for HTML comment syntax

### DIFF
--- a/src/duk_lexer.c
+++ b/src/duk_lexer.c
@@ -975,6 +975,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		advtok = DUK__ADVTOK(1, DUK_TOK_COMMA);
 		break;
 	case DUK_ASC_LANGLE:  /* '<' */
+		/* FIXME: add HTML comment <!-- ... --> support here. */
 		if (DUK__L1() == '<' && DUK__L2() == '=') {
 			advtok = DUK__ADVTOK(3, DUK_TOK_ALSHIFT_EQ);
 		} else if (DUK__L1() == '=') {


### PR DESCRIPTION
https://www.mail-archive.com/netsurf-users@netsurf-browser.org/msg06825.html

HTML comment syntax is not part of ES5 but is an optional part of ES6:
- http://www.ecma-international.org/ecma-262/6.0/#sec-html-like-comments
