### PR TITLE
API and website documentation and minor cleanups for AppRequest/AppNotify

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1383,6 +1383,9 @@ Planned
 
 * Add Windows version of the debugger example TCP transport (GH-579)
 
+* Add support for application specific debugger commands (AppRequest) and
+  notifications (AppNotify) (GH-596, GH-563)
+
 * A DukLuv-based JSON debug proxy is now included in the dist package;
   it should allow much easier and more flexible packaging of a JSON debug
   proxy into a debug client (GH-590)

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -57,7 +57,8 @@ duk_debug_meta.json:
 	python merge_debug_meta.py --output $@ \
 		--class-names duk_classnames.yaml \
 		--opcodes duk_opcodes.yaml \
-		--debug-commands duk_debugcommands.yaml
+		--debug-commands duk_debugcommands.yaml \
+		--debug-errors duk_debugerrors.yaml
 
 static/socket.io-1.2.0.js:
 	wget -O $@ http://cdn.socket.io/socket.io-1.2.0.js

--- a/debugger/duk_debugerrors.yaml
+++ b/debugger/duk_debugerrors.yaml
@@ -1,0 +1,6 @@
+error_codes:
+  - Unknown
+  - UnsupportedCommand
+  - TooMany
+  - NotFound
+  - ApplicationError

--- a/debugger/merge_debug_meta.py
+++ b/debugger/merge_debug_meta.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
 	parser.add_option('--output', dest='output', default=None, help='output JSON filename')
 	parser.add_option('--class-names', dest='class_names', help='YAML metadata for class names')
 	parser.add_option('--debug-commands', dest='debug_commands', help='YAML metadata for debug commands')
+	parser.add_option('--debug-errors', dest='debug_errors', help='YAML metadata for debug protocol error codes')
 	parser.add_option('--opcodes', dest='opcodes', help='YAML metadata for opcodes')
 	(opts, args) = parser.parse_args()
 
@@ -23,6 +24,7 @@ if __name__ == '__main__':
 
 	merge(opts.class_names)
 	merge(opts.debug_commands)
+	merge(opts.debug_errors)
 	merge(opts.opcodes)
 
 	with open(opts.output, 'wb') as f:

--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -153,6 +153,20 @@ result to minimize error proneness::
    * similar reasons.
    */
 
+Labels are intended by one space relative to the parent tab depth::
+
+  DUK_LOCAL void duk__helper(duk_context *ctx) {
+          if (!ctx) {
+                  DUK_D(DUK_DPRINT("ctx is NULL"));
+                  goto fail;
+          }
+
+          return;
+
+   fail:
+          DUK_D(DUK_DPRINT("failed, detaching"));
+  }
+
 Local variable declarations
 ---------------------------
 

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -87,6 +87,8 @@ void AJS_Free(void *udata, void *ptr);
 #define  MEM_LIMIT_HIGH     (2047*1024*1024)  /* ~2 GB */
 #define  LINEBUF_SIZE       65536
 
+static int main_argc = 0;
+static char **main_argv = NULL;
 static int interactive_mode = 0;
 #if defined(DUK_CMDLINE_DEBUGGER_SUPPORT)
 static int debugger_reattach = 0;
