### PR TITLE
Fix double definition of `duk_double_nan` (and others) in a single file build

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1484,6 +1484,9 @@ Planned
 
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 
+* Portability improvement for VS2012 C++ compilation: avoid double definition
+  of replacement double constants (GH-595)
+
 * Rework setjmp/longjmp configuration model: (1) removed DUK_OPT_SETJMP,
   DUK_OPT_SIGSETJMP, and DUK_OPT_UNDERSCORE_SETJMP; (2) added DUK_JMPBUF_TYPE
   to duk_config.h to allow the jmp_buf struct to be replaced; (3) Duktape

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,34 +17,136 @@ install:
 
 build_script:
   # C:\projects\duktape
-  #- set
-  #- dir "C:\Program Files\"
-  #- dir "C:\Program Files (x86)\"
+  # https://en.wikipedia.org/wiki/Microsoft_Visual_Studio#History
+  #- cmd: set
+  #- cmd: dir "C:\Program Files\"
+  #- cmd: dir "C:\Program Files (x86)\"
+
+  # Make dist.
+
+  - cmd: cd C:\projects\duktape
+  - cmd: python util\make_dist.py
+
+  # --- Visual Studio 2015 ---
 
   # PATH doesn't include any 'cl' by default, not sure how to do this correctly.
   # https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
-  # Multi-line commands are run line-by-line (?)
+  # Multi-line commands are run line-by-line (?).
+  - cmd: set VCPATH="\Program Files (x86)\Microsoft Visual Studio 14.0\VC"
+  - cmd: set VCPLATFORM="NONE"
+  - cmd: if "%PLATFORM%"=="x86" ( set VCPLATFORM=x86 )
+  - cmd: if "%PLATFORM%"=="x64" ( set VCPLATFORM=x86_amd64 )
+  - cmd: echo PLATFORM=%PLATFORM%, VCPLATFORM=%VCPLATFORM%
+  - cmd: "%VCPATH%\\vcvarsall %VCPLATFORM%"
+  - cmd: cl
+
+  # Normal build.
+  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-vs2015.exe
+
+  # DLL build.
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /LD dist\src\duktape.c
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll-vs2015.exe duktape.lib
+
+  # Build as C++, catches some static variable issues specific to C++.
+  # Also test C++ exceptions on Windows.
+  # /TP forces files to be interpreted as C++ despite their extension.
+  # /EHsc enables exception unwind support.
+  - cmd: cl /TP /EHsc /W3 /O2 /DDUK_OPT_CPP_EXCEPTIONS /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-cxx-vs2015.exe
+
+  # --- Visual Studio 2013 ---
+
   - cmd: set VCPATH="\Program Files (x86)\Microsoft Visual Studio 12.0\VC"
   - cmd: set VCPLATFORM="NONE"
   - cmd: if "%PLATFORM%"=="x86" ( set VCPLATFORM=x86 )
   - cmd: if "%PLATFORM%"=="x64" ( set VCPLATFORM=x86_amd64 )
   - cmd: echo PLATFORM=%PLATFORM%, VCPLATFORM=%VCPLATFORM%
   - cmd: "%VCPATH%\\vcvarsall %VCPLATFORM%"
+  - cmd: cl
 
-  # Normal build
-  - cmd: cd C:\projects\duktape
-  - cmd: python util\make_dist.py
-  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk.exe
-  - cmd: del *.obj *.lib
+  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-vs2013.exe
 
-  # DLL build
   - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /LD dist\src\duktape.c
-  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll.exe duktape.lib
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll-vs2013.exe duktape.lib
 
