### PR TITLE
Change automatic filename for eval/compile from __FILE__ to "eval" / "input"

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1391,6 +1391,11 @@ Planned
 * Make .stack format a bit more user friendly; if you are parsing the stack
   trace format this may need changes in your parser (GH-588, GH-592)
 
+* Change automatic filename of compiled functions and eval code from
+  __FILE__ to "eval" (eval code) or "input" (other compiled code) when no
+  explicit filename is known; this makes file/line information thrown from
+  such code more useful in practice (GH-516, GH-644)
+
 * Add Windows version of the debugger example TCP transport (GH-579)
 
 * Add support for application specific debugger commands (AppRequest) and

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -160,13 +160,18 @@ struct duk_number_list_entry {
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 << 5)    /* enumerate a proxy object itself without invoking proxy behavior */
 
 /* Compilation flags for duk_compile() and duk_eval() */
-#define DUK_COMPILE_EVAL                  (1 << 0)    /* compile eval code (instead of global code) */
-#define DUK_COMPILE_FUNCTION              (1 << 1)    /* compile function code (instead of global code) */
-#define DUK_COMPILE_STRICT                (1 << 2)    /* use strict (outer) context for global, eval, or function code */
-#define DUK_COMPILE_SAFE                  (1 << 3)    /* (internal) catch compilation errors */
-#define DUK_COMPILE_NORESULT              (1 << 4)    /* (internal) omit eval result */
-#define DUK_COMPILE_NOSOURCE              (1 << 5)    /* (internal) no source string on stack */
-#define DUK_COMPILE_STRLEN                (1 << 6)    /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
+/* DUK_COMPILE_xxx bits 0-2 are reserved for an internal 'nargs' argument
+ * (the nargs value passed is direct stack arguments + 1 to account for an
+ * internal extra argument).
+ */
+#define DUK_COMPILE_EVAL                  (1 << 3)    /* compile eval code (instead of global code) */
+#define DUK_COMPILE_FUNCTION              (1 << 4)    /* compile function code (instead of global code) */
+#define DUK_COMPILE_STRICT                (1 << 5)    /* use strict (outer) context for global, eval, or function code */
+#define DUK_COMPILE_SAFE                  (1 << 6)    /* (internal) catch compilation errors */
+#define DUK_COMPILE_NORESULT              (1 << 7)    /* (internal) omit eval result */
+#define DUK_COMPILE_NOSOURCE              (1 << 8)    /* (internal) no source string on stack */
+#define DUK_COMPILE_STRLEN                (1 << 9)    /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
+#define DUK_COMPILE_NOFILENAME            (1 << 10)    /* (internal) no filename on stack */
 
 /* Flags for duk_def_prop() and its variants */
 #define DUK_DEFPROP_WRITABLE              (1 << 0)    /* set writable (effective if DUK_DEFPROP_HAVE_WRITABLE set) */
@@ -788,119 +793,103 @@ DUK_EXTERNAL_DECL duk_int_t duk_compile_raw(duk_context *ctx, const char *src_bu
 
 /* plain */
 #define duk_eval(ctx)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL))
+	((void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_noresult(ctx)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT))
+	((void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval(ctx)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE))
+	(duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_noresult(ctx)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT))
+	(duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile(ctx,flags)  \
-	((void) duk_compile_raw((ctx), NULL, 0, (flags)))
+	((void) duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags)))
 
 #define duk_pcompile(ctx,flags)  \
-	(duk_compile_raw((ctx), NULL, 0, (flags) | DUK_COMPILE_SAFE))
+	(duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags) | DUK_COMPILE_SAFE))
 
 /* string */
 #define duk_eval_string(ctx,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), (src), 0, DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	((void) duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_string_noresult(ctx,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), (src), 0, DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT))
