### PR TITLE
Implement "pause debugger now" API

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1389,6 +1389,9 @@ Planned
 * Add support for application specific debugger commands (AppRequest) and
   notifications (AppNotify) (GH-596, GH-563)
 
+* Add duk_debugger_pause() API which allows the target to quickly pause
+  Ecmascript execution and break into the debugger (GH-615)
+
 * Add sizeof void pointer to the BasicInfo debugger command (GH-611)
 
 * Extend debugger GetBytecode command to accept an optional callstack level

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -320,6 +320,25 @@ blocking), you can also use it like this::
         /*...*/
     }
 
+duk_debugger_pause()
+--------------------
+
+The target may call this at any time to pause Ecmascript execution and turn over
+control to the attached debug client.  This is safe to call if the debugger is
+not attached, in which case it has no effect::
+
+    duk_debugger_pause(ctx);
+
+A pause so requested may not happen immediately; for example if a long-running
+native call such as a Duktape/C function is in progress. The target will pause
+once the bytecode executor is re-entered, either by the native call returning
+into Ecmascript code or calling e.g. ``duk_eval()`` or ``duk_call()``.
+
+A common use case for this call is to bind it to a hotkey, which allows the
+user to break out of and debug infinite loops.  However, like all Duktape API
+calls, the call is not thread safe and must be called from the same thread used
+to run the Ecmascript code being debugged.
+
 Debug transport
 ===============
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -959,6 +959,7 @@ DUK_EXTERNAL_DECL void duk_debugger_attach_custom(duk_context *ctx,
 DUK_EXTERNAL_DECL void duk_debugger_detach(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_debugger_cooperate(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_bool_t duk_debugger_notify(duk_context *ctx, duk_idx_t nvalues);
+DUK_EXTERNAL_DECL void duk_debugger_pause(duk_context *ctx);
 
 /*
  *  Date provider related constants

--- a/website/api/duk_debugger_pause.yaml
+++ b/website/api/duk_debugger_pause.yaml
@@ -1,0 +1,32 @@
+name: duk_debugger_pause
+
+proto: |
+  void duk_debugger_pause(duk_context *ctx);
+
+summary: |
+  <p>Trigger a debugger pause as soon as possible.  In most cases Duktape pauses
+  immediately; however if a native call such as a Duktape/C function is in
+  progress or no Ecmascript code is currently executing, the pause will be
+  triggered the next time Ecmascript bytecode is executed.  This may take some
+  time e.g. if the native call in progress is long-running.</p>
+
+  <p>If debugger support has not been compiled in, or if the debugger is not
+  attached, the call is a no-op.  This mimics the semantics of the Ecmascript
+  <code>debugger</code> statement.</p>
+
+  <div class="note">
+  Like all Duktape API calls, this call is not thread safe.  It may be tempting
+  to want to trigger a pause from a thread different than one running Ecmascript
+  code for the context, but this is unsafe and must be avoided.
+  </div>
+
+example: |
+  /* In your event loop: */
+  if (key_pressed == KEY_F12) {
+      duk_debugger_pause(ctx);
+  }
+
+tags:
+  - debugger
+
+introduced: 1.5.0


### PR DESCRIPTION
The target can call `duk_debugger_pause()` to initiate an immediate debugger pause, enabling implementation of a "break into debugger now" hotkey or similar mechanism.

The intent is that `duk_debugger_pause()` will pause execution at the exact point where it was called.  I'm not sure if this is true in practice due to the way the interrupt counter works.