### PR TITLE
Make stack trace format more user friendly

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1381,6 +1381,9 @@ Planned
   type is indicated using a fake directive rather than a comment; for example,
   'function () {"ecmascript"}' (GH-554)
 
+* Make .stack format a bit more user friendly; if you are parsing the stack
+  trace format this may need changes in your parser (GH-588, GH-592)
+
 * Add Windows version of the debugger example TCP transport (GH-579)
 
 * Add support for application specific debugger commands (AppRequest) and

--- a/src/duk_bi_error.c
+++ b/src/duk_bi_error.c
@@ -120,7 +120,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 	duk_small_int_t i;  /* traceback depth fits into 16 bits */
 	duk_small_int_t t;  /* stack type fits into 16 bits */
 	duk_small_int_t count_func = 0;  /* traceback depth ensures fits into 16 bits */
-	const char *str_tailcalled = " tailcalled";
+	const char *str_tailcall = " tailcall";
 	const char *str_strict = " strict";
 	const char *str_construct = " construct";
 	const char *str_prevyield = " preventsyield";
@@ -134,7 +134,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TRACEDATA);
 	idx_td = duk_get_top_index(ctx);
 
-	duk_push_hstring_stridx(ctx, DUK_STRIDX_NEWLINE_TAB);
+	duk_push_hstring_stridx(ctx, DUK_STRIDX_NEWLINE_4SPACE);
 	duk_push_this(ctx);
 
 	/* [ ... this tracedata sep this ] */
@@ -199,36 +199,36 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 				/* XXX: Could be improved by coercing to a readable duk_tval (especially string escaping) */
 				h_name = duk_get_hstring(ctx, -2);  /* may be NULL */
 				funcname = (h_name == NULL || h_name == DUK_HTHREAD_STRING_EMPTY_STRING(thr)) ?
-				           "anon" : (const char *) DUK_HSTRING_GET_DATA(h_name);
+				           "[anon]" : (const char *) DUK_HSTRING_GET_DATA(h_name);
 				filename = duk_get_string(ctx, -1);
 				filename = filename ? filename : "";
 				DUK_ASSERT(funcname != NULL);
 				DUK_ASSERT(filename != NULL);
 
 				if (h_func == NULL) {
-					duk_push_sprintf(ctx, "%s light%s%s%s%s%s",
+					duk_push_sprintf(ctx, "at %s light%s%s%s%s%s",
 					                 (const char *) funcname,
 					                 (const char *) ((flags & DUK_ACT_FLAG_STRICT) ? str_strict : str_empty),
-					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcalled : str_empty),
+					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcall : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_CONSTRUCT) ? str_construct : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_DIRECT_EVAL) ? str_directeval : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_PREVENT_YIELD) ? str_prevyield : str_empty));
 				} else if (DUK_HOBJECT_HAS_NATIVEFUNCTION(h_func)) {
-					duk_push_sprintf(ctx, "%s %s native%s%s%s%s%s",
+					duk_push_sprintf(ctx, "at %s (%s) native%s%s%s%s%s",
 					                 (const char *) funcname,
 					                 (const char *) filename,
 					                 (const char *) ((flags & DUK_ACT_FLAG_STRICT) ? str_strict : str_empty),
-					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcalled : str_empty),
+					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcall : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_CONSTRUCT) ? str_construct : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_DIRECT_EVAL) ? str_directeval : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_PREVENT_YIELD) ? str_prevyield : str_empty));
 				} else {
-					duk_push_sprintf(ctx, "%s %s:%ld%s%s%s%s%s",
+					duk_push_sprintf(ctx, "at %s (%s:%ld)%s%s%s%s%s",
 					                 (const char *) funcname,
 					                 (const char *) filename,
 					                 (long) line,
 					                 (const char *) ((flags & DUK_ACT_FLAG_STRICT) ? str_strict : str_empty),
-					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcalled : str_empty),
+					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcall : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_CONSTRUCT) ? str_construct : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_DIRECT_EVAL) ? str_directeval : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_PREVENT_YIELD) ? str_prevyield : str_empty));
@@ -257,7 +257,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 					}
 				}
 
