### PR TITLE
Add support for module.fileName and module.name

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1396,6 +1396,17 @@ Planned
   explicit filename is known; this makes file/line information thrown from
   such code more useful in practice (GH-516, GH-644)
 
+* Add support for non-standard module.fileName (initialized to resolved
+  module ID) and module.name (initialized to last component of resolved
+  module ID) which are used for the internal module wrapper function's
+  .fileName and .name properties; they show up in stack traces, debugger
+  integration, logger instance default naming, etc, and can now be
+  controlled by modSearch() (GH-639)
+
+* Add a .name property for the require() functions created for included
+  modules, so that they have a readable name in stack traces like the top
+  level require() function (GH-639)
+
 * Add Windows version of the debugger example TCP transport (GH-579)
 
 * Add support for application specific debugger commands (AppRequest) and

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -12,7 +12,8 @@ built into Duktape:
 
   - http://wiki.commonjs.org/wiki/Modules/1.1.1
 
-  - Duktape supports also ``module.exports``
+  - Duktape supports also ``module.exports`` and a few Duktape specific
+    properties (``module.fileName`` and ``module.name``)
 
 * The user must provide a *module search function* which locates a module
   corresponding to a resolved module ID, and can register module symbols
@@ -251,6 +252,19 @@ which initially has the same value as ``exports``:
 Duktape supports ``module.exports`` since Duktape 1.3, see:
 
 * ``test-commonjs-module-exports-repl.js``
+
+module.fileName and module.name
+===============================
+
+The ``module.fileName`` and ``module.name`` properties are Duktape specific
+and allow modSearch() to control the ``.fileName`` and ``.name`` properties
+of the module wrapper function used to implement module loading.  This is
+useful because they appear in e.g. tracebacks for errors created from the
+module, see: https://github.com/svaarala/duktape/pull/639.
+
+The initial value for ``module.fileName`` is the full resolved module ID
+(e.g. ``foo/bar``) and for ``module.name`` the last component of the
+resolved module ID (e.g. ``bar``).
 
 C modules and DLLs
 ==================

