### PR TITLE
Add a minimal multi-platform testrunner with push webhook script jobs

### DIFF
--- a/testrunner/Makefile
+++ b/testrunner/Makefile
@@ -1,0 +1,15 @@
+# Some useful development targets.
+
+.PHONY: dist
+dist:
+	rm -f testrunner-server-node.tar.gz
+	rm -f testrunner-client-simple-node.tar.gz
+	tar cvfz testrunner-server-node.tar.gz \
+		server-node/*.js \
+		server-node/package.json \
+		server-node/config.yaml.template
+	tar cvfz testrunner-client-simple-node.tar.gz \
+		client-simple-node/*.js \
+		client-simple-node/*.sh \
+		client-simple-node/package.json \
+		client-simple-node/config.yaml.template

--- a/testrunner/README.rst
+++ b/testrunner/README.rst
@@ -1,0 +1,312 @@
+==================
+Duktape testrunner
+==================
+
+Overview
+========
+
+Duktape testrunner provides multi-platform client-server test execution
+which is integrated with Github webhooks.  Current functionality:
+
+* Accepting webhook POSTs from Github
+
+* Managing the execution of a set of tests associated with commits
+  ("push" events) together with test clients; each test is a simple
+  script with a textual output and a success/failure indication
+
+* Integrating test execution status with Github status API
+
+* Providing a placeholder web UI for showing pending tests
+
+The main goals for the client-server model are:
+
+* The ability of execute tests on a wide variety of platforms, including
+  exotic platforms which have no emulators and sometimes no TCP/IP networking.
+
+* Allow easy integration of simple test scripts to make it easy to extend test
+  coverage incrementally.  For example, test scripts might include basic
+  compile/test runs for some applications using Duktape.
+
+At this point the functionality is very limited; future work is listed at
+the end of this document.
+
+Server architecture
+===================
+
+The server is written in Node.js, using Express.js for the HTTP/HTTPS
+interfaces to interface with Github, test clients, and for serving the
+web UI.
+
+A NeDB database is used for persistent state, with individual objects stored
+as one-line JSON entries in a single database file.  The database file is
+grep-friendly so that you can e.g. grep for objects by type or field value.
+
+There's some temporary RAM-based state for handling hanging requests, so that
+they can be woken up on state changes.  This state is non-critical and doesn't
+need to be persisted.
+
+NeDB conventions:
+
+* Each document has a ``type`` field, with lowercase, underscore separated
+  value identifying the document type.
+
+* Keys are lowercase, underscore separated.
+
+* Platform, architecture, compiler names, job types, etc. are lowercase and
+  underscore separated too.
+
+Simple commit jobs
+==================
+
+Basics
+------
+
+The term "simple commit job" refers (here) to a simple script based test run:
+
+* A test run is associated with a repo/sha pair (where the commit hash is
+  from a Github "push" webhook) and a named "context".  A fresh temporary
+  directory (automatically cleaned up on exit) is created for each run.
+
+* The "context" identifies the test type and maps to (1) a test script in the
+  test client, and (2) a Github status line associated with the repo/sha pair.
+  The status line is shown in the Github Web UI (similar to Travis CI).
+  Example contexts:
+
+  - "x64-qecmatest": maps to ``run_x64_qecmatest.sh`` in the test client.
+
+  - "x64-apitest": maps to ``run_x64_apitest.sh``
+
+  - "rombuild": maps to ``run_rombuild.sh`` which ultimately runs
+    ``util/example_rombuild.sh``
+
+* Each test run ultimately produces a success/failure indication and some
+  text associated with the test run.  The Github status line links to an
+  URI provided by the test server, serving the text on demand.
+
+Test scripts
+------------
+
+A test script can be implemented e.g. as a bash script:
+
+* The script gets various arguments, including a clone URI, a full repo name,
+  the commit hash, etc.
+
+* The script clones the repo and checks out the commit hash, and runs the
+  test.  As a practical optimization a full checkout should be avoided, e.g.
+  as follows:
+
+  - Clone the target repo and create a local tar.gz package of the clone.
+    When running a test, unpack the tar.gz and ``git pull --rebase`` to get the
+    latest changes.  This works even with parallel tests and minimizes Git
+    pull traffic.
+
+  - Keep the repo checkout and reuse it for the next run; ``git clean -f`` can
+    be used to clean the repo for the next run.  This only works if there's
+    no parallelism.
+
+* Because the test script will be run without interaction, it must have the
+  necessary credentials to clone repositories (but not commit to them).
+
+Limitations
+-----------
+
+Simple commit jobs have many limitations, e.g. they don't parallelize well,
+and the result feedback is sparse.  The main point is that new jobs are easy
+to add, and easy to test independent of the testrunner infrastructure as the
+actual test script can be e.g. a very simple bash script.  Existing tests in
+the top level Makefile can also be easily added as simple commit jobs.
+
+More complex test job models will be added later; for example, the full matrix
+of Duktape versions, config options, testcases, platforms, and compilers could
+be tracked with very small individual test runs.  This parallelizes much better
+and merges the existing test suite and matrix test runs into one.  This needs
+more state in the server and also requires a much more complicated test client
+so the ability to add simple script jobs will still remain.
+
+Testrunner API HTTPS conventions
+================================
+
+Conventions used for testrunner API calls.
+
+HTTPS
+-----
+
+HTTPS with mutual authentication is used for all requests.  POST requests are
+used for JSON-based API methods.  GET requests are used to both download JSON
+data and arbitrary files like test log files (and in the future, Duktape
+distributable packages, test cases, etc).
+
+Proper authentication is important because test clients compile and execute
+code provided by the test server, which is very easily exploitable using a
+fake server.
+
+Server authentication
+---------------------
+
+A self signed Duktape CA certificate is used as the client trust root.  The CA
+keypair is used to sign the testrunner server certificate, forming a two level
+hierarchy.  A single level hierarchy, i.e. direct trust on a self-signed server
+certificate, seems to work poorly with existing libraries.  There's no subject
+name validation.
+
+``X-TestRunner-Authenticator`` header in responses provides some additional
+security against a misconfigured client accidentally talking to a fake server.
+
+Client authentication
+---------------------
+
+HTTP basic authentication, i.e. ``Authorization`` header is used for both
+GET and POST requests.  Basic authentication is also easy to use from e.g.
+``curl``.
+
+POST request content
+--------------------
+
+POST request body is a JSON object.  Content-Type is ignored by server to
+make it easier to write clients, but should be set to ``application/json``.
+
+POST response content
+---------------------
+
+POST response body is a JSON object.  Content-Type is ``application/json``.
+
+JSON conventions
+----------------
+
+Keys are lowercase and underscore separated, e.g. ``repo_full``.
+
+Server always sends packed one-liner JSON but accepts arbitrary JSON.
+Getting a single line JSON response makes it simpler for clients doing
+ad hoc parsing instead of using an actual JSON parser.
+
+Other naming conventions
+------------------------
+
+HTTP(S) method paths as lowercase, dash separated, e.g. ``/get-job``.
+
+Error codes are uppercase and underscore separated, e.g. ``NO_JOBS``.
+
+Github webhook HTTPS conventions
+================================
+
+Conventions used for inbound and outbound Github calls.
+
+Client (Github) authentication
+------------------------------
+
+Github uses a ``X-Hub-Signature`` header in its POST requests, the value
+being a HMAC-SHA1 of the POST body and a secret key.
+
+Committer authorization
+-----------------------
+
+A pull request from a random third party poses a serious security risk for
+the test clients because the test client will compile and run arbitrary C
+code.  (Because the committer is known, an attack will be traceable however.)
+
+For now, the testrunner will trigger automatic test runs only when the
+commit being tested comes from a whitelisted list of trusted authors.  Other
+webhooks are accepted but won't automatically trigger test runs.
+
+Testrunner URIs
+===============
+
+URIs served by testrunner; these are not documented in detail here, see source
+for details:
+
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| URI                         | Method   | Authentication | Description                                            |
++=============================+==========+================+========================================================+
+| /index.html                 | GET      | none           | Web UI index page                                      |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| /                           | GET      | none           | Web UI index page                                      |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| /out/xxx                    | GET      | none           | Test run output files, named by data hash              |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| /github-webhook             | POST     | Github         | Github webhook: https://developer.github.com/webhooks/ |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| /get-simple-commit          | POST     | Testrunner     | Request a commit-related test for list of supported    |
+|                             |          |                | contexts                                               |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+| /finish-simple-commit       | POST     | Testrunner     | Finish a commit-related test for a context             |
++-----------------------------+----------+----------------+--------------------------------------------------------+
+
+Nedb document types
+===================
+
+These are not documented in detail here, see source for details:
+
++----------------------------+-------------------------------------------------------+
+| Type                       | Description                                           |
++============================+=======================================================+
+| ``github_status``          | Github status target, may be out-of-sync              |
++----------------------------+-------------------------------------------------------+
+| ``github_webhook``         | Github webhook information                            |
++----------------------------+-------------------------------------------------------+
+| ``commit_simple``          | State for simple tests related to a single commit     |
++----------------------------+-------------------------------------------------------+
+
+Security considerations
+=======================
+
+Foreign pull requests
+---------------------
+
+Running test cases involves compiling and executing arbitrary C code on the
+test target.  It's therefore quite dangerous to automatically execute tests
+for all pull requests -- anyone can create pull requests and place arbitrary
+code in them.
+
+For now there are filters in place so that the test server only reacts to
+webhook requests coming from trusted repositories / committers.
+
+If the test client is properly sandboxed it would be possible to run tests
+for pull requests from unknown sources.  Sandboxing would need to include
+network filtering, backstop sanity timeouts, etc.
+
+See similar discussion related to Travis secure environment variables:
+
+* http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests
+
+Future work
+===========
+
+* Test timeouts and other sanity checks.
+
+* Multiple client identifiers/passwords, now shared.
+
+* Consistent error handling: error code, message, details.
+
+* Add better server tracking for pending test jobs, so that a job can be
+  reassigned or retried if the client never comes back.  Alternatively,
+  support for manually retriggering a job.
+
+* Add ``accept-simple-commit`` so that the client can explicitly indicate
+  it has received a job and is running it.  This would make it clear for
+  the server whether the ``get-simple-commit`` response was actually received;
+  this is not always the case e.g. if the client has already exited.
+
+* Add persistent client state for accepted jobs so that if the client dies
+  it can report that it didn't finish the job.  Ensure clear separation
+  between errors in trying to run the tests and errors in the tests themselves
+  (this is not always 100% because an out-of-memory error, for example, can
+  look like an error in trying to run the test rather than indicating an
+  actual bug).  The server should get the necessary information to retry the
+  job a few times.
+
+* Add enough state to list recently connected clients, as well as all
+  clients ever seen in the web UI status page.
+
+* Proper web UI, serve static HTML/CSS/JS and use e.g. socket.io for a
+  dynamic listing, status, etc.
+
+* Better test isolation.
+
+References
+==========
+
+* http://expressjs.com/
+
+* https://github.com/louischatriot/nedb
+
+* https://developer.github.com/webhooks/

--- a/testrunner/client-simple-node/client.js
+++ b/testrunner/client-simple-node/client.js
@@ -1,0 +1,337 @@
+/*
+ *  Testrunner client for simple commit jobs
+ *
+ *  Node.js based default client intended for Linux, OSX, and Windows.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var yaml = require('yamljs');
+var Promise = require('bluebird');
+var http = require('http');
+var https = require('https');
+var tmp = require('tmp');
+var child_process = require('child_process');
+var crypto = require('crypto');
+
+/*
+ *  Command line and config parsing
+ */
+
+var argv = require('minimist')(process.argv.slice(2));
+console.log('Command line options: ' + JSON.stringify(argv));
+var configFile = argv.config || './config.yaml';
+console.log('Load config: ' + configFile);
+var clientConfig = yaml.load(configFile);
+
+/*
+ *  Misc utils
+ */
+
+function sha1sum(x) {
+    return crypto.createHash('sha1').update(x).digest('hex');
+}
+
+function sha1sumFile(x) {
+    return sha1sum(fs.readFileSync(x));
+}
+
+function assert(x) {
+    if (x) { return x; }
+    throw new Error('assertion failed');
+}
+
+/*
+ *  HTTP(S) helpers
+ */
+
+var serverTrustRoot = fs.readFileSync(clientConfig.serverCertificate);
+
+// Path -> file data
+var fileCache = {};
+
+function getBasicAuthHeader() {
+    return 'Basic ' + new Buffer(assert(clientConfig.clientAuthUsername) + ':' + assert(clientConfig.clientAuthPassword)).toString('base64');
+}
+
+function getUserAgent() {
+    return 'testrunner-client';
+}
+
+function serverAuthCheck(res) {
+    var auth = res.headers['x-testrunner-authenticator'];  // lowercase intentionally
+    if (typeof auth !== 'string' ||
+        auth !== assert(clientConfig.serverAuthPassword)) {
+        throw new Error('server not authorized');
+    }
+}
+
+function postJson(path, request, cb) {
+    return new Promise(function (resolve, reject) {
+        var requestData = new Buffer(JSON.stringify(request), 'utf8');
+        var headers = {
+            'User-Agent': getUserAgent(),
+            'Authorization': getBasicAuthHeader(),
+            'Content-Type': 'application/json',
+            'Content-Length': requestData.length,
+        };
+        var options = {
+            host: clientConfig.serverHost,
+            port: clientConfig.serverPort,
+            ca: serverTrustRoot,
+            rejectUnauthorized: true,
+            path: path,
+            method: 'POST',
+            auth: assert(clientConfig.clientAuthUsername) + ':' + assert(clientConfig.clientAuthPassword),
+            headers: headers
+        };
+
+        console.log('sending POST ' + path);
+
+        var req = https.request(options, function (res) {
+            //res.setEncoding('utf8');  // we just want binary
+
+            var buffers = [];
+            res.on('data', function (data) {
+                try {
+                    buffers.push(data);
+                } catch (e) {
+                    console.log(e);
+                }
+            });
+            res.on('end', function () {
+                try {
+                    serverAuthCheck(res);
+                    var data = Buffer.concat(buffers);
+                    var rep = JSON.parse(data.toString('utf8'));
+                } catch (e) {
+                    reject(e);
+                    return;
+                }
+                resolve(rep);
+            });
+        });
+
+        req.on('error', function (err) {
+            reject(err);
+        });
+
+        req.write(requestData);
+        req.end();
+    });
+}
+
+function getFile(path, cb) {
+    return new Promise(function (resolve, reject) {
+        var headers = {
+            'User-Agent': getUserAgent(),
+            'Authorization': getBasicAuthHeader()
+        };
+        var options = {
+            host: clientConfig.serverHost,
+            port: clientConfig.serverPort,
+            ca: serverTrustRoot,
+            rejectUnauthorized: true,
+            path: path,
+            method: 'GET',
+            auth: assert(clientConfig.clientAuthUsername) + ':' + assert(clientConfig.clientAuthPassword),
+            headers: headers
+        };
+
+        console.log('sending GET ' + path);
+
+        var req = https.request(options, function (res) {
+            //res.setEncoding('utf8');  // we just want binary
+
+            var buffers = [];
+            res.on('data', function (data) {
+                try {
+                    buffers.push(data);
+                } catch (e) {
+                    console.log(e);
+                }
+            });
+            res.on('end', function () {
+                try {
+                    serverAuthCheck(res);
+                    var data = Buffer.concat(buffers);
+                } catch (e) {
+                    reject(e);
+                    return;
+                }
+                resolve(data);
+            });
+        });
+
+        req.on('error', function (err) {
+            reject(err);
+        });
+
+        req.end();
+    });
+}
+
+function cachedGetFile(path) {
+    if (fileCache[path]) {
+        return new Promise(function (resolve, reject) {
+            resolve(fileCache[path]);
+        });
+    } else {
+        return getFile(path).then(function (data) {
+            fileCache[path] = data;
+            return data;
+        });
+    }
+}
+
+/*
+ *  Simple commit jobs
+ */
+
+function processSimpleScriptJob(rep) {
+    var context, repo, repoFull, repoCloneUrl, sha, script;
+    var tmpDir;
+
+    var tmpDir = tmp.dirSync({
+        mode: 0750,
+        prefix: 'testrunner-' + context + '-',
+        unsafeCleanup: true
+    });
+
+    return new Promise(function (resolve, reject) {
+        var i;
+
+        context = assert(rep.context);
+        repo = assert(rep.repo);
+        repoFull = assert(rep.repo_full);
+        repoCloneUrl = assert(rep.repo_clone_url);
+        sha = assert(rep.sha);
+
+        for (i = 0; i < clientConfig.supportedContexts.length; i++) {
+            if (clientConfig.supportedContexts[i].context === assert(rep.context)) {
+                script = clientConfig.supportedContexts[i].script;
+            }
+        }
+        if (!script) {
+            reject(new Error('unsupported context: ' + context));
+            return;
+        }
+
+        console.log('start simple commit test, repo ' + repoCloneUrl + ', sha ' + sha + ', context ' + context);
+
+        var args = [ assert(repoFull), assert(repoCloneUrl), assert(sha), assert(context), assert(tmpDir.name) ];
+        var cld = child_process.spawn(assert(script), args, { cwd: '/tmp' });
+        var buffers = [];
+        cld.stdout.on('data', function (data) {
+            buffers.push(data);
+        });
+        cld.stderr.on('data', function (data) {
+            buffers.push(data);  // just interleave stdout/stderr for now
+        });
+        cld.on('close', function (code) {
+            resolve({ code: code, data: Buffer.concat(buffers) });
+        });
+    }).then(function (res) {
+        // Test execution finished, test case may have succeeded or failed.
+        console.log('finished simple commit test, repo ' + repoCloneUrl + ', sha ' + sha + ', context ' + context + ', code ' + res.code);
+        //console.log(res.data.toString());
+
+        // Initial heuristic for providing descriptions from test script,
+        // could also use an explicit output file.  Match last occurrence
+        // on purpose so that the script can always override a previous
+        // status if necessary.
+        var desc = null;
+        try {
+            desc = (function () {
+                var txt = res.data.toString('utf8');  // XXX: want something lenient
+                var re = /^TESTRUNNER_DESCRIPTION: (.*?)$/gm;
+                var m;
+                var out = null;
+                while ((m = re.exec(txt)) !== null) {
+                    out = m[1];
+                }
+                return out;
+            })();
+        } catch (e) {
+            console.log(e);
+        }
+
+        postJson('/finish-commit-simple', {
+            repo: assert(repo),
+            repo_full: assert(repoFull),
+            repo_clone_url: assert(repoCloneUrl),
+            sha: assert(sha),
+            context: assert(context),
+            state: res.code === 0 ? 'success' : 'failure',
+            description: desc || (res.code === 0 ? 'Success' : 'Failure'),
+            text: res.data.toString('base64')
+        }).then(function (rep) {
+            //console.log(rep);
+        }).catch(function (err) {
+            console.log(err);  // XXX: chain error
+        });
+    }).catch(function (err) {
+        // Test execution attempt failed (which is different from a test case
+        // failing).
+        console.log('FAILED simple commit test, repo ' + repoCloneUrl + ', sha ' + sha + ', context ' + context);
+        console.log(err);
+
+        var data = new Buffer(String(err.stack || err));
+
+        // XXX: indicate possibly transient nature of error
+
+        postJson('/finish-commit-simple', {
+            repo: assert(repo),
+            repo_full: assert(repoFull),
+            repo_clone_url: assert(repoCloneUrl),
+            sha: assert(sha),
+            context: assert(context),
+            state: 'failure',
+            description: 'Failed: ' + String(err),
+            text: data.toString('base64')
+        }).then(function (rep) {
+            //console.log(rep);
+        }).catch(function (err) {
+            console.log(err);  // XXX: chain error
+        });
+    }).finally(function () {
+        if (tmpDir) {
+            tmpDir.removeCallback();
+            console.log('cleaned up ' + tmpDir.name);
+        }
+    });
+}
+
+function requestAndExecute() {
+    var contexts = [];
+    var i;
+
+    for (i = 0; i < clientConfig.supportedContexts.length; i++) {
+        contexts.push(clientConfig.supportedContexts[i].context);
+    }
+
+    postJson('/get-commit-simple', {
+        contexts: contexts
+    }).then(function (rep) {
+        console.log(rep);
+        if (rep.error_code) {
+            throw new Error('job failed; error code ' + rep.error_code + ': ' + rep.error_description);
+        }
+        return processSimpleScriptJob(rep);
+    }).then(function () {
+        setTimeout(function () { requestAndExecute(); }, clientConfig.sleepJobSuccess);
+    }).catch(function (err) {
+        // XXX: differentiate between TIMEOUT and other errors
+        console.log('job failed; sleep a bit and retry:', err);
+        console.log(err.stack);
+        setTimeout(function () { requestAndExecute(); }, clientConfig.sleepJobFailure);
+    });
+
+    setTimeout(function () {}, 10000000);  // avoid exit
+}
+
+function main() {
+    requestAndExecute();
+}
+
+main();

