### PR TITLE
Change OSX identification in Duktape.env from "ios" to "osx"

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1396,6 +1396,9 @@ Planned
 
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 
+* Change OS string (visible in Duktape.env) from "ios" to "osx" for non-phone
+  targets (GH-570, GH-571)
+
 2.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/config/platforms/platform_apple.h.in
+++ b/config/platforms/platform_apple.h.in
@@ -14,9 +14,9 @@
 #elif TARGET_OS_IPHONE
 #define DUK_USE_OS_STRING "iphone"
 #elif TARGET_OS_MAC
-#define DUK_USE_OS_STRING "ios"
+#define DUK_USE_OS_STRING "osx"
 #else
-#define DUK_USE_OS_STRING "ios-unknown"
+#define DUK_USE_OS_STRING "osx-unknown"
 #endif
 
 /* Use _setjmp() on Apple by default, see GH-55. */


### PR DESCRIPTION
Fixes #570.