### PR TITLE
Use plain integer dvalues instead of IEEE double when serializing duk_tval numbers in debug protocol

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1401,6 +1401,10 @@ Planned
   it should allow much easier and more flexible packaging of a JSON debug
   proxy into a debug client (GH-590)
 
+* Use plain integer dvalues when serializing duk_tval numbers in the debugger
+  protocol when it's safe to do so, i.e. when the plain integer converts back
+  to an identical IEEE double with no loss of precision (GH-604)
+
 * Fix potentially memory unsafe behavior when a refcount-triggered finalizer
   function rescues an object; the memory unsafe behavior doesn't happen
   immediately which makes the cause of the unsafe behavior difficult to

--- a/doc/release-notes-v1-5.rst
+++ b/doc/release-notes-v1-5.rst
@@ -1,0 +1,67 @@
+=========================
+Duktape 1.5 release notes
+=========================
+
+Release overview
+================
+
+FIXME.
+
+Upgrading from Duktape 1.4.x
+============================
+
+No action (other than recompiling) should be needed for most users to upgrade
+from Duktape v1.3.x.  Note the following:
+
+* When a debugger is attached and Duktape is in a paused state garbage
+  collection is now disabled by default.  As a result, garbage created during
+  the paused state will not be collected immediately, but may remain in the
+  Duktape heap until the next mark-and-sweep pass after resuming execution.
+  This also postpones finalizer execution for such garbage.  Preventing
+  garbage collection during paused state allows debugger heap inspection
+  commands to work reliably for even temporary values created using e.g. Eval.
+
+* When serializing duk_tval numbers, the debugger implementation now uses
+  plain integer dvalues instead of full IEEE number dvalues when it's safe to
+  do so without loss of information.  For example, if you Eval "1+2" the
+  result (3) is serialized as a plain integer.  This is allowed by the
+  debugger protocol but hasn't been done before, so it may have an effect on
+  a debug client which assumes, for instance, that Eval result numbers are
+  always in IEEE double format.
+
+There are bug fixes and other minor behavioral changes which may affect some
+applications, see ``RELEASES.rst`` for details.
+
+Known issues
+============
+
+This release has the following known issues worth noting.
+
+Ecmascript features
+-------------------
+
+* FIXME
+
+Portability and platforms
+-------------------------
+
+* FIXME
+
+Raw issues from test runs
+=========================
+
+API tests
+---------
+
+* FIXME
+
+
+Ecmascript tests
+----------------
+
+* FIXME
+
+test262
+-------
+
+* FIXME

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -630,10 +630,17 @@ DUK_INTERNAL void duk_debug_write_int(duk_hthread *thr, duk_int32_t x) {
 
 /* Write unsigned 32-bit integer. */
 DUK_INTERNAL void duk_debug_write_uint(duk_hthread *thr, duk_uint32_t x) {
-	/* XXX: there's currently no need to support full 32-bit unsigned
-	 * integer range in practice.  If that becomes necessary, add a new
-	 * dvalue type or encode as an IEEE double.
+	/* The debugger protocol doesn't support a plain integer encoding for
+	 * the full 32-bit unsigned range (only 32-bit signed).  For now,
+	 * unsigned 32-bit values simply written as signed ones.  This is not
+	 * a concrete issue except for 32-bit heaphdr fields.  Proper solutions
+	 * would be to (a) write such integers as IEEE doubles or (b) add an
+	 * unsigned 32-bit dvalue.
 	 */
+	if (x >= 0x80000000UL) {
+		DUK_D(DUK_DPRINT("writing unsigned integer 0x%08lx as signed integer",
+		                 (long) x));
+	}
 	duk_debug_write_int(thr, (duk_int32_t) x);
 }
 
@@ -755,7 +762,9 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 	duk_c_function lf_func;
 	duk_small_uint_t lf_flags;
 	duk_uint8_t buf[4];
-	duk_double_union du;
+	duk_double_union du1;
+	duk_double_union du2;
+	duk_int32_t i32;
 
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(tv != NULL);
@@ -801,14 +810,39 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 	case DUK_TAG_FASTINT:
 #endif
 	default:
-		/* Numbers are normalized to big (network) endian. */
+		/* Numbers are normalized to big (network) endian.  We can
+		 * (but are not required) to use integer dvalues when there's
+		 * no loss of precision.
+		 *
+		 * XXX: share check with other code; this check is slow but
+		 * reliable and doesn't require careful exponent/mantissa
+		 * mask tricks as in the fastint downgrade code.
+		 */
 		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
-		du.d = DUK_TVAL_GET_NUMBER(tv);
-		DUK_DBLUNION_DOUBLE_HTON(&du);
+		du1.d = DUK_TVAL_GET_NUMBER(tv);
+		i32 = (duk_int32_t) du1.d;
+		du2.d = (duk_double_t) i32;
 
-		duk_debug_write_byte(thr, DUK_DBG_IB_NUMBER);
-		duk_debug_write_bytes(thr, (const duk_uint8_t *) du.uc, sizeof(du.uc));
+		DUK_DD(DUK_DDPRINT("i32=%ld du1=%02x%02x%02x%02x%02x%02x%02x%02x "
+		                   "du2=%02x%02x%02x%02x%02x%02x%02x%02x",
+		                   (long) i32,
+		                   (unsigned int) du1.uc[0], (unsigned int) du1.uc[1],
+		                   (unsigned int) du1.uc[2], (unsigned int) du1.uc[3],
+		                   (unsigned int) du1.uc[4], (unsigned int) du1.uc[5],
+		                   (unsigned int) du1.uc[6], (unsigned int) du1.uc[7],
+		                   (unsigned int) du2.uc[0], (unsigned int) du2.uc[1],
+		                   (unsigned int) du2.uc[2], (unsigned int) du2.uc[3],
+		                   (unsigned int) du2.uc[4], (unsigned int) du2.uc[5],
+		                   (unsigned int) du2.uc[6], (unsigned int) du2.uc[7]));
+
+		if (DUK_MEMCMP((const void *) du1.uc, (const void *) du2.uc, sizeof(du1.uc)) == 0) {
+			duk_debug_write_int(thr, i32);
+		} else {
+			DUK_DBLUNION_DOUBLE_HTON(&du1);
+			duk_debug_write_byte(thr, DUK_DBG_IB_NUMBER);
+			duk_debug_write_bytes(thr, (const duk_uint8_t *) du1.uc, sizeof(du1.uc));
+		}
 	}
 }
 

--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -106,6 +106,9 @@ DUK_LOCAL duk_uint32_t duk__tval_number_to_arr_idx(duk_tval *tv) {
 	DUK_ASSERT(tv != NULL);
 	DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 
+	/* -0 is accepted here as index 0 because ToString(-0) == "0" which is
+	 * in canonical form and thus an array index.
+	 */
 	dbl = DUK_TVAL_GET_NUMBER(tv);
 	idx = (duk_uint32_t) dbl;
 	if ((duk_double_t) idx == dbl) {

--- a/tests/ecmascript/test-dev-negzero-arridx.js
+++ b/tests/ecmascript/test-dev-negzero-arridx.js
@@ -1,0 +1,41 @@
+/*
+ *  The number -0 is accepted as an "array index" and triggers exotic .length
+ *  behavior because ToString(-0) == "0" which is in canonical form and thus a
+ *  valid array index.
+ *
+ *  The string "-0" does *not* trigger the exotic behavior because it's not in
+ *  canonical form.  Same goes for "+0".
+ */
+
+/*===
+1 ["foo"]
+1 ["foo"]
+0 []
+0 []
+===*/
+
+function test() {
+    var arr;
+
+    arr = [];
+    arr[-0] = 'foo';
+    print(arr.length, JSON.stringify(arr));
+
+    arr = [];
+    arr['0'] = 'foo';
+    print(arr.length, JSON.stringify(arr));
+
+    arr = [];
+    arr['+0'] = 'foo';
+    print(arr.length, JSON.stringify(arr));
+
+    arr = [];
+    arr['-0'] = 'foo';
+    print(arr.length, JSON.stringify(arr));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
When the debugger serializes `duk_tval` numbers it currently always sends them as "number" dvalues which sends the IEEE double value as is. Change the serialization so that plain integers are used when the value being serialized can be safely expressed as a plain integer: this is shorter and easier to read.