--- a/testrunner/client-simple-node/config.yaml.template
+++ b/testrunner/client-simple-node/config.yaml.template
@@ -1,0 +1,26 @@
+# Testrunner client example configuration
+
+# Testrunner server host/port.
+serverHost: 'localhost'
+serverPort: 9080
+
+# Testrunner server SSL trust root (Duktape CA).
+serverCertificate: 'server.crt'
+
+# Testrunner API authentication.
+serverAuthPassword: 'foobarx'
+clientAuthUsername: 'foouser'
+clientAuthPassword: 'foopass'
+
+# Sleeps between successful/failed jobs.
+sleepJobSuccess: 10000
+sleepJobFailure: 60000
+
+# Supported simple commit job types (contexts).  Each context has a string
+# name which appears directly in Github web UI, and a script which is used
+# to execute test jobs of that type.
+supportedContexts:
+  - context: 'qecmatest'
+    script: '/path/to/run_qecmatest.sh'  # script paths must be absolute
+  - context: 'apitest'
+    script: '/path/to/run_apitest.sh'

--- a/testrunner/client-simple-node/package.json
+++ b/testrunner/client-simple-node/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "testrunner-client",
+  "version": "0.1.0",
+  "description": "Duktape testrunner client",
+  "author": {
+    "name": "Sami Vaarala",
+    "email": "sami.vaarala@iki.fi"
+  },
+  "dependencies": {
+    "bluebird": "^2.9.25",
+    "crypto": "0.0.3",
+    "https": "^1.0.0",
+    "yamljs": "^0.2.2",
+    "tmp": "~0.0.27",
+    "minimist": "~1.2.0"
+  },
+  "main": "client.js"
+}

