### PR TITLE
Add an "extra" for non-BMP string handling

### DIFF
--- a/extras/nonbmp-string-util/README.rst
+++ b/extras/nonbmp-string-util/README.rst
@@ -1,0 +1,5 @@
+========================
+Non-BMP string utilities
+========================
+
+Helper functions to convert between UTF-8 strings and surrogate pair encoding.


### PR DESCRIPTION
Some user code needs to deal with standard Ecmascript strings where non-BMP characters are represented as surrogate pairs. Add some utility functions to decode surrogate pairs into raw UTF-8 and vice versa so that C code can work with the raw UTF-8 form conveniently.