### PR TITLE
Minor cleanups for debugger heap object inspection support

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1371,8 +1371,8 @@ Planned
   (read-only data section) which reduces the startup RAM usage of a low
   memory build to ~3kB (from ~27kB) (GH-559)
 
-* Add debugger heap object inspection commands GetHeapObjInfo, GetObjProp,
-  and GetObjPropRange, which allow a debug client to inspect heap objects
+* Add debugger heap object inspection commands GetHeapObjInfo, GetObjPropDesc,
+  and GetObjPropDescRange, which allow a debug client to inspect heap objects
   in detail, walk prototype chains, etc (GH-358, GH-617)
 
 * Garbage collection is now automatically disabled when execution is paused

--- a/config/config-options/DUK_USE_DEBUGGER_INSPECT.yaml
+++ b/config/config-options/DUK_USE_DEBUGGER_INSPECT.yaml
@@ -8,6 +8,7 @@ default: false
 tags:
   - debugger
 description: >
-  Support debugger heap object inspection commands GetHeapObjInfo, GetObjProp,
-  GetObjPropRange.  These are optional because the commands have a relatively
-  high code footprint (about 3kB) and are not always needed.
+  Support debugger heap object inspection commands GetHeapObjInfo,
+  GetObjPropDesc, GetObjPropDescRange.  These are optional because the
+  commands have a relatively high code footprint (about 3kB) and are not
+  always needed.

--- a/config/examples/debugger_support.yaml
+++ b/config/examples/debugger_support.yaml
@@ -13,8 +13,8 @@ DUK_USE_DEBUGGER_PAUSE_UNCAUGHT: true
 # Enable DumpHeap command (experimental).
 DUK_USE_DEBUGGER_DUMPHEAP: true
 
-# Enable object inspection commands: GetHeapObjInfo, GetObjProp,
-# GetObjPropRange.
+# Enable object inspection commands: GetHeapObjInfo, GetObjPropDesc,
+# GetObjPropDescRange.
 DUK_USE_DEBUGGER_INSPECT: true
 
 # Transport torture testing: enable when testing your transport

--- a/debugger/duk_debugcommands.yaml
+++ b/debugger/duk_debugcommands.yaml
@@ -48,5 +48,5 @@ target_commands:
   - GetBytecode
   - AppRequest
   - GetHeapObjInfo
-  - GetObjProp
-  - GetObjPropRange
+  - GetObjPropDesc
+  - GetObjPropDescRange

--- a/doc/testcase-known-issues.yaml
+++ b/doc/testcase-known-issues.yaml
@@ -87,6 +87,9 @@
 -
   test: "test-bi-json-enc-proxy.js"
   knownissue: "JSON enumeration behavior for Proxy targets is incomplete and uses 'enumerate' trap instead of 'ownKeys' trap"
+-
+  test: "test-bi-proxy-object-tostring.js"
+  knownissue: "Object class handling for Proxy objects is incomplete"
 
 # Ecmascript testcases that need special options or environment to work
 

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1888,7 +1888,8 @@ DUK_LOCAL void duk__debug_handle_get_bytecode(duk_hthread *thr, duk_heap *heap) 
 }
 
 /*
- *  Object inspection commands: GetHeapObjInfo, GetObjProp, GetObjPropRange
+ *  Object inspection commands: GetHeapObjInfo, GetObjPropDesc,
+ *  GetObjPropDescRange
  */
 
 #if defined(DUK_USE_DEBUGGER_INSPECT)
@@ -2249,13 +2250,13 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 	duk_debug_write_eom(thr);
 }
 