--- a/testrunner/client-simple-node/run_dukgxx.sh
+++ b/testrunner/client-simple-node/run_dukgxx.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# Full name of repo, e.g. "svaarala/duktape".
+REPOFULLNAME=$1
+
+# Repo HTTPS clone URL, e.g. "https://github.com/svaarala/duktape.git".
+REPOCLONEURL=$2
+
+# Commit hash.
+SHA=$3
+
+# Context, e.g. "x64-qecmatest".
+CONTEXT=$4
+
+# Automatic temporary directory created by testclient, automatically
+# deleted (recursively) by testclient.
+TEMPDIR=$5
+
+# Directory holding repo tar.gz clone snapshots for faster test init.
+# Example: /tmp/repo-snapshots/svaarala/duktape.tar.gz.
+REPO_TARGZS=/tmp/repo-snapshots
+
+set -e
+
+echo "*** Run duk-g++ test: `date`"
+echo "REPOFULLNAME=$REPOFULLNAME"
+echo "REPOCLONEURL=$REPOCLONEURL"
+echo "SHA=$SHA"
+echo "CONTEXT=$CONTEXT"
+
+if [ "x$TEMPDIR" = "x" ]; then
+	echo "Missing TEMPDIR."
+	exit 1
+fi
+cd "$TEMPDIR"
+
+if echo "$REPOFULLNAME" | grep -E '[[:space:]\.]'; then
+	echo "Repo full name contains invalid characters"
+	exit 1
+fi
+if [ "$REPOFULLNAME" != "svaarala/duktape" ]; then
+	echo "Repo is not whitelisted"
+	exit 1
+fi
+
+# This isn't great security-wise, but $REPOFULLNAME has been checked not to
+# contain dots (e.g. '../').  It'd be better to resolve the absolute filename
+# and ensure it begins with $REPO_TARGZS.
+TARGZ=$REPO_TARGZS/$REPOFULLNAME.tar.gz
+echo "Using repo tar.gz: '$TARGZ'"
+if [ ! -f "$TARGZ" ]; then
+	echo "Repo snapshot doesn't exist: $TARGZ."
+	exit 1
+fi
+
+echo "Git preparations"
+cd "$TEMPDIR"
+mkdir repo
+cd repo
+tar -x --strip-components 1 -z -f "$TARGZ"
+git clean -f
+git checkout master
+git pull --rebase
+git clean -f
+git checkout "$SHA"
+
+echo ""
+echo "Running: make clean duk-g++"
+make clean duk-g++
+
+echo ""
+echo "Hello world test"
+./duk-g++ -e "print('hello world!');" >hello.out
+echo "hello world!" >hello.require
+cat hello.out
+
+# If stdout contains "TESTRUNNER_DESCRIPTION: xxx" it will become the Github
+# status description.  Last occurrence wins.  If no such line is printed, the
+# test client will use a generic "Success" or "Failure" text.
+echo "TESTRUNNER_DESCRIPTION: DUMMY"
+if cmp hello.out hello.require; then
+	echo "match"
+	echo "TESTRUNNER_DESCRIPTION: Hello world success"
+	exit 0
+else
+	echo "no match"
+	echo "TESTRUNNER_DESCRIPTION: Hello world failed"
+	exit 1
+fi

