### PR TITLE
Add inline macros for MSVC

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1487,6 +1487,8 @@ Planned
 * Portability improvement for VS2012 C++ compilation: avoid double definition
   of replacement double constants (GH-595)
 
+* Portability improvement for Windows MSVC: add inline macros (GH-580)
+
 * Rework setjmp/longjmp configuration model: (1) removed DUK_OPT_SETJMP,
   DUK_OPT_SIGSETJMP, and DUK_OPT_UNDERSCORE_SETJMP; (2) added DUK_JMPBUF_TYPE
   to duk_config.h to allow the jmp_buf struct to be replaced; (3) Duktape

--- a/config/compilers/compiler_msvc.h.in
+++ b/config/compilers/compiler_msvc.h.in
@@ -50,6 +50,15 @@
 
 #define DUK_USE_PACK_MSVC_PRAGMA
 
+/* These have been tested from VS2008 onwards; may work in older VS versions
+ * too but not enabled by default.
+ */
+#if defined(_MSC_VER) && (_MSC_VER >= 1500)
+#define DUK_NOINLINE        __declspec(noinline)
+#define DUK_INLINE          __inline
+#define DUK_ALWAYS_INLINE   __forceinline
+#endif
+
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
 #define DUK_SNPRINTF     snprintf
 #define DUK_VSNPRINTF    vsnprintf


### PR DESCRIPTION
- [x] Add DUK_NOINLINE, DUK_INLINE, and DUK_ALWAYS_INLINE for Windows
- [x] Figure out correct condition for MSVC version - use VS2008 as a limit for now
- [x] Test on VS2013 at least (what I have installed) - works
- [x] Check effect on binary size - adds around 22kB to unstripped x64 binary
- [x] Check effect on performance - only relevant effect is in dump/load right now