-				duk_push_sprintf(ctx, "%s:%ld",
+				duk_push_sprintf(ctx, "at [anon] (%s:%ld) internal",
 				                 (const char *) duk_get_string(ctx, -2), (long) pc);
 				duk_replace(ctx, -3);  /* [ ... v1 v2 str ] -> [ ... str v2 ] */
 				duk_pop(ctx);          /* -> [ ... str ] */

--- a/src/strings.yaml
+++ b/src/strings.yaml
@@ -389,12 +389,12 @@ strings:
   - str: "0"
   - str: "+0"
   - str: "-0"
-  - str: ""       # used as a class name for unused/invalid class
+  - str: ""        # used as a class name for unused/invalid class
     class_name: true
-  - str: ","      # for array joining
-  - str: " "      # for print()
-  - str: "\n\t"   # for tracebacks
-  - str: "[...]"  # for tracebacks
+  - str: ","       # for array joining
+  - str: " "       # for print()
+  - str: "\n    "  # for tracebacks
+  - str: "[...]"   # for tracebacks
   - str: "Invalid Date"  # for invalid Date instances
 
   # arguments object (E5 Section 10.6)
@@ -1216,7 +1216,7 @@ special_define_names:
   "": "EMPTY_STRING"
   ",": "COMMA"
   " ": "SPACE"
-  "\n\t": "NEWLINE_TAB"
+  "\n    ": "NEWLINE_4SPACE"
   "[...]": "BRACKETED_ELLIPSIS"
 
   "{\"_undef\":true}": "JSON_EXT_UNDEFINED"

--- a/tests/api/test-dev-cfunc-name.c
+++ b/tests/api/test-dev-cfunc-name.c
@@ -9,16 +9,16 @@
 *** test_without_name (duk_safe_call)
 my name is: ''
 URIError: uri error (rc -106)
-	anon  native strict preventsyield
-	forEach  native strict preventsyield
-	eval XXX preventsyield
+    at [anon] () native strict preventsyield
+    at forEach () native strict preventsyield
+    at eval XXX preventsyield
 ==> rc=0, result='undefined'
 *** test_with_name (duk_safe_call)
 my name is: 'my_func'
 URIError: uri error (rc -106)
-	my_func  native strict preventsyield
-	forEach  native strict preventsyield
-	eval XXX preventsyield
+    at my_func () native strict preventsyield
+    at forEach () native strict preventsyield
+    at eval XXX preventsyield
 ==> rc=0, result='undefined'
 ===*/
 

--- a/tests/ecmascript/test-dev-lightfunc.js
+++ b/tests/ecmascript/test-dev-lightfunc.js
@@ -95,9 +95,9 @@ function sanitizeTraceback(x) {
 
 /*===
 light func support test
-info.length: 1
+info.length: 2
 typeof: function
-[9]
+9
 ===*/
 
 function lightFuncSupportTest() {
@@ -111,7 +111,8 @@ function lightFuncSupportTest() {
     /* Value is primitive (no prop allocations etc) but still callable. */
     print('info.length:', info.length);
     print('typeof:', typeof fun);
-    print(Duktape.enc('jx', Duktape.info(fun)));
+    print(Duktape.enc('jx', Duktape.info(fun)[0]));
+    // fun[1] is internal type tag which we don't want to test here
 }
 
 try {
@@ -495,9 +496,9 @@ try {
 
 /*===
 arithmetic test
-string: testfunction light_PTR_0511() {(* light *)}function light_PTR_0a11() {(* light *)}
-string: function light_PTR_0511() {(* light *)}function light_PTR_0a11() {(* light *)}
-string: function foo() {(* ecmascript *)}function bar() {(* ecmascript *)}
+string: testfunction light_PTR_0511() {"light"}function light_PTR_0a11() {"light"}
+string: function light_PTR_0511() {"light"}function light_PTR_0a11() {"light"}
+string: function foo() {"ecmascript"}function bar() {"ecmascript"}
 ===*/
 
 function arithmeticTest() {
@@ -519,9 +520,9 @@ try {
 
 /*===
 toString() test
-function light_PTR_002f() {(* light *)}
-function light_PTR_002f() {(* light *)}
-function light_PTR_002f() {(* light *)}
+function light_PTR_002f() {"light"}
+function light_PTR_002f() {"light"}
+function light_PTR_002f() {"light"}
 true
 true
 ===*/
@@ -648,8 +649,8 @@ try {
 
 /*===
 toBuffer() test
-buffer: function light_PTR_0511() {(* light *)}
-buffer: function light_PTR_0a11() {(* light *)}
+buffer: function light_PTR_0511() {"light"}
+buffer: function light_PTR_0a11() {"light"}
 ===*/
 
 function toBufferTest() {
@@ -1124,15 +1125,15 @@ try {
 
 /*===
 bound function test
-F: function light_PTR_002f() {(* light *)}
+F: function light_PTR_002f() {"light"}
 F type tag: 9
-G: function light_PTR_002f() {(* bound *)}
+G: function light_PTR_002f() {"bound"}
 G type tag: 6
 G.length: 1
-H: function light_PTR_002f() {(* bound *)}
+H: function light_PTR_002f() {"bound"}
 H type tag: 6
 H.length: 0
-I: function light_PTR_002f() {(* bound *)}
+I: function light_PTR_002f() {"bound"}
 I type tag: 6
 I.length: 0
 G(123): 234
@@ -1193,8 +1194,8 @@ toString coerced object (return "length")
 read from length -> 2
 read from testWritable -> 123
 read from testNonWritable -> 234
-read from call -> function light_PTR_001f() {(* light *)}
-read from apply -> function light_PTR_0022() {(* light *)}
+read from call -> function light_PTR_001f() {"light"}
+read from apply -> function light_PTR_0022() {"light"}
 read from nonexistent -> undefined
 ===*/
 
@@ -1644,10 +1645,10 @@ try {
 /*===
 traceback test
 URIError: invalid input
-	duk_bi_global.c:NNN
-	light_PTR_0011 light strict preventsyield
-	tracebackTest TESTCASE:NNN
-	global TESTCASE:NNN preventsyield
+    at [anon] (duk_bi_global.c:NNN) internal
+    at light_PTR_0011 light strict preventsyield
+    at tracebackTest (TESTCASE:NNN)
+    at global (TESTCASE:NNN) preventsyield
 ===*/
 
 function tracebackTest() {
@@ -1673,10 +1674,10 @@ try {
 /*===
 Duktape.act() test
 Error: for traceback
-	callback TESTCASE:NNN preventsyield
-	light_PTR_0212 light strict preventsyield
-	duktapeActTest TESTCASE:NNN
-	global TESTCASE:NNN preventsyield
+    at callback (TESTCASE:NNN) preventsyield
+    at light_PTR_0212 light strict preventsyield
+    at duktapeActTest (TESTCASE:NNN)
+    at global (TESTCASE:NNN) preventsyield
 -1 ["lineNumber","pc","function"] light_PTR_0011
 -2 ["lineNumber","pc","function"] callback
 -3 ["lineNumber","pc","function"] light_PTR_0212
@@ -2393,12 +2394,12 @@ try {
 
 /*===
 Duktape built-in test
-info: object [9]
+info: number 9
 act: undefined undefined
 gc: boolean true
 fin-get: TypeError
 fin-set: TypeError
-encdec-hex: string "function light_PTR_0511() {(* light *)}"
+encdec-hex: string "function light_PTR_0511() {\"light\"}"
 dec-hex: TypeError
 compact: function {_func:true}
 ===*/
@@ -2406,7 +2407,8 @@ compact: function {_func:true}
 function duktapeBuiltinTest() {
     var lfunc = Math.cos;
 
-    testTypedJx(function () { return Duktape.info(lfunc); }, 'info');
+    // avoid printing internal tag type
+    testTypedJx(function () { return Duktape.info(lfunc)[0]; }, 'info');
 
     // doesn't really make sense
     testTypedJx(function () { return Duktape.act(lfunc); }, 'act');
@@ -2462,7 +2464,7 @@ try {
 Function built-in test
 Function: function {_func:true}
 new Function: function {_func:true}
-toString: string "function light_PTR_0511() {(* light *)}"
+toString: string "function light_PTR_0511() {\"light\"}"
 valueOf: function {_func:true}
 ===*/
 
@@ -2494,8 +2496,8 @@ parseInt: number NaN
 parseFloat: number NaN
 isNaN: boolean true
 isFinite: boolean false
-decodeURI: string "function light_PTR_0511() {(* light *)}"
-decodeURIComponent: string "function light_PTR_0511() {(* light *)}"
+decodeURI: string "function light_PTR_0511() {\"light\"}"
+decodeURIComponent: string "function light_PTR_0511() {\"light\"}"
 encodeURI: string "string"
 encodeURIComponent: string "string"
 escape: string "string"
@@ -2559,7 +2561,7 @@ Duktape.Logger: TypeError
 new Duktape.Logger: object {}
 fmt: TypeError
 raw: TypeError
-TIMESTAMP INF test: My light func is: function light_PTR_0511() {(* light *)}
+TIMESTAMP INF test: My light func is: function light_PTR_0511() {"light"}
 ===*/
 
 function duktapeLoggerBuiltinTest() {
@@ -2690,7 +2692,7 @@ isSealed: boolean true
 isFrozen: boolean true
 isExtensible: boolean false
 toString: string "[object Function]"
-toLocaleString: string "function light_PTR_0511() {(* native *)}"
+toLocaleString: string "function light_PTR_0511() {\"native\"}"
 valueOf: function {_func:true}
 isPrototypeOf: boolean false
 ===*/
@@ -2763,26 +2765,26 @@ try {
 Proxy built-in test
 get
 this: object false [object Object]
-target: function false function light_PTR_0511() {(* native *)}
+target: function false function light_PTR_0511() {"native"}
 key: string name
 proxy.name: light_PTR_0511
 get
 this: object false [object Object]
-target: function false function light_PTR_0511() {(* native *)}
+target: function false function light_PTR_0511() {"native"}
 key: string length
 proxy.length: 1
 get
 this: object false [object Object]
-target: function false function light_PTR_0511() {(* native *)}
+target: function false function light_PTR_0511() {"native"}
 key: string nonExistent
 proxy.nonExistent: dummy
 get
-this: function false function light_PTR_0511() {(* native *)}
+this: function false function light_PTR_0511() {"native"}
 target: object false [object Object]
 key: string foo
 proxy.foo: bar
 get
-this: function false function light_PTR_0511() {(* native *)}
+this: function false function light_PTR_0511() {"native"}
 target: object false [object Object]
 key: string nonExistent
 proxy.nonExistent: dummy
@@ -2837,8 +2839,8 @@ try {
 
 /*===
 RegExp built-in test
-RegExp: SyntaxError
-new RegExp: SyntaxError
+RegExp: object {}
+new RegExp: object {}
 exec: TypeError
 test: TypeError
 toString: TypeError
@@ -2848,6 +2850,9 @@ valueOf: function {_func:true}
 function regexpBuiltinTest() {
     var lfunc = Math.cos;
 
+    // Before Duktape 1.5.x a lightfunc coerced to string wouldn't parse as a
+    // RegExp because it contained unescaped curly braces.  Since 1.5.x it does
+    // parse as a (non-sensical) RegExp.
     testTypedJx(function () { return RegExp(lfunc); }, 'RegExp');
     testTypedJx(function () { return new RegExp(lfunc); }, 'new RegExp');
 
@@ -2866,30 +2871,30 @@ try {
 
 /*===
 String built-in test
-String: string "function light_PTR_0511() {(* light *)}"
-new String: string "function light_PTR_0511() {(* light *)}"
+String: string "function light_PTR_0511() {\"light\"}"
+new String: string "function light_PTR_0511() {\"light\"}"
 new String: string "object"
 fromCharCode: string "\x00"
 toString: TypeError
 valueOf: TypeError
 charAt: string "f"
 charCodeAt: number 102
-concat: string "function light_PTR_0511() {(* light *)}function light_PTR_0511() {(* light *)}"
+concat: string "function light_PTR_0511() {\"light\"}function light_PTR_0511() {\"light\"}"
 indexOf: number 0
 lastIndexOf: number 0
 localeCompare: number 0
-match: SyntaxError
+match: object null
 replace: string "undefined"
-search: SyntaxError
-slice: string "function light_PTR_0511() {(* light *)}"
+search: number -1
+slice: string "function light_PTR_0511() {\"light\"}"
 split: object ["",""]
-substring: string "function light_PTR_0511() {(* light *)}"
-toLowerCase: string "function light_PTR_0511() {(* light *)}"
-toLocaleLowerCase: string "function light_PTR_0511() {(* light *)}"
-toUpperCase: string "FUNCTION LIGHT_PTR_0511() {(* LIGHT *)}"
-toLocaleUpperCase: string "FUNCTION LIGHT_PTR_0511() {(* LIGHT *)}"
-trim: string "function light_PTR_0511() {(* light *)}"
-substr: string "function light_PTR_0511() {(* light *)}"
+substring: string "function light_PTR_0511() {\"light\"}"
+toLowerCase: string "function light_PTR_0511() {\"light\"}"
+toLocaleLowerCase: string "function light_PTR_0511() {\"light\"}"
+toUpperCase: string "FUNCTION LIGHT_PTR_0511() {\"LIGHT\"}"
+toLocaleUpperCase: string "FUNCTION LIGHT_PTR_0511() {\"LIGHT\"}"
+trim: string "function light_PTR_0511() {\"light\"}"
+substr: string "function light_PTR_0511() {\"light\"}"
 ===*/
 
 function stringBuiltinTest() {

--- a/website/guide/errorobjects.html
+++ b/website/guide/errorobjects.html
@@ -83,7 +83,9 @@ You shouldn't access the traceback data directly.</p>
 
 <p>The printable traceback format is intended to be human readable only.
 You shouldn't rely on an exact traceback format as it may change between
-versions.  As an example of the current traceback format, the program:</p>
+versions (for example,
+<a href="https://github.com/svaarala/duktape/pull/592">tracebacks were improved for the 1.5.0 release</a>).
+As an example of the current traceback format, the program:</p>
 <pre class="ecmascript-code">
 // shortened from tests/ecmascript/test-dev-traceback-example.js
 try {
@@ -96,9 +98,9 @@ try {
 <p>would print something like:</p>
 <pre>
 URIError: invalid input
-        duk_bi_global.c:316
-        decodeURIComponent  native strict preventsyield
-        global tests/ecmascript/test-dev-traceback-example.js:3 preventsyield
+    at [anon] (duk_bi_global.c:343) internal
+    at decodeURIComponent () native strict preventsyield
+    at global (test.js:3) preventsyield
 </pre>
 
 <p>In builds where tracebacks are disabled, the <code>stack</code> accessor

--- a/website/guide/limitations.html
+++ b/website/guide/limitations.html
@@ -43,9 +43,9 @@ a "no match" result but hits an internal recursion limit instead:</p>
 $ duk
 duk&gt; t = /(x*)*/.exec('y');
 RangeError: regexp executor recursion limit
-        duk_regexp_executor.c:145
-        exec (null) native strict preventsyield
-        global input:1 preventsyield
+    at [anon] (duk_regexp_executor.c:145) internal
+    at exec () native strict preventsyield
+    at global (input:1) preventsyield
 </pre>
 
 <h2>Duktape does not fully support locales</h2>


### PR DESCRIPTION
Make stack trace format a little bit more user friendly. Fixes #588.

Tasks:
- [x] Figure out improvements
- [x] Testcase fixes
- [x] Test test-dev-lightfunc.js manually (it depends on lightfunc built-ins)
- [x] Update website examples
- [x] Releases