-DUK_LOCAL void duk__debug_handle_get_obj_prop(duk_hthread *thr, duk_heap *heap) {
+DUK_LOCAL void duk__debug_handle_get_obj_prop_desc(duk_hthread *thr, duk_heap *heap) {
 	duk_heaphdr *h;
 	duk_hobject *h_obj;
 	duk_hstring *h_key;
 	duk_propdesc desc;
 
-	DUK_D(DUK_DPRINT("debug command GetObjProp"));
+	DUK_D(DUK_DPRINT("debug command GetObjPropDesc"));
 	DUK_UNREF(heap);
 
 	h = duk_debug_read_any_ptr(thr);
@@ -2292,12 +2293,12 @@ DUK_LOCAL void duk__debug_handle_get_obj_prop(duk_hthread *thr, duk_heap *heap) 
 	duk_debug_write_error_eom(thr, DUK_DBG_ERR_UNKNOWN, "invalid args");
 }
 
-DUK_LOCAL void duk__debug_handle_get_obj_prop_range(duk_hthread *thr, duk_heap *heap) {
+DUK_LOCAL void duk__debug_handle_get_obj_prop_desc_range(duk_hthread *thr, duk_heap *heap) {
 	duk_heaphdr *h;
 	duk_hobject *h_obj;
 	duk_uint_t idx, idx_start, idx_end;
 
-	DUK_D(DUK_DPRINT("debug command GetObjPropRange"));
+	DUK_D(DUK_DPRINT("debug command GetObjPropDescRange"));
 	DUK_UNREF(heap);
 
 	h = duk_debug_read_any_ptr(thr);
@@ -2442,12 +2443,12 @@ DUK_LOCAL void duk__debug_process_message(duk_hthread *thr) {
 			duk__debug_handle_get_heap_obj_info(thr, heap);
 			break;
 		}
-		case DUK_DBG_CMD_GETOBJPROP: {
-			duk__debug_handle_get_obj_prop(thr, heap);
+		case DUK_DBG_CMD_GETOBJPROPDESC: {
+			duk__debug_handle_get_obj_prop_desc(thr, heap);
 			break;
 		}
-		case DUK_DBG_CMD_GETOBJPROPRANGE: {
-			duk__debug_handle_get_obj_prop_range(thr, heap);
+		case DUK_DBG_CMD_GETOBJPROPDESCRANGE: {
+			duk__debug_handle_get_obj_prop_desc_range(thr, heap);
 			break;
 		}
 #endif  /* DUK_USE_DEBUGGER_INSPECT */

--- a/src/duk_debugger.h
+++ b/src/duk_debugger.h
@@ -4,76 +4,76 @@
 /* Debugger protocol version is defined in the public API header. */
 
 /* Initial bytes for markers. */
-#define DUK_DBG_IB_EOM               0x00
-#define DUK_DBG_IB_REQUEST           0x01
-#define DUK_DBG_IB_REPLY             0x02
-#define DUK_DBG_IB_ERROR             0x03
-#define DUK_DBG_IB_NOTIFY            0x04
+#define DUK_DBG_IB_EOM                   0x00
+#define DUK_DBG_IB_REQUEST               0x01
+#define DUK_DBG_IB_REPLY                 0x02
+#define DUK_DBG_IB_ERROR                 0x03
+#define DUK_DBG_IB_NOTIFY                0x04
 
 /* Other initial bytes. */
-#define DUK_DBG_IB_INT4              0x10
-#define DUK_DBG_IB_STR4              0x11
-#define DUK_DBG_IB_STR2              0x12
-#define DUK_DBG_IB_BUF4              0x13
-#define DUK_DBG_IB_BUF2              0x14
-#define DUK_DBG_IB_UNUSED            0x15
-#define DUK_DBG_IB_UNDEFINED         0x16
-#define DUK_DBG_IB_NULL              0x17
-#define DUK_DBG_IB_TRUE              0x18
-#define DUK_DBG_IB_FALSE             0x19
-#define DUK_DBG_IB_NUMBER            0x1a
-#define DUK_DBG_IB_OBJECT            0x1b
-#define DUK_DBG_IB_POINTER           0x1c
-#define DUK_DBG_IB_LIGHTFUNC         0x1d
-#define DUK_DBG_IB_HEAPPTR           0x1e
+#define DUK_DBG_IB_INT4                  0x10
+#define DUK_DBG_IB_STR4                  0x11
+#define DUK_DBG_IB_STR2                  0x12
+#define DUK_DBG_IB_BUF4                  0x13
+#define DUK_DBG_IB_BUF2                  0x14
+#define DUK_DBG_IB_UNUSED                0x15
+#define DUK_DBG_IB_UNDEFINED             0x16
+#define DUK_DBG_IB_NULL                  0x17
+#define DUK_DBG_IB_TRUE                  0x18
+#define DUK_DBG_IB_FALSE                 0x19
+#define DUK_DBG_IB_NUMBER                0x1a
+#define DUK_DBG_IB_OBJECT                0x1b
+#define DUK_DBG_IB_POINTER               0x1c
+#define DUK_DBG_IB_LIGHTFUNC             0x1d
+#define DUK_DBG_IB_HEAPPTR               0x1e
 /* The short string/integer initial bytes starting from 0x60 don't have
  * defines now.
  */
 
 /* Error codes. */
-#define DUK_DBG_ERR_UNKNOWN          0x00
-#define DUK_DBG_ERR_UNSUPPORTED      0x01
-#define DUK_DBG_ERR_TOOMANY          0x02
-#define DUK_DBG_ERR_NOTFOUND         0x03
-#define DUK_DBG_ERR_APPLICATION      0x04
+#define DUK_DBG_ERR_UNKNOWN              0x00
+#define DUK_DBG_ERR_UNSUPPORTED          0x01
+#define DUK_DBG_ERR_TOOMANY              0x02
+#define DUK_DBG_ERR_NOTFOUND             0x03
+#define DUK_DBG_ERR_APPLICATION          0x04
 
 /* Commands and notifys initiated by Duktape. */
-#define DUK_DBG_CMD_STATUS           0x01
-#define DUK_DBG_CMD_PRINT            0x02
-#define DUK_DBG_CMD_ALERT            0x03
-#define DUK_DBG_CMD_LOG              0x04
-#define DUK_DBG_CMD_THROW            0x05
-#define DUK_DBG_CMD_DETACHING        0x06
-#define DUK_DBG_CMD_APPNOTIFY        0x07
+#define DUK_DBG_CMD_STATUS               0x01
+#define DUK_DBG_CMD_PRINT                0x02
+#define DUK_DBG_CMD_ALERT                0x03
+#define DUK_DBG_CMD_LOG                  0x04
+#define DUK_DBG_CMD_THROW                0x05
+#define DUK_DBG_CMD_DETACHING            0x06
+#define DUK_DBG_CMD_APPNOTIFY            0x07
 
 /* Commands initiated by debug client. */
-#define DUK_DBG_CMD_BASICINFO        0x10
-#define DUK_DBG_CMD_TRIGGERSTATUS    0x11
-#define DUK_DBG_CMD_PAUSE            0x12
-#define DUK_DBG_CMD_RESUME           0x13
-#define DUK_DBG_CMD_STEPINTO         0x14
-#define DUK_DBG_CMD_STEPOVER         0x15
-#define DUK_DBG_CMD_STEPOUT          0x16
-#define DUK_DBG_CMD_LISTBREAK        0x17
-#define DUK_DBG_CMD_ADDBREAK         0x18
-#define DUK_DBG_CMD_DELBREAK         0x19
-#define DUK_DBG_CMD_GETVAR           0x1a
-#define DUK_DBG_CMD_PUTVAR           0x1b
-#define DUK_DBG_CMD_GETCALLSTACK     0x1c
-#define DUK_DBG_CMD_GETLOCALS        0x1d
-#define DUK_DBG_CMD_EVAL             0x1e
-#define DUK_DBG_CMD_DETACH           0x1f
-#define DUK_DBG_CMD_DUMPHEAP         0x20
-#define DUK_DBG_CMD_GETBYTECODE      0x21
-#define DUK_DBG_CMD_APPREQUEST       0x22
-#define DUK_DBG_CMD_GETHEAPOBJINFO   0x23
-#define DUK_DBG_CMD_GETOBJPROP       0x24
-#define DUK_DBG_CMD_GETOBJPROPRANGE  0x25
+#define DUK_DBG_CMD_BASICINFO            0x10
+#define DUK_DBG_CMD_TRIGGERSTATUS        0x11
+#define DUK_DBG_CMD_PAUSE                0x12
+#define DUK_DBG_CMD_RESUME               0x13
+#define DUK_DBG_CMD_STEPINTO             0x14
+#define DUK_DBG_CMD_STEPOVER             0x15
+#define DUK_DBG_CMD_STEPOUT              0x16
+#define DUK_DBG_CMD_LISTBREAK            0x17
+#define DUK_DBG_CMD_ADDBREAK             0x18
+#define DUK_DBG_CMD_DELBREAK             0x19
+#define DUK_DBG_CMD_GETVAR               0x1a
+#define DUK_DBG_CMD_PUTVAR               0x1b
+#define DUK_DBG_CMD_GETCALLSTACK         0x1c
+#define DUK_DBG_CMD_GETLOCALS            0x1d
+#define DUK_DBG_CMD_EVAL                 0x1e
+#define DUK_DBG_CMD_DETACH               0x1f
+#define DUK_DBG_CMD_DUMPHEAP             0x20
+#define DUK_DBG_CMD_GETBYTECODE          0x21
+#define DUK_DBG_CMD_APPREQUEST           0x22
+#define DUK_DBG_CMD_GETHEAPOBJINFO       0x23
+#define DUK_DBG_CMD_GETOBJPROPDESC       0x24
+#define DUK_DBG_CMD_GETOBJPROPDESCRANGE  0x25
 
 /* The low 8 bits map directly to duk_hobject.h DUK_PROPDESC_FLAG_xxx.
  * The remaining flags are specific to the debugger.
  */
-#define DUK_DBG_PROPFLAG_INTERNAL    (1 << 8)
+#define DUK_DBG_PROPFLAG_INTERNAL        (1 << 8)
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 DUK_INTERNAL_DECL void duk_debug_do_detach(duk_heap *heap);

--- a/src/duk_heap_markandsweep.c
+++ b/src/duk_heap_markandsweep.c
@@ -1157,7 +1157,8 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 	 */
 
 	/* If thr != NULL, the thr may still be in the middle of
-	 * initialization; improve the thread viability test.
+	 * initialization.
+	 * XXX: Improve the thread viability test.
 	 */
 	thr = duk__get_temp_hthread(heap);
 	if (thr == NULL) {

--- a/tests/ecmascript/test-bi-proxy-object-tostring.js
+++ b/tests/ecmascript/test-bi-proxy-object-tostring.js
@@ -1,0 +1,21 @@
+/*
+ *  Object.prototype.toString() for a Proxy object should reflect the target,
+ *  not the Proxy itself.
+ */
+
+/*===
+[object Array]
+===*/
+
+function test() {
+    var proxy = new Proxy([], {});
+
+    // This should print [object Array] (verified against Firefox).
+    print(Object.prototype.toString.call(proxy));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
- [x] Minor code comment improvements
- [x] Document guaranteed artificial properties which will have version guarantees
- [x] Add explicit note on how Proxy objects are treated, i.e. traps are not invoked, how to detect a Proxy
- [x] Note on sparse arrays, missing elements, and potentially unordered indices
- [x] Command naming, downside of using "get" is that "get with side effects" (normally called "get") clashes
- [x] Comment on crossed indices in GetObjPropRange
- [x] Test command names with debug proxy