### PR TITLE
Add void pointer size to debugger BasicInfo

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1389,6 +1389,8 @@ Planned
 * Add support for application specific debugger commands (AppRequest) and
   notifications (AppNotify) (GH-596, GH-563)
 
+* Add sizeof void pointer to the BasicInfo debugger command (GH-611)
+
 * A DukLuv-based JSON debug proxy is now included in the dist package;
   it should allow much easier and more flexible packaging of a JSON debug
   proxy into a debug client (GH-590)

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1442,12 +1442,13 @@ BasicInfo request (0x10)
 Format::
 
     REQ <int: 0x10> EOM
-    REP <int: DUK_VERSION> <str: DUK_GIT_DESCRIBE> <str: target info> <int: endianness> EOM
+    REP <int: DUK_VERSION> <str: DUK_GIT_DESCRIBE> <str: target info>
+        <int: endianness> <int: sizeof(void *)> EOM
 
 Example::
 
     REQ 16 EOM
-    REP 10099 "v1.0.0-254-g2459e88" "Arduino Yun" 2 EOM
+    REP 10099 "v1.0.0-254-g2459e88" "Arduino Yun" 2 4 EOM
 
 Endianness:
 
@@ -1461,6 +1462,9 @@ Endianness affects decoding of a few dvalues.
 
 Target info is a string that can be compiled in, and can e.g. describe the
 device type.
+
+Void pointer size indicates pointer size used for pointer-related values.
+Note that function pointers may have a different size.
 
 TriggerStatus request (0x11)
 ----------------------------

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1063,6 +1063,7 @@ DUK_LOCAL void duk__debug_handle_basic_info(duk_hthread *thr, duk_heap *heap) {
 #else
 	duk_debug_write_int(thr, 0);
 #endif
+	duk_debug_write_int(thr, (duk_int_t) sizeof(void *));
 	duk_debug_write_eom(thr);
 }
 


### PR DESCRIPTION
Add `sizeof(void *)` to the end of debugger BasicInfo command response, which provides the debug client with an expected size for pointer-related dvalues.