+  - cmd: cl /TP /EHsc /W3 /O2 /DDUK_OPT_CPP_EXCEPTIONS /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-cxx-vs2013.exe
+
+  # --- Visual Studio 2012 ---
+
+  # Use VS2012 (11.0) to catch https://github.com/svaarala/duktape/pull/595.
+  - cmd: set VCPATH="\Program Files (x86)\Microsoft Visual Studio 11.0\VC"
+  - cmd: set VCPLATFORM="NONE"
+  - cmd: if "%PLATFORM%"=="x86" ( set VCPLATFORM=x86 )
+  - cmd: if "%PLATFORM%"=="x64" ( set VCPLATFORM=x86_amd64 )
+  - cmd: echo PLATFORM=%PLATFORM%, VCPLATFORM=%VCPLATFORM%
+  - cmd: "%VCPATH%\\vcvarsall %VCPLATFORM%"
+  - cmd: cl
+
+  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-vs2012.exe
+
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /LD dist\src\duktape.c
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll-vs2012.exe duktape.lib
+
+  - cmd: cl /TP /EHsc /W3 /O2 /DDUK_OPT_CPP_EXCEPTIONS /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-cxx-vs2012.exe
+
+  # --- Visual Studio 2010 ---
+
+  - cmd: set VCPATH="\Program Files (x86)\Microsoft Visual Studio 10.0\VC"
+  - cmd: set VCPLATFORM="NONE"
+  - cmd: if "%PLATFORM%"=="x86" ( set VCPLATFORM=x86 )
+  - cmd: if "%PLATFORM%"=="x64" ( set VCPLATFORM=x86_amd64 )
+  - cmd: echo PLATFORM=%PLATFORM%, VCPLATFORM=%VCPLATFORM%
+  - cmd: "%VCPATH%\\vcvarsall %VCPLATFORM%"
+  - cmd: cl
+
+  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-vs2010.exe
+
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /LD dist\src\duktape.c
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll-vs2010.exe duktape.lib
+
+  - cmd: cl /TP /EHsc /W3 /O2 /DDUK_OPT_CPP_EXCEPTIONS /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-cxx-vs2010.exe
+
+  # --- Visual Studio 2008 ---
+
+  - cmd: set VCPATH="\Program Files (x86)\Microsoft Visual Studio 9.0\VC"
+  - cmd: set VCPLATFORM="NONE"
+  - cmd: if "%PLATFORM%"=="x86" ( set VCPLATFORM=x86 )
+  - cmd: if "%PLATFORM%"=="x64" ( set VCPLATFORM=x86_amd64 )
+  - cmd: echo PLATFORM=%PLATFORM%, VCPLATFORM=%VCPLATFORM%
+  - cmd: "%VCPATH%\\vcvarsall %VCPLATFORM%"
+  - cmd: cl
+
+  - cmd: cl /W3 /O2 /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-vs2008.exe
+
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /LD dist\src\duktape.c
+  - cmd: cl /W3 /O2 /DDUK_OPT_DLL_BUILD /Idist\src /Idist\examples\cmdline dist\examples\cmdline\duk_cmdline.c /Feduk-dll-vs2008.exe duktape.lib
+
+  - cmd: cl /TP /EHsc /W3 /O2 /DDUK_OPT_CPP_EXCEPTIONS /Idist\src /Idist\examples\cmdline dist\src\duktape.c dist\examples\cmdline\duk_cmdline.c /Feduk-cxx-vs2008.exe
+
+  # Show what was built.
   - cmd: dir
 
 test_script:
-  - cmd: duk.exe -e "print(Duktape.env);"
-  - cmd: duk.exe -e "print('Hello world!');"
-  - cmd: duk-dll.exe -e "print(Duktape.env);"
-  - cmd: duk-dll.exe -e "print('Hello world!');"
+  - cmd: echo --- VS2015
+  - cmd: duk-vs2015.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-dll-vs2015.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-cxx-vs2015.exe -e "print(Duktape.env); print('Hello world!');"
+
+  - cmd: echo --- VS2013
+  - cmd: duk-vs2013.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-dll-vs2013.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-cxx-vs2013.exe -e "print(Duktape.env); print('Hello world!');"
+
+  - cmd: echo --- VS2012
+  - cmd: duk-vs2012.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-dll-vs2012.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-cxx-vs2012.exe -e "print(Duktape.env); print('Hello world!');"
+
+  - cmd: echo --- VS2010
+  - cmd: duk-vs2010.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-dll-vs2010.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-cxx-vs2010.exe -e "print(Duktape.env); print('Hello world!');"
+
+  - cmd: echo --- VS2008
+  - cmd: duk-vs2008.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-dll-vs2008.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-cxx-vs2008.exe -e "print(Duktape.env); print('Hello world!');"

--- a/config/header-snippets/msvc_visibility.h.in
+++ b/config/header-snippets/msvc_visibility.h.in
@@ -17,4 +17,3 @@
 #endif
 #define DUK_LOCAL_DECL     static
 #define DUK_LOCAL          static
