### PR TITLE
Add option callstack level or object argument to GetBytecode

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1391,6 +1391,9 @@ Planned
 
 * Add sizeof void pointer to the BasicInfo debugger command (GH-611)
 
+* Extend debugger GetBytecode command to accept an optional callstack level
+  or direct heap object argument (GH-610)
+
 * A DukLuv-based JSON debug proxy is now included in the dist package;
   it should allow much easier and more flexible packaging of a JSON debug
   proxy into a debug client (GH-590)
@@ -1424,6 +1427,10 @@ Planned
 * Fix debugger transport write error bug which could cause Duktape to call
   the debug transport write callback after it had already returned an error
   (GH-599)
+
+* Fix debugger PutVar command bug where a failure to read the PutVar variable
+  value (e.g. due to a transport detach) could lead to memory unsafe behavior
+  (GH-610)
 
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)
 

--- a/src/duk_debugger.h
+++ b/src/duk_debugger.h
@@ -61,7 +61,7 @@ DUK_INTERNAL_DECL duk_hstring *duk_debug_read_hstring(duk_hthread *thr);
 /* XXX: exposed duk_debug_read_pointer */
 /* XXX: exposed duk_debug_read_buffer */
 /* XXX: exposed duk_debug_read_hbuffer */
-DUK_INTERNAL_DECL void duk_debug_read_tval(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_tval *duk_debug_read_tval(duk_hthread *thr);
 
 DUK_INTERNAL_DECL void duk_debug_write_bytes(duk_hthread *thr, const duk_uint8_t *data, duk_size_t length);
 DUK_INTERNAL_DECL void duk_debug_write_byte(duk_hthread *thr, duk_uint8_t x);


### PR DESCRIPTION
Extend GetBytecode behavior to match e.g. GetLocals by adding an additional argument which be either:

- A negative integer to indicate a callstack level
- An object dvalue to specify an explicit target function

Tasks:

- [x] Change GetBytecode behavior
- [x] Test manually: no argument, valid integer, out-of-bounds integer, valid object pointer, invalid object pointer, invalid type
- [x] Test PutVar
- [x] Test AppRequest
- [x] Fix bug in `duk_debug_read_tval()` call sites when read fails and we detach: nothing gets pushed but some call sites will assume so: AppRequest, PutVar
- [x] Debugger documentation
- [x] Releases