### PR TITLE
Fix external buffer allocation bug affecting compressed pointer build

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1403,6 +1403,9 @@ Planned
   immediately which makes the cause of the unsafe behavior difficult to
   diagnose (GH-531)
 
+* Fix memory unsafe behavior when an external plain buffer was allocated
+  with heap pointer compression enabled (DUK_USE_HEAPPTR16) (GH-618)
+
 * Fix pointer arithmetic portability issues with platforms/compilers with
   exotic pointer models by avoiding arithmetic and binary operations on
   (u)intptr_t values (GH-530, GH-539)

--- a/src/duk_hbuffer_alloc.c
+++ b/src/duk_hbuffer_alloc.c
@@ -31,7 +31,7 @@ DUK_INTERNAL duk_hbuffer *duk_hbuffer_alloc(duk_heap *heap, duk_size_t size, duk
 	if (flags & DUK_BUF_FLAG_EXTERNAL) {
 		header_size = sizeof(duk_hbuffer_external);
 		alloc_size = sizeof(duk_hbuffer_external);
-	} if (flags & DUK_BUF_FLAG_DYNAMIC) {
+	} else if (flags & DUK_BUF_FLAG_DYNAMIC) {
 		header_size = sizeof(duk_hbuffer_dynamic);
 		alloc_size = sizeof(duk_hbuffer_dynamic);
 	} else {


### PR DESCRIPTION
Fix bug in external buffer allocation which caused incorrect size when using compressed pointers. As a result memory unsafe behavior could happen.