--- a/tests/ecmascript/test-commonjs-module-filename.js
+++ b/tests/ecmascript/test-commonjs-module-filename.js
@@ -1,0 +1,87 @@
+/*
+ *  Duktape 1.5 added module.fileName and module.name support.
+ */
+
+/*===
+default behavior
+test/foo2 test/foo2 test/foo2 foo2
+test/foo2
+2
+foo2
+TIME INF test/foo2: test
+override .name and .fileName
+test/bar2 test/bar2 test/bar2 bar2
+my_source.js
+2
+my_module
+TIME INF my_source.js: test
+.name shadowing test
+test/quux2 test/quux2 test/quux2 quux2
+object
+number
+123
+===*/
+
+var testSource =
+    '/* test */\n' +
+    'var err = new Error("aiee");\n' +
+    'print(err.fileName);\n' +
+    'print(err.lineNumber);\n' +
+    'print(Duktape.act(-2).function.name);\n' +
+    '/*print(err.stack);*/\n' +
+    'var logger = new Duktape.Logger();\n' +
+    'logger.info("test");\n';
+
+function test() {
+    // Replace Duktape.Logger.prototype.raw to censor timestamps.
+
+    Duktape.Logger.prototype.raw = function (buf) {
+        print(String(buf).replace(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.*?Z/, 'TIME'));
+    };
+
+    // Default behavior, module.fileName is resolved module ID.
+
+    Duktape.modSearch = function modSearch(id, require, exports, module) {
+        print(id, module.id, module.fileName, module.name);
+        return testSource;
+    };
+
+    print('default behavior');
+    var tmp = require('test/foo1/../foo2');
+
+    // Override module.fileName and module.name in modSearch().
+
+    Duktape.modSearch = function modSearch(id, require, exports, module) {
+        print(id, module.id, module.fileName, module.name);
+        module.fileName = 'my_source.js';  // match source filename for example
+        module.name = 'my_module';
+        return testSource;
+    };
+
+    print('override .name and .fileName');
+    var tmp = require('test/bar1/../bar2');
+
+    // Test that the forced .name property of the module wrapper function
+    // does not introduce a shadowing binding -- this is important for
+    // semantics and works because the wrapper function is initially
+    // compiled as an anonymous function (which ensures the function doesn't
+    // get a "has a name binding" flag) and .name is then forced manually.
+
+    var global = new Function('return this')();
+    global.myFileName = 123;  // this should be visible
+
+    Duktape.modSearch = function modSearch(id, require, exports, module) {
+        print(id, module.id, module.fileName, module.name);
+        module.fileName = 'myFileName';
+        return 'print(typeof Math); print(typeof myFileName); print(myFileName);';
+    };
+
+    print('.name shadowing test');
+    var tmp = require('test/quux1/../quux2');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-commonjs-require-filename.js
+++ b/tests/ecmascript/test-commonjs-require-filename.js
@@ -2,8 +2,14 @@
  *  Filename for functions inside a module loaded using require()
  *
  *  In Duktape 1.0.0 this would always be "duk_bi_global.c" which is confusing.
- *  For Duktape 1.1.0 this was fixed to be the fully resolved module ID.
+ *
+ *  In Duktape 1.1.0 this was fixed to be the fully resolved module ID.
  *  See GH-58 for discussion.
+ *
+ *  In Duktape 1.5.0 the module wrapper function is also given a .name which
+ *  defaults to the last component of the resolved module ID.  Both the .name
+ *  and .fileName can be overridden by modSearch via module.name and
+ *  module.fileName.
  */
 
 /*---
@@ -13,10 +19,10 @@
 ---*/
 
 /*===
-moduleFunc name: 
-moduleFunc fileName: foo
+moduleFunc name: foo
+moduleFunc fileName: my/foo
 testFunc name: testFunc
-testFunc fileName: foo
+testFunc fileName: my/foo
 ===*/
 
 function modSearch() {
@@ -35,7 +41,7 @@ function test() {
      */
 
     Duktape.modSearch = modSearch;
-    var mod = require('foo');
+    var mod = require('my/foo');
 
     /* However, functions defined within the module don't have a proper
      * fileName in Duktape 1.0.0.

--- a/tests/ecmascript/test-commonjs-require-subrequire-name.js
+++ b/tests/ecmascript/test-commonjs-require-subrequire-name.js
@@ -1,0 +1,38 @@
+/*
+ *  The fresh require() functions given to modules should have a .name so that
+ *  they appear nicely in tracebacks.  This was not the case in Duktape 1.4.x,
+ *  fixed in Duktape 1.5.x.
+ */
+
+/*===
+function
+string
+require
+false false false
+===*/
+
+function test() {
+    Duktape.modSearch = function modSearch(id, require, exports, module) {
+        var pd;
+
+        print(typeof require);
+        print(typeof require.name);
+        print(require.name);
+
+        pd = Object.getOwnPropertyDescriptor(require, 'name');
+        print(pd.writable, pd.enumerable, pd.configurable);
+
+        //print(new Error('aiee').stack);
+        //require('../../../../foo')
+
+        return undefined;
+    };
+
+    require('foo/bar');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/website/guide/modules.html
+++ b/website/guide/modules.html
@@ -3,7 +3,8 @@
 
 <p>Duktape has a built-in minimal module loading framework based on
 <a href="http://wiki.commonjs.org/wiki/Modules/1.1.1">CommonJS modules version 1.1.1</a>,
-with additional support for <code>module.exports</code>.
+with additional support for <code>module.exports</code> and a few Duktape
+specific <code>module</code> object properties.
 The internals are documented in
 <a href="https://github.com/svaarala/duktape/blob/master/doc/modules.rst">modules.rst</a>.
 A recommended (but not mandatory) C module convention is described in


### PR DESCRIPTION
Currently Ecmascript modules are loaded using a wrapper function whose `.fileName` is automatically set to the module ID. This is a useful default, but in some situations user code may want to use a different fileName, e.g. mapping to a concrete file when one exists. See #637.

Change current behavior so that:

- `module.fileName` is initialized to the resolved module ID, i.e. the current .fileName used
- `module.name` is initialized to the last component of the resolved module ID (e.g. `foo/bar` -> `bar`)
- Allow user modSearch() to replace `module.fileName` and/or `module.name`
- Use `module.fileName` for the wrapper function `.fileName` so that it shows up in tracebacks etc
- Similarly `module.name` is used for the wrapper function `.name`

Tasks:

- [x] Change `require()` behavior to use module.fileName
- [x] Change module wrapper function .name also to match module.fileName
- [x] Add module.name handling
- [x] Add #defines for stack indices in require() implementation
- [x] Rewrite `q_last` tracking to avoid explicit scan
- [x] Add .name for fresh `require()` function
- [x] Testcase for setting module.fileName in modSearch()
- [x] Testcase for module wrapper function name, affects stack traces generated during module load
- [x] Testcase for initializing a logger within a module with default fileName (= module resolved ID) and modified module.fileName
- [x] Testcase for ensuring that module wrapper function's `.name` does not create a capturing function name binding
- [x] Testcase for module.name overriding
- [x] Testcase for fresh require() .name
- [x] Stress testcase for last component scanning (truncated IDs etc)
- [ ] Assertion run
- [x] Update documentation
- [x] Wiki modules howto update: https://github.com/svaarala/duktape-wiki/pull/104
- [x] Releases entry