### PR TITLE
Accept numeric 'request' or 'notify' in debug proxy protocol

### DIFF
--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -2166,14 +2166,16 @@ function DebugProxy(serverPort) {
     this.dval_err = formatDebugValue(DVAL_ERR);
 }
 
-DebugProxy.prototype.determineCommandNumber = function (cmdString, cmdNumber) {
+DebugProxy.prototype.determineCommandNumber = function (cmdName, cmdNumber) {
     var ret;
-    if (typeof cmdString === 'string') {
-        ret = debugCommandNumbers[cmdString];
+    if (typeof cmdName === 'string') {
+        ret = debugCommandNumbers[cmdName];
+    } else if (typeof cmdName === 'number') {
+        ret = cmdName;
     }
     ret = ret || cmdNumber;
     if (typeof ret !== 'number') {
-        throw Error('cannot figure out command number for "' + cmdString + '" (' + cmdNumber + ')');
+        throw Error('cannot figure out command number for "' + cmdName + '" (' + cmdNumber + ')');
     }
     return ret;
 };

--- a/debugger/duk_debug_proxy.js
+++ b/debugger/duk_debug_proxy.js
@@ -399,15 +399,17 @@ JsonConnHandler.prototype.dispatchJsonMessage = function dispatchJsonMessage(msg
 JsonConnHandler.prototype.determineCommandNumber = function determineCommandNumber(name, val) {
     var res;
 
-    if (typeof(name) === 'string') {
+    if (typeof name === 'string') {
         res = this.commandNumberLookup[name];
         if (!res) {
             log.info('Unknown command name: ' + name + ', command number: ' + val);
         }
+    } else if (typeof name === 'number') {
+        res = name;
     } else if (name !== true) {
-        throw new Error('invalid command name (must be string or "true"): ' + name);
+        throw new Error('invalid command name (must be string, number, or "true"): ' + name);
     }
-    if (typeof res === 'undefined' && typeof(val) === 'undefined') {
+    if (typeof res === 'undefined' && typeof val === 'undefined') {
         throw new Error('cannot determine command number from name: ' + name);
     }
     if (typeof val !== 'number' && typeof val !== 'undefined') {


### PR DESCRIPTION
Accept a numeric request/notify directly, e.g. `"request": 24` or `"notify": 6`. Still supports the previous form.