--- a/testrunner/server-node/config.yaml.template
+++ b/testrunner/server-node/config.yaml.template
@@ -1,0 +1,45 @@
+# Testrunner server example configuration
+
+# Server HTTPS port.
+serverPort: 9080
+
+# Server SSL key and certificate.
+serverPrivateKey: 'server.key'
+serverCertificate: 'server.crt'
+
+# NeDB database file, created automatically if missing.
+databaseFile: 'server.db'
+
+# Testrunner API authentication.
+serverAuthPassword: 'foobar'
+clientAuthUsername: 'foouser'
+clientAuthPassword: 'foopass'
+
+# Github webhook authentication (inbound).
+githubWebhookSecret: 'foo'
+
+# Github API authentication (outbound).  Use a personal access token with
+# limited permissions as password.
+githubAuthUsername: 'foouser'
+githubAuthPassword: 'foopass'
+githubStatusUsername: 'foouser'
+
+# Github rate limitation; ensures testrunner server doesn't hammer Github
+# in case a code or configuration bug causes repeated requests to be made.
+githubTokensPerHour: 120
+
+# Github repos for which webhooks are processed.
+githubRepos:
+  - svaarala/duktape  # full repo names
+
+# Trusted github authors whose commits will get automatic test runs.
+githubTrustedAuthors:
+  - user1
+  - user2
+  - user3
+
+# Directory for storing data files.
+dataDumpDirectory: '/tmp/testrunner-datafiles'
+
+# Base URI for web links served by testrunner.
+webBaseUri: 'https://localhost:9080'

--- a/testrunner/server-node/dbutil.js
+++ b/testrunner/server-node/dbutil.js
@@ -1,0 +1,38 @@
+/*
+ *  Db utilities.
+ */
+
+var Promise = require('bluebird');
+
+// Delete all documents.
+function deleteAll(db) {
+    return new Promise(function (resolve, reject) {
+        db.remove({
+        }, {
+            multi: true
+        }, function (err, numRemoved) {
+            console.log('removed', numRemoved, 'documents');
+            if (err) {
+                reject(err);
+            } else {
+                resolve(numRemoved);
+            }
+        });
+    });
+}
+
+// Find document(s).
+function find(db, arg) {
+    return new Promise(function (resolve, reject) {
+        db.find(arg, function (err, docs) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(docs);
+            }
+        });
+    });
+}
+
+exports.deleteAll = deleteAll;
+exports.find = find;

