### PR TITLE
Fix debugger re-entry while detaching

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1404,6 +1404,19 @@ Planned
   command (with "pause on uncaught" option enabled) would cause a recursive
   attempt to halt execution (GH-558, GH-562)
 
+* Fix debugger detach handling bug which could cause the debugger to be
+  re-entered recursively during detach handling; this could cause various
+  difficult to diagnose side effects (GH-599, GH-597, GH-591)
+
+* Fix debugger detach handling bug which could cause detach handling to be
+  initiated but not completed if the debug transport write error occurred
+  outside of the debugger message loop (for example when writing a Status
+  notify in running state) (GH-599, GH-597, GH-591)
+
+* Fix debugger transport write error bug which could cause Duktape to call
+  the debug transport write callback after it had already returned an error
+  (GH-599)
+
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 
 * Change OS string (visible in Duktape.env) from "ios" to "osx" for non-phone

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -3022,3 +3022,25 @@ Buffer object support
 
 Make it easier to see buffer object contents (like for plain buffers), either
 by serializing them differently, or through heap walking.
+
+Separate callback for checking transport status
+-----------------------------------------------
+
+When Duktape is in the running state (not paused), Duktape will only call:
+
+* The peek callback periodically to see if there is anything to read.
+  There's no way to indicate a transport detach/error with peek now.
+
+* The write callback periodically, as a side effect of sending Status
+  notifies.  This is the main mechanism now for detecting a broken
+  transport in the running state.  If Status notifies were removed,
+  Duktape would not notice a transport break unless something else prompted
+  a write to the debug transport.
+
+It might be cleaner to provide either:
+
+* A callback to check transport status explicitly and perhaps allows even
+  an error message to be indicated.
+
+* Allow user code to proactively call into Duktape to indicate the transport
+  is broken (beyond calling ``duk_debugger_detach()``).

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -88,6 +88,9 @@ void AJS_Free(void *udata, void *ptr);
 #define  LINEBUF_SIZE       65536
 
 static int interactive_mode = 0;
+#if defined(DUK_CMDLINE_DEBUGGER_SUPPORT)
+static int debugger_reattach = 0;
+#endif
 
 /*
  *  Misc helpers
@@ -131,6 +134,7 @@ static void my_sighandler(int x) {
 }
 static void set_sigint_handler(void) {
 	(void) signal(SIGINT, my_sighandler);
+	(void) signal(SIGPIPE, SIG_IGN);  /* avoid SIGPIPE killing process */
 }
 #endif  /* NO_SIGNAL */
 
@@ -720,21 +724,26 @@ static void debugger_detached(void *udata) {
 	fprintf(stderr, "Debugger detached, udata: %p\n", (void *) udata);
 	fflush(stderr);
 
-#if 0  /* For manual auto-reattach test */
-	duk_trans_socket_finish();
-	duk_trans_socket_init();
-	duk_trans_socket_waitconn();
-	fprintf(stderr, "Debugger connected, call duk_debugger_attach() and then execute requested file(s)/eval\n");
-	fflush(stderr);
-	duk_debugger_attach(ctx,
-	                    duk_trans_socket_read_cb,
-	                    duk_trans_socket_write_cb,
-	                    duk_trans_socket_peek_cb,
-	                    duk_trans_socket_read_flush_cb,
-	                    duk_trans_socket_write_flush_cb,
-	                    debugger_detached,
-	                    (void *) ctx);
+	if (debugger_reattach) {
+		/* For automatic reattach testing. */
+		duk_trans_socket_finish();
+		duk_trans_socket_init();
+		duk_trans_socket_waitconn();
+		fprintf(stderr, "Debugger reconnected, call duk_debugger_attach()\n");
+		fflush(stderr);
+#if 0
+		/* This is not necessary but should be harmless. */
+		duk_debugger_detach(ctx);
 #endif
+		duk_debugger_attach(ctx,
+		                    duk_trans_socket_read_cb,
+		                    duk_trans_socket_write_cb,
+		                    duk_trans_socket_peek_cb,
+		                    duk_trans_socket_read_flush_cb,
+		                    duk_trans_socket_write_flush_cb,
+		                    debugger_detached,
+		                    (void *) ctx);
+	}
 }
 #endif
 
