### PR TITLE
Document DUK_(V)SNPRINTF() portability requirements

### DIFF
--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -1274,6 +1274,8 @@ Examples of snprintf() calls which don't NUL terminate on truncation:
 
 * Windows ``_snprintf()``: http://msdn.microsoft.com/en-us/library/2ts7cx93.aspx
 
+FIXME: return value differences on truncation.
+
 s(n)printf %s and NULL value
 ::::::::::::::::::::::::::::
 


### PR DESCRIPTION
The explicit portability requirements for C standard library wrappers like `DUK_(V)SNPRINTF()` are not documented explicitly. This is important especially for library functions which have concrete variance across platforms (e.g. snprintf() NUL termination and return value variance, malloc() alignment guarantees, free() handling of NULL argument, etc).

Add self tests for the important guarantees where possible.

Duktape internals also don't make the same assumptions everywhere. For example, some code assumes that if the return value from `DUK_SNPRINTF()` is smaller than the buffer size given, the buffer is correctly NUL terminated (which is in practice guaranteed by all platforms). However, other code has explicit NUL termination even for these cases which is unnecessary.