### PR TITLE
Minor footprint optimization for module ID normalization in require()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1396,12 +1396,11 @@ Planned
   explicit filename is known; this makes file/line information thrown from
   such code more useful in practice (GH-516, GH-644)
 
-* Add support for non-standard module.fileName (initialized to resolved
-  module ID) and module.name (initialized to last component of resolved
-  module ID) which are used for the internal module wrapper function's
-  .fileName and .name properties; they show up in stack traces, debugger
-  integration, logger instance default naming, etc, and can now be
-  controlled by modSearch() (GH-639)
+* Add support for non-standard module.fileName and module.name used for the
+  internal module wrapper function's .fileName and .name properties
+  respectively (if unset, defaults are resolved module ID and last component
+  of the resolved module ID, respectively); these properties affect e.g.
+  stack traces and can now be controlled by modSearch() (GH-639)
 
 * Add a .name property for the require() functions created for included
   modules, so that they have a readable name in stack traces like the top

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -262,9 +262,10 @@ of the module wrapper function used to implement module loading.  This is
 useful because they appear in e.g. tracebacks for errors created from the
 module, see: https://github.com/svaarala/duktape/pull/639.
 
-The initial value for ``module.fileName`` is the full resolved module ID
-(e.g. ``foo/bar``) and for ``module.name`` the last component of the
-resolved module ID (e.g. ``bar``).
+The properties are missing by default.  If modSearch() doesn't set them,
+module.fileName defaults to the full resolved module ID (e.g. ``foo/bar``)
+and ``name`` defaults to the last component of the resolved module ID
+(e.g. ``bar``).
 
 C modules and DLLs
 ==================

--- a/tests/ecmascript/test-commonjs-module-filename.js
+++ b/tests/ecmascript/test-commonjs-module-filename.js
@@ -4,19 +4,19 @@
 
 /*===
 default behavior
-test/foo2 test/foo2 test/foo2 foo2
+test/foo2 test/foo2 undefined undefined
 test/foo2
 2
 foo2
 TIME INF test/foo2: test
 override .name and .fileName
-test/bar2 test/bar2 test/bar2 bar2
+test/bar2 test/bar2 undefined undefined
 my_source.js
 2
 my_module
 TIME INF my_source.js: test
 .name shadowing test
-test/quux2 test/quux2 test/quux2 quux2
+test/quux2 test/quux2 undefined undefined
 object
 number
 123
@@ -39,7 +39,9 @@ function test() {
         print(String(buf).replace(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.*?Z/, 'TIME'));
     };
 
-    // Default behavior, module.fileName is resolved module ID.
+    // Default behavior, module wrapper .fileName is resolved module ID,
+    // .name is last component of resolved ID (module.fileName and module.name
+    // are not set by default which triggers the default values).
 
     Duktape.modSearch = function modSearch(id, require, exports, module) {
         print(id, module.id, module.fileName, module.name);

--- a/tests/ecmascript/test-commonjs-require-resolution.js
+++ b/tests/ecmascript/test-commonjs-require-resolution.js
@@ -265,7 +265,7 @@ Duktape.modSearch foo/bar
 252: foo/bar
 253: foo/bar
 254: foo/bar
-255: TypeError
+255: foo/bar
 256: TypeError
 257: TypeError
 258: TypeError
@@ -286,7 +286,7 @@ Duktape.modSearch foo/bar
 232: bar
 233: bar
 234: bar
-235: TypeError
+235: bar
 236: TypeError
 237: TypeError
 238: TypeError


### PR DESCRIPTION
Minor footprint optimization:

- Simpler setup for initial module resolution input
- Use the same buffer for resolution input and output: possible because output is always at most as long as input
- Change `module.fileName` and `module.name` handling so that the properties are not present at all by default and the default values are used if modSearch() doesn't explicitly set the properties; this is better for RAM usage and has slightly shorter code