--- a/testrunner/server-node/expressutil.js
+++ b/testrunner/server-node/expressutil.js
@@ -1,0 +1,81 @@
+/*
+ *  Express.js utilities.
+ */
+
+var bodyParser = require('body-parser');
+var basicAuth = require('basic-auth');
+var crypto = require('crypto');
+
+var util = require('./util');
+var sha1sum = util.sha1sum;
+var sha1sumFile = util.sha1sumFile;
+var assert = util.assert;
+
+// Express.js API JSON body parser.
+// http://stackoverflow.com/questions/19917401/node-js-express-request-entity-too-large
+var makeApiJsonBodyParser = function makeApiJsonBodyParse() {
+    return bodyParser.json({
+        limit: '50mb'
+    });
+};
+
+// Express.js Github JSON body parser with github auth.
+function makeGithubJsonBodyParser(webhookSecret) {
+    return bodyParser.json({
+        limit: '50mb',
+        verify: function (req, res, buf, encoding) {
+            function authFail() {
+                console.log(req.method + ' ' + req.url + ': github authentication failure');
+                throw new Error('github authentication failure');
+            }
+            if (typeof webhookSecret !== 'string') {
+                authFail();
+            }
+            var hubSig = req.get('X-Hub-Signature');
+            if (typeof hubSig !== 'string') {
+                authFail();
+            }
+            var mac = crypto.createHmac('sha1', assert(webhookSecret));
+            mac.update(buf);
+            var compare = 'sha1=' + mac.digest('hex').toLowerCase();
+            if (hubSig !== compare) {
+                authFail();
+            }
+        }
+    });
+}
+
+// Express.js API authentication for testrunner API calls.
+function makeApiBasicAuth(clientUsername, clientPassword, serverPassword) {
+    return function (req, res, next) {
+        function unauthorized(res) {
+            console.log(req.method + ' ' + req.url + ': api authentication failed');
+            res.set('WWW-Authenticate', 'Basic realm=API Authorization Required');
+            return res.sendStatus(401);
+        }
+        var user = basicAuth(req);
+        if (!user || !user.name || !user.pass) {
+            return unauthorized(res);
+        }
+        if (user.name === assert(clientUsername) &&
+            user.pass === assert(clientPassword)) {
+            res.set('X-TestRunner-Authenticator', assert(serverPassword));
+            return next();
+        } else {
+            return unauthorized(res);
+        }
+    };
+}
+
+// Express.js request logger.
+function makeLogRequest() {
+    return function (req, res, next) {
+        console.log(req.method + ' ' + req.url);
+        next();
+    };
+}
+
+exports.makeApiJsonBodyParser = makeApiJsonBodyParser;
+exports.makeGithubJsonBodyParser = makeGithubJsonBodyParser;
+exports.makeApiBasicAuth = makeApiBasicAuth;
+exports.makeLogRequest = makeLogRequest;

--- a/testrunner/server-node/gencert.sh
+++ b/testrunner/server-node/gencert.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+#  Generate SSL keypair and self-signed certificate.  Use a two level
+#  hierarchy to avoid limitations in SSL libraries (for some reason a
+#  self-signed one level trust root is an issue).
+#
+
+if [ -f ca.key ]; then
+    echo "ca.key already exists"
+    exit 1
+fi
+if [ -f ca.csr ]; then
+    echo "ca.csr already exists"
+    exit 1
+fi
+if [ -f ca.crt ]; then
+    echo "ca.crt already exists"
+    exit 1
+fi
+if [ -f server.key ]; then
+    echo "server.key already exists"
+    exit 1
+fi
+if [ -f server.csr ]; then
+    echo "server.csr already exists"
+    exit 1
+fi
+if [ -f server.crt ]; then
+    echo "server.crt already exists"
+    exit 1
+fi
+
+echo
+echo "*** Creating non-encrypted private key (CA) ***"
+echo
+#openssl genrsa -des3 -out ca.key 2048
+openssl genrsa -out ca.key 2048
+
+echo
+echo "*** Creating certificate signing request (CA) ***"
+echo
+echo "Respond to CSR prompts manually.  Common name should probably match"
+echo "FQDN or IP address used by client."
+echo
+openssl req -new -key ca.key -out ca.csr
+
+echo
+echo "*** Creating self-signed certificate (CA) ***"
+echo
+
+DAYS=5475  # 15*365
+openssl x509 -req -days $DAYS -in ca.csr -signkey ca.key -out ca.crt
+
+echo
+echo "*** Creating non-encrypted private key (server) ***"
+echo
+#openssl genrsa -des3 -out server.key 2048
+openssl genrsa -out server.key 2048
+
+echo
+echo "*** Creating certificate signing request (server) ***"
+echo
+echo "Respond to CSR prompts manually.  Common name should probably match"
+echo "FQDN or IP address used by client."
+echo
+openssl req -new -key server.key -out server.csr
+
+echo
+echo "*** Creating certificate (server) ***"
+echo
+
+DAYS=5475  # 15*365
+openssl x509 -req -days $DAYS -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt

