### PR TITLE
Free ajsheap on heap destroy in 'duk' command

### DIFF
--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -63,6 +63,7 @@
 #if defined(DUK_CMDLINE_AJSHEAP)
 /* Defined in duk_cmdline_ajduk.c or alljoyn.js headers. */
 void ajsheap_init(void);
+void ajsheap_free(void);
 void ajsheap_dump(void);
 void ajsheap_register(duk_context *ctx);
 void ajsheap_start_exec_timeout(void);
@@ -777,6 +778,7 @@ static void destroy_duktape_heap(duk_context *ctx, int alloc_provider) {
 		fprintf(stdout, "Pool dump after duk_destroy_heap() (should have zero allocs)\n");
 		ajsheap_dump();
 	}
+	ajsheap_free();
 #endif
 }
 

--- a/examples/cmdline/duk_cmdline_ajduk.c
+++ b/examples/cmdline/duk_cmdline_ajduk.c
@@ -158,6 +158,13 @@ void ajsheap_init(void) {
 #endif
 }
 
+void ajsheap_free(void) {
+	if (ajsheap_ram != NULL) {
+		free(ajsheap_ram);
+		ajsheap_ram = NULL;
+	}
+}
+
 /* AjsHeap.dump(), allows Ecmascript code to dump heap status at suitable
  * points.
  */


### PR DESCRIPTION
`valgrind ./ajduk` shows a single ~190kb leak caused by the single allocation for the pool allocator. This pull adds a free() for the ajsheap on Duktape heap destroy.