-

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -1106,6 +1106,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 			DUK_ERROR_FMT1(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
+			DUK_UNREF(exc);
 			duk__handle_call_error(thr,
 			                       entry_valstack_bottom_index,
 			                       entry_valstack_end,
@@ -1125,6 +1126,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 			DUK_ERROR_API(thr, "caught invalid c++ exception (perhaps thrown by user code)");
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
+			DUK_UNREF(exc);
 			duk__handle_call_error(thr,
 			                       entry_valstack_bottom_index,
 			                       entry_valstack_end,
@@ -1991,6 +1993,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 			DUK_ERROR_FMT1(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
+			DUK_UNREF(exc);
 			duk__handle_safe_call_error(thr,
 			                            idx_retbase,
 			                            num_stack_rets,
@@ -2006,6 +2009,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 			DUK_ERROR_API(thr, "caught invalid c++ exception (perhaps thrown by user code)");
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
+			DUK_UNREF(exc);
 			duk__handle_safe_call_error(thr,
 			                            idx_retbase,
 			                            num_stack_rets,

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -2091,6 +2091,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 				DUK_ERROR_FMT1(heap->curr_thread, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
+				DUK_UNREF(exc);
 				duk__handle_executor_error(heap,
 				                           entry_thread,
 				                           entry_callstack_top,
@@ -2104,6 +2105,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 				DUK_ERROR_API(heap->curr_thread, "caught invalid c++ exception (perhaps thrown by user code)");
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
+				DUK_UNREF(exc);
 				duk__handle_executor_error(heap,
 				                           entry_thread,
 				                           entry_callstack_top,

--- a/src/duk_replacements.h
+++ b/src/duk_replacements.h
@@ -1,32 +1,28 @@
 #ifndef DUK_REPLACEMENTS_H_INCLUDED
 #define DUK_REPLACEMENTS_H_INCLUDED
 
+#if !defined(DUK_SINGLE_FILE)
 #if defined(DUK_USE_COMPUTED_INFINITY)
 DUK_INTERNAL_DECL double duk_computed_infinity;
 #endif
-
 #if defined(DUK_USE_COMPUTED_NAN)
 DUK_INTERNAL_DECL double duk_computed_nan;
 #endif
-
 #if defined(DUK_USE_REPL_FPCLASSIFY)
 DUK_INTERNAL_DECL int duk_repl_fpclassify(double x);
 #endif
-
 #if defined(DUK_USE_REPL_SIGNBIT)
 DUK_INTERNAL_DECL int duk_repl_signbit(double x);
 #endif
-
 #if defined(DUK_USE_REPL_ISFINITE)
 DUK_INTERNAL_DECL int duk_repl_isfinite(double x);
 #endif
-
 #if defined(DUK_USE_REPL_ISNAN)
 DUK_INTERNAL_DECL int duk_repl_isnan(double x);
 #endif
-
 #if defined(DUK_USE_REPL_ISINF)
 DUK_INTERNAL_DECL int duk_repl_isinf(double x);
 #endif
+#endif  /* !DUK_SINGLE_FILE */
 
 #endif  /* DUK_REPLACEMENTS_H_INCLUDED */

--- a/util/combine_src.py
+++ b/util/combine_src.py
@@ -277,14 +277,17 @@ def main():
 	files = []
 	filelist = os.listdir(opts.source_dir)
 	filelist.sort()  # for consistency
-	handpick = [ 'duk_strings.c',
-	             'duk_debug_macros.c',
-	             'duk_builtins.c',
-	             'duk_error_macros.c',
-	             'duk_unicode_support.c',
-	             'duk_util_misc.c',
-	             'duk_util_hashprime.c',
-	             'duk_hobject_class.c' ]
+	handpick = [
+		'duk_replacements.c',
+		'duk_strings.c',
+		'duk_debug_macros.c',
+		'duk_builtins.c',
+		'duk_error_macros.c',
+		'duk_unicode_support.c',
+		'duk_util_misc.c',
+		'duk_util_hashprime.c',
+		'duk_hobject_class.c'
+	]
 	handpick.reverse()
 	for fn in handpick:
 		# These files must appear before the alphabetically sorted


### PR DESCRIPTION
Reported on IRC, not diagnosed yet.

Happens in VS2012, `duktape.c` renamed to `duktape.cpp`, options:

    WIN32;_DEBUG;_CONSOLE; DUK_OPT_CPP_EXCEPTIONS;%(PreprocessorDefinitions)