--- a/testrunner/server-node/githubutil.js
+++ b/testrunner/server-node/githubutil.js
@@ -1,0 +1,475 @@
+/*
+ *  Github API and Webhook handling.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var dbutil = require('./dbutil');
+var util = require('./util');
+var assert = util.assert;
+
+// Send a JSON reply to an Express response.
+function sendJsonReply(res, obj) {
+    var repData = new Buffer(JSON.stringify(obj), 'utf8');
+    res.send(repData);
+}
+
+// Create a new github status entry and mark it dirty for background push.
+function createGithubStatus(state, status) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+
+    db.find({
+        type: 'github_status',
+        user: assert(status.user),
+        repo: assert(status.repo),
+        sha: assert(status.sha),
+        context: assert(status.context)
+    }, function (err, docs) {
+        var doc;
+        if (err) { console.log(err); return; }
+        if (docs && docs.length > 0) {
+            console.log('github-status already exists');
+            return;
+        }
+
+        db.insert({
+            type: 'github_status',
+            user: assert(status.user),
+            repo: assert(status.repo),
+            sha: assert(status.sha),
+            state: assert(status.state),
+            target_url: assert(status.target_url),
+            description: assert(status.description),
+            context: assert(status.context),
+            dirty: true
+        });
+    });
+}
+
+// Update an existing github status and mark it dirty.
+function updateGithubStatus(state, status) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+
+    db.find({
+        type: 'github_status',
+        user: assert(status.user),
+        repo: assert(status.repo),
+        sha: assert(status.sha),
+        context: assert(status.context)
+    }, function (err, docs) {
+        var doc;
+        if (err) { console.log(err); return; }
+        if (!docs || docs.length <= 0) {
+            console.log('github-status not found');
+            return;
+        }
+        if (docs.length >= 2) {
+            console.log('more than one github-status matches, unexpected');
+        }
+        doc = docs[docs.length - 1];
+
+        var setValues = { dirty: true };
+        function check(key) {
+            if (typeof status[key] !== 'undefined') {
+                setValues[key] = status[key];
+            }
+        }
+        check('state');
+        check('target_url');
+        check('description');
+
+        db.update({
+            _id: doc._id
+        }, {
+            $set: setValues
+        }, function (err, numReplaced) {
+            if (err) { throw err; }
+        });
+    });
+}
+
+// Push dirty github status items.  Rate limit Github operations to avoid
+// behaving badly even if something goes wrong and we end up retrying a
+// push indefinitely.
+function pushGithubStatuses(state) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+
+    db.find({
+        type: 'github_status',
+        dirty: true
+    }, function (err, docs) {
+        if (err) { console.log(err); return; }
+        if (!docs || docs.length <= 0) { return; }
+
+        docs.forEach(function (doc) {
+            state.githubLimiter.removeTokens(1, function (err, remainingTokens) {
+                if (err) {
+                    console.log(err);
+                    return;
+                }
+                if (remainingTokens < 0) {
+                    console.log('skip github status push, rate limited');
+                    return;
+                }
+
+                console.log('push github status for repo ' + doc.user + '/' + doc.repo +
+                            ', commit ' + doc.sha + ', context ' + doc.context +
+                            ', state ' + doc.state + '; tokens left: ' + remainingTokens);
+
+                github.authenticate({
+                    type: 'basic',
+                    username: assert(state.githubAuthUsername),
+                    password: assert(state.githubAuthPassword)
+                });
+                github.statuses.create({
+                    user: assert(doc.user),
+                    repo: assert(doc.repo),
+                    sha: assert(doc.sha),
+                    state: assert(doc.state),
+                    target_url: assert(doc.target_url),
+                    description: assert(doc.description),
+                    context: assert(doc.context),
+                }, function statusCreated(err, ret) {
+                    //console.log('status created:', err, ret);
+                    if (err) {
+                        console.log(err);
+                        return;
+                    }
+
+                    db.update({
+                        _id: doc._id
+                    }, {
+                        $set: {
+                            dirty: false
+                        },
+                    }, function (err, numReplaced) {
+                        if (err) { throw err; }
+                    });
+                });
+            });
+        });
+    });
+}
+
+// Tracking table for hanging get-commit-simple, i.e. clients waiting for a
+// job to execute.  Clients will be hanging most of the time which avoids
+// slow response time due to periodic polling.
+var getCommitRequests = [];
+var getCommitRequestsCount = null;  // for logging
+
+// Recheck pending get-commit-simple requests: if new matching jobs are
+// available, respond to the client and remove the tracking state.  Also
+// handles request timeouts.
+function handleGetCommitRequests(state) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+    var now = Date.now();
+
+    // XXX: Quite inefficient but good enough for now.
+
+    db.find({
+        type: 'commit_simple'
+    }, function (err, docs) {
+        if (err) { console.log(err); return; }
+        if (!docs || docs.length <= 0) { return; }
+
+        docs.forEach(function (doc) {
+            if (now - doc.time > 3 * 24 * 3600e3) {
+                return;  // ignore webhooks several days old
+            }
+
+            getCommitRequests = getCommitRequests.filter(function (client) {
+                var i, j, ctx, run, found;
+
+                // XXX: This is racy at the moment, rework to only send a
+                // client response when the database has been updated.
+
+                if (now - client.time >= 300e3) {
+                    console.log('client request for simple commit job timed out');
+                    sendJsonReply(client.res, {
+                        error_code: 'TIMEOUT'
+                    });  // XXX
+                    return false;  // remove
+                }
+
+                for (i = 0; i < client.contexts.length; i++) {
+                    ctx = client.contexts[i];
+                    found = false;
+                    for (j = 0; j < doc.runs.length; j++) {
+                        run = doc.runs[j];
+                        if (run.context === ctx) {
+                            found = true;
+                        }
+                    }
+                    if (!found) {
+                        // Context ctx not found in runs already, add to runs
+                        // and respond to client.
+
+                        doc.runs.push({
+                            start_time: Date.now(),
+                            end_time: null,
+                            context: ctx
+                        });
+
+                        db.update({
+                            _id: doc._id
+                        }, {
+                            $set: {
+                                runs: doc.runs
+                            }
+                        }, function (err, numReplaced) {
+                            if (err) { throw err; }
+                        });
+
+                        console.log('start simple commit job for sha ' + doc.sha + ', context ' + ctx);
+                        sendJsonReply(client.res, {
+                            repo: assert(doc.repo),
+                            repo_full: assert(doc.repo_full),
+                            repo_clone_url: assert(doc.repo_clone_url),
+                            sha: assert(doc.sha),
+                            context: ctx
+                        });
+
+                        createGithubStatus(state, {
+                            user: assert(state.githubStatusUsername),
+                            repo: assert(doc.repo),
+                            sha: assert(doc.sha),
+                            context: assert(ctx),
+                            state: 'pending',
+                            target_url: 'http://duktape.org/',  // XXX: useful temporary URI? web UI job status?
+                            description: 'Running...'
+                        });
+
+                        // XXX: error recovery / restart; check for start_time
+                        // age over sanity (24h?) and remove/reassign job
+
+                        return false;  // no longer pending
+                    }
+                }
+
+                // No context found, keep in pending state.
+                return true;
+            });
+        });
+
+        var pendingAfter = getCommitRequests.length;
+        if (pendingAfter !== getCommitRequestsCount) {
+            console.log('pending clients: ' + getCommitRequestsCount + ' -> ' + pendingAfter);
+        }
+        getCommitRequestsCount = pendingAfter;
+    });
+}
+
+// Handle a 'push' webhook.
+function handleGithubPush(req, res, state) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+    var trustedAuthors = assert(state.githubTrustedAuthors);
+    var allowedRepos = assert(state.githubRepos);
+
+    // Careful to avoid automatic test runs unless repo/author is
+    // whitelisted.
+
+    var body = req.body;
+    var commitHash = body.after;
+    var committerName = body.head_commit && body.head_commit.committer && body.head_commit.committer.username;
+    var repoName = body.repository && body.repository.name;
+    var repoFullName = body.repository && body.repository.full_name;
+    if (!repoFullName || !repoName) {
+        console.log('ignoring github webhook "push", missing repo name');
+        return;
+    }
+    if (trustedAuthors.indexOf(committerName) < 0) {
+        console.log('ignoring github webhook "push" from untrusted committer: ' + committerName);
+        return;
+    }
+    if (allowedRepos.indexOf(repoFullName) < 0) {
+        console.log('ignoring github webhook "push" for non-allowed repo: ' + repoFullName);
+        return;
+    }
+
+    console.log('github webhook "push" to repo ' + repoFullName + ' from trusted committer ' + committerName + ', add automatic jobs');
+
+    // XXX: add a commit_simple UUID for exact matching for get/finish?
+
+    // Tracking object for commit related simple test runs identified by
+    // run name, with 'runs' tracking the individual runs and their status.
+    // A named run maps directly to a Github status item.
+    db.insert({
+        type: 'commit_simple',
+        time: Date.now(),
+        runs: [],
+        repo: repoName,
+        repo_full: repoFullName,
+        repo_clone_url: assert(body.repository.clone_url),
+        committer: committerName,
+        sha: assert(commitHash)
+    });
+
+    handleGetCommitRequests(state);
+}
+
+// Create a github-webhook handler.
+function makeGithubWebhookHandler(state) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+
+    return function githubWebhookHandler(req, res) {
+        var body = req.body;
+        if (typeof body !== 'object') {
+           throw new Error('invalid POST body, perhaps client is missing Content-Type?');
+        }
+        var ghEvent = req.get('X-Github-Event');
+        var ghDelivery = req.get('X-Github-Delivery');
+
+        console.log('github webhook, event: ' + ghEvent + ', delivery: ' + ghDelivery);
+
+        // Raw record of webhook requests received.
+        db.insert({
+            type: 'github_webhook',
+            x_github_event: ghEvent,
+            x_github_delivery: ghDelivery,
+            data: assert(body)
+        });
+
+        if (ghEvent === 'push') {
+            handleGithubPush(req, res, state);
+        } else {
+            console.log('unhandled github webhook: ' + ghEvent);
+        }
+
+        var rep = {};
+        var repData = new Buffer(JSON.stringify(rep), 'utf8');
+        res.setHeader('content-type', 'application/json');
+        res.send(repData);
+    };
+}
+
+// Create a get-commit-simple handler.
+function makeGetCommitSimpleHandler(state) {
+    return function getCommitSimpleHandler(req, res) {
+        var body = req.body;
+        if (typeof body !== 'object') {
+           throw new Error('invalid POST body, perhaps client is missing Content-Type?');
+        }
+
+        // body.contexts: list of contexts supported
+
+        getCommitRequests.push({
+            time: Date.now(),
+            res: res,
+            contexts: assert(body.contexts)
+        });
+        handleGetCommitRequests(state);
+    };
+}
+
+// Create a finish-commit-simple handler.
+function makeFinishCommitSimpleHandler(state) {
+    var db = assert(state.db);
+    var github = assert(state.github);
+
+    return function finishCommitSimpleHandler(req, res) {
+        var body = req.body;
+        if (typeof body !== 'object') {
+           throw new Error('invalid POST body, perhaps client is missing Content-Type?');
+        }
+
+        // XXX: add an explicit webhook identifier to update the exact 'commit_simple'
+        // instead of the awkward scan below?
+
+        // body.repo_full
+        // body.sha
+        // body.context
+        // body.state        success/failure
+        // body.description  oneline description
+        // body.text         text, automatically served, github status URI will point to this text file
+
+        function fail(code, desc) {
+            var rep = { error_code: code, error_description: desc };
+            var repData = new Buffer(JSON.stringify(rep), 'utf8');
+            res.setHeader('content-type', 'application/json');
+            res.send(repData);
+        }
+        dbutil.find(db, {
+            type: 'commit_simple',
+            repo_full: assert(body.repo_full),
+            sha: assert(body.sha)
+        }).then(function (docs) {
+            var doc, i, run;
+
+            // XXX: This is racy now.  Client should also be allowed to retry
+            // persistently even if we respond but the response is lost.
+
+            if (!docs || docs.length <= 0) {
+                throw new Error('target webhook commit not found');
+            }
+            if (docs.length > 1) {
+                console.log('more than one commit_simple docs found');
+            }
+            doc = docs[docs.length - 1];
+
+            var output = new Buffer(assert(body.text), 'base64');
+            var outputSha = util.sha1sum(output);
+            var outputFn = path.join(state.dataDumpDirectory, outputSha);
+            var outputUri = assert(state.webBaseUri) + '/out/' + outputSha;
+            fs.writeFileSync(outputFn, output);
+            console.log('wrote output data to ' + outputFn + ', ' + output.length + ' bytes' +
+                        ', link is ' + outputUri);
+
+            for (i = 0; i < doc.runs.length; i++) {
+                run = doc.runs[i];
+                if (run.context === body.context) {
+                    if (run.end_time !== null) {
+                        console.log('finish-commit-job already finished, ignoring');
+                    } else {
+                        run.end_time = Date.now();
+                        console.log('finish-commit-job for sha ' + body.sha + ', context ' + body.context + '; took ' +
+                                    (run.end_time - run.start_time) / 60e3 + ' mins');
+
+                        db.update({
+                            _id: doc.id
+                        }, {
+                            $set: {
+                                runs: doc.runs
+                            }
+                        }, function (err, numReplaced) {
+                            if (err) { throw err; }
+                        });
+                    }
+
+                    sendJsonReply(res, {});
+
+                    updateGithubStatus(state, {
+                        user: assert(state.githubStatusUsername),
+                        repo: assert(doc.repo),
+                        sha: assert(doc.sha),
+                        context: assert(body.context),
+                        state: assert(body.state),
+                        description: assert(body.description),
+                        target_url: assert(outputUri)
+                    });
+
+                    return;
+                }
+            }
+
+            throw new Error('cannot find internal tracking state for context');
+        }).catch(function (err) {
+            console.log(err);
+            fail('INTERNAL_ERROR', String(err));
+        });
+    }
+}
+
+exports.createGithubStatus = createGithubStatus;
+exports.updateGithubStatus = updateGithubStatus;
+exports.pushGithubStatuses = pushGithubStatuses;
+exports.handleGetCommitRequests = handleGetCommitRequests;
+exports.makeGithubWebhookHandler = makeGithubWebhookHandler;
+exports.makeGetCommitSimpleHandler = makeGetCommitSimpleHandler;
+exports.makeFinishCommitSimpleHandler = makeFinishCommitSimpleHandler;

--- a/testrunner/server-node/package.json
+++ b/testrunner/server-node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "testrunner-server",
+  "version": "1.0.0",
+  "description": "Duktape testrunner server",
+  "author": {
+    "name": "Sami Vaarala",
+    "email": "sami.vaarala@iki.fi"
+  },
+  "dependencies": {
+    "yamljs": "~0.2.6",
+    "bluebird": "~3.3.4",
+    "express": "~4.13.4",
+    "body-parser": "~1.15.0",
+    "nedb": "~1.8.0",
+    "github": "~0.2.4",
+    "basic-auth": "~1.0.3",
+    "minimist": "~1.2.0",
+    "limiter": "~1.1.0"
+  },
+  "main": "server.js"
+}

--- a/testrunner/server-node/server.js
+++ b/testrunner/server-node/server.js
@@ -1,0 +1,93 @@
+/*
+ *  Testrunner server.
+ */
+
+var fs = require('fs');
+var yaml = require('yamljs');
+var express = require('express');
+var bodyParser = require('body-parser');
+var Datastore = require('nedb');
+var https = require('https');
+var GitHubApi = require('github');
+var Promise = require('bluebird');
+var RateLimiter = require('limiter').RateLimiter;
+
+var util = require('./util');
+var assert = util.assert;
+var expressutil = require('./expressutil');
+var dbutil = require('./dbutil');
+var githubutil = require('./githubutil');
+var webuiutil = require('./webuiutil');
+
+function main() {
+    console.log('Duktape testrunner server');
+
+    // Parse args and config, initialize a shared 'state' object.
+    var argv = require('minimist')(process.argv.slice(2));
+    console.log('Command line options: ' + JSON.stringify(argv));
+    var configFile = argv.config || './config.yaml';
+    console.log('Load config: ' + configFile);
+    var state = yaml.load(configFile);
+
+    // Datastore
+    console.log('Initialize NeDB datastore: ' + state.databaseFile);
+    var db = new Datastore({
+        filename: state.databaseFile,
+        autoload: true
+    });
+    state.db = db;
+    //dbutil.deleteAll(db);
+
+    // Github API instance.
+    var github = new GitHubApi({
+        version: '3.0.0',
+        debug: false,
+        protocol: 'https',
+        host: 'api.github.com',
+        timeout: 5000,
+        header: {
+            'user-agent': 'duktape-testrunner'
+        }
+    });
+    state.github = github;
+    state.githubLimiter = new RateLimiter(assert(state.githubTokensPerHour), 'hour', true);  // sanity limit
+
+    // Express and shared helpers.
+    var app = express();
+    var apiJsonBodyParser = expressutil.makeApiJsonBodyParser();
+    var githubJsonBodyParser = expressutil.makeGithubJsonBodyParser(state.githubWebhookSecret);
+    var apiBasicAuth = expressutil.makeApiBasicAuth(state.clientAuthUsername, state.clientAuthPassword, state.serverAuthPassword);
+    var logRequest = expressutil.makeLogRequest();
+
+    // URI paths served.
+    app.get('/', logRequest,
+            webuiutil.makeIndexHandler(state));
+    app.get('/out/:sha', logRequest,
+            webuiutil.makeDataFileHandler(state));
+    app.post('/github-webhook', logRequest, githubJsonBodyParser,
+             githubutil.makeGithubWebhookHandler(state));
+    app.post('/get-commit-simple', logRequest, apiBasicAuth, apiJsonBodyParser,
+             githubutil.makeGetCommitSimpleHandler(state));
+    app.post('/finish-commit-simple', logRequest, apiBasicAuth, apiJsonBodyParser,
+             githubutil.makeFinishCommitSimpleHandler(state));
+
+    // HTTPS server.
+    var apiServer = https.createServer({
+        key: fs.readFileSync(state.serverPrivateKey),
+        cert: fs.readFileSync(state.serverCertificate)
+    }, app);
+    apiServer.listen(state.serverPort, function () {
+        var host = apiServer.address().address;
+        var port = apiServer.address().port;
+        console.log('Duktape testrunner server listening at https://%s:%s', host, port);
+    });
+
+    // Background job for hanging request timeouts, persistent
+    // Github pushes, etc.
+    function periodicDatabaseScan() {
+        githubutil.pushGithubStatuses(state);       // persistent github status pushing
+        githubutil.handleGetCommitRequests(state);  // webhook client timeouts
+    }
+    var dbScanTimer = setInterval(periodicDatabaseScan, 5000);
+}
+main();