@@ -1025,6 +1034,10 @@ int main(int argc, char *argv[]) {
 			ajsheap_log = 1;
 		} else if (strcmp(arg, "--debugger") == 0) {
 			debugger = 1;
+#if defined(DUK_CMDLINE_DEBUGGER_SUPPORT)
+		} else if (strcmp(arg, "--reattach") == 0) {
+			debugger_reattach = 1;
+#endif
 		} else if (strcmp(arg, "--recreate-heap") == 0) {
 			recreate_heap = 1;
 		} else if (strcmp(arg, "--no-heap-destroy") == 0) {
@@ -1191,6 +1204,7 @@ int main(int argc, char *argv[]) {
 #endif
 #if defined(DUK_CMDLINE_DEBUGGER_SUPPORT)
 			"   --debugger         start example debugger\n"
+			"   --reattach         automatically reattach debugger on detach\n"
 #endif
 			"   --recreate-heap    recreate heap after every file\n"
 			"   --no-heap-destroy  force GC, but don't destroy heap at end (leak testing)\n"

--- a/examples/debug-trans-socket/duk_trans_socket_unix.c
+++ b/examples/debug-trans-socket/duk_trans_socket_unix.c
@@ -206,7 +206,7 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 
 #if defined(DEBUG_PRINTS)
 	fprintf(stderr, "%s: udata=%p, buffer=%p, length=%ld\n",
-	        __func__, (void *) udata, (void *) buffer, (long) length);
+	        __func__, (void *) udata, (const void *) buffer, (long) length);
 	fflush(stderr);
 #endif
 

--- a/examples/debug-trans-socket/duk_trans_socket_windows.c
+++ b/examples/debug-trans-socket/duk_trans_socket_windows.c
@@ -282,7 +282,7 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 
 #if defined(DEBUG_PRINTS)
 	fprintf(stderr, "%s: udata=%p, buffer=%p, length=%ld\n",
-	        __FUNCTION__, (void *) udata, (void *) buffer, (long) length);
+	        __FUNCTION__, (void *) udata, (const void *) buffer, (long) length);
 	fflush(stderr);
 #endif
 

