### PR TITLE
put_function_list with magic

### DIFF
--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -475,6 +475,24 @@ DUK_EXTERNAL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, c
 	}
 }
 
+DUK_EXTERNAL void duk_put_function_list_magic(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_magic_entry *funcs) {
+	const duk_function_list_magic_entry *ent = funcs;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	obj_index = duk_require_normalize_index(ctx, obj_index);
+	if (ent != NULL) {
+		while (ent->key != NULL) {
+			duk_push_c_function(ctx, ent->value, ent->nargs);
+			if (ent->magic != 0) {
+				duk_set_magic(ctx, -1, ent->magic);
+			}
+			duk_put_prop_string(ctx, obj_index, ent->key);
+			ent++;
+		}
+	}
+}
+
 DUK_EXTERNAL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers) {
 	const duk_number_list_entry *ent = numbers;
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -34,6 +34,7 @@ extern "C" {
 
 struct duk_memory_functions;
 struct duk_function_list_entry;
+struct duk_function_list_magic_entry;
 struct duk_number_list_entry;
 
 /* duk_context is now defined in duk_config.h because it may also be
@@ -41,6 +42,7 @@ struct duk_number_list_entry;
  */
 typedef struct duk_memory_functions duk_memory_functions;
 typedef struct duk_function_list_entry duk_function_list_entry;
+typedef struct duk_function_list_magic_entry duk_function_list_magic_entry;
 typedef struct duk_number_list_entry duk_number_list_entry;
 
 typedef duk_ret_t (*duk_c_function)(duk_context *ctx);
@@ -69,6 +71,13 @@ struct duk_function_list_entry {
 	const char *key;
 	duk_c_function value;
 	duk_idx_t nargs;
+};
+
+struct duk_function_list_magic_entry {
+	const char *key;
+	duk_c_function value;
+	duk_idx_t nargs;
+	duk_int_t magic;
 };
 
 struct duk_number_list_entry {
@@ -714,6 +723,7 @@ DUK_EXTERNAL_DECL duk_int_t duk_get_current_magic(duk_context *ctx);
  */
 
 DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs);
+DUK_EXTERNAL_DECL void duk_put_function_list_magic(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_magic_entry *funcs);
 DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers);
 
 /*

--- a/tests/api/test-put-func-num-list.c
+++ b/tests/api/test-put-func-num-list.c
@@ -2,7 +2,7 @@
 *** test_1 (duk_safe_call)
 after definition, top=0
 object
-tweak,adjust,frobnicate,FLAG_FOO,FLAG_BAR,FLAG_QUUX,meaning
+tweak,adjust,frobnicate,text,textColored,textDisabled,no_magic,FLAG_FOO,FLAG_BAR,FLAG_QUUX,meaning
 1
 2
 4
@@ -13,6 +13,14 @@ adjust, top=3
 4
 frobnicate, top=6
 5
+text, top=0, magic=1
+0
+textColored, top=3, magic=2
+4
+textDisabled, top=6, magic=3
+5
+tweak, top=0
+0
 final top: 0
 ==> rc=0, result='undefined'
 ===*/
@@ -38,10 +46,39 @@ static duk_ret_t do_frobnicate(duk_context *ctx) {
 	return 1;
 }
 
+static duk_ret_t do_text(duk_context *ctx) {
+	duk_int_t magic = duk_get_current_magic(ctx);
+	switch (magic) {
+		case 1:
+			printf("text, top=%ld, magic=%ld\n", (long) duk_get_top(ctx), (long) magic);
+			duk_push_int(ctx, duk_get_int(ctx, 0) + duk_get_int(ctx, 1));
+			break;
+		case 2:
+			printf("textColored, top=%ld, magic=%ld\n", (long) duk_get_top(ctx), (long) magic);
+			duk_push_int(ctx, duk_get_int(ctx, 0) + duk_get_int(ctx, 2));
+			break;
+		case 3:
+			printf("textDisabled, top=%ld, magic=%ld\n", (long) duk_get_top(ctx), (long) magic);
+			duk_push_int(ctx, duk_get_int(ctx, 1) + duk_get_int(ctx, 2));
+			break;
+		default:
+			printf("Unknown magic=%ld", (long) magic);
+	}
+	return 1;
+}
+
 static const duk_function_list_entry my_funcs[] = {
 	{ "tweak", do_tweak, 0 },
 	{ "adjust", do_adjust, 3 },
 	{ "frobnicate", do_frobnicate, DUK_VARARGS },
+	{ NULL, NULL, 0 }
+};
+
+static const duk_function_list_magic_entry my_funcs_magic[] = {
+	{ "text", do_text, 0, 1 },
+	{ "textColored", do_text, 3, 2 },
+	{ "textDisabled", do_text, DUK_VARARGS, 3 },
+	{ "no_magic", do_tweak, 0, 0 },
 	{ NULL, NULL, 0 }
 };
 
@@ -60,6 +97,7 @@ int test_1(duk_context *ctx) {
 
 	/* Define functions and constants. */
 	duk_put_function_list(ctx, -2, my_funcs);
+	duk_put_function_list_magic(ctx, -2, my_funcs_magic);
 	duk_put_number_list(ctx, -2, my_consts);
 
 	/* Define module into global object. */
@@ -81,6 +119,10 @@ int test_1(duk_context *ctx) {
 	    "print(MyModule.tweak(1, 2, 3, 4, 5, 6));\n"
 	    "print(MyModule.adjust(1, 2, 3, 4, 5, 6));\n"
 	    "print(MyModule.frobnicate(1, 2, 3, 4, 5, 6));\n"
+	    "print(MyModule.text(1, 2, 3, 4, 5, 6));\n"
+	    "print(MyModule.textColored(1, 2, 3, 4, 5, 6));\n"
+	    "print(MyModule.textDisabled(1, 2, 3, 4, 5, 6));\n"
+	    "print(MyModule.no_magic(1, 2, 3, 4, 5, 6));\n"
 	);
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));


### PR DESCRIPTION
Hi, I find it convenient to be able to specify the `magic` flag when bulk loading functions using `duk_put_function_list`. As an example, I opened this pull request which adds the function `duk_put_function_list_magic` and struct `duk_function_list_magic_entry` with the field `magic`.

One could bulk load functions in a module and specify magics like this:

```
const duk_function_list_magic_entry module_funcs[] = {
    { "text",                  fun_text,    DUK_VARARGS,    1 },
    { "textColored",     fun_text,    DUK_VARARGS,     2 },
    { "textDisabled",    fun_text,    DUK_VARARGS,    3 },
    { "textWrapped",   fun_text,    DUK_VARARGS,     4 },
    { NULL, NULL, 0 }
};

duk_put_function_list_magic(ctx, -1, module_funcs);
```
