### PR TITLE
Update module convention for module.exports

### DIFF
--- a/doc/c-module-convention.rst
+++ b/doc/c-module-convention.rst
@@ -111,11 +111,26 @@ The algorithm for Duktape 2.0 is still under design, but at a high level:
   (Alternatively, expose RET with a fixed name, e.g. initialize ``exports``
   as ``{ value: RET }``.)
 
+Since Duktape 1.3 the ``modSearch()`` function can overwrite ``module.exports``
+which allows you to implement the Duktape 2.0 approach in Duktape 1.x too.
+
 Duktape 1.x CommonJS notes
 ==========================
 
-In Duktape 1.x the module ``exports`` value is always an object created by
-Duktape, and cannot be replaced by modSearch().  modSearch() can only add
+Duktape 1.3 and above
+---------------------
+
+In Duktape 1.3 you can replace ``module.exports`` with the object returned
+by the native module initialization function.  That value then becomes the
+result of the original ``require()`` call.
+
+For an example, see: https://github.com/svaarala/duktape/blob/master/tests/api/test-dev-cmodule-guide.c.
+
+Prior to Duktape 1.3
+--------------------
+
+Prior to Duktape 1.3 the module ``exports`` value is always an object created
+by Duktape, and cannot be replaced by modSearch().  modSearch() can only add
 symbols to the pre-created object.  This has two implications for
 implementing modSearch():
 
@@ -132,9 +147,6 @@ implementing modSearch():
   + The modSearch() function can copy the module value into a fixed name in
     the ``exports`` table.  Suggested name is ``exports.value``.
 
-These limitations will most likely be fixed in Duktape 2.0 module loading
-rework.
-
 Limitations
 ===========
 
@@ -147,7 +159,7 @@ Limitations
   identifier).  This trade-off is intentional to keep the C module convention
   as simple as possible.
 
-* Duktape 1.x CommonJS module loading doesn't support modules with a non-object
-  return value (i.e. all modules return an ``exports`` table).  This module
-  convention is not limited to object return values so that non-object modules
-  can be supported in Duktape 2.0.
+* CommonJS module loading prior to Duktape 1.3 doesn't support modules with
+  a non-object return value (i.e. all modules return an ``exports`` table).
+  This module convention is not limited to object return values so that
+  non-object modules can be supported in Duktape 1.3 and above.

--- a/tests/api/test-dev-cmodule-guide.c
+++ b/tests/api/test-dev-cmodule-guide.c
@@ -2,13 +2,6 @@
  *  Module example from guide, as a more concrete test case.
  */
 
-/*===
-*** test_use_module (duk_safe_call)
-my_func_2() called
-final top: 0
-==> rc=0, result='undefined'
-===*/
-
 /* Include duktape.h and whatever platform headers are needed. */
 #include "duktape.h"
 
@@ -52,6 +45,13 @@ static duk_ret_t dukopen_my_module(duk_context *ctx) {
  *  Calling code
  */
 
+/*===
+*** test_use_module (duk_safe_call)
+my_func_2() called
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
 static duk_ret_t test_use_module(duk_context *ignored_ctx) {
 	duk_context *ctx;
 
@@ -72,6 +72,68 @@ static duk_ret_t test_use_module(duk_context *ignored_ctx) {
 	return 0;
 }
 
+/*
+ *  Example of how a modSearch() function can use module.exports to return
+ *  the C module initialization value.
+ */
+
+/*===
+*** test_modsearch_module (duk_safe_call)
+1
+my_func_1() called
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t my_modsearch(duk_context *ctx) {
+	/* Arguments: id, require, exports, module.
+	 *
+	 * The 'id' is ignored in this example, normally you'd use 'id' to
+	 * select which module to initialize.
+	 */
+
+	/* Initialize the C module. */
+	duk_push_c_function(ctx, dukopen_my_module, 0);
+	duk_call(ctx, 0);
+
+	/* Result is now on stack top.  Overwrite module.exports to make
+	 * that value come out from require().
+	 */
+
+	/* [ id require exports module c_module ] */
+	duk_put_prop_string(ctx, 3 /*module*/, "exports");  /* module.exports = c_module; */
+
+	return 0;  /* return undefined, no Ecmascript source code */
+}
+
+static duk_ret_t test_modsearch_module(duk_context *ignored_ctx) {
+	duk_context *ctx;
+
+	ctx = duk_create_heap_default();
+	if (!ctx) {
+		printf("Failed to create heap\n");
+		return 0;
+	}
+
+	/* Register Duktape.modSearch. */
+	duk_eval_string(ctx, "(function (fun) { Duktape.modSearch = fun; })");
+	duk_push_c_function(ctx, my_modsearch, 4 /*nargs*/);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	/* Require test. */
+	duk_eval_string_noresult(ctx, "var mod = require('my_module'); print(mod.FLAG_FOO); mod.func1();");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	duk_destroy_heap(ctx);
+	return 0;
+}
+
+/*
+ *  Main
+ */
+
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_use_module);
+	TEST_SAFE_CALL(test_modsearch_module);
 }


### PR DESCRIPTION
With Duktape 1.3 and support for overwriting `module.exports` C modules can now be returned directly from `modSearch()` by simply setting `module.exports = my_c_initializer_result;`. Update the internal documentation and API testcase to match.