### PR TITLE
Add a self test for FP rounding mode

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1776,6 +1776,9 @@ Planned
 * Add a minimal alloc/realloc/free self test to the (optional) internal
   self test (GH-877)
 
+* Add an FP rounding mode self test (Duktape assumes rounding mode is
+  IEEE 754 round-to-nearest, C99 FE_TONEAREST) (GH-606)
+
 * Simplify call related bytecode opcodes for better performance; as a
   result maximum argument count to normal and constructor calls dropped
   from 511 to 255, and calling a user function (i.e. not the built-in


### PR DESCRIPTION
Duktape assumes the default IEEE rounding mode (round to nearest). Add a self test to check for that because if that's not the case, some arithmetic won't be Ecmascript compliant.

- [x] Add portable check (when possible)
- [x] Releases

With C99 including `fenv.h` and checking for `fegetround() == FE_TONEAREST` should be correct.