### PR TITLE
Make things work on systems defaulting to python3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Bruce Pascoe <fatcerberus1@gmail.com>
 * René Hollander <rene@rene8888.at>
 * Julien Hamaide (https://github.com/crazyjul)
+* Sebastian Götte (https://github.com/jaseg)
 
 Other contributions
 ===================

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ NODE:=$(shell which nodejs node | head -1)
 WGET:=$(shell which wget)
 JAVA:=$(shell which java)
 VALGRIND:=$(shell which valgrind)
-PYTHON:=$(shell which python)
+PYTHON:=$(shell which python2 python|head -1)
 
 # Scrape version from the public header; convert from e.g. 10203 -> '1.2.3'
 DUK_VERSION:=$(shell cat src/duk_api_public.h.in | grep define | grep DUK_VERSION | tr -s ' ' ' ' | cut -d ' ' -f 3 | tr -d 'L')
@@ -551,16 +551,16 @@ endif
 
 .PHONY: matrix10
 matrix10: dist
-	cd dist; python ../util/matrix_compile.py --count=10
+	cd dist; $(PYTHON) ../util/matrix_compile.py --count=10
 .PHONY: matrix100
 matrix100: dist
-	cd dist; python ../util/matrix_compile.py --count=100
+	cd dist; $(PYTHON) ../util/matrix_compile.py --count=100
 .PHONY: matrix1000
 matrix1000: dist
-	cd dist; python ../util/matrix_compile.py --count=1000
+	cd dist; $(PYTHON) ../util/matrix_compile.py --count=1000
 .PHONY: matrix10000
 matrix10000: dist
-	cd dist; python ../util/matrix_compile.py --count=10000
+	cd dist; $(PYTHON) ../util/matrix_compile.py --count=10000
 
 regfuzz-0.1.tar.gz:
 	# https://code.google.com/p/regfuzz/
@@ -1044,7 +1044,7 @@ cloc:	dist cloc-1.60.pl
 # XXX: make prints a harmless warning related to the sub-make.
 dist:
 	@make codepolicycheck
-	if [ -f compiler.jar ]; then python util/make_dist.py --minify closure --create-spdx; else python util/make_dist.py --minify none; fi
+	if [ -f compiler.jar ]; then $(PYTHON) util/make_dist.py --minify closure --create-spdx; else $(PYTHON) util/make_dist.py --minify none; fi
 
 .PHONY:	dist-src
 dist-src:	dist
@@ -1108,7 +1108,7 @@ endif
 .PHONY: codepolicycheck
 codepolicycheck:
 	@echo Code policy check
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-debug-log-calls \
 		--check-carriage-returns \
@@ -1122,7 +1122,7 @@ codepolicycheck:
 		--check-cpp-comment \
 		--dump-vim-commands \
 		src/*.c src/*.h src/*.h.in tests/api/*.c
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-debug-log-calls \
 		--check-carriage-returns \
@@ -1133,7 +1133,7 @@ codepolicycheck:
 		--check-nonleading-tab \
 		--dump-vim-commands \
 		tests/ecmascript/*.js
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-carriage-returns \
 		--check-fixme \
@@ -1158,7 +1158,7 @@ codepolicycheck:
 		config/examples/* config/header-snippets/* config/helper-snippets/* \
 		config/*.yaml
 	# XXX: not yet FIXME pure
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-carriage-returns \
 		--check-non-ascii \
@@ -1167,7 +1167,7 @@ codepolicycheck:
 		--check-nonleading-tab \
 		--dump-vim-commands \
 		config/config-options/*.yaml config/other-defines/*.yaml
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-carriage-returns \
 		--check-fixme \
@@ -1177,7 +1177,7 @@ codepolicycheck:
 		--check-nonleading-tab \
 		--dump-vim-commands \
 		debugger/*.yaml
-	@python util/check_code_policy.py \
+	@$(PYTHON) util/check_code_policy.py \
 		$(CODEPOLICYOPTS) \
 		--check-carriage-returns \
 		--check-fixme \
@@ -1190,7 +1190,7 @@ codepolicycheck:
 
 .PHONY: codepolicycheckvim
 codepolicycheckvim:
-	-python util/check_code_policy.py --dump-vim-commands src/*.c src/*.h src/*.h.in tests/api/*.c
+	-$(PYTHON) util/check_code_policy.py --dump-vim-commands src/*.c src/*.h src/*.h.in tests/api/*.c
 
 .PHONY: big-git-files
 big-git-files:
@@ -1233,9 +1233,9 @@ massif-arcfour: massif-test-dev-arcfour
 # - Node.js (V8) is JITed
 # - Luajit is JITed
 
-#TIME=python util/time_multi.py --count 1 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
-#TIME=python util/time_multi.py --count 3 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
-TIME=python util/time_multi.py --count 5 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
+#TIME=$(PYTHON) util/time_multi.py --count 1 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
+#TIME=$(PYTHON) util/time_multi.py --count 3 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
+TIME=$(PYTHON) util/time_multi.py --count 5 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
 
 # Blocks: optimization variants, previous versions, other interpreting engines,
 # other JIT engines.
@@ -1254,7 +1254,7 @@ perftest: duk duk.O2 duk.O3 duk.O4
 		printf ' |'; \
 		printf ' mujs %5s' "`$(TIME) mujs $$i`"; \
 		printf ' lua %5s' "`$(TIME) lua $${i%%.js}.lua`"; \
-		printf ' python %5s' "`$(TIME) python $${i%%.js}.py`"; \
+		printf ' python %5s' "`$(TIME) $(PYTHON) $${i%%.js}.py`"; \
 		printf ' perl %5s' "`$(TIME) perl $${i%%.js}.pl`"; \
 		printf ' ruby %5s' "`$(TIME) ruby $${i%%.js}.rb`"; \
 		printf ' |'; \

--- a/config/extract_unique_options.py
+++ b/config/extract_unique_options.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Extract unique DUK_USE_xxx flags from current code base:
 #

--- a/config/genconfig.py
+++ b/config/genconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Process Duktape option metadata and produce various useful outputs:
 #

--- a/debugger/merge_debug_meta.py
+++ b/debugger/merge_debug_meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Merge debugger YAML metadata files and output a merged JSON metadata file.
 #

--- a/debugger/util/heapjson_convert.py
+++ b/debugger/util/heapjson_convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Convert a HeapDump JSON file into a more useful format.
 #

--- a/examples/alloc-logging/log2gnuplot.py
+++ b/examples/alloc-logging/log2gnuplot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Analyze allocator logs and write total-bytes-in-use after every
 #  operation to stdout.  The output can be gnuplotted as:

--- a/examples/alloc-logging/pool_simulator.py
+++ b/examples/alloc-logging/pool_simulator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Simulate pool allocator behavior against a memory allocation log written
 #  by duk_alloc_logging.c or in matching format.  Provide commands to provide

--- a/misc/c_overflow_test.py
+++ b/misc/c_overflow_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import math
 

--- a/misc/chaos.py
+++ b/misc/chaos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  $ ./duk test-dev-chaos.js | python chaos.py > chaos.raw
 #  $ sox -r 8k -e unsigned -b 8 -c 1 chaos.raw chaos.wav

--- a/src/dukutil.py
+++ b/src/dukutil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Python utilities shared by the build scripts.
 #

--- a/src/extract_caseconv.py
+++ b/src/extract_caseconv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Extract rules for Unicode case conversion, specifically the behavior
 #  required by Ecmascript E5 in Sections 15.5.4.16 to 15.5.4.19.  The

--- a/src/extract_chars.py
+++ b/src/extract_chars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Select a set of Unicode characters (based on included/excluded categories
 #  etc) and write out a compact bitstream for matching a character against

--- a/src/genbuildparams.py
+++ b/src/genbuildparams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Generate build parameter files based on build information.
 #  A C header is generated for C code, and a JSON file for

--- a/src/genbuiltins.py
+++ b/src/genbuiltins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Generate initialization data for built-in strings and objects.
 #

--- a/src/gendoubleconsts.py
+++ b/src/gendoubleconsts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # Double constants, see http://en.wikipedia.org/wiki/Double-precision_floating-point_format.
 # Some double constants have been created with 'python-mpmath'.  The constants are in binary

--- a/src/genequivyear.py
+++ b/src/genequivyear.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Generate equivalent year table needed by duk_bi_date.c.  Based on:
 #

--- a/src/genexesizereport.py
+++ b/src/genexesizereport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Generate a size report from a Duktape library / executable.
 #  Write out useful information about function sizes in a variety

--- a/src/genhashsizes.py
+++ b/src/genhashsizes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Find a sequence of duk_hobject hash sizes which have a desired 'ratio'
 #  and are primes.  Prime hash sizes ensure that all probe sequence values

--- a/src/gennumdigits.py
+++ b/src/gennumdigits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Generate a table indicating how many digits should be considered
 #  significant for each radix (2 to 36) when doing string-to-number

--- a/src/genobjsizereport.py
+++ b/src/genobjsizereport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Size report of (stripped) object and source files.
 #

--- a/src/prepare_unicode_data.py
+++ b/src/prepare_unicode_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  UnicodeData.txt may contain ranges in addition to individual characters.
 #  Unpack the ranges into individual characters for the other scripts to use.

--- a/src/scan_used_stridx_bidx.py
+++ b/src/scan_used_stridx_bidx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Scan Duktape code base for references to built-in strings and built-in
 #  objects, i.e. for:

--- a/util/autofix_debuglog_calls.py
+++ b/util/autofix_debuglog_calls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Automatically fix one-line broken debug log calls.  Adds a missing
 #  wrapper for such lines, e.g. changes:

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Check various C source code policy rules and issue warnings for offenders
 #

--- a/util/combine_src.py
+++ b/util/combine_src.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Combine all source and header files in source directory into
 #  a single C file.

--- a/util/create_spdx_license.py
+++ b/util/create_spdx_license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Helper to create an SPDX license file (http://spdx.org)
 #

--- a/util/ditz_hack.py
+++ b/util/ditz_hack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Throwaway utility to dump Ditz issues for grooming.
 #

--- a/util/duk_meta_to_strarray.py
+++ b/util/duk_meta_to_strarray.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Create an array of C strings with Duktape built-in strings.
 #  Useful when using external strings.

--- a/util/dump_bytecode.py
+++ b/util/dump_bytecode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Utility to dump bytecode into a human readable form.
 #

--- a/util/fastint_reps.py
+++ b/util/fastint_reps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Print out a few IEEE double representations related to the Duktape fastint
 #  number model.

--- a/util/filter_test262_log.py
+++ b/util/filter_test262_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/util/find_func_calls.py
+++ b/util/find_func_calls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Extract function call names from source C/H files.
 #

--- a/util/find_non_ascii.py
+++ b/util/find_non_ascii.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Example:
 #

--- a/util/fix_emscripten.py
+++ b/util/fix_emscripten.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Fix a few errors from Emscripten output (stopgap until emscripten mainline
 #  is updated).

--- a/util/format_perftest.py
+++ b/util/format_perftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Format a perftest text dump into a HTML table.
 

--- a/util/make_ascii.py
+++ b/util/make_ascii.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Paranoia escape input file to be printable ASCII.
 #

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Create a distributable Duktape package into 'dist' directory.  The contents
 #  of this directory can then be packaged into a source distributable.
@@ -615,7 +615,7 @@ print('Create duk_config.h headers')
 
 # Merge debugger metadata.
 merged = exec_print_stdout([
-	'python', os.path.join('debugger', 'merge_debug_meta.py'),
+	sys.executable, os.path.join('debugger', 'merge_debug_meta.py'),
 	'--output', os.path.join(dist, 'debugger', 'duk_debug_meta.json'),
 	'--class-names', os.path.join('debugger', 'duk_classnames.yaml'),
 	'--debug-commands', os.path.join('debugger', 'duk_debugcommands.yaml'),
@@ -625,7 +625,7 @@ merged = exec_print_stdout([
 
 # Build default duk_config.h from snippets using genconfig.
 exec_print_stdout([
-	'python', os.path.join('config', 'genconfig.py'), '--metadata', 'config',
+	sys.executable, os.path.join('config', 'genconfig.py'), '--metadata', 'config',
 	'--output', os.path.join(dist, 'duk_config.h.tmp'),
 	'--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch,
 	'--omit-removed-config-options', '--omit-unused-config-options',
@@ -641,7 +641,7 @@ copy_file(os.path.join(dist, 'duk_config.h.tmp'), os.path.join(distsrcsep, 'duk_
 
 # Build duk_config.h without feature option support.
 exec_print_stdout([
-	'python', os.path.join('config', 'genconfig.py'), '--metadata', 'config',
+	sys.executable, os.path.join('config', 'genconfig.py'), '--metadata', 'config',
 	'--output', os.path.join(dist, 'config', 'duk_config.h-modular-static'),
 	'--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch,
 	'--omit-removed-config-options', '--omit-unused-config-options',
@@ -649,7 +649,7 @@ exec_print_stdout([
 	'duk-config-header'
 ])
 exec_print_stdout([
-	'python', os.path.join('config', 'genconfig.py'), '--metadata', 'config',
+	sys.executable, os.path.join('config', 'genconfig.py'), '--metadata', 'config',
 	'--output', os.path.join(dist, 'config', 'duk_config.h-modular-dll'),
 	'--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch,
 	'--omit-removed-config-options', '--omit-unused-config-options',
@@ -661,7 +661,7 @@ exec_print_stdout([
 # Generate a few barebones config examples
 def genconfig_barebones(platform, architecture, compiler):
 	exec_print_stdout([
-		'python', os.path.join('config', 'genconfig.py'), '--metadata', 'config',
+		sys.executable, os.path.join('config', 'genconfig.py'), '--metadata', 'config',
 		'--output', os.path.join(dist, 'config', 'duk_config.h-%s-%s-%s' % (platform, architecture, compiler)),
 		'--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch,
 		'--platform', platform, '--architecture', architecture, '--compiler', compiler,
@@ -778,7 +778,7 @@ with open(os.path.join(distsrcsep, 'duk_initjs_min.js'), 'wb') as f:
 # this will probably change when functions are added/removed based on profile.
 
 exec_print_stdout([
-	'python',
+	sys.executable,
 	os.path.join('src', 'genbuildparams.py'),
 	'--version=' + str(duk_version),
 	'--git-commit=' + git_commit,
@@ -789,7 +789,7 @@ exec_print_stdout([
 ])
 
 res = exec_get_stdout([
-	'python',
+	sys.executable,
 	os.path.join('src', 'scan_used_stridx_bidx.py')
 ] + glob_files(os.path.join('src', '*.c')) \
   + glob_files(os.path.join('src', '*.h')) \
@@ -809,7 +809,7 @@ for fn in opts.user_builtin_metadata:
 	gb_opts.append('--user-builtin-metadata')
 	gb_opts.append(fn)
 exec_print_stdout([
-	'python',
+	sys.executable,
 	os.path.join('src', 'genbuiltins.py'),
 	'--buildinfo=' + os.path.join(distsrcsep, 'buildparams.json.tmp'),
 	'--used-stridx-metadata=' + os.path.join(dist, 'duk_used_stridx_bidx_defs.json.tmp'),
@@ -883,7 +883,7 @@ IDPART_MINUS_IDSTART_NOABMP_EXCL='Lu,Ll,Lt,Lm,Lo,Nl,0024,005F,ASCII,NONBMP'
 print('Expand UnicodeData.txt ranges')
 
 exec_print_stdout([
-	'python',
+	sys.executable,
 	os.path.join('src', 'prepare_unicode_data.py'),
 	os.path.join('src', 'UnicodeData.txt'),
 	os.path.join(distsrcsep, 'UnicodeData-expanded.tmp')
@@ -892,7 +892,7 @@ exec_print_stdout([
 def extract_chars(incl, excl, suffix):
 	#print('- extract_chars: %s %s %s' % (incl, excl, suffix))
 	res = exec_get_stdout([
-		'python',
+		sys.executable,
 		os.path.join('src', 'extract_chars.py'),
 		'--unicode-data=' + os.path.join(distsrcsep, 'UnicodeData-expanded.tmp'),
 		'--include-categories=' + incl,
@@ -907,7 +907,7 @@ def extract_chars(incl, excl, suffix):
 def extract_caseconv():
 	#print('- extract_caseconv case conversion')
 	res = exec_get_stdout([
-		'python',
+		sys.executable,
 		os.path.join('src', 'extract_caseconv.py'),
 		'--command=caseconv_bitpacked',
 		'--unicode-data=' + os.path.join(distsrcsep, 'UnicodeData-expanded.tmp'),
@@ -922,7 +922,7 @@ def extract_caseconv():
 
 	#print('- extract_caseconv canon lookup')
 	res = exec_get_stdout([
-		'python',
+		sys.executable,
 		os.path.join('src', 'extract_caseconv.py'),
 		'--command=re_canon_lookup',
 		'--unicode-data=' + os.path.join(distsrcsep, 'UnicodeData-expanded.tmp'),
@@ -1006,7 +1006,7 @@ delete_matching_files(distsrcsep, lambda x: x[0:8] == 'caseconv' and x[-4:] == '
 # created for that, see: https://github.com/svaarala/duktape/pull/363.
 
 exec_print_stdout([
-	'python',
+	sys.executable,
 	os.path.join('util', 'combine_src.py'),
 	'--source-dir', distsrcsep,
 	'--output-source', os.path.join(distsrccom, 'duktape.c'),
@@ -1021,7 +1021,7 @@ exec_print_stdout([
 ])
 
 exec_print_stdout([
-	'python',
+	sys.executable,
 	os.path.join('util', 'combine_src.py'),
 	'--source-dir', distsrcsep,
 	'--output-source', os.path.join(distsrcnol, 'duktape.c'),
@@ -1041,7 +1041,7 @@ delete_matching_files(dist, lambda x: x[-4:] == '.tmp')
 if opts.create_spdx:
 	print('Create SPDX license')
 	exec_get_stdout([
-		'python',
+		sys.executable,
 		os.path.join('util', 'create_spdx_license.py'),
 		os.path.join(dist, 'license.spdx')
 	])

--- a/util/matrix_compile.py
+++ b/util/matrix_compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Compile test for a lot of option combinations
 #

--- a/util/prep_test.py
+++ b/util/prep_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Prepare an Ecmascript or API testcase file for execution.
 #

--- a/util/resolve_combined_lineno.py
+++ b/util/resolve_combined_lineno.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Resolve a line number in the combined source into an uncombined file/line
 #  using a dist/src/metadata.json file.

--- a/util/scan_strings.py
+++ b/util/scan_strings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Scan potential external strings from Ecmascript and C files.
 #

--- a/util/time_multi.py
+++ b/util/time_multi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Small helper for perftest runs.
 #

--- a/website/api2yaml.py
+++ b/website/api2yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  One-time tool to convert from old custom API document format to YAML.
 #

--- a/website/buildimages.py
+++ b/website/buildimages.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python2
 #
 #  Build data URIs for images.  Results are manually embedded into CSS.
 #

--- a/website/buildsite.py
+++ b/website/buildsite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 #  Build Duktape website.  Must be run with cwd in the website/ directory.
 #


### PR DESCRIPTION
There is a significant fraction of systems running with python symlinked to python3. To aid portability to these systems, use explicit python2 instead of generic python. I hope I did not forget or break anything. At least the build now runs on my system (archlinux).