@@ -423,6 +425,11 @@ static int handle_file(duk_context *ctx, const char *filename, const char *bytec
 	int retval;
 	char fnbuf[256];
 
+	/* Example of sending an application specific debugger notification. */
+	duk_push_string(ctx, "DebuggerHandleFile");
+	duk_push_string(ctx, filename);
+	duk_debugger_notify(ctx, 2);
+
 #if defined(EMSCRIPTEN)
 	if (filename[0] == '/') {
 		snprintf(fnbuf, sizeof(fnbuf), "%s", filename);
@@ -718,6 +725,36 @@ static duk_ret_t fileio_write_file(duk_context *ctx) {
  */
 
 #if defined(DUK_CMDLINE_DEBUGGER_SUPPORT)
+static duk_idx_t debugger_request(duk_context *ctx, void *udata, duk_idx_t nvalues) {
+	const char *cmd;
+	int i;
+
+	(void) udata;
+
+	if (nvalues < 1) {
+		duk_push_string(ctx, "missing AppRequest argument(s)");
+		return -1;
+	}
+
+	cmd = duk_get_string(ctx, -nvalues + 0);
+
+	if (cmd && strcmp(cmd, "CommandLine") == 0) {
+		if (!duk_check_stack(ctx, main_argc)) {
+			/* Callback should avoid errors for now, so use
+			 * duk_check_stack() rather than duk_require_stack().
+			 */
+			duk_push_string(ctx, "failed to extend stack");
+			return -1;
+		}
+		for (i = 0; i < main_argc; i++) {
+			duk_push_string(ctx, main_argv[i]);
+		}
+		return main_argc;
+	}
+	duk_push_sprintf(ctx, "command not supported");
+	return -1;
+}
+
 static void debugger_detached(void *udata) {
 	duk_context *ctx = (duk_context *) udata;
 	(void) ctx;
@@ -735,14 +772,15 @@ static void debugger_detached(void *udata) {
 		/* This is not necessary but should be harmless. */
 		duk_debugger_detach(ctx);
 #endif
-		duk_debugger_attach(ctx,
-		                    duk_trans_socket_read_cb,
-		                    duk_trans_socket_write_cb,
-		                    duk_trans_socket_peek_cb,
-		                    duk_trans_socket_read_flush_cb,
-		                    duk_trans_socket_write_flush_cb,
-		                    debugger_detached,
-		                    (void *) ctx);
+		duk_debugger_attach_custom(ctx,
+		                           duk_trans_socket_read_cb,
+		                           duk_trans_socket_write_cb,
+		                           duk_trans_socket_peek_cb,
+		                           duk_trans_socket_read_flush_cb,
+		                           duk_trans_socket_write_flush_cb,
+		                           debugger_request,
+		                           debugger_detached,
+		                           (void *) ctx);
 	}
 }
 #endif
@@ -855,14 +893,15 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 		duk_trans_socket_waitconn();
 		fprintf(stderr, "Debugger connected, call duk_debugger_attach() and then execute requested file(s)/eval\n");
 		fflush(stderr);
-		duk_debugger_attach(ctx,
-		                    duk_trans_socket_read_cb,
-		                    duk_trans_socket_write_cb,
-		                    duk_trans_socket_peek_cb,
-		                    duk_trans_socket_read_flush_cb,
-		                    duk_trans_socket_write_flush_cb,
-		                    debugger_detached,
-		                    (void *) ctx);
+		duk_debugger_attach_custom(ctx,
+		                           duk_trans_socket_read_cb,
+		                           duk_trans_socket_write_cb,
+		                           duk_trans_socket_peek_cb,
+		                           duk_trans_socket_read_flush_cb,
+		                           duk_trans_socket_write_flush_cb,
+		                           debugger_request,
+		                           debugger_detached,
+		                           (void *) ctx);
 #else
 		fprintf(stderr, "Warning: option --debugger ignored, no debugger support\n");
 		fflush(stderr);
@@ -931,6 +970,9 @@ int main(int argc, char *argv[]) {
 	int run_stdin = 0;
 	const char *compile_filename = NULL;
 	int i;
+
+	main_argc = argc;
+	main_argv = (char **) argv;
 
 #if defined(EMSCRIPTEN)
 	/* Try to use NODEFS to provide access to local files.  Mount the

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -50,8 +50,10 @@ static duk_ret_t test_func(duk_context *ctx) {
 	(void) duk_create_heap_default();
 	(void) duk_create_heap(NULL, NULL, NULL, NULL, NULL);
 	(void) duk_debugger_attach(ctx, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+	(void) duk_debugger_attach_custom(ctx, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 	(void) duk_debugger_cooperate(ctx);
 	(void) duk_debugger_detach(ctx);
+	(void) duk_debugger_notify(ctx, 0);
 	(void) duk_decode_string(ctx, 0, NULL, NULL);
 	(void) duk_def_prop(ctx, 0, 0);
 	(void) duk_del_prop_index(ctx, 0, 0);

--- a/tests/api/test-debugger-notify.c
+++ b/tests/api/test-debugger-notify.c
@@ -1,0 +1,68 @@
+/*
+ *  duk_debugger_notify()
+ */
+
+/*===
+*** test_notify_not_attached (duk_safe_call)
+top: 0
+top: 0
+top: 1
+string: dummy below nvalues
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_notify_not_attached(duk_context *ctx) {
+	/* Not attached, ignored; no arguments. */
+	duk_debugger_notify(ctx, 0);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+
+	/* Not attached, ignored, two arguments. */
+	duk_push_string(ctx, "DummyNotify");
+	duk_push_int(ctx, 123);
+	duk_debugger_notify(ctx, 2);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+
+	/* Check that argument below 'nvalues' is untouched. */
+	duk_push_string(ctx, "dummy below nvalues");
+	duk_push_string(ctx, "DummyNotify");
+	duk_push_int(ctx, 123);
+	duk_debugger_notify(ctx, 2);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("string: %s\n", duk_safe_to_string(ctx, 0));
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/*===
+*** test_notify_invalid_count1 (duk_safe_call)
+==> rc=1, result='Error: not enough stack values for notify'
+===*/
+
+static duk_ret_t test_notify_invalid_count1(duk_context *ctx) {
+	duk_push_string(ctx, "DummyNotify");
+	duk_debugger_notify(ctx, 2);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/*===
+*** test_notify_invalid_count2 (duk_safe_call)
+==> rc=1, result='Error: invalid count'
+===*/
+
+static duk_ret_t test_notify_invalid_count2(duk_context *ctx) {
+	duk_push_string(ctx, "DummyNotify");
+	duk_debugger_notify(ctx, -1);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_notify_not_attached);
+	TEST_SAFE_CALL(test_notify_invalid_count1);
+	TEST_SAFE_CALL(test_notify_invalid_count2);
+}

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -431,6 +431,7 @@ copy_files([
 	'duk_debug_proxy.js',
 	'duk_classnames.yaml',
 	'duk_debugcommands.yaml',
+	'duk_debugerrors.yaml',
 	'duk_opcodes.yaml',
 	'merge_debug_meta.py'
 ], 'debugger', os.path.join(dist, 'debugger'))
@@ -618,6 +619,7 @@ merged = exec_print_stdout([
 	'--output', os.path.join(dist, 'debugger', 'duk_debug_meta.json'),
 	'--class-names', os.path.join('debugger', 'duk_classnames.yaml'),
 	'--debug-commands', os.path.join('debugger', 'duk_debugcommands.yaml'),
+	'--debug-errors', os.path.join('debugger', 'duk_debugerrors.yaml'),
 	'--opcodes', os.path.join('debugger', 'duk_opcodes.yaml')
 ])
 

--- a/website/api/duk_debugger_attach.yaml
+++ b/website/api/duk_debugger_attach.yaml
@@ -11,7 +11,8 @@ proto: |
                            void *udata);
 
 summary: |
-  <p>Attach a debugger to the Duktape heap.  If debugger support is not
+  <p>Attach a debugger to the Duktape heap.  The debugger will automatically
+  enter paused state when the attach is complete.  If debugger support is not
   compiled into Duktape, throws an error.  See
   <a href="https://github.com/svaarala/duktape/blob/master/doc/debugger.rst">debugger.rst</a>
   for more information.</p>
@@ -20,6 +21,12 @@ summary: |
   The <code>peek_cb</code> is strongly recommended but optional.  The
   <code>read_flush_cb</code> and <code>write_flush_cb</code> callbacks are
   optional.  Unimplemented callbacks are indicated using a <code>NULL</code>.</p>
+
+  <div class="note">
+  The <code><a href="#duk_debugger_attach_custom">duk_debugger_attach_custom()</a></code>
+  variant accepts an additional callback to support application specific commands
+  (AppRequest).  These two calls will be merged in Duktape 2.x.
+  </div>
 
   <div class="note">
   Since Duktape 1.4.0 the debugger detached callback is allowed to call
@@ -40,10 +47,12 @@ example: |
                       my_udata);
 
 tags:
-  - debug
+  - debugger
 
 seealso:
+  - duk_debugger_attach_custom
   - duk_debugger_detach
   - duk_debugger_cooperate
+  - duk_debugger_notify
 
 introduced: 1.2.0

--- a/website/api/duk_debugger_attach_custom.yaml
+++ b/website/api/duk_debugger_attach_custom.yaml
@@ -1,0 +1,43 @@
+name: duk_debugger_attach_custom
+
+proto: |
+  void duk_debugger_attach_custom(duk_context *ctx,
+                                  duk_debug_read_function read_cb,
+                                  duk_debug_write_function write_cb,
+                                  duk_debug_peek_function peek_cb,
+                                  duk_debug_read_flush_function read_flush_cb,
+                                  duk_debug_write_flush_function write_flush_cb,
+                                  duk_debug_request_function request_cb,
+                                  duk_debug_detached_function detached_cb,
+                                  void *udata);
+
+summary: |
+  <p>Same as <code><a href="#duk_debugger_attach">duk_debugger_attach()</a></code>
+  but has an additional <code>request_cb</code> callback to support application
+  specific debug commands (AppRequest).  The <code>request_cb</code> may also be
+  NULL to indicate that the application doesn't support AppRequest.</p>
+
+  <p>See the debugger documentation for more information and examples on how
+  to use application specific commands.</p>
+
+example: |
+  duk_debugger_attach(ctx,
+                      my_read_cb,
+                      my_write_cb,
+                      my_peek_cb,
+                      NULL,
+                      NULL,
+                      my_request_cb,
+                      my_detached_cb,
+                      my_udata);
+
+tags:
+  - debugger
+
+seealso:
+  - duk_debugger_attach
+  - duk_debugger_detach
+  - duk_debugger_cooperate
+  - duk_debugger_notify
+
+introduced: 1.5.0

--- a/website/api/duk_debugger_cooperate.yaml
+++ b/website/api/duk_debugger_cooperate.yaml
@@ -15,7 +15,7 @@ example: |
   duk_debugger_cooperate(ctx);
 
 tags:
-  - debug
+  - debugger
 
 seealso:
   - duk_debugger_attach

--- a/website/api/duk_debugger_detach.yaml
+++ b/website/api/duk_debugger_detach.yaml
@@ -13,7 +13,7 @@ example: |
   duk_debugger_detach(ctx);
 
 tags:
-  - debug
+  - debugger
 
 seealso:
   - duk_debugger_attach

--- a/website/api/duk_debugger_notify.yaml
+++ b/website/api/duk_debugger_notify.yaml
@@ -1,0 +1,43 @@
+name: duk_debugger_notify
+
+proto: |
+  duk_bool_t duk_debugger_notify(duk_context *ctx, duk_idx_t nvalues);
+
+stack: |
+  [ ... val1! ...! valN! ] -> [ ... ]
+
+summary: |
+  <p>Send an application specific debugger notify (AppNotify) containing the
+  <code>nvalues</code> values on the value stack top mapped to debug protocol
+  dvalues.  The return value indicates whether the notify was successfully
+  sent (non-zero) or not (zero).  The <code>nvalues</code> arguments are
+  always popped off the stack top.  The call is a no-op if debugger support
+  has not been compiled in, or if the debugger is not attached; in both cases
+  the call will return zero to indicate that the notify was not sent.</p>
+
+  <p>See the debugger documentation for more information and examples on how
+  to use application specific notifications.</p>
+
+example: |
+  /* Causes the following notify to be sent over the debugger protocol:
+   *
+   *   NFY AppNotify "BatteryStatus" 740 1000 true EOM
+   */
+  int battery_current = 740;
+  int battery_limit = 1000;
+  int battery_charging = 1;
+
+  duk_push_string(ctx, "BatteryStatus");
+  duk_push_int(ctx, battery_current);
+  duk_push_int(ctx, battery_limit);
+  duk_push_boolean(ctx, battery_charging);
+  if (duk_debugger_notify(ctx, 4 /*nvalues*/)) {
+      printf("battery status notification sent\n");
+  } else {
+      printf("battery status notification not sent\n");
+  }
+
+tags:
+  - debugger
+
+introduced: 1.5.0

--- a/website/guide/debugger.html
+++ b/website/guide/debugger.html
@@ -2,7 +2,21 @@
 
 <p>Duktape has built-in debugger support as an option you can enable during
 compilation.  Debugger support adds about 15-20kB of code footprint (depending
-on what debugger features are enabled) and has very minimal memory footprint.</p>
+on what debugger features are enabled) and has very minimal memory footprint.
+Debugger features include:</p>
+<ul>
+<li>Execution status information such running/paused at file/line, callstack,
+    local variables for different callstack levels</li>
+<li>Execution control including pause/resume, step over/into/out, breakpoints
+    targeted at file/line, debugger statement</li>
+<li>Generic Eval at any callstack level, get/put variable at any callstack
+    level</li>
+<li>A mechanism for application-defined requests (AppRequest) and notifications
+    (AppNotify)</li>
+<li>Forwarding of print(), alert(), and logger writes</li>
+<li>Heap object in-depth inspection, Duktape heap walking, and getting a
+    full heap dump</li>
+</ul>
 
 <p>The debugger is based on the following main concepts:</p>
 <ul>
@@ -59,6 +73,17 @@ using the binary debug protocol, or use the JSON proxy provided by
 (Node.js) or
 <a href="https://github.com/svaarala/duktape/blob/master/debugger/duk_debug_proxy.js">duk_debug_proxy.js</a>
 (DukLuv).</p>
+
+<p>Debug targets and debug clients are intended to be mixed and matched:
+apart from the transport (which is usually either TCP or easy to adapt) the
+debug protocol is the same.  Core functionality will be the same regardless
+of the debug client or the debug target, but some optional features may be
+missing.  Debug clients and debug targets may also implement application
+specific commands (AppRequest) and notifications (AppNotify) for richer
+integration which can be used when both the client and the target support
+them (they're easy and safe to ignore if not supported).  Custom commands
+and notifications allow e.g. deep inspection of the state of a custom target
+specific memory allocator, rebooting the target on command, etc.</p>
 
 <p>For more details on the implementation and how to get started, see:</p>
 <ul>


### PR DESCRIPTION
- [x] Debugger document improvements
- [x] Minor debug print improvements for debugger AppRequest/AppNotify
- [x] Add 'duk' example for AppRequest, provide a custom "CommandLine" AppRequest
- [x] Add 'duk' example for AppNotify, provide custom "DebuggerHandleFile" when running files
- [x] Add debugger error code metadata into the debugger build (not used yet)
- [x] Add API document for `duk_debugger_attach_custom()` and `duk_debugger_notify()`
- [x] Add note to `duk_debugger_attach()` to API document
- [x] Discuss Duktape 2.x deprecation of one or the other (most likely `duk_debugger_attach_custom()` staying and renamed to something else)
- [x] Add one paragraph summary of the feature to website Debugger section
- [x] API testcase for `duk_debugger_notify()` checking that it returns false and consumes arguments; also check API error for invalid nvalues
- [x] Releases entry for AppRequest/AppNotify