### PR TITLE
Ensure V8 benchmarks throws at the end with errors

### DIFF
--- a/tests/google-v8-benchmark-v7/run_harness.js
+++ b/tests/google-v8-benchmark-v7/run_harness.js
@@ -1,9 +1,17 @@
+var globalObject = new Function('return this')();
+
+if (typeof globalObject.print !== 'function') {
+  globalObject.print = globalObject.console.log;
+}
+
 function Run() {
   BenchmarkSuite.RunSuites({ NotifyStep: ShowProgress,
                              NotifyError: AddError,
                              NotifyResult: AddResult,
                              NotifyScore: AddScore });
 }
+
+var harnessErrorCount = 0;
 
 function ShowProgress(name) {
   print('PROGRESS', name);
@@ -12,6 +20,7 @@ function ShowProgress(name) {
 function AddError(name, error) {
   print('ERROR', name, error);
   print(error.stack);
+  harnessErrorCount++;
 }
 
 function AddResult(name, result) {
@@ -27,4 +36,10 @@ try {
 } catch (e) {
   print('*** Run() failed');
   print(e.stack || e);
+}
+
+if (harnessErrorCount > 0) {
+  // Throw an error so that 'duk' has a non-zero exit code which helps
+  // automatic testing.
+  throw new Error('Benchmark had ' + harnessErrorCount + ' errors');
 }


### PR DESCRIPTION
This makes it easier to use the benchmark in regression tests.  Also default print to console.log if missing, to allow running with Node.js.