### PR TITLE
Cleanups for minimal webhook testrunner

### DIFF
--- a/testrunner/Makefile
+++ b/testrunner/Makefile
@@ -7,7 +7,8 @@ dist:
 	tar cvfz testrunner-server-node.tar.gz \
 		server-node/*.js \
 		server-node/package.json \
-		server-node/config.yaml.template
+		server-node/config.yaml.template \
+		server-node/style.css
 	tar cvfz testrunner-client-simple-node.tar.gz \
 		client-simple-node/*.js \
 		client-simple-node/*.sh \

--- a/testrunner/server-node/server.js
+++ b/testrunner/server-node/server.js
@@ -2,6 +2,13 @@
  *  Testrunner server.
  */
 
+// FIXME: separate contexts in web UI; identify client by human readable name (e.g. "OS X testclient"
+// FIXME: minimal web UI styling (tables mainly, zebra pattern, margins)
+// FIXME: add webhook identifier to allow retriggering
+// FIXME: prefer newest webhook when possible (useful for successive forced pushes)
+// FIXME: plain http port
+// FIXME: separate script exit code for "certain test failure" vs "other failure"; automatic server-driven retry
+
 var fs = require('fs');
 var yaml = require('yamljs');
 var express = require('express');
@@ -60,8 +67,11 @@ function main() {
     var logRequest = expressutil.makeLogRequest();
 
     // URI paths served.
-    app.get('/', logRequest,
-            webuiutil.makeIndexHandler(state));
+    var indexHandler = webuiutil.makeIndexHandler(state);
+    app.get('/', logRequest, indexHandler);
+    app.get('/index.html', logRequest, indexHandler);
+    app.get('/style.css', logRequest,
+            webuiutil.makeStaticFileHandler(state, 'style.css', 'text/css'));
     app.get('/out/:sha', logRequest,
             webuiutil.makeDataFileHandler(state));
     app.post('/github-webhook', logRequest, githubJsonBodyParser,


### PR DESCRIPTION
- [x] Add test client name (e.g. "OS X testclient") which can be shown for pending jobs #653
- [x] Include test client name in Github status for "Running..."
- [ ] Include test client name in barebones web UI front page
- [ ] Minimal web UI front page styling, zebra patterns, margins, etc
- [ ] Add an explicit ID for simple commit job tracking states, so that get/finish primitives can reference a specific state without guesswork (improves handling of re-delivered webhooks)
- [ ] Add plain HTTP port for the server, provide web UI also there; change data links to plain HTTP to avoid issues with self-signed certificate
- [ ] Add explicit script indication of "unknown error" vs. "certain testcase error"; a certain testcase error never needs a retry, but other errors warrant one or two automatic server-driven retries (e.g. OS X github.com DNS issues when user logged out)
- [x] Avoid Makefile targets, as they depend on writing and cleaning `/tmp` which conflicts with parallel runs (e.g. test262test is broken for this reason now)
- [x] Linux x64 coverage
- [x] Linux x86 coverage
- [x] OS X x64 coverage - skipped due to OS X wifi issues
- [x] Windows x64 coverage (concrete issue is running a Cygwin bash script; Node.js doesn't execute BAT files) - same as OS X (VM runs on OS X), use AppVeyor to get some Windows coverage
- [x] From release checklist: dddprint coverage
- [x] From release checklist: separate sources build
- [x] From release checklist: packed duk_tval by default on x86
- [x] From release checklist: genconfig from distributable
- [ ] Note compiler warnings in e.g. duk-clang build (can mark as success but use description to indicate warning count)
- [ ] Scan-build automatically, at least to see results if known issues can't be suppressed
- [ ] Coverage for Array fast paths
- [ ] Coverage for fastints
- [ ] Show testcase diffs