--- a/src/duk_api_debug.c
+++ b/src/duk_api_debug.c
@@ -57,6 +57,8 @@ DUK_EXTERNAL void duk_debugger_attach(duk_context *ctx,
 	 * already attached?
 	 */
 
+	DUK_D(DUK_DPRINT("application called duk_debugger_attach()"));
+
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(read_cb != NULL);
 	DUK_ASSERT(write_cb != NULL);
@@ -103,6 +105,8 @@ DUK_EXTERNAL void duk_debugger_attach(duk_context *ctx,
 DUK_EXTERNAL void duk_debugger_detach(duk_context *ctx) {
 	duk_hthread *thr;
 
+	DUK_D(DUK_DPRINT("application called duk_debugger_detach()"));
+
 	DUK_ASSERT_CTX_VALID(ctx);
 	thr = (duk_hthread *) ctx;
 	DUK_ASSERT(thr != NULL);
@@ -132,9 +136,7 @@ DUK_EXTERNAL void duk_debugger_cooperate(duk_context *ctx) {
 		return;
 	}
 
-	thr->heap->dbg_processing = 1;
 	processed_messages = duk_debug_process_messages(thr, 1 /*no_block*/);
-	thr->heap->dbg_processing = 0;
 	DUK_UNREF(processed_messages);
 }
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -112,6 +112,22 @@ DUK_INTERNAL void duk_debug_do_detach(duk_heap *heap) {
 	duk__debug_do_detach2(heap);
 }
 
+/* Called on a read/write error: NULL all transport related callbacks except
+ * the detached callback so that we never accidentally call them after a
+ * read/write error has been indicated.
+ */
+DUK_LOCAL void duk__debug_null_io_callbacks(duk_hthread *thr) {
+	duk_heap *heap;
+	heap = thr->heap;
+	DUK_D(DUK_DPRINT("transport read/write error, NULL all I/O callbacks (everything but detached)"));
+	heap->dbg_read_cb = NULL;
+	heap->dbg_write_cb = NULL;  /* this is especially critical to avoid another write call in detach1() */
+	heap->dbg_peek_cb = NULL;
+	heap->dbg_read_flush_cb = NULL;
+	heap->dbg_write_flush_cb = NULL;
+	/* keep heap->dbg_detached_cb */
+}
+
 /*
  *  Debug connection peek and flush primitives
  */
@@ -250,8 +266,8 @@ DUK_INTERNAL void duk_debug_read_bytes(duk_hthread *thr, duk_uint8_t *data, duk_
 #endif
 		got = heap->dbg_read_cb(heap->dbg_udata, (char *) p, left);
 		if (got == 0 || got > left) {
-			heap->dbg_write_cb = NULL;  /* squelch further writes in detach1() */
 			DUK_D(DUK_DPRINT("connection error during read, return zero data"));
+			duk__debug_null_io_callbacks(thr);  /* avoid calling write callback in detach1() */
 			DUK__SET_CONN_BROKEN(thr, 1);
 			goto fail;
 		}
@@ -545,7 +561,7 @@ DUK_INTERNAL void duk_debug_write_bytes(duk_hthread *thr, const duk_uint8_t *dat
 #endif
 		got = heap->dbg_write_cb(heap->dbg_udata, (const char *) p, left);
 		if (got == 0 || got > left) {
-			heap->dbg_write_cb = NULL;  /* squelch further writes in detach1() */
+			duk__debug_null_io_callbacks(thr);  /* avoid calling write callback in detach1() */
 			DUK_D(DUK_DPRINT("connection error during write"));
 			DUK__SET_CONN_BROKEN(thr, 1);
 			return;

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -1487,7 +1487,6 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 	duk_breakpoint *bp;
 	duk_breakpoint **bp_active;
 	duk_uint_fast32_t line = 0;
-	duk_bool_t send_status;
 	duk_bool_t process_messages;
 	duk_bool_t processed_messages = 0;
 
@@ -1569,16 +1568,12 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 	 *  counter is used to rate limit getting timestamps.
 	 */
 
-	if (thr->heap->dbg_state_dirty || thr->heap->dbg_paused) {
-		send_status = 1;
-	} else {
-		send_status = 0;
-	}
-
-	if (thr->heap->dbg_paused) {
+	process_messages = 0;
+	if (thr->heap->dbg_state_dirty || thr->heap->dbg_paused || thr->heap->dbg_detaching) {
+		/* Enter message processing loop for sending Status notifys and
+		 * to finish a pending detach.
+		 */
 		process_messages = 1;
-	} else {
-		process_messages = 0;
 	}
 
 	/* XXX: remove heap->dbg_exec_counter, use heap->inst_count_interrupt instead? */
@@ -1603,35 +1598,32 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 			 */
 
 			thr->heap->dbg_last_time = now;
-			send_status = 1;
+			thr->heap->dbg_state_dirty = 1;
 			process_messages = 1;
 		}
 	}
 
 	/*
-	 *  Send status
+	 *  Process messages and send status if necessary.
+	 *
+	 *  If we're paused, we'll block for new messages.  If we're not
+	 *  paused, we'll process anything we can peek but won't block
+	 *  for more.  Detach (and re-attach) handling is all localized
+	 *  to duk_debug_process_messages() too.
+	 *
+	 *  Debugger writes outside the message loop may cause debugger
+	 *  detach1 phase to run, after which dbg_read_cb == NULL and
+	 *  dbg_detaching != 0.  The message loop will finish the detach
+	 *  by running detach2 phase, so enter the message loop also when
+	 *  detaching.
 	 */
 
 	act = NULL;  /* may be changed */
-	if (send_status) {
-		duk_debug_send_status(thr);
-		thr->heap->dbg_state_dirty = 0;
-	}
-
-	/*
-	 *  Process messages.  If we're paused, we'll block for new messages.
-	 *  if we're not paused, we'll process anything we can peek but won't
-	 *  block for more.
-	 */
-
 	if (process_messages) {
 		DUK_ASSERT(thr->heap->dbg_processing == 0);
-		thr->heap->dbg_processing = 1;
 		processed_messages = duk_debug_process_messages(thr, 0 /*no_block*/);
-		thr->heap->dbg_processing = 0;
+		DUK_ASSERT(thr->heap->dbg_processing == 0);
 	}
-
-	/* XXX: any case here where we need to re-send status? */
 
 	/* Continue checked execution if there are breakpoints or we're stepping.
 	 * Also use checked execution if paused flag is active - it shouldn't be
@@ -1745,7 +1737,11 @@ DUK_LOCAL duk_small_uint_t duk__executor_interrupt(duk_hthread *thr) {
 #endif  /* DUK_USE_EXEC_TIMEOUT_CHECK */
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-	if (DUK_HEAP_IS_DEBUGGER_ATTACHED(thr->heap) && !thr->heap->dbg_processing) {
+	if (!thr->heap->dbg_processing &&
+	    (thr->heap->dbg_read_cb != NULL || thr->heap->dbg_detaching)) {
+		/* Avoid recursive re-entry; enter when we're attached or
+		 * detaching (to finish off the pending detach).
+		 */
 		duk__interrupt_handle_debugger(thr, &immediate, &retval);
 		act = thr->callstack + thr->callstack_top - 1;  /* relookup if changed */
 	}

--- a/src/duk_regexp_compiler.c
+++ b/src/duk_regexp_compiler.c
@@ -962,7 +962,7 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 	 *  Compilation
 	 */
 
-	DUK_D(DUK_DPRINT("starting regexp compilation"));
+	DUK_DD(DUK_DDPRINT("starting regexp compilation"));
 
 	duk__append_u32(&re_ctx, DUK_REOP_SAVE);
 	duk__append_u32(&re_ctx, 0);
@@ -1006,8 +1006,8 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 	duk_remove(ctx, -4);     /* -> [ ... flags escaped_source bytecode ] */
 	duk_remove(ctx, -3);     /* -> [ ... escaped_source bytecode ] */
 
-	DUK_D(DUK_DPRINT("regexp compilation successful, bytecode: %!T, escaped source: %!T",
-	                 (duk_tval *) duk_get_tval(ctx, -1), (duk_tval *) duk_get_tval(ctx, -2)));
+	DUK_DD(DUK_DDPRINT("regexp compilation successful, bytecode: %!T, escaped source: %!T",
+	                   (duk_tval *) duk_get_tval(ctx, -1), (duk_tval *) duk_get_tval(ctx, -2)));
 }
 
 /*


### PR DESCRIPTION
Fixes #597. Possibly related to debugger read callback re-entry issue described in #591.

Tasks:

- [x] Fix debugger re-entry when dbg_processing was set to zero during detach1()
- [x] Fix Duktape never doing detach2() if detach1() occurred outside of debugger message loop
- [x] Fix write_cb NULLing for duk_debug_write_byte()
- [x] Any way to repeat @harold-b's issue with repeated read calls not resetting callbacks to NULL? => Could not reproduce.
- [x] Add fix backport notes for earlier releases where appropriate
- [x] Releases