+	((void) duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_string(ctx,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), (src), 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	(duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_string_noresult(ctx,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), (src), 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT))
+	(duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_string(ctx,flags,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_compile_raw((ctx), (src), 0, (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	((void) duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_string_filename(ctx,flags,src)  \
-	((void) duk_compile_raw((ctx), (src), 0, (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	((void) duk_compile_raw((ctx), (src), 0, 2 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
 
 #define duk_pcompile_string(ctx,flags,src)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_compile_raw((ctx), (src), 0, (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	(duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_pcompile_string_filename(ctx,flags,src)  \
-	(duk_compile_raw((ctx), (src), 0, (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	(duk_compile_raw((ctx), (src), 0, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
 
 /* lstring */
 #define duk_eval_lstring(ctx,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), buf, len, DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE))
+	((void) duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_lstring_noresult(ctx,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_eval_raw((ctx), buf, len, DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT))
+	((void) duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_lstring(ctx,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), buf, len, DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_SAFE))
+	(duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_lstring_noresult(ctx,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_eval_raw((ctx), buf, len, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT))
+	(duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_lstring(ctx,flags,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 (void) duk_compile_raw((ctx), buf, len, (flags) | DUK_COMPILE_NOSOURCE))
+	((void) duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_lstring_filename(ctx,flags,buf,len)  \
-	((void) duk_compile_raw((ctx), buf, len, (flags) | DUK_COMPILE_NOSOURCE))
+	((void) duk_compile_raw((ctx), buf, len, 2 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE))
 
 #define duk_pcompile_lstring(ctx,flags,buf,len)  \
-	((void) duk_push_string((ctx), (const char *) (__FILE__)), \
-	 duk_compile_raw((ctx), buf, len, (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE))
+	(duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_pcompile_lstring_filename(ctx,flags,buf,len)  \
-	(duk_compile_raw((ctx), buf, len, (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE))
+	(duk_compile_raw((ctx), buf, len, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE))
 
 /* file */
 #define duk_eval_file(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL))
+	 (void) duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL))
 
 #define duk_eval_file_noresult(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT))
+	 (void) duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT))
 
 #define duk_peval_file(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE))
+	 duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE))
 
 #define duk_peval_file_noresult(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_eval_raw((ctx), NULL, 0, DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT))
+	 duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT))
 
 #define duk_compile_file(ctx,flags,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_compile_raw((ctx), NULL, 0, (flags)))
+	 (void) duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags)))
 
 #define duk_pcompile_file(ctx,flags,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_compile_raw((ctx), NULL, 0, (flags) | DUK_COMPILE_SAFE))
+	 duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags) | DUK_COMPILE_SAFE))
 
 /*
  *  Bytecode load/dump

--- a/tests/api/test-compile-filename.c
+++ b/tests/api/test-compile-filename.c
@@ -1,0 +1,38 @@
+/*
+ *  Test for duk_(p)compile_string() automatic .fileName change in Duktape 1.5.x:
+ *  https://github.com/svaarala/duktape/issues/516
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+rc: 0
+rc: 1
+err.fileName: input
+err.lineNumber: 3
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx) {
+	duk_int_t rc;
+
+	rc = duk_pcompile_string(ctx, 0, "\n\naiee");
+	printf("rc: %ld\n", (long) rc);
+	rc = duk_pcall(ctx, 0);
+	printf("rc: %ld\n", (long) rc);
+
+	duk_get_prop_string(ctx, -1, "fileName");
+	printf("err.fileName: %s\n", duk_require_string(ctx, -1));
+	duk_pop(ctx);
+
+	duk_get_prop_string(ctx, -1, "lineNumber");
+	printf("err.lineNumber: %ld\n", (long) duk_require_int(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/tests/api/test-eval-filename.c
+++ b/tests/api/test-eval-filename.c
@@ -1,0 +1,35 @@
+/*
+ *  Test for duk_(p)eval_string() automatic .fileName change in Duktape 1.5.x:
+ *  https://github.com/svaarala/duktape/issues/516
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+rc: 1
+err.fileName: eval
+err.lineNumber: 3
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx) {
+	duk_int_t rc;
+
+	rc = duk_peval_string(ctx, "\n\naiee");
+	printf("rc: %ld\n", (long) rc);
+
+	duk_get_prop_string(ctx, -1, "fileName");
+	printf("err.fileName: %s\n", duk_require_string(ctx, -1));
+	duk_pop(ctx);
+
+	duk_get_prop_string(ctx, -1, "lineNumber");
+	printf("err.lineNumber: %ld\n", (long) duk_require_int(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/website/api/duk_compile_lstring.yaml
+++ b/website/api/duk_compile_lstring.yaml
@@ -10,8 +10,7 @@ summary: |
   <p>Like
   <code><a href="#duk_compile">duk_compile()</a></code>, but the compile input
   is given as a C string with explicit length.  The filename associated with the
-  function is automatically provided from the <code>__FILE__</code> preprocessor
-  define of the caller.</p>
+  function is <code>"input"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_compile_string.yaml
+++ b/website/api/duk_compile_string.yaml
@@ -10,8 +10,7 @@ summary: |
   <p>Like
   <code><a href="#duk_compile">duk_compile()</a></code>, but the compile input
   is given as a C string.  The filename associated with the function is
-  automatically provided from the <code>__FILE__</code> preprocessor define of
-  the caller.</p>
+  <code>"input"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_eval.yaml
+++ b/website/api/duk_eval.yaml
@@ -10,12 +10,11 @@ summary: |
   <p>Evaluate the Ecmascript source code at the top of the stack, and leave a single
   return value on top of the stack.  May throw an error, errors are not caught
   automatically.  The filename associated with the temporary eval function is
-  automatically provided from the <code>__FILE__</code> preprocessor define
-  of the caller.</p>
+  <code>"eval"</code>.</p>
 
   <p>This is essentially a shortcut for:</p>
   <pre class="c-code">
-  duk_push_string(ctx, __FILE__);
+  duk_push_string(ctx, "eval");
   duk_compile(ctx, DUK_COMPILE_EVAL);  /* [ ... source filename ] -> [ function ] */
   duk_call(ctx, 0);
   </pre>

--- a/website/api/duk_eval_file.yaml
+++ b/website/api/duk_eval_file.yaml
@@ -10,7 +10,7 @@ summary: |
   <p>Like
   <code><a href="#duk_eval">duk_eval()</a></code>, but the eval input
   is given as a filename.  The filename associated with the temporary
-  function created for the eval code is <code>path</code> as is.</p>
+  eval function is <code>path</code> as is.</p>
 
   <div include="path-encoding.html" />
 

--- a/website/api/duk_eval_lstring.yaml
+++ b/website/api/duk_eval_lstring.yaml
@@ -9,9 +9,8 @@ stack: |
 summary: |
   <p>Like
   <code><a href="#duk_eval">duk_eval()</a></code>, but the eval input
-  is given as a C string with explicit length.  The filename associated with the
-  temporary is automatically provided from the <code>__FILE__</code> preprocessor
-  define of the caller.</p>
+  is given as a C string with explicit length.  The filename associated with
+  the temporary eval function is <code>"eval"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_eval_string.yaml
+++ b/website/api/duk_eval_string.yaml
@@ -10,8 +10,7 @@ summary: |
   <p>Like
   <code><a href="#duk_eval">duk_eval()</a></code>, but the eval input
   is given as a C string.  The filename associated with the temporary
-  is automatically provided from the <code>__FILE__</code> preprocessor define
-  of the caller.</p>
+  eval function is <code>"eval"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_pcompile_lstring.yaml
+++ b/website/api/duk_pcompile_lstring.yaml
@@ -11,8 +11,7 @@ summary: |
   <p>Like
   <code><a href="#duk_pcompile">duk_pcompile()</a></code>, but the compile input
   is given as a C string with explicit length.  The filename associated with the
-  function is automatically provided from the <code>__FILE__</code> preprocessor
-  define of the caller.</p>
+  function is <code>"input"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_pcompile_string.yaml
+++ b/website/api/duk_pcompile_string.yaml
@@ -11,8 +11,7 @@ summary: |
   <p>Like
   <code><a href="#duk_pcompile">duk_pcompile()</a></code>, but the compile input
   is given as a C string.  The filename associated with the function is
-  automatically provided from the <code>__FILE__</code> preprocessor define
-  of the caller.</p>
+  <code>"input"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_peval_lstring.yaml
+++ b/website/api/duk_peval_lstring.yaml
@@ -11,8 +11,7 @@ summary: |
   <p>Like
   <code><a href="#duk_peval">duk_peval()</a></code>, but the eval input
   is given as a C string with explicit length.  The filename associated with the
-  temporary is automatically provided from the <code>__FILE__</code> preprocessor
-  define of the caller.</p>
+  temporary eval function is <code>"eval"</code>.</p>
 
   <div include="no-string-intern.html" />
 

--- a/website/api/duk_peval_string.yaml
+++ b/website/api/duk_peval_string.yaml
@@ -11,8 +11,7 @@ summary: |
   <p>Like
   <code><a href="#duk_peval">duk_peval()</a></code>, but the eval input
   is given as a C string.  The filename associated with the temporary
-  is automatically provided from the <code>__FILE__</code> preprocessor define
-  of the caller.</p>
+  eval function is <code>"eval"</code>.</p>
 
   <div include="no-string-intern.html" />
 


### PR DESCRIPTION
In Duktape 1.4.x API calls like `duk_eval_string()` and `duk_compile_string()` will use `__FILE__` for the automatic .fileName property associated with the function compiled. As a result file/line pairs reported for errors inside the eval/function code can be misleading: the filename refers to a C file but the line refers to a line inside the source compiled: #516.

Change this behavior so that eval API call without an explicit filename use `"eval"` for the automatic .fileName so that errors get associated with e.g. `eval:17` (17th line in eval source code). For functions use `"input"`.

Tasks:

- [x] API change
- [x] Testcases for new behavior
- [x] Assertion run
- [x] Website and API doc updates
- [x] Releases entry