### PR TITLE
Add debugger Break notify

### DIFF
--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1350,6 +1350,21 @@ reestablish the link).
 ``msg`` is an optional string elaborating on the reason for the detach.  It may
 or may not be present depending on the nature of detachment.
 
+Break notification (0x07)
+-------------------------
+
+Format::
+
+    NFY <int: 7> <int: index> EOM
+
+Example::
+
+    NFY 7 3 EOM
+
+Duktape sends a Break notification whenever a breakpoint is hit during checked
+execution. ``index`` is the number of the breakpoint which was hit, as returned
+in the response for AddBreak (see below).
+
 Commands sent by debug client
 =============================
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -906,6 +906,16 @@ DUK_INTERNAL void duk_debug_send_status(duk_hthread *thr) {
 	duk_debug_write_eom(thr);
 }
 
+DUK_INTERNAL void duk_debug_send_break(duk_hthread *thr, duk_uint32_t index) {
+	/*
+	 *  NFY <int: 7> <int: index> EOM
+	 */
+
+	duk_debug_write_notify(thr, DUK_DBG_CMD_BREAK);
+	duk_debug_write_int(thr, index);
+	duk_debug_write_eom(thr);
+}
+
 #if defined(DUK_USE_DEBUGGER_THROW_NOTIFY)
 DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 	/*

--- a/src/duk_debugger.h
+++ b/src/duk_debugger.h
@@ -21,6 +21,7 @@
 #define DUK_DBG_CMD_LOG           0x04
 #define DUK_DBG_CMD_THROW         0x05
 #define DUK_DBG_CMD_DETACHING     0x06
+#define DUK_DBG_CMD_BREAK         0x07
 
 /* Initiated by debug client */
 #define DUK_DBG_CMD_BASICINFO     0x10
@@ -87,7 +88,9 @@ DUK_INTERNAL_DECL void duk_debug_write_notify(duk_hthread *thr, duk_small_uint_t
 DUK_INTERNAL_DECL void duk_debug_write_eom(duk_hthread *thr);
 
 DUK_INTERNAL_DECL duk_uint_fast32_t duk_debug_curr_line(duk_hthread *thr);
+
 DUK_INTERNAL_DECL void duk_debug_send_status(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_debug_send_break(duk_hthread *thr, duk_uint32_t index);
 #if defined(DUK_USE_DEBUGGER_THROW_NOTIFY)
 DUK_INTERNAL_DECL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal);
 #endif

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -1484,6 +1484,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 	duk_activation *act;
 	duk_breakpoint *bp;
 	duk_breakpoint **bp_active;
+	duk_uint32_t bp_idx;
 	duk_uint_fast32_t line = 0;
 	duk_bool_t send_status;
 	duk_bool_t process_messages;
@@ -1532,6 +1533,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 			 * described in: https://github.com/svaarala/duktape/issues/263.
 			 */
 			bp_active = thr->heap->dbg_breakpoints_active;
+			bp_idx = 0;
 			for (;;) {
 				bp = *bp_active++;
 				if (bp == NULL) {
@@ -1543,8 +1545,11 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 					DUK_D(DUK_DPRINT("BREAKPOINT TRIGGERED at %!O:%ld",
 					                 (duk_heaphdr *) bp->filename, (long) bp->line));
 
+					duk_debug_send_break(thr, bp_idx);
 					DUK_HEAP_SET_PAUSED(thr->heap);
 				}
+
+				bp_idx++;
 			}
 		} else {
 			;


### PR DESCRIPTION
This is an initial prototype for a Break notify which is sent whenever a breakpoint is hit during execution.  The notify message indicates the breakpoint number that was hit, information which is not available in a Status notify.