--- a/testrunner/server-node/util.js
+++ b/testrunner/server-node/util.js
@@ -1,0 +1,33 @@
+/*
+ *  Misc utils.
+ */
+
+var fs = require('fs');
+var crypto = require('crypto');
+
+function sha1sum(x) {
+    return crypto.createHash('sha1').update(x).digest('hex');
+}
+
+function sha1sumFile(x) {
+    return sha1sum(fs.readFileSync(x));
+}
+
+function assert(x) {
+    if (x) { return x; }
+    throw new Error('assertion failed');
+}
+
+// For 'svaarala/duktape' returns 'duktape'.
+function plainRepoName(fullRepoName) {
+    t = /.*?\/(.*)$/.exec(fullRepoName);
+    if (!t || !t[1]) {
+        throw new Error('cannot get plain repo name from "' + fullRepoName + '"');
+    }
+    return t[1];
+}
+
+exports.sha1sum = sha1sum;
+exports.sha1sumFile = sha1sumFile;
+exports.assert = assert;
+exports.plainRepoName = plainRepoName;

--- a/testrunner/server-node/webuiutil.js
+++ b/testrunner/server-node/webuiutil.js
@@ -1,0 +1,103 @@
+/*
+ *  Web UI helpers.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var Promise = require('bluebird');
+
+var dbutil = require('./dbutil');
+var util = require('./util');
+var assert = util.assert;
+
+function makeIndexHandler(state) {
+    return function (req, res) {
+        var out = [];
+
+        // XXX: replace with an actually useful status page, proper html generation
+        // XXX: eventually allow commit jobs to be started/restarted
+
+        Promise.resolve().then(function () {
+            out.push('<html>');
+            out.push('<head>');
+            out.push('<title>Duktape testrunner</title>');
+            out.push('</head>');
+            out.push('<body>');
+            out.push('<h1>Duktape testrunner</h1>');
+
+            return dbutil.find(state.db, {
+                type: 'commit_simple'
+            });
+        }).then(function (docs) {
+            out.push('<h2>Simple jobs</h2>');
+            out.push('<table>');
+            out.push('<tr><th>Repo</th><th>Commit hash</th><th>Committer</th><th>Runs</th></tr>');
+            docs.forEach(function (d) {
+                out.push('<tr>');
+                out.push('<td>' + d.repo_full + '</td>');
+                out.push('<td>' + d.sha + '</td>');
+                out.push('<td>' + d.committer + '</td>');
+                out.push('<td>');
+                d.runs.forEach(function (r) {
+                    out.push(' ' + r.context + '/' + r.start_time + '/' + r.end_time);
+                });
+                out.push('</td>');
+                out.push('</tr>');
+            });
+            out.push('</table>');
+
+            return dbutil.find(state.db, {
+                type: 'github_status'
+            });
+        }).then(function (docs) {
+            out.push('<h2>Github statuses</h2>');
+            out.push('<table>');
+            out.push('<tr><th>Repo</th><th>Commit hash</th><th>Context</th><th>State</th><th>Description</th><th>Target URL</th><th>Dirty</th></tr>');
+            docs.forEach(function (d) {
+                out.push('<tr>');
+                out.push('<td>' + d.repo + '</td>');
+                out.push('<td>' + d.sha + '</td>');
+                out.push('<td>' + d.context + '</td>');
+                out.push('<td>' + d.state + '</td>');
+                out.push('<td>' + d.description + '</td>');
+                out.push('<td>' + d.target_url + '</td>');
+                out.push('<td>' + d.dirty + '</td>');
+                out.push('</tr>');
+            });
+            out.push('</table>');
+        }).then(function () {
+            out.push('</body>');
+            out.push('</html>');
+        }).then(function () {
+            res.send(out.join(''));
+        }).catch(function (err) {
+            res.send('ERROR: ' + err);
+        });
+    }
+}
+
+function makeDataFileHandler(state) {
+    return function (req, res) {
+        Promise.resolve().then(function () {
+            assert(req.params);
+            var sha = req.params.sha;
+            assert(sha);
+
+            // minimal validation, also ensures no '..' etc.
+            if (!/^[0-9a-f$]+/.test(sha)) {
+                throw new Error('invalid URI: ' + req.url);
+            }
+
+            var fn = path.join(assert(state.dataDumpDirectory), sha);
+            var data = fs.readFileSync(fn);
+            res.setHeader('content-type', 'text/plain');
+            res.send(data);
+        }).catch(function (err) {
+            res.status(500);
+            res.send('ERROR: ' + err);
+        });
+    }
+}
+
+exports.makeIndexHandler = makeIndexHandler;
+exports.makeDataFileHandler = makeDataFileHandler;


### PR DESCRIPTION
Add a minimal multi-platform test runner which integrates to Github webhook "push" events. For each authorized push, run a set of script test cases using a client/server approach. The goal is to include current makefile tests as script jobs, and run them on multiple platforms (in particular OS X and Windows) automatically for each commit.

This is very early work but still functional and will be enabled for the main repo incrementally. Expect to see funny Github status lines :)