### PR TITLE
Miscellaneous setjmp() fixes

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1442,6 +1442,8 @@ Planned
   value (e.g. due to a transport detach) could lead to memory unsafe behavior
   (GH-610)
 
+* Remove branch hint from around setjmp() for better portability (GH-605)
+
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 
 * Change OS string (visible in Duktape.env) from "ios" to "osx" for non-phone

--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -1298,6 +1298,9 @@ See separate section below.
 Setjmp, longjmp, and volatile
 =============================
 
+Volatile variables
+------------------
+
 When a local variable in the function containing a ``setjmp()`` gets changed
 between ``setjmp()`` and ``longjmp()`` there is no guarantee that the change
 is visible after a ``longjmp()`` unless the variable is declared volatile.
@@ -1381,6 +1384,38 @@ variables, e.g.::
 (As of Duktape 1.3 this has not yet been done for all setjmp/longjmp
 functions.  Rather, volatile declarations have been added where they
 seem to be needed in practice.)
+
+Limitations in setjmp() call site
+---------------------------------
+
+There are limitations to what a ``setjmp()`` call site can look like,
+see e.g.:
+
+- https://www.securecoding.cert.org/confluence/display/c/MSC22-C.+Use+the+setjmp%28%29,+longjmp%28%29+facility+securely
+
+This is fine for example::
+
+  if (DUK_SETJMP(jb) == 0) {
+          /* ... */
+  }
+
+But this is not::
+
+  /* NOT OK */
+  if (DUK_LIKELY(DUK_SETJMP(jb) == 0)) {
+          /* ... */
+  }
+
+Setjmp and floating points
+--------------------------
+
+There may be limitations on what floating point registers or state is
+actually saved and restored, see e.g.:
+
+- http://www-personal.umich.edu/~williams/archive/computation/setjmp-fpmode.html
+
+To minimize portability issues, floating point variables used in the setjmp
+longjmp path should be volatile so that they won't be stored in registers.
 
 Numeric types
 =============

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -1054,7 +1054,8 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 #if defined(DUK_USE_CPP_EXCEPTIONS)
 	try {
 #else
-	if (DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0) {
+	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == &our_jmpbuf);
+	if (DUK_SETJMP(our_jmpbuf.jb) == 0) {
 #endif
 		/* Call handling and success path.  Success path exit cleans
 		 * up almost all state.
@@ -1954,7 +1955,8 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 #if defined(DUK_USE_CPP_EXCEPTIONS)
 	try {
 #else
-	if (DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0) {
+	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == &our_jmpbuf);
+	if (DUK_SETJMP(our_jmpbuf.jb) == 0) {
 		/* Success path. */
 #endif
 		DUK_DDD(DUK_DDDPRINT("safe_call setjmp catchpoint setup complete"));

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -1054,7 +1054,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 #if defined(DUK_USE_CPP_EXCEPTIONS)
 	try {
 #else
-	if (DUK_LIKELY(DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0)) {
+	if (DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0) {
 #endif
 		/* Call handling and success path.  Success path exit cleans
 		 * up almost all state.
@@ -1954,7 +1954,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 #if defined(DUK_USE_CPP_EXCEPTIONS)
 	try {
 #else
-	if (DUK_LIKELY(DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0)) {
+	if (DUK_SETJMP(thr->heap->lj.jmpbuf_ptr->jb) == 0) {
 		/* Success path. */
 #endif
 		DUK_DDD(DUK_DDDPRINT("safe_call setjmp catchpoint setup complete"));

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -2066,7 +2066,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 #if defined(DUK_USE_CPP_EXCEPTIONS)
 		try {
 #else
-		if (DUK_LIKELY(DUK_SETJMP(heap->lj.jmpbuf_ptr->jb) == 0)) {
+		if (DUK_SETJMP(heap->lj.jmpbuf_ptr->jb) == 0) {
 #endif
 			/* Execute bytecode until returned or longjmp(). */
 			duk__js_execute_bytecode_inner(entry_thread, entry_callstack_top);


### PR DESCRIPTION
- [x] Remove branch hint wrapper from around setjmp(), it's technically not allowed and may be an actual issue depending on how setjmp is implemented
- [x] Simplify DUK_SETJMP() arguments: jmpbuf_ptr should always point to a local jmpbuf so we can just `DUK_SETJMP(our_jmpbuf.jb)`
- [x] Releases entry