### PR TITLE
Use shared error macros for error codes

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1432,6 +1432,12 @@ Planned
   protocol when it's safe to do so, i.e. when the plain integer converts back
   to an identical IEEE double with no loss of precision (GH-604)
 
+* Change the error type for some current internal errors to RangeError when
+  the underlying cause is an implementation limit (like compiler temp limit)
+  rather than an unexpected internal situation (GH-661)
+
+* Minor changes to error message strings (GH-661)
+
 * Fix potentially memory unsafe behavior when a refcount-triggered finalizer
   function rescues an object; the memory unsafe behavior doesn't happen
   immediately which makes the cause of the unsafe behavior difficult to
@@ -1492,6 +1498,8 @@ Planned
 
 * Internal performance improvement: single step encoding for JSON values in
   the JSON slow path (GH-447)
+
+* Internal footprint improvement: reduce error call site size (GH-661)
 
 2.0.0 (XXXX-XX-XX)
 ------------------

--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -900,8 +900,11 @@ No variadic macros
 ------------------
 
 Lack of variadic macros can be worked around by using comma expressions.
-The ``duk_push_error_object()`` API call is a good example.  Without
-variadic macros it's defined as::
+The ``duk_push_error_object()`` API call is a good example.  It needs to
+capture the call site's ``__FILE__`` and ``__LINE__`` which needs some
+macro expansions to be included in the function call arguments.
+
+Without variadic macros it's defined as::
 
     DUK_EXTERNAL_DECL duk_idx_t duk_push_error_object_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...);
     /* Note: parentheses are required so that the comma expression works in assignments. */
@@ -932,6 +935,12 @@ not work::
                   duk_push_error_object_stash (ctx, 123, "foo %s", "bar");
 
 The problem is that ``__FILE__`` gets assigned to err_idx.
+
+The limitation in this technique is the need to "stash" the file/line
+information temporarily which is not thread safe unless the stash is
+located e.g. in the ``duk_hthread`` or ``duk_heap`` structure.  (At least
+up to Duktape 1.4.x the stashes for file/line are global and thus not
+thread safe; the potential issues don't compromise memory safety though.)
 
 Missing or broken platform functions
 ------------------------------------

--- a/src/duk_api_buffer.c
+++ b/src/duk_api_buffer.c
@@ -14,7 +14,7 @@ DUK_EXTERNAL void *duk_resize_buffer(duk_context *ctx, duk_idx_t index, duk_size
 	DUK_ASSERT(h != NULL);
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
 	}
 
 	/* maximum size check is handled by callee */
@@ -35,7 +35,7 @@ DUK_EXTERNAL void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_
 	DUK_ASSERT(h != NULL);
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
 	}
 
 	/* Forget the previous allocation, setting size to 0 and alloc to
@@ -64,7 +64,7 @@ DUK_EXTERNAL void duk_config_buffer(duk_context *ctx, duk_idx_t index, void *ptr
 	DUK_ASSERT(h != NULL);
 
 	if (!DUK_HBUFFER_HAS_EXTERNAL(h)) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
 	}
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(h));
 

--- a/src/duk_api_bytecode.c
+++ b/src/duk_api_bytecode.c
@@ -705,7 +705,7 @@ DUK_EXTERNAL void duk_load_function(duk_context *ctx) {
 	return;
 
  format_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_DECODE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
 #undef DUK__SER_MARKER
@@ -717,11 +717,11 @@ DUK_EXTERNAL void duk_load_function(duk_context *ctx) {
 #else  /* DUK_USE_BYTECODE_DUMP_SUPPORT */
 
 DUK_EXTERNAL void duk_dump_function(duk_context *ctx) {
-	DUK_ERROR((duk_hthread *) ctx, DUK_ERR_ERROR, DUK_STR_UNSUPPORTED);
+	DUK_ERROR_UNSUPPORTED_DEFMSG((duk_hthread *) ctx);
 }
 
 DUK_EXTERNAL void duk_load_function(duk_context *ctx) {
-	DUK_ERROR((duk_hthread *) ctx, DUK_ERR_ERROR, DUK_STR_UNSUPPORTED);
+	DUK_ERROR_UNSUPPORTED_DEFMSG((duk_hthread *) ctx);
 }
 
 #endif  /* DUK_USE_BYTECODE_DUMP_SUPPORT */

--- a/src/duk_api_call.c
+++ b/src/duk_api_call.c
@@ -46,7 +46,7 @@ DUK_EXTERNAL void duk_call(duk_context *ctx, duk_idx_t nargs) {
 	idx_func = duk_get_top(ctx) - nargs - 1;
 	if (idx_func < 0 || nargs < 0) {
 		/* note that we can't reliably pop anything here */
-		DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_CALL_ARGS);
+		DUK_ERROR_API(thr, DUK_STR_INVALID_CALL_ARGS);
 	}
 
 	/* XXX: awkward; we assume there is space for this, overwrite
@@ -73,7 +73,7 @@ DUK_EXTERNAL void duk_call_method(duk_context *ctx, duk_idx_t nargs) {
 	idx_func = duk_get_top(ctx) - nargs - 2;  /* must work for nargs <= 0 */
 	if (idx_func < 0 || nargs < 0) {
 		/* note that we can't reliably pop anything here */
-		DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_CALL_ARGS);
+		DUK_ERROR_API(thr, DUK_STR_INVALID_CALL_ARGS);
 	}
 
 	call_flags = 0;  /* not protected, respect reclimit, not constructor */
@@ -121,7 +121,7 @@ DUK_EXTERNAL duk_int_t duk_pcall(duk_context *ctx, duk_idx_t nargs) {
 		 * might STILL throw an out-of-memory error or some other internal
 		 * fatal error.
 		 */
-		DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_CALL_ARGS);
+		DUK_ERROR_API(thr, DUK_STR_INVALID_CALL_ARGS);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
 
@@ -150,7 +150,7 @@ DUK_EXTERNAL duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs) {
 	idx_func = duk_get_top(ctx) - nargs - 2;  /* must work for nargs <= 0 */
 	if (idx_func < 0 || nargs < 0) {
 		/* See comments in duk_pcall(). */
-		DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_CALL_ARGS);
+		DUK_ERROR_API(thr, DUK_STR_INVALID_CALL_ARGS);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
 
@@ -210,7 +210,7 @@ DUK_EXTERNAL duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function fu
 
 	if (duk_get_top(ctx) < nargs || nrets < 0) {
 		/* See comments in duk_pcall(). */
-		DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_CALL_ARGS);
+		DUK_ERROR_API(thr, DUK_STR_INVALID_CALL_ARGS);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
 
@@ -397,7 +397,7 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 	return;
 
  not_constructable:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONSTRUCTABLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONSTRUCTABLE);
 }
 
 DUK_LOCAL duk_ret_t duk__pnew_helper(duk_context *ctx) {
@@ -520,7 +520,7 @@ DUK_EXTERNAL duk_int_t duk_get_magic(duk_context *ctx, duk_idx_t index) {
 
 	/* fall through */
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_UNEXPECTED_TYPE);
+	DUK_ERROR_TYPE(thr, DUK_STR_UNEXPECTED_TYPE);
 	return 0;
 }
 

--- a/src/duk_api_codec.c
+++ b/src/duk_api_codec.c
@@ -403,7 +403,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index) {
 	return ret;
 
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_ENCODE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_ENCODE_FAILED);
 	return NULL;  /* never here */
 }
 
@@ -448,7 +448,7 @@ DUK_EXTERNAL void duk_base64_decode(duk_context *ctx, duk_idx_t index) {
 	return;
 
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_DECODE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
 DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t index) {
@@ -588,7 +588,7 @@ DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t index) {
 	return;
 
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_DECODE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
 DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t index) {

--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -414,11 +414,11 @@ DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t
 	return;
 
  fail_invalid_desc:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_DESCRIPTOR);
+	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_DESCRIPTOR);
 	return;
 
  fail_not_callable:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CALLABLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CALLABLE);
 	return;
 }
 
@@ -569,7 +569,7 @@ DUK_EXTERNAL void duk_set_prototype(duk_context *ctx, duk_idx_t index) {
 
 #if defined(DUK_USE_ROM_OBJECTS)
 	if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) obj)) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONFIGURABLE);  /* XXX: "read only object"? */
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);  /* XXX: "read only object"? */
 		return;
 	}
 #endif

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -197,15 +197,15 @@ struct duk_number_list_entry {
 /* Flags for duk_push_string_file_raw() */
 #define DUK_STRING_PUSH_SAFE              (1 << 0)    /* no error if file does not exist */
 
-/* Duktape specific error codes */
+/* Duktape specific error codes (must be 8 bits at most, see duk_error.h) */
 #define DUK_ERR_NONE                      0    /* no error (e.g. from duk_get_error_code()) */
-#define DUK_ERR_UNIMPLEMENTED_ERROR       50   /* UnimplementedError */
-#define DUK_ERR_UNSUPPORTED_ERROR         51   /* UnsupportedError */
-#define DUK_ERR_INTERNAL_ERROR            52   /* InternalError */
-#define DUK_ERR_ALLOC_ERROR               53   /* AllocError */
-#define DUK_ERR_ASSERTION_ERROR           54   /* AssertionError */
-#define DUK_ERR_API_ERROR                 55   /* APIError */
-#define DUK_ERR_UNCAUGHT_ERROR            56   /* UncaughtError */
+#define DUK_ERR_UNIMPLEMENTED_ERROR       50   /* UnimplementedError */  /* XXX: replace with TypeError? */
+#define DUK_ERR_UNSUPPORTED_ERROR         51   /* UnsupportedError */    /* XXX: replace with TypeError? */
+#define DUK_ERR_INTERNAL_ERROR            52   /* InternalError */       /* XXX: replace with plain Error? */
+#define DUK_ERR_ALLOC_ERROR               53   /* AllocError */          /* XXX: replace with RangeError? */
+#define DUK_ERR_ASSERTION_ERROR           54   /* AssertionError */      /* XXX: to be removed? */
+#define DUK_ERR_API_ERROR                 55   /* APIError */            /* XXX: replace with TypeError? */
+#define DUK_ERR_UNCAUGHT_ERROR            56   /* UncaughtError */       /* XXX: to be removed? */
 
 /* Ecmascript E5 specification error codes */
 #define DUK_ERR_ERROR                     100  /* Error */
@@ -232,7 +232,7 @@ struct duk_number_list_entry {
 #define DUK_RET_TYPE_ERROR                (-DUK_ERR_TYPE_ERROR)
 #define DUK_RET_URI_ERROR                 (-DUK_ERR_URI_ERROR)
 
-/* Return codes for protected calls (duk_safe_call(), duk_pcall()). */
+/* Return codes for protected calls (duk_safe_call(), duk_pcall()) */
 #define DUK_EXEC_SUCCESS                  0
 #define DUK_EXEC_ERROR                    1
 

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -677,7 +677,7 @@ duk_bool_t duk_valstack_resize_raw(duk_context *ctx,
 		 * plan limit accordingly (taking DUK_VALSTACK_GROW_STEP into account).
 		 */
 		if (throw_flag) {
-			DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_VALSTACK_LIMIT);
+			DUK_ERROR_RANGE(thr, DUK_STR_VALSTACK_LIMIT);
 		} else {
 			return 0;
 		}
@@ -704,7 +704,7 @@ duk_bool_t duk_valstack_resize_raw(duk_context *ctx,
 		DUK_DD(DUK_DDPRINT("valstack resize failed"));
 
 		if (throw_flag) {
-			DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_FAILED_TO_EXTEND_VALSTACK);
+			DUK_ERROR_ALLOC_DEFMSG(thr);
 		} else {
 			return 0;
 		}
@@ -1825,7 +1825,7 @@ DUK_EXTERNAL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int
 		return;
 	}
 
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_DEFAULTVALUE_COERCE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_DEFAULTVALUE_COERCE_FAILED);
 }
 
 DUK_EXTERNAL void duk_to_undefined(duk_context *ctx, duk_idx_t index) {
@@ -2210,7 +2210,7 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index,
 	} else {
 		/* coerced value is updated to value stack even when RangeError thrown */
 		if (clamped) {
-			DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_NUMBER_OUTSIDE_RANGE);
+			DUK_ERROR_RANGE(thr, DUK_STR_NUMBER_OUTSIDE_RANGE);
 		}
 	}
 
@@ -2452,7 +2452,7 @@ DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t index) {
 	switch (DUK_TVAL_GET_TAG(tv)) {
 	case DUK_TAG_UNDEFINED:
 	case DUK_TAG_NULL: {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_OBJECT_COERCIBLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_OBJECT_COERCIBLE);
 		break;
 	}
 	case DUK_TAG_BOOLEAN: {
@@ -2731,7 +2731,7 @@ DUK_EXTERNAL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t index, d
 		return 1;
 	}
 	if (mask & DUK_TYPE_MASK_THROW) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_UNEXPECTED_TYPE);
+		DUK_ERROR_TYPE(thr, DUK_STR_UNEXPECTED_TYPE);
 		DUK_UNREACHABLE();
 	}
 	return 0;
@@ -3164,7 +3164,7 @@ DUK_EXTERNAL const char *duk_push_lstring(duk_context *ctx, const char *str, duk
 
 	/* Check for maximum string length */
 	if (len > DUK_HSTRING_MAX_BYTELEN) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_STRING_TOO_LONG);
+		DUK_ERROR_RANGE(thr, DUK_STR_STRING_TOO_LONG);
 	}
 
 	h = duk_heap_string_intern_checked(thr, (const duk_uint8_t *) str, (duk_uint32_t) len);
@@ -3237,7 +3237,7 @@ DUK_EXTERNAL const char *duk_push_string_file_raw(duk_context *ctx, const char *
 		duk_push_undefined(ctx);
 	} else {
 		/* XXX: string not shared because it is conditional */
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "read file error");
+		DUK_ERROR_TYPE(thr, "read file error");
 	}
 	return NULL;
 }
@@ -3252,7 +3252,7 @@ DUK_EXTERNAL const char *duk_push_string_file_raw(duk_context *ctx, const char *
 		duk_push_undefined(ctx);
 	} else {
 		/* XXX: string not shared because it is conditional */
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "file I/O disabled");
+		DUK_ERROR_UNSUPPORTED(thr, "file I/O disabled");
 	}
 	return NULL;
 }
@@ -3305,7 +3305,7 @@ DUK_LOCAL void duk__push_this_helper(duk_context *ctx, duk_small_uint_t check_ob
 	return;
 
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_OBJECT_COERCIBLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_OBJECT_COERCIBLE);
 }
 
 DUK_EXTERNAL void duk_push_this(duk_context *ctx) {
@@ -3548,7 +3548,7 @@ DUK_INTERNAL duk_idx_t duk_push_object_helper(duk_context *ctx, duk_uint_t hobje
 
 	h = duk_hobject_alloc(thr->heap, hobject_flags_and_class);
 	if (!h) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("created object with flags: 0x%08lx", (unsigned long) h->hdr.h_flags));
@@ -3651,7 +3651,7 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t flags) {
 	                        DUK_HOBJECT_FLAG_THREAD |
 	                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_THREAD));
 	if (!obj) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	obj->state = DUK_HTHREAD_STATE_INACTIVE;
 #if defined(DUK_USE_ROM_STRINGS)
@@ -3674,7 +3674,7 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t flags) {
 
 	/* important to do this *after* pushing, to make the thread reachable for gc */
 	if (!duk_hthread_init_stacks(thr->heap, obj)) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	/* initialize built-ins - either by copying or creating new ones */
@@ -3719,7 +3719,7 @@ DUK_INTERNAL duk_idx_t duk_push_compiledfunction(duk_context *ctx) {
 	                                  DUK_HOBJECT_FLAG_COMPILEDFUNCTION |
 	                                  DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION));
 	if (!obj) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("created compiled function object with flags: 0x%08lx", (unsigned long) obj->obj.hdr.h_flags));
@@ -3762,7 +3762,7 @@ DUK_LOCAL duk_idx_t duk__push_c_function_raw(duk_context *ctx, duk_c_function fu
 
 	obj = duk_hnativefunction_alloc(thr->heap, flags);
 	if (!obj) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	obj->func = func;
@@ -3887,7 +3887,7 @@ DUK_INTERNAL duk_hbufferobject *duk_push_bufferobject_raw(duk_context *ctx, duk_
 
 	obj = duk_hbufferobject_alloc(thr->heap, hobject_flags_and_class);
 	if (!obj) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, (duk_hobject *) obj, thr->builtins[prototype_bidx]);
@@ -4021,11 +4021,11 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_context *ctx, duk_idx_t idx_buffer,
 	return;
 
  range_error:
-	DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_INVALID_CALL_ARGS);
+	DUK_ERROR_RANGE(thr, DUK_STR_INVALID_CALL_ARGS);
 	return;  /* not reached */
 
  arg_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_CALL_ARGS);
+	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_CALL_ARGS);
 	return;  /* not reached */
 }
 
@@ -4126,12 +4126,12 @@ DUK_EXTERNAL void *duk_push_buffer_raw(duk_context *ctx, duk_size_t size, duk_sm
 
 	/* Check for maximum buffer length. */
 	if (size > DUK_HBUFFER_MAX_BYTELEN) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_BUFFER_TOO_LONG);
+		DUK_ERROR_RANGE(thr, DUK_STR_BUFFER_TOO_LONG);
 	}
 
 	h = duk_hbuffer_alloc(thr->heap, size, flags, &buf_data);
 	if (!h) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	tv_slot = thr->valstack_top;

--- a/src/duk_api_string.c
+++ b/src/duk_api_string.c
@@ -103,7 +103,7 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_context *ctx, duk_idx_t count_in,
 	return;
 
  error_overflow:
-	DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_CONCAT_RESULT_TOO_LONG);
+	DUK_ERROR_RANGE(thr, DUK_STR_CONCAT_RESULT_TOO_LONG);
 }
 
 DUK_EXTERNAL void duk_concat(duk_context *ctx, duk_idx_t count) {

--- a/src/duk_api_var.c
+++ b/src/duk_api_var.c
@@ -74,13 +74,13 @@ DUK_EXTERNAL void duk_put_var(duk_context *ctx) {
 DUK_EXTERNAL duk_bool_t duk_del_var(duk_context *ctx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	DUK_ERROR((duk_hthread *) ctx, DUK_ERR_UNIMPLEMENTED_ERROR, DUK_STR_UNIMPLEMENTED);
+	DUK_ERROR_UNIMPLEMENTED_DEFMSG((duk_hthread *) ctx);
 	return 0;
 }
 
 DUK_EXTERNAL duk_bool_t duk_has_var(duk_context *ctx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	DUK_ERROR((duk_hthread *) ctx, DUK_ERR_UNIMPLEMENTED_ERROR, DUK_STR_UNIMPLEMENTED);
+	DUK_ERROR_UNIMPLEMENTED_DEFMSG((duk_hthread *) ctx);
 	return 0;
 }

--- a/src/duk_bi_array.c
+++ b/src/duk_bi_array.c
@@ -69,7 +69,7 @@ DUK_LOCAL duk_uint32_t duk__push_this_obj_len_u32_limited(duk_context *ctx) {
 	 */
 	duk_uint32_t ret = duk__push_this_obj_len_u32(ctx);
 	if (DUK_UNLIKELY(ret >= 0x80000000UL)) {
-		DUK_ERROR((duk_hthread *) ctx, DUK_ERR_INTERNAL_ERROR, DUK_STR_ARRAY_LENGTH_OVER_2G);
+		DUK_ERROR_RANGE((duk_hthread *) ctx, DUK_STR_ARRAY_LENGTH_OVER_2G);
 	}
 	return ret;
 }

--- a/src/duk_bi_buffer.c
+++ b/src/duk_bi_buffer.c
@@ -125,7 +125,7 @@ DUK_LOCAL duk_hbufferobject *duk__getrequire_bufobj_this(duk_context *ctx, duk_b
 	}
 
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_BUFFER);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_BUFFER);
 	}
 	return NULL;
 }
@@ -170,7 +170,7 @@ DUK_LOCAL duk_hbufferobject *duk__require_bufobj_value(duk_context *ctx, duk_idx
 		}
 	}
 
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_BUFFER);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_BUFFER);
 	return NULL;  /* not reachable */
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
@@ -277,7 +277,7 @@ DUK_LOCAL void duk__resolve_offset_opt_length(duk_context *ctx,
 	return;
 
  fail_range:
-	duk_error(thr, DUK_ERR_RANGE_ERROR, DUK_STR_INVALID_CALL_ARGS);
+	DUK_ERROR_RANGE(thr, DUK_STR_INVALID_CALL_ARGS);
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 

--- a/src/duk_bi_date.c
+++ b/src/duk_bi_date.c
@@ -895,7 +895,7 @@ DUK_LOCAL duk_double_t duk__push_this_get_timeval_tzoffset(duk_context *ctx, duk
 	duk_push_this(ctx);
 	h = duk_get_hobject(ctx, -1);  /* XXX: getter with class check, useful in built-ins */
 	if (h == NULL || DUK_HOBJECT_GET_CLASS_NUMBER(h) != DUK_HOBJECT_CLASS_DATE) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "expected Date");
+		DUK_ERROR_TYPE(thr, "expected Date");
 	}
 
 	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
@@ -907,7 +907,7 @@ DUK_LOCAL duk_double_t duk__push_this_get_timeval_tzoffset(duk_context *ctx, duk
 			d = 0.0;
 		}
 		if (flags & DUK_DATE_FLAG_NAN_TO_RANGE_ERROR) {
-			DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, "Invalid Date");
+			DUK_ERROR_RANGE(thr, "Invalid Date");
 		}
 	}
 	/* if no NaN handling flag, may still be NaN here, but not Inf */

--- a/src/duk_bi_date_unix.c
+++ b/src/duk_bi_date_unix.c
@@ -22,7 +22,7 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(duk_context *ctx) {
 	duk_double_t d;
 
 	if (gettimeofday(&tv, NULL) != 0) {
-		DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "gettimeofday failed");
+		DUK_ERROR_INTERNAL_DEFMSG(thr);
 	}
 
 	d = ((duk_double_t) tv.tv_sec) * 1000.0 +

--- a/src/duk_bi_global.c
+++ b/src/duk_bi_global.c
@@ -380,7 +380,7 @@ DUK_LOCAL void duk__transform_callback_escape(duk__transform_context *tfm_ctx, c
 	return;
 
  esc_error:
-	DUK_ERROR(tfm_ctx->thr, DUK_ERR_TYPE_ERROR, "invalid input");
+	DUK_ERROR_TYPE(tfm_ctx->thr, "invalid input");
 }
 
 DUK_LOCAL void duk__transform_callback_unescape(duk__transform_context *tfm_ctx, const void *udata, duk_codepoint_t cp) {
@@ -1002,7 +1002,7 @@ DUK_LOCAL void duk__bi_global_resolve_module_id(duk_context *ctx, const char *re
 	return;
 
  resolve_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "cannot resolve module id: %s", (const char *) req_id);
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "cannot resolve module id: %s", (const char *) req_id);
 }
 #endif  /* DUK_USE_COMMONJS_MODULES */
 

--- a/src/duk_bi_json.c
+++ b/src/duk_bi_json.c
@@ -203,8 +203,8 @@ DUK_LOCAL void duk__dec_syntax_error(duk_json_dec_ctx *js_ctx) {
 	 * hidden, unfortunately, but we'll have an offset which
 	 * is often quite enough.
 	 */
-	DUK_ERROR(js_ctx->thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_FMT_INVALID_JSON,
-	         (long) (js_ctx->p - js_ctx->p_start));
+	DUK_ERROR_FMT1(js_ctx->thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_FMT_INVALID_JSON,
+	               (long) (js_ctx->p - js_ctx->p_start));
 }
 
 DUK_LOCAL void duk__dec_eat_white(duk_json_dec_ctx *js_ctx) {
@@ -712,7 +712,7 @@ DUK_LOCAL void duk__dec_objarr_entry(duk_json_dec_ctx *js_ctx) {
 	DUK_ASSERT(js_ctx->recursion_depth >= 0);
 	DUK_ASSERT(js_ctx->recursion_depth <= js_ctx->recursion_limit);
 	if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
-		DUK_ERROR((duk_hthread *) ctx, DUK_ERR_RANGE_ERROR, DUK_STR_JSONDEC_RECLIMIT);
+		DUK_ERROR_RANGE((duk_hthread *) ctx, DUK_STR_JSONDEC_RECLIMIT);
 	}
 	js_ctx->recursion_depth++;
 }
@@ -1703,7 +1703,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 	for (i = 0; i < n; i++) {
 		if (DUK_UNLIKELY(js_ctx->visiting[i] == h_target)) {
 			DUK_DD(DUK_DDPRINT("slow path loop detect"));
-			DUK_ERROR(js_ctx->thr, DUK_ERR_TYPE_ERROR, DUK_STR_CYCLIC_INPUT);
+			DUK_ERROR_TYPE((duk_hthread *) ctx, DUK_STR_CYCLIC_INPUT);
 		}
 	}
 	if (js_ctx->recursion_depth < DUK_JSON_ENC_LOOPARRAY) {
@@ -1712,7 +1712,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 		duk_push_sprintf(ctx, DUK_STR_FMT_PTR, (void *) h_target);
 		duk_dup_top(ctx);  /* -> [ ... voidp voidp ] */
 		if (duk_has_prop(ctx, js_ctx->idx_loop)) {
-			DUK_ERROR((duk_hthread *) ctx, DUK_ERR_TYPE_ERROR, DUK_STR_CYCLIC_INPUT);
+			DUK_ERROR_TYPE((duk_hthread *) ctx, DUK_STR_CYCLIC_INPUT);
 		}
 		duk_push_true(ctx);  /* -> [ ... voidp true ] */
 		duk_put_prop(ctx, js_ctx->idx_loop);  /* -> [ ... ] */
@@ -1723,7 +1723,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 	DUK_ASSERT(js_ctx->recursion_depth >= 0);
 	DUK_ASSERT(js_ctx->recursion_depth <= js_ctx->recursion_limit);
 	if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
-		DUK_ERROR((duk_hthread *) ctx, DUK_ERR_RANGE_ERROR, DUK_STR_JSONENC_RECLIMIT);
+		DUK_ERROR_RANGE((duk_hthread *) ctx, DUK_STR_JSONENC_RECLIMIT);
 	}
 	js_ctx->recursion_depth++;
 
@@ -2297,13 +2297,13 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		DUK_ASSERT(js_ctx->recursion_depth <= js_ctx->recursion_limit);
 		if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
 			DUK_DD(DUK_DDPRINT("fast path recursion limit"));
-			DUK_ERROR(js_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_JSONDEC_RECLIMIT);
+			DUK_ERROR_RANGE(js_ctx->thr, DUK_STR_JSONDEC_RECLIMIT);
 		}
 
 		for (i = 0, n = (duk_uint_fast32_t) js_ctx->recursion_depth; i < n; i++) {
 			if (DUK_UNLIKELY(js_ctx->visiting[i] == obj)) {
 				DUK_DD(DUK_DDPRINT("fast path loop detect"));
-				DUK_ERROR(js_ctx->thr, DUK_ERR_TYPE_ERROR, DUK_STR_CYCLIC_INPUT);
+				DUK_ERROR_TYPE(js_ctx->thr, DUK_STR_CYCLIC_INPUT);
 			}
 		}
 
@@ -2643,7 +2643,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
  abort_fastpath:
 	/* Error message doesn't matter: the error is ignored anyway. */
 	DUK_DD(DUK_DDPRINT("aborting fast path"));
-	DUK_ERROR(js_ctx->thr, DUK_ERR_ERROR, DUK_STR_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(js_ctx->thr);
 	return 0;  /* unreachable */
 }
 

--- a/src/duk_bi_number.c
+++ b/src/duk_bi_number.c
@@ -20,7 +20,7 @@ DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_context *ctx) {
 	if (!h ||
 	    (DUK_HOBJECT_GET_CLASS_NUMBER(h) != DUK_HOBJECT_CLASS_NUMBER)) {
 		DUK_DDD(DUK_DDDPRINT("unacceptable this value: %!T", (duk_tval *) duk_get_tval(ctx, -1)));
-		DUK_ERROR((duk_hthread *) ctx, DUK_ERR_TYPE_ERROR, "expected a number");
+		DUK_ERROR_TYPE((duk_hthread *) ctx, "number expected");
 	}
 	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
 	DUK_ASSERT(duk_is_number(ctx, -1));

--- a/src/duk_bi_thread.c
+++ b/src/duk_bi_thread.c
@@ -178,11 +178,11 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	return 0;  /* never here */
 
  state_invalid_initial:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid initial thread state/stack");
+	DUK_ERROR_TYPE(thr, "invalid initial thread state/stack");
 	return 0;  /* never here */
 
  state_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid state for resume");
+	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
 
@@ -295,7 +295,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	return 0;  /* never here */
 
  state_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid state for yield");
+	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
 

--- a/src/duk_error_macros.c
+++ b/src/duk_error_macros.c
@@ -8,64 +8,25 @@
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 
-#if defined(DUK_USE_VARIADIC_MACROS)
-DUK_INTERNAL void duk_err_handle_error(const char *filename, duk_int_t line, duk_hthread *thr, duk_errcode_t code, const char *fmt, ...) {
+DUK_INTERNAL void duk_err_handle_error_fmt(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *fmt, ...) {
 	va_list ap;
 	char msg[DUK__ERRFMT_BUFSIZE];
 	va_start(ap, fmt);
 	(void) DUK_VSNPRINTF(msg, sizeof(msg), fmt, ap);
 	msg[sizeof(msg) - 1] = (char) 0;
-	duk_err_create_and_throw(thr, code, msg, filename, line);
+	duk_err_create_and_throw(thr, (duk_errcode_t) (line_and_code >> 24), msg, filename, (duk_int_t) (line_and_code & 0x00ffffffL));
 	va_end(ap);  /* dead code, but ensures portability (see Linux man page notes) */
 }
-#else  /* DUK_USE_VARIADIC_MACROS */
-DUK_INTERNAL const char *duk_err_file_stash = NULL;
-DUK_INTERNAL duk_int_t duk_err_line_stash = 0;
 
-DUK_NORETURN(DUK_LOCAL_DECL void duk__handle_error(const char *filename, duk_int_t line, duk_hthread *thr, duk_errcode_t code, const char *fmt, va_list ap));
-
-DUK_LOCAL void duk__handle_error(const char *filename, duk_int_t line, duk_hthread *thr, duk_errcode_t code, const char *fmt, va_list ap) {
-	char msg[DUK__ERRFMT_BUFSIZE];
-	(void) DUK_VSNPRINTF(msg, sizeof(msg), fmt, ap);
-	msg[sizeof(msg) - 1] = (char) 0;
-	duk_err_create_and_throw(thr, code, msg, filename, line);
+DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *msg) {
+	duk_err_create_and_throw(thr, (duk_errcode_t) (line_and_code >> 24), msg, filename, (duk_int_t) (line_and_code & 0x00ffffffL));
 }
-
-DUK_INTERNAL void duk_err_handle_error(const char *filename, duk_int_t line, duk_hthread *thr, duk_errcode_t code, const char *fmt, ...) {
-	va_list ap;
-	va_start(ap, fmt);
-	duk__handle_error(filename, line, thr, code, fmt, ap);
-	va_end(ap);  /* dead code */
-}
-
-DUK_INTERNAL void duk_err_handle_error_stash(duk_hthread *thr, duk_errcode_t code, const char *fmt, ...) {
-	va_list ap;
-	va_start(ap, fmt);
-	duk__handle_error(duk_err_file_stash, duk_err_line_stash, thr, code, fmt, ap);
-	va_end(ap);  /* dead code */
-}
-#endif  /* DUK_USE_VARIADIC_MACROS */
 
 #else  /* DUK_USE_VERBOSE_ERRORS */
 
-#if defined(DUK_USE_VARIADIC_MACROS)
 DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, duk_errcode_t code) {
 	duk_err_create_and_throw(thr, code);
 }
-
-#else  /* DUK_USE_VARIADIC_MACROS */
-DUK_INTERNAL void duk_err_handle_error_nonverbose1(duk_hthread *thr, duk_errcode_t code, const char *fmt, ...) {
-	DUK_UNREF(fmt);
-	duk_err_create_and_throw(thr, code);
-}
-
-DUK_INTERNAL void duk_err_handle_error_nonverbose2(const char *filename, duk_int_t line, duk_hthread *thr, duk_errcode_t code, const char *fmt, ...) {
-	DUK_UNREF(filename);
-	DUK_UNREF(line);
-	DUK_UNREF(fmt);
-	duk_err_create_and_throw(thr, code);
-}
-#endif  /* DUK_USE_VARIADIC_MACROS */
 
 #endif  /* DUK_USE_VERBOSE_ERRORS */
 
@@ -75,34 +36,67 @@ DUK_INTERNAL void duk_err_handle_error_nonverbose2(const char *filename, duk_int
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 #if defined(DUK_USE_PARANOID_ERRORS)
-DUK_INTERNAL void duk_err_require_type_index(const char *filename, duk_int_t linenumber, duk_hthread *thr, duk_idx_t index, const char *expect_name) {
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
-	              expect_name, duk_get_type_name((duk_context *) thr, index), (long) index);
+DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name) {
+	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
+	                   expect_name, duk_get_type_name((duk_context *) thr, index), (long) index);
 }
 #else
-DUK_INTERNAL void duk_err_require_type_index(const char *filename, duk_int_t linenumber, duk_hthread *thr, duk_idx_t index, const char *expect_name) {
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
-	              expect_name, duk_push_string_readable((duk_context *) thr, index), (long) index);
+DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name) {
+	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
+	                   expect_name, duk_push_string_readable((duk_context *) thr, index), (long) index);
 }
 #endif
-DUK_INTERNAL void duk_err_api_index(const char *filename, duk_int_t linenumber, duk_hthread *thr, duk_idx_t index) {
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_API_ERROR, "invalid stack index %ld", (long) (index));
+DUK_INTERNAL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_RANGE_ERROR, message);
 }
-DUK_INTERNAL void duk_err_api(const char *filename, duk_int_t linenumber, duk_hthread *thr, const char *message) {
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_API_ERROR, message);
+DUK_INTERNAL void duk_err_api_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index) {
+	DUK_ERROR_RAW_FMT1(thr, filename, linenumber, DUK_ERR_API_ERROR, "invalid stack index %ld", (long) (index));
+}
+DUK_INTERNAL void duk_err_api(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_API_ERROR, message);
+}
+DUK_INTERNAL void duk_err_unimplemented_defmsg(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_UNIMPLEMENTED_ERROR, DUK_STR_UNIMPLEMENTED);
+}
+DUK_INTERNAL void duk_err_unsupported_defmsg(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_UNSUPPORTED_ERROR, DUK_STR_UNSUPPORTED);
+}
+DUK_INTERNAL void duk_err_internal_defmsg(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+}
+DUK_INTERNAL void duk_err_internal(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_INTERNAL_ERROR, message);
+}
+DUK_INTERNAL void duk_err_alloc(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_ALLOC_ERROR, message);
 }
 #else
-DUK_INTERNAL void duk_err_require_type_index(const char *filename, duk_int_t linenumber, duk_hthread *thr, const char *message) {
-	DUK_UNREF(filename); DUK_UNREF(linenumber); DUK_UNREF(message);
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_TYPE_ERROR, message);
+/* The file/line arguments are NULL and 0, they're ignored by DUK_ERROR_RAW()
+ * when non-verbose errors are used.
+ */
+DUK_INTERNAL void duk_err_type(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_TYPE_ERROR, NULL);
 }
-DUK_INTERNAL void duk_err_api_index(const char *filename, duk_int_t linenumber, duk_hthread *thr) {
-	DUK_UNREF(filename); DUK_UNREF(linenumber);
-	DUK_ERROR(thr, DUK_ERR_API_ERROR, DUK_STR_INVALID_INDEX);
+DUK_INTERNAL void duk_err_api(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_API_ERROR, NULL);
 }
-DUK_INTERNAL void duk_err_api(const char *filename, duk_int_t linenumber, duk_hthread *thr, const char *message) {
-	DUK_UNREF(filename); DUK_UNREF(linenumber); DUK_UNREF(message);
-	DUK_ERROR_RAW(filename, linenumber, thr, DUK_ERR_API_ERROR, message);
+DUK_INTERNAL void duk_err_range(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_RANGE_ERROR, NULL);
+}
+DUK_INTERNAL void duk_err_syntax(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_SYNTAX_ERROR, NULL);
+}
+DUK_INTERNAL void duk_err_unimplemented(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_UNIMPLEMENTED_ERROR, NULL);
+}
+DUK_INTERNAL void duk_err_unsupported(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_UNSUPPORTED_ERROR, NULL);
+}
+DUK_INTERNAL void duk_err_internal(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, 0, DUK_ERR_INTERNAL_ERROR, NULL);
+}
+DUK_INTERNAL void duk_err_alloc(duk_hthread *thr) {
+	DUK_ERROR_RAW(thr, NULL, thr, DUK_ERR_ALLOC_ERROR, NULL);
 }
 #endif
 

--- a/src/duk_hbuffer_ops.c
+++ b/src/duk_hbuffer_ops.c
@@ -29,7 +29,7 @@ DUK_INTERNAL void duk_hbuffer_resize(duk_hthread *thr, duk_hbuffer_dynamic *buf,
 	 */
 
 	if (new_size > DUK_HBUFFER_MAX_BYTELEN) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, "buffer too long");
+		DUK_ERROR_RANGE(thr, "buffer too long");
 	}
 
 	/*
@@ -66,9 +66,7 @@ DUK_INTERNAL void duk_hbuffer_resize(duk_hthread *thr, duk_hbuffer_dynamic *buf,
 		DUK_HBUFFER_DYNAMIC_SET_SIZE(buf, new_size);
 		DUK_HBUFFER_DYNAMIC_SET_DATA_PTR(thr->heap, buf, res);
 	} else {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, "buffer resize failed: %ld to %ld",
-		          (long) DUK_HBUFFER_DYNAMIC_GET_SIZE(buf),
-		          (long) new_size);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	DUK_ASSERT(res != NULL || new_size == 0);

--- a/src/duk_heap_stringcache.c
+++ b/src/duk_heap_stringcache.c
@@ -293,6 +293,6 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	return byte_offset;
 
  error:
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "string scan error");
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return 0;
 }

--- a/src/duk_heap_stringtable.c
+++ b/src/duk_heap_stringtable.c
@@ -977,7 +977,7 @@ DUK_INTERNAL duk_hstring *duk_heap_string_intern(duk_heap *heap, const duk_uint8
 DUK_INTERNAL duk_hstring *duk_heap_string_intern_checked(duk_hthread *thr, const duk_uint8_t *str, duk_uint32_t blen) {
 	duk_hstring *res = duk_heap_string_intern(thr->heap, str, blen);
 	if (!res) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, "failed to intern string");
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	return res;
 }
@@ -1003,7 +1003,7 @@ DUK_INTERNAL duk_hstring *duk_heap_string_intern_u32(duk_heap *heap, duk_uint32_
 DUK_INTERNAL duk_hstring *duk_heap_string_intern_u32_checked(duk_hthread *thr, duk_uint32_t val) {
 	duk_hstring *res = duk_heap_string_intern_u32(thr->heap, val);
 	if (!res) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, "failed to intern string");
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	return res;
 }

--- a/src/duk_hobject_alloc.c
+++ b/src/duk_hobject_alloc.c
@@ -185,7 +185,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_f
 DUK_INTERNAL duk_hobject *duk_hobject_alloc_checked(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hobject *res = duk_hobject_alloc(thr->heap, hobject_flags);
 	if (!res) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, "failed to allocate an object");
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	return res;
 }

--- a/src/duk_hobject_misc.c
+++ b/src/duk_hobject_misc.c
@@ -21,7 +21,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_prototype_chain_contains(duk_hthread *thr, d
 			if (ignore_loop) {
 				break;
 			} else {
-				DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+				DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 			}
 		}
 		h = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h);

--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -335,7 +335,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_proxy_check(duk_hthread *thr, duk_hobject *o
 
 	tv_handler = duk_hobject_find_existing_entry_tval_ptr(thr->heap, obj, DUK_HTHREAD_STRING_INT_HANDLER(thr));
 	if (!tv_handler) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REVOKED);
+		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REVOKED);
 		return 0;
 	}
 	DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv_handler));
@@ -346,7 +346,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_proxy_check(duk_hthread *thr, duk_hobject *o
 
 	tv_target = duk_hobject_find_existing_entry_tval_ptr(thr->heap, obj, DUK_HTHREAD_STRING_INT_TARGET(thr));
 	if (!tv_target) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REVOKED);
+		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REVOKED);
 		return 0;
 	}
 	DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv_target));
@@ -583,7 +583,7 @@ void duk__realloc_props(duk_hthread *thr,
 	 */
 
 	if (new_e_size_adjusted + new_a_size > DUK_HOBJECT_MAX_PROPERTIES) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_OBJECT_PROPERTY_LIMIT);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 
 	/*
@@ -933,7 +933,7 @@ void duk__realloc_props(duk_hthread *thr,
 	thr->heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
 #endif
 
-	DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_OBJECT_RESIZE_FAILED);
+	DUK_ERROR_ALLOC_DEFMSG(thr);
 }
 
 /*
@@ -1938,7 +1938,7 @@ DUK_LOCAL duk_bool_t duk__get_propdesc(duk_hthread *thr, duk_hobject *obj, duk_h
 				/* treat like property not found */
 				break;
 			} else {
-				DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+				DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 			}
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
@@ -2075,7 +2075,7 @@ DUK_LOCAL duk_bool_t duk__putprop_shallow_fastpath_array_tval(duk_hthread *thr, 
 		                     "(arr_idx=%ld, old_len=%ld)",
 		                     (long) idx, (long) old_len));
 		if (!(temp_desc->flags & DUK_PROPDESC_FLAG_WRITABLE)) {
-			DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_WRITABLE);
+			DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
 			return 0;  /* not reachable */
 		}
 		new_len = idx + 1;
@@ -2263,10 +2263,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		/* Note: unconditional throw */
 		DUK_DDD(DUK_DDDPRINT("base object is undefined or null -> reject"));
 #if defined(DUK_USE_PARANOID_ERRORS)
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_BASE);
+		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
 #else
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "cannot read property %s of %s",
-		          duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
+		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot read property %s of %s",
+		               duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
 #endif
 		return 0;
 	}
@@ -2402,7 +2402,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 					                 (desc.get == NULL) &&
 					                 !DUK_TVAL_IS_UNDEFINED(tv_hook);
 					if (datadesc_reject || accdesc_reject) {
-						DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 					}
 
 					duk_pop_2(ctx);
@@ -2624,7 +2624,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		 * hit might be useful.
 		 */
 		if (sanity-- == 0) {
-			DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
 	} while (curr);
@@ -2694,7 +2694,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			    DUK_HOBJECT_IS_FUNCTION(h) &&
 			    DUK_HOBJECT_HAS_STRICT(h)) {
 				/* XXX: sufficient to check 'strict', assert for 'is function' */
-				DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_STRICT_CALLER_READ);
+				DUK_ERROR_TYPE(thr, DUK_STR_STRICT_CALLER_READ);
 			}
 		}
 	}
@@ -2771,7 +2771,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 	} else {
 		/* Note: unconditional throw */
 		DUK_DDD(DUK_DDDPRINT("base object is not an object -> reject"));
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_BASE);
+		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
 	}
 
 	/* XXX: fast path for arrays? */
@@ -2814,7 +2814,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 					 */
 					if (!((desc.flags & DUK_PROPDESC_FLAG_CONFIGURABLE) &&  /* property is configurable and */
 					      DUK_HOBJECT_HAS_EXTENSIBLE(h_target))) {          /* ... target is extensible */
-						DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 					}
 				}
 			}
@@ -2930,7 +2930,7 @@ DUK_LOCAL duk_uint32_t duk__to_new_array_length_checked(duk_hthread *thr) {
 	d = duk_to_number(ctx, -1);
 	res = (duk_uint32_t) d;
 	if ((duk_double_t) res != d) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_INVALID_ARRAY_LENGTH);
+		DUK_ERROR_RANGE(thr, DUK_STR_INVALID_ARRAY_LENGTH);
 	}
 	duk_pop(ctx);
 	return res;
@@ -3303,10 +3303,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		DUK_DDD(DUK_DDDPRINT("base object is undefined or null -> reject (object=%!iT)",
 		                     (duk_tval *) tv_obj));
 #if defined(DUK_USE_PARANOID_ERRORS)
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_BASE);
+		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
 #else
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
-		          duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
+		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
+		               duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
 #endif
 		return 0;
 	}
@@ -3429,7 +3429,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 					                 !(desc.flags & DUK_PROPDESC_FLAG_CONFIGURABLE) &&
 					                 (desc.set == NULL);
 					if (datadesc_reject || accdesc_reject) {
-						DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 					}
 
 					duk_pop_2(ctx);
@@ -3703,7 +3703,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		 * hit might be useful.
 		 */
 		if (sanity-- == 0) {
-			DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
 	} while (curr);
@@ -4087,7 +4087,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_proxy_rejected:
 	DUK_DDD(DUK_DDDPRINT("result: error, proxy rejects"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 	}
 	/* Note: no key on stack */
 	return 0;
@@ -4097,10 +4097,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, base primitive"));
 	if (throw_flag) {
 #if defined(DUK_USE_PARANOID_ERRORS)
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_BASE);
+		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
 #else
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
-		          duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
+		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
+		               duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
 #endif
 	}
 	duk_pop(ctx);  /* remove key */
@@ -4109,7 +4109,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_not_extensible:
 	DUK_DDD(DUK_DDDPRINT("result: error, not extensible"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_EXTENSIBLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_EXTENSIBLE);
 	}
 	duk_pop(ctx);  /* remove key */
 	return 0;
@@ -4117,7 +4117,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_not_writable:
 	DUK_DDD(DUK_DDDPRINT("result: error, not writable"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_WRITABLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
 	}
 	duk_pop(ctx);  /* remove key */
 	return 0;
@@ -4126,7 +4126,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_not_writable_no_pop:
 	DUK_DDD(DUK_DDDPRINT("result: error, not writable"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_WRITABLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
 	}
 	return 0;
 #endif
@@ -4134,7 +4134,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_array_length_partial:
 	DUK_DDD(DUK_DDDPRINT("result: error, array length write only partially successful"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_ARRAY_LENGTH_WRITE_FAILED);
+		DUK_ERROR_TYPE(thr, DUK_STR_ARRAY_LENGTH_WRITE_FAILED);
 	}
 	duk_pop(ctx);  /* remove key */
 	return 0;
@@ -4142,7 +4142,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_no_setter:
 	DUK_DDD(DUK_DDDPRINT("result: error, accessor property without setter"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_SETTER_UNDEFINED);
+		DUK_ERROR_TYPE(thr, DUK_STR_SETTER_UNDEFINED);
 	}
 	duk_pop(ctx);  /* remove key */
 	return 0;
@@ -4150,7 +4150,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_internal:
 	DUK_DDD(DUK_DDDPRINT("result: error, internal"));
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INTERNAL_ERROR);
+		DUK_ERROR_INTERNAL_DEFMSG(thr);
 	}
 	duk_pop(ctx);  /* remove key */
 	return 0;
@@ -4299,7 +4299,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 	DUK_DDD(DUK_DDDPRINT("delete failed: property found, force flag, but virtual"));
 
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROPERTY_IS_VIRTUAL);
+		DUK_ERROR_TYPE(thr, DUK_STR_PROPERTY_IS_VIRTUAL);
 	}
 	return 0;
 
@@ -4307,7 +4307,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 	DUK_DDD(DUK_DDDPRINT("delete failed: property found, not configurable"));
 
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONFIGURABLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
 	}
 	return 0;
 }
@@ -4394,7 +4394,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 					desc_reject = !(desc.flags & DUK_PROPDESC_FLAG_CONFIGURABLE);
 					if (desc_reject) {
 						/* unconditional */
-						DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 					}
 				}
 				rc = 1;  /* success */
@@ -4480,17 +4480,17 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 	/* Note: unconditional throw */
 	DUK_ASSERT(duk_get_top(ctx) == entry_top);
 #if defined(DUK_USE_PARANOID_ERRORS)
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_BASE);
+	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
 #else
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "cannot delete property %s of %s",
-	          duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
+	DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot delete property %s of %s",
+	               duk_push_string_tval_readable(ctx, tv_key), duk_push_string_tval_readable(ctx, tv_obj));
 #endif
 	return 0;
 
 #if defined(DUK_USE_ES6_PROXY)
  fail_proxy_rejected:
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
+		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
 	}
 	duk_set_top(ctx, entry_top);
 	return 0;
@@ -4498,7 +4498,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 
  fail_not_configurable:
 	if (throw_flag) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONFIGURABLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
 	}
 	duk_set_top(ctx, entry_top);
 	return 0;
@@ -4625,11 +4625,11 @@ DUK_INTERNAL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hob
 	return;
 
  error_internal:
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return;
 
  error_virtual:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_REDEFINE_VIRT_PROP);
+	DUK_ERROR_TYPE(thr, DUK_STR_REDEFINE_VIRT_PROP);
 	return;
 }
 
@@ -4990,7 +4990,7 @@ void duk_hobject_prepare_property_descriptor(duk_context *ctx,
 	return;
 
  type_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_DESCRIPTOR);
+	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_DESCRIPTOR);
 }
 
 /*
@@ -5815,23 +5815,23 @@ void duk_hobject_define_property_helper(duk_context *ctx,
 	return;
 
  fail_virtual:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_PROPERTY_IS_VIRTUAL);
+	DUK_ERROR_TYPE(thr, DUK_STR_PROPERTY_IS_VIRTUAL);
 	return;
 
  fail_not_writable_array_length:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_ARRAY_LENGTH_NOT_WRITABLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_ARRAY_LENGTH_NOT_WRITABLE);
 	return;
 
  fail_not_extensible:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_EXTENSIBLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_EXTENSIBLE);
 	return;
 
  fail_not_configurable:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONFIGURABLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
 	return;
 
  fail_array_length_partial:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_ARRAY_LENGTH_WRITE_FAILED);
+	DUK_ERROR_TYPE(thr, DUK_STR_ARRAY_LENGTH_WRITE_FAILED);
 	return;
 }
 
@@ -5886,7 +5886,7 @@ DUK_INTERNAL void duk_hobject_object_seal_freeze_helper(duk_hthread *thr, duk_ho
 #if defined(DUK_USE_ROM_OBJECTS)
 	if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) obj)) {
 		DUK_DD(DUK_DDPRINT("attempt to seal/freeze a readonly object, reject"));
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CONFIGURABLE);
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
 	}
 #endif
 

--- a/src/duk_hthread_builtins.c
+++ b/src/duk_hthread_builtins.c
@@ -88,7 +88,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	DUK_ASSERT(alloc_size > 0);
 	props = DUK_ALLOC(thr->heap, alloc_size);
 	if (!props) {
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_ALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 		return;
 	}
 	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, h2) != NULL);

--- a/src/duk_hthread_stacks.c
+++ b/src/duk_hthread_stacks.c
@@ -41,7 +41,7 @@ DUK_INTERNAL void duk_hthread_callstack_grow(duk_hthread *thr) {
 
 	/* this is a bit approximate (errors out before max is reached); this is OK */
 	if (new_size >= thr->callstack_max) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_CALLSTACK_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_CALLSTACK_LIMIT);
 	}
 
 	DUK_DD(DUK_DDPRINT("growing callstack %ld -> %ld", (long) old_size, (long) new_size));
@@ -55,7 +55,7 @@ DUK_INTERNAL void duk_hthread_callstack_grow(duk_hthread *thr) {
 	new_ptr = (duk_activation *) DUK_REALLOC_INDIRECT(thr->heap, duk_hthread_get_callstack_ptr, (void *) thr, sizeof(duk_activation) * new_size);
 	if (!new_ptr) {
 		/* No need for a NULL/zero-size check because new_size > 0) */
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_REALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	thr->callstack = new_ptr;
 	thr->callstack_size = new_size;
@@ -346,7 +346,7 @@ DUK_INTERNAL void duk_hthread_catchstack_grow(duk_hthread *thr) {
 
 	/* this is a bit approximate (errors out before max is reached); this is OK */
 	if (new_size >= thr->catchstack_max) {
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_CATCHSTACK_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_CATCHSTACK_LIMIT);
 	}
 
 	DUK_DD(DUK_DDPRINT("growing catchstack %ld -> %ld", (long) old_size, (long) new_size));
@@ -360,7 +360,7 @@ DUK_INTERNAL void duk_hthread_catchstack_grow(duk_hthread *thr) {
 	new_ptr = (duk_catcher *) DUK_REALLOC_INDIRECT(thr->heap, duk_hthread_get_catchstack_ptr, (void *) thr, sizeof(duk_catcher) * new_size);
 	if (!new_ptr) {
 		/* No need for a NULL/zero-size check because new_size > 0) */
-		DUK_ERROR(thr, DUK_ERR_ALLOC_ERROR, DUK_STR_REALLOC_FAILED);
+		DUK_ERROR_ALLOC_DEFMSG(thr);
 	}
 	thr->catchstack = new_ptr;
 	thr->catchstack_size = new_size;

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -442,7 +442,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 			/* Function.prototype.bind() should never let this happen,
 			 * ugly error message is enough.
 			 */
-			DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+			DUK_ERROR_INTERNAL_DEFMSG(thr);
 		}
 		DUK_ASSERT(DUK_TVAL_GET_OBJECT(tv_func) != NULL);
 
@@ -494,7 +494,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 	} while (--sanity > 0);
 
 	if (sanity == 0) {
-		DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_BOUND_CHAIN_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_BOUND_CHAIN_LIMIT);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("final non-bound function is: %!T", duk_get_tval(ctx, idx_func)));
@@ -765,9 +765,9 @@ DUK_LOCAL duk_hobject *duk__nonbound_func_lookup(duk_context *ctx,
  not_callable_error:
 	DUK_ASSERT(tv_func != NULL);
 #if defined(DUK_USE_PARANOID_ERRORS)
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CALLABLE);
+	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CALLABLE);
 #else
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "%s not callable", duk_push_string_tval_readable(ctx, tv_func));
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "%s not callable", duk_push_string_tval_readable(ctx, tv_func));
 #endif
 	DUK_UNREACHABLE();
 	return NULL;  /* never executed */
@@ -1103,7 +1103,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 		}
 		DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
 		try {
-			DUK_ERROR(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
+			DUK_ERROR_FMT1(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
 			duk__handle_call_error(thr,
@@ -1122,7 +1122,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	} catch (...) {
 		DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
 		try {
-			DUK_ERROR(thr, DUK_ERR_API_ERROR, "caught invalid c++ exception (perhaps thrown by user code)");
+			DUK_ERROR_API(thr, "caught invalid c++ exception (perhaps thrown by user code)");
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
 			duk__handle_call_error(thr,
@@ -1282,7 +1282,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			 * limit which is also essentially the same as a C callstack limit
 			 * (except perhaps with some relaxed threading assumptions).
 			 */
-			DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_C_CALLSTACK_LIMIT);
+			DUK_ERROR_RANGE(thr, DUK_STR_C_CALLSTACK_LIMIT);
 		}
 		thr->heap->call_recursion_depth++;
 	}
@@ -1383,7 +1383,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			nregs = nargs;
 		} else {
 			/* XXX: this should be an assert */
-			DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_NOT_CALLABLE);
+			DUK_ERROR_TYPE(thr, DUK_STR_NOT_CALLABLE);
 		}
 	} else {
 		duk_small_uint_t lf_flags;
@@ -1629,7 +1629,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			duk_error_throw_from_negative_rc(thr, rc);
 			DUK_UNREACHABLE();
 		} else if (rc > 1) {
-			DUK_ERROR(thr, DUK_ERR_API_ERROR, "c function returned invalid rc");
+			DUK_ERROR_API(thr, "c function returned invalid rc");
 		}
 		DUK_ASSERT(rc == 0 || rc == 1);
 
@@ -1723,7 +1723,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	return;
 
  thread_state_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for call (%ld)", (long) thr->state);
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for call (%ld)", (long) thr->state);
 	DUK_UNREACHABLE();
 	return;  /* never executed */
 }
@@ -1988,7 +1988,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 		}
 		DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
 		try {
-			DUK_ERROR(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
+			DUK_ERROR_FMT1(thr, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
 			duk__handle_safe_call_error(thr,
@@ -2003,7 +2003,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	} catch (...) {
 		DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
 		try {
-			DUK_ERROR(thr, DUK_ERR_API_ERROR, "caught invalid c++ exception (perhaps thrown by user code)");
+			DUK_ERROR_API(thr, "caught invalid c++ exception (perhaps thrown by user code)");
 		} catch (duk_internal_exception exc) {
 			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
 			duk__handle_safe_call_error(thr,
@@ -2090,7 +2090,7 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 		 * limit which is also essentially the same as a C callstack limit
 		 * (except perhaps with some relaxed threading assumptions).
 		 */
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_C_CALLSTACK_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_C_CALLSTACK_LIMIT);
 	}
 	thr->heap->call_recursion_depth++;
 
@@ -2136,7 +2136,7 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 	return;
 
  thread_state_error:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for safe_call (%ld)", (long) thr->state);
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for safe_call (%ld)", (long) thr->state);
 	DUK_UNREACHABLE();
 }
 

--- a/src/duk_js_compiler.c
+++ b/src/duk_js_compiler.c
@@ -381,7 +381,7 @@ DUK_LOCAL void duk__recursion_increase(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(comp_ctx != NULL);
 	DUK_ASSERT(comp_ctx->recursion_depth >= 0);
 	if (comp_ctx->recursion_depth >= comp_ctx->recursion_limit) {
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_COMPILER_RECURSION_LIMIT);
+		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_COMPILER_RECURSION_LIMIT);
 	}
 	comp_ctx->recursion_depth++;
 }
@@ -440,7 +440,7 @@ DUK_LOCAL void duk__advance_helper(duk_compiler_ctx *comp_ctx, duk_small_int_t e
 	if (expect >= 0 && comp_ctx->curr_token.t != expect) {
 		DUK_D(DUK_DPRINT("parse error: expect=%ld, got=%ld",
 		                 (long) expect, (long) comp_ctx->curr_token.t));
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_PARSE_ERROR);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
 	}
 
 	/* make current token the previous; need to fiddle with valstack "backing store" */
@@ -1094,7 +1094,7 @@ DUK_LOCAL void duk__emit(duk_compiler_ctx *comp_ctx, duk_instr_t ins) {
 	return;
 
   fail_bc_limit:
-	DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_BYTECODE_LIMIT);
+	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_BYTECODE_LIMIT);
 }
 
 /* Update function min/max line from current token.  Needed to improve
@@ -1373,7 +1373,7 @@ DUK_LOCAL void duk__emit_a_b_c(duk_compiler_ctx *comp_ctx, duk_small_uint_t op_f
 	return;
 
  error_outofregs:
-	DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_REG_LIMIT);
+	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
 }
 
 DUK_LOCAL void duk__emit_a_b(duk_compiler_ctx *comp_ctx, duk_small_uint_t op_flags, duk_regconst_t a, duk_regconst_t b) {
@@ -1432,7 +1432,7 @@ DUK_LOCAL void duk__emit_a_bc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op_fl
 	return;
 
  error_outofregs:
-	DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_REG_LIMIT);
+	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
 }
 
 DUK_LOCAL void duk__emit_abc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op, duk_regconst_t abc) {
@@ -1458,7 +1458,7 @@ DUK_LOCAL void duk__emit_abc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op, du
 	return;
 
  error_outofregs:
-	DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_REG_LIMIT);
+	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
 }
 
 DUK_LOCAL void duk__emit_extraop_b_c(duk_compiler_ctx *comp_ctx, duk_small_uint_t extraop_flags, duk_regconst_t b, duk_regconst_t c) {
@@ -1606,7 +1606,7 @@ DUK_LOCAL void duk__insert_jump_entry(duk_compiler_ctx *comp_ctx, duk_int_t jump
 	return;
 
   fail_bc_limit:
-	DUK_ERROR(comp_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_BYTECODE_LIMIT);
+	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_BYTECODE_LIMIT);
 }
 
 /* Does not assume that jump_pc contains a DUK_OP_JUMP previously; this is intentional
@@ -1661,7 +1661,7 @@ DUK_LOCAL void duk__patch_trycatch(duk_compiler_ctx *comp_ctx, duk_int_t ldconst
 			 */
 			DUK_D(DUK_DPRINT("failed to patch trycatch: flags=%ld, reg_catch=%ld, const_varname=%ld (0x%08lx)",
 			                 (long) flags, (long) reg_catch, (long) const_varname, (long) const_varname));
-			DUK_ERROR(comp_ctx->thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_REG_LIMIT);
+			DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
 		}
 		instr->ins |= DUK_ENC_OP_A_BC(0, 0, const_varname);
 	} else {
@@ -1860,7 +1860,7 @@ DUK_LOCAL duk_reg_t duk__alloctemps(duk_compiler_ctx *comp_ctx, duk_small_int_t 
 	comp_ctx->curr_func.temp_next += num;
 
 	if (comp_ctx->curr_func.temp_next > DUK__MAX_TEMPS) {  /* == DUK__MAX_TEMPS is OK */
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_TEMP_LIMIT);
+		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_TEMP_LIMIT);
 	}
 
 	/* maintain highest 'used' temporary, needed to figure out nregs of function */
@@ -1920,7 +1920,7 @@ DUK_LOCAL duk_regconst_t duk__getconst(duk_compiler_ctx *comp_ctx) {
 	}
 
 	if (n > DUK__MAX_CONSTS) {
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_CONST_LIMIT);
+		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_CONST_LIMIT);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("allocating new constant for %!T -> const index %ld",
@@ -2113,7 +2113,7 @@ duk_regconst_t duk__ispec_toregconst_raw(duk_compiler_ctx *comp_ctx,
 	}
 	}
 
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return 0;
 }
 
@@ -2337,7 +2337,7 @@ DUK_LOCAL void duk__ivalue_toplain_raw(duk_compiler_ctx *comp_ctx, duk_ivalue *x
 	}
 	}
 
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return;
 }
 
@@ -2559,7 +2559,7 @@ DUK_LOCAL void duk__add_label(duk_compiler_ctx *comp_ctx, duk_hstring *h_label, 
 		li--;
 
 		if (li->h_label == h_label && h_label != DUK_HTHREAD_STRING_EMPTY_STRING(thr)) {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_DUPLICATE_LABEL);
+			DUK_ERROR_SYNTAX(thr, DUK_STR_DUPLICATE_LABEL);
 		}
 	}
 
@@ -2689,7 +2689,7 @@ DUK_LOCAL void duk__lookup_active_label(duk_compiler_ctx *comp_ctx, duk_hstring 
 			 * finding a match deeper in the label stack.
 			 */
 			if (h_label != DUK_HTHREAD_STRING_EMPTY_STRING(thr)) {
-				DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_LABEL);
+				DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LABEL);
 			} else {
 				DUK_DDD(DUK_DDDPRINT("continue matched an empty label which does not "
 				                     "allow a continue -> continue lookup deeper in label stack"));
@@ -2698,7 +2698,7 @@ DUK_LOCAL void duk__lookup_active_label(duk_compiler_ctx *comp_ctx, duk_hstring 
 	}
 	/* XXX: match flag is awkward, rework */
 	if (!match) {
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_LABEL);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LABEL);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("label match: %!O -> label_id %ld, catch_depth=%ld, pc_label=%ld",
@@ -2882,7 +2882,7 @@ DUK_LOCAL void duk__nud_array_literal(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_ARRAY_LITERAL);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_ARRAY_LITERAL);
 }
 
 /* duplicate/invalid key checks; returns 1 if syntax error */
@@ -3183,7 +3183,7 @@ DUK_LOCAL void duk__nud_object_literal(duk_compiler_ctx *comp_ctx, duk_ivalue *r
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_OBJECT_LITERAL);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_OBJECT_LITERAL);
 }
 
 /* Parse argument list.  Arguments are written to temps starting from
@@ -3483,7 +3483,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 			duk_regconst_t rc_varname;
 
 			if (comp_ctx->curr_func.is_strict) {
-				DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_CANNOT_DELETE_IDENTIFIER);
+				DUK_ERROR_SYNTAX(thr, DUK_STR_CANNOT_DELETE_IDENTIFIER);
 			}
 
 			DUK__SETTEMP(comp_ctx, temp_at_entry);
@@ -3654,7 +3654,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 
 	}  /* end switch */
 
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_PARSE_ERROR);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
 	return;
 
  unary_extraop:
@@ -3757,7 +3757,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 	}
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_EXPRESSION);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_EXPRESSION);
 }
 
 /* XXX: add flag to indicate whether caller cares about return value; this
@@ -3812,7 +3812,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 		/* NB: must accept reserved words as property name */
 		if (comp_ctx->curr_token.t_nores != DUK_TOK_IDENTIFIER) {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_EXPECTED_IDENTIFIER);
+			DUK_ERROR_SYNTAX(thr, DUK_STR_EXPECTED_IDENTIFIER);
 		}
 
 		res->t = DUK_IVAL_PROP;
@@ -4206,7 +4206,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 	}
 
 	DUK_D(DUK_DPRINT("parse error: unexpected token: %ld", (long) tok));
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_PARSE_ERROR);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
 	return;
 
 #if 0
@@ -4641,11 +4641,11 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 	}
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_EXPRESSION);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_EXPRESSION);
 	return;
 
  syntax_error_lvalue:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_LVALUE);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LVALUE);
 	return;
 }
 
@@ -4730,7 +4730,7 @@ DUK_LOCAL void duk__expr(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_small_
 		/* XXX: possibly incorrect handling of empty expression */
 		DUK_DDD(DUK_DDDPRINT("empty expression"));
 		if (!(rbp_flags & DUK__EXPR_FLAG_ALLOW_EMPTY)) {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
+			DUK_ERROR_SYNTAX(thr, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
 		}
 		res->t = DUK_IVAL_PLAIN;
 		res->x1.t = DUK_ISPEC_VALUE;
@@ -4770,7 +4770,7 @@ DUK_LOCAL void duk__exprtop(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_sma
 	duk__expr(comp_ctx, res, rbp_flags);
 
 	if (!(rbp_flags & DUK__EXPR_FLAG_ALLOW_EMPTY) && duk__expr_is_empty(comp_ctx)) {
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
 	}
 }
 
@@ -4979,7 +4979,7 @@ DUK_LOCAL void duk__parse_var_decl(duk_compiler_ctx *comp_ctx, duk_ivalue *res, 
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_VAR_DECLARATION);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_VAR_DECLARATION);
 }
 
 DUK_LOCAL void duk__parse_var_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_small_uint_t expr_flags) {
@@ -5351,7 +5351,7 @@ DUK_LOCAL void duk__parse_for_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, 
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_FOR);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_FOR);
 }
 
 DUK_LOCAL void duk__parse_switch_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_int_t pc_label_site) {
@@ -5550,7 +5550,7 @@ DUK_LOCAL void duk__parse_switch_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_SWITCH);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_SWITCH);
 }
 
 DUK_LOCAL void duk__parse_if_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
@@ -5684,7 +5684,7 @@ DUK_LOCAL void duk__parse_break_or_continue_stmt(duk_compiler_ctx *comp_ctx, duk
 		duk__lookup_active_label(comp_ctx, comp_ctx->curr_token.str1, is_break, &label_id, &label_catch_depth, &label_pc, &label_is_closest);
 		duk__advance(comp_ctx);
 	} else {
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_BREAK_CONT_LABEL);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_BREAK_CONT_LABEL);
 	}
 
 	/* Use a fast break/continue when possible.  A fast break/continue is
@@ -5726,7 +5726,7 @@ DUK_LOCAL void duk__parse_return_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 	 * not as part of eval or global code.
 	 */
 	if (!comp_ctx->curr_func.is_function) {
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_RETURN);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_RETURN);
 	}
 
 	ret_flags = 0;
@@ -5823,7 +5823,7 @@ DUK_LOCAL void duk__parse_throw_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res
 	/* Unlike break/continue, throw statement does not allow an empty value. */
 
 	if (comp_ctx->curr_token.lineterm) {
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_THROW);
+		DUK_ERROR_SYNTAX(comp_ctx->thr, DUK_STR_INVALID_THROW);
 	}
 
 	reg_val = duk__exprtop_toreg(comp_ctx, res, DUK__BP_FOR_EXPR /*rbp_flags*/);
@@ -6064,7 +6064,7 @@ DUK_LOCAL void duk__parse_try_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) 
 	return;
 
  syntax_error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_TRY);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_TRY);
 }
 
 DUK_LOCAL void duk__parse_with_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
@@ -6074,7 +6074,7 @@ DUK_LOCAL void duk__parse_with_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res)
 	duk_small_uint_t trycatch_flags;
 
 	if (comp_ctx->curr_func.is_strict) {
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_WITH_IN_STRICT_MODE);
+		DUK_ERROR_SYNTAX(comp_ctx->thr, DUK_STR_WITH_IN_STRICT_MODE);
 	}
 
 	comp_ctx->curr_func.catch_depth++;
@@ -6256,7 +6256,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 			stmt_flags = 0;
 			break;
 		} else {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_FUNC_STMT_NOT_ALLOWED);
+			DUK_ERROR_SYNTAX(thr, DUK_STR_FUNC_STMT_NOT_ALLOWED);
 		}
 		break;
 	}
@@ -6593,7 +6593,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 				DUK_DDD(DUK_DDDPRINT("automatic semicolon terminates statement (allowed for compatibility "
 				                     "even though no lineterm present before next token)"));
 			} else {
-				DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_UNTERMINATED_STMT);
+				DUK_ERROR_SYNTAX(thr, DUK_STR_UNTERMINATED_STMT);
 			}
 		}
 	} else {
@@ -7018,12 +7018,12 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 	return;
 
  error_outofregs:
-	DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, DUK_STR_REG_LIMIT);
+	DUK_ERROR_RANGE(thr, DUK_STR_REG_LIMIT);
 	DUK_UNREACHABLE();
 	return;
 
  error_argname:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_ARG_NAME);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_ARG_NAME);
 	DUK_UNREACHABLE();
 	return;
 }
@@ -7272,7 +7272,7 @@ DUK_LOCAL void duk__parse_func_body(duk_compiler_ctx *comp_ctx, duk_bool_t expec
 		if (compile_round >= 3) {
 			/* Should never happen but avoid infinite loop just in case. */
 			DUK_D(DUK_DPRINT("more than 3 compile passes needed, should never happen"));
-			DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+			DUK_ERROR_INTERNAL_DEFMSG(thr);
 		}
 		DUK_D(DUK_DPRINT("need additional round to compile function, round now %d", (int) compile_round));
 	}
@@ -7320,7 +7320,7 @@ DUK_LOCAL void duk__parse_func_body(duk_compiler_ctx *comp_ctx, duk_bool_t expec
 	return;
 
  error_funcname:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_FUNC_NAME);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_FUNC_NAME);
 }
 
 /*
@@ -7369,7 +7369,7 @@ DUK_LOCAL void duk__parse_func_formals(duk_compiler_ctx *comp_ctx) {
 		 */
 
 		if (comp_ctx->curr_token.t != DUK_TOK_IDENTIFIER) {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, "expected identifier");
+			DUK_ERROR_SYNTAX(thr, "expected identifier");
 		}
 		DUK_ASSERT(comp_ctx->curr_token.t == DUK_TOK_IDENTIFIER);
 		DUK_ASSERT(comp_ctx->curr_token.str1 != NULL);
@@ -7424,7 +7424,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_bool_t i
 			duk_push_number(ctx, comp_ctx->curr_token.num);
 			duk_to_string(ctx, -1);
 		} else {
-			DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_GETSET_NAME);
+			DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_GETSET_NAME);
 		}
 		comp_ctx->curr_func.h_name = duk_get_hstring(ctx, -1);  /* borrowed reference */
 		DUK_ASSERT(comp_ctx->curr_func.h_name != NULL);
@@ -7443,7 +7443,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_bool_t i
 			/* valstack will be unbalanced, which is OK */
 			DUK_ASSERT(!is_setget);
 			if (is_decl) {
-				DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_FUNC_NAME_REQUIRED);
+				DUK_ERROR_SYNTAX(thr, DUK_STR_FUNC_NAME_REQUIRED);
 			}
 		}
 	}
@@ -7575,7 +7575,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_bo
 	fnum = old_func.fnum_next++;
 
 	if (fnum > DUK__MAX_FUNCS) {
-		DUK_ERROR(comp_ctx->thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_FUNC_LIMIT);
+		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_FUNC_LIMIT);
 	}
 
 	/* array writes autoincrement length */

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -990,7 +990,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 			                                      call_flags);    /* call_flags */
 			if (setup_rc == 0) {
 				/* Shouldn't happen but check anyway. */
-				DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+				DUK_ERROR_INTERNAL_DEFMSG(thr);
 			}
 
 			resumee->resumer = thr;
@@ -1214,7 +1214,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 	 * but it's better for internal errors to bubble outwards so that we won't
 	 * infinite loop in this catchpoint.
 	 */
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR_EXEC_LONGJMP);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	DUK_UNREACHABLE();
 	return retval;
 }
@@ -1292,7 +1292,7 @@ DUK_LOCAL void duk__handle_break_or_continue(duk_hthread *thr,
 
 	/* should never happen, but be robust */
 	DUK_D(DUK_DPRINT("-> break/continue not caught by anything in the current function (should never happen), throw internal error"));
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return;
 }
 
@@ -1732,7 +1732,7 @@ DUK_LOCAL duk_small_uint_t duk__executor_interrupt(duk_hthread *thr) {
 		thr->interrupt_init = 0;
 		thr->interrupt_counter = 0;
 		DUK_HEAP_CLEAR_INTERRUPT_RUNNING(thr->heap);
-		DUK_ERROR(thr, DUK_ERR_RANGE_ERROR, "execution timeout");
+		DUK_ERROR_RANGE(thr, "execution timeout");
 	}
 #endif  /* DUK_USE_EXEC_TIMEOUT_CHECK */
 
@@ -1951,7 +1951,7 @@ DUK_LOCAL void duk__executor_recheck_debugger(duk_hthread *thr, duk_activation *
 
 #ifdef DUK_USE_VERBOSE_EXECUTOR_ERRORS
 #define DUK__INTERNAL_ERROR(msg)  do { \
-		DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, (msg)); \
+		DUK_ERROR_INTERNAL(thr, (msg)); \
 	} while (0)
 #else
 #define DUK__INTERNAL_ERROR(msg)  do { \
@@ -2088,7 +2088,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 			DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
 			try {
 				DUK_ASSERT(heap->curr_thread != NULL);
-				DUK_ERROR(heap->curr_thread, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
+				DUK_ERROR_FMT1(heap->curr_thread, DUK_ERR_API_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
 				duk__handle_executor_error(heap,
@@ -2101,7 +2101,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 			DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
 			try {
 				DUK_ASSERT(heap->curr_thread != NULL);
-				DUK_ERROR(heap->curr_thread, DUK_ERR_API_ERROR, "caught invalid c++ exception (perhaps thrown by user code)");
+				DUK_ERROR_API(heap->curr_thread, "caught invalid c++ exception (perhaps thrown by user code)");
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
 				duk__handle_executor_error(heap,
@@ -3807,7 +3807,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			}
 
 			case DUK_EXTRAOP_INVALID: {
-				DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "INVALID opcode (%ld)", (long) DUK_DEC_BC(ins));
+				DUK_ERROR_FMT1(thr, DUK_ERR_INTERNAL_ERROR, "INVALID opcode (%ld)", (long) DUK_DEC_BC(ins));
 				break;
 			}
 
@@ -4475,7 +4475,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 #ifndef DUK_USE_VERBOSE_EXECUTOR_ERRORS
  internal_error:
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "internal error in bytecode executor");
+	DUK_ERROR_INTERNAL(thr, "internal error in bytecode executor");
 #endif
 }
 

--- a/src/duk_js_ops.c
+++ b/src/duk_js_ops.c
@@ -393,7 +393,7 @@ DUK_INTERNAL void duk_js_checkobjectcoercible(duk_hthread *thr, duk_tval *tv_x) 
 	    tag == DUK_TAG_NULL ||
 	    tag == DUK_TAG_POINTER ||
 	    tag == DUK_TAG_BUFFER) {
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "not object coercible");
+		DUK_ERROR_TYPE(thr, "not object coercible");
 	}
 }
 #endif
@@ -1081,7 +1081,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 			 *
 			 *  XXX: add a separate flag, DUK_HOBJECT_FLAG_ALLOW_INSTANCEOF?
 			 */
-			DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "invalid instanceof rval");
+			DUK_ERROR_TYPE(thr, "invalid instanceof rval");
 		}
 
 		if (!DUK_HOBJECT_HAS_BOUND(func)) {
@@ -1098,7 +1098,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 	} while (--sanity > 0);
 
 	if (sanity == 0) {
-		DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_BOUND_CHAIN_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_BOUND_CHAIN_LIMIT);
 	}
 
 	/*
@@ -1170,7 +1170,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 	} while (--sanity > 0);
 
 	if (sanity == 0) {
-		DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+		DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 	}
 	DUK_UNREACHABLE();
 

--- a/src/duk_js_var.c
+++ b/src/duk_js_var.c
@@ -1116,7 +1116,7 @@ duk_bool_t duk__get_identifier_reference(duk_hthread *thr,
 		}
 
                 if (sanity-- == 0) {
-                        DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+                        DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
                 }
 		env = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, env);
 	};
@@ -1254,9 +1254,9 @@ duk_bool_t duk__getvar_helper(duk_hthread *thr,
 		return 1;
 	} else {
 		if (throw_flag) {
-			DUK_ERROR(thr, DUK_ERR_REFERENCE_ERROR,
-			          "identifier '%s' undefined",
-			          (const char *) DUK_HSTRING_GET_DATA(name));
+			DUK_ERROR_FMT1(thr, DUK_ERR_REFERENCE_ERROR,
+			               "identifier '%s' undefined",
+			               (const char *) DUK_HSTRING_GET_DATA(name));
 		}
 
 		return 0;
@@ -1772,7 +1772,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 
  fail_existing_attributes:
  fail_not_extensible:
-	DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, "declaration failed");
+	DUK_ERROR_TYPE(thr, "declaration failed");
 	return 0;
 }
 

--- a/src/duk_numconv.c
+++ b/src/duk_numconv.c
@@ -2067,7 +2067,7 @@ DUK_INTERNAL void duk_numconv_parse(duk_context *ctx, duk_small_int_t radix, duk
 				 * doesn't need to get tracked using a bigint.
 				 */
 				DUK_DDD(DUK_DDDPRINT("parse failed: exponent too large"));
-				goto parse_int_error;
+				goto parse_explimit_error;
 			}
 			dig_expt++;
 		}
@@ -2259,8 +2259,8 @@ DUK_INTERNAL void duk_numconv_parse(duk_context *ctx, duk_small_int_t radix, duk
 	duk_push_nan(ctx);
 	return;
 
- parse_int_error:
+ parse_explimit_error:
 	DUK_DDD(DUK_DDDPRINT("parse failed, internal error, can't return a value"));
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "number parse error");
+	DUK_ERROR_RANGE(thr, "exponent too large");
 	return;
 }

--- a/src/duk_regexp_compiler.c
+++ b/src/duk_regexp_compiler.c
@@ -296,8 +296,7 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 	DUK_ASSERT(out_atom_info != NULL);
 
 	if (re_ctx->recursion_depth >= re_ctx->recursion_limit) {
-		DUK_ERROR(re_ctx->thr, DUK_ERR_RANGE_ERROR,
-		          DUK_STR_REGEXP_COMPILER_RECURSION_LIMIT);
+		DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_COMPILER_RECURSION_LIMIT);
 	}
 	re_ctx->recursion_depth++;
 
@@ -370,12 +369,10 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 		}
 		case DUK_RETOK_QUANTIFIER: {
 			if (atom_start_offset < 0) {
-				DUK_ERROR(re_ctx->thr, DUK_ERR_SYNTAX_ERROR,
-				          DUK_STR_INVALID_QUANTIFIER_NO_ATOM);
+				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_INVALID_QUANTIFIER_NO_ATOM);
 			}
 			if (re_ctx->curr_token.qmin > re_ctx->curr_token.qmax) {
-				DUK_ERROR(re_ctx->thr, DUK_ERR_SYNTAX_ERROR,
-				          DUK_STR_INVALID_QUANTIFIER_VALUES);
+				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_INVALID_QUANTIFIER_VALUES);
 			}
 			if (atom_char_length >= 0) {
 				/*
@@ -443,8 +440,7 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 				atom_copies = (re_ctx->curr_token.qmax == DUK_RE_QUANTIFIER_INFINITE) ?
 				              re_ctx->curr_token.qmin : re_ctx->curr_token.qmax;
 				if (atom_copies > DUK_RE_MAX_ATOM_COPIES) {
-					DUK_ERROR(re_ctx->thr, DUK_ERR_RANGE_ERROR,
-					          DUK_STR_QUANTIFIER_TOO_MANY_COPIES);
+					DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_QUANTIFIER_TOO_MANY_COPIES);
 				}
 
 				/* wipe the capture range made by the atom (if any) */
@@ -706,21 +702,18 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 		}
 		case DUK_RETOK_ATOM_END_GROUP: {
 			if (expect_eof) {
-				DUK_ERROR(re_ctx->thr, DUK_ERR_SYNTAX_ERROR,
-				          DUK_STR_UNEXPECTED_CLOSING_PAREN);
+				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_CLOSING_PAREN);
 			}
 			goto done;
 		}
 		case DUK_RETOK_EOF: {
 			if (!expect_eof) {
-				DUK_ERROR(re_ctx->thr, DUK_ERR_SYNTAX_ERROR,
-				          DUK_STR_UNEXPECTED_END_OF_PATTERN);
+				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_END_OF_PATTERN);
 			}
 			goto done;
 		}
 		default: {
-			DUK_ERROR(re_ctx->thr, DUK_ERR_SYNTAX_ERROR,
-			          DUK_STR_UNEXPECTED_REGEXP_TOKEN);
+			DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_REGEXP_TOKEN);
 		}
 		}
 
@@ -814,7 +807,7 @@ DUK_LOCAL duk_uint32_t duk__parse_regexp_flags(duk_hthread *thr, duk_hstring *h)
 	return flags;
 
  error:
-	DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_REGEXP_FLAGS);
+	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_REGEXP_FLAGS);
 	return 0;  /* never here */
 }
 
@@ -981,7 +974,7 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 	 */
 
 	if (re_ctx.highest_backref > re_ctx.captures) {
-		DUK_ERROR(thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_INVALID_BACKREFS);
+		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_BACKREFS);
 	}
 
 	/*

--- a/src/duk_regexp_executor.c
+++ b/src/duk_regexp_executor.c
@@ -67,7 +67,7 @@ DUK_LOCAL const duk_uint8_t *duk__utf8_backtrack(duk_hthread *thr, const duk_uin
 	return p;
 
  fail:
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_REGEXP_BACKTRACK_FAILED);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return NULL;  /* never here */
 }
 
@@ -98,7 +98,7 @@ DUK_LOCAL const duk_uint8_t *duk__utf8_advance(duk_hthread *thr, const duk_uint8
 	return p;
 
  fail:
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_REGEXP_ADVANCE_FAILED);
+	DUK_ERROR_INTERNAL_DEFMSG(thr);
 	return NULL;  /* never here */
 }
 
@@ -142,7 +142,7 @@ DUK_LOCAL duk_codepoint_t duk__inp_get_prev_cp(duk_re_matcher_ctx *re_ctx, const
 
 DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_uint8_t *pc, const duk_uint8_t *sp) {
 	if (re_ctx->recursion_depth >= re_ctx->recursion_limit) {
-		DUK_ERROR(re_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_REGEXP_EXECUTOR_RECURSION_LIMIT);
+		DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_EXECUTOR_RECURSION_LIMIT);
 	}
 	re_ctx->recursion_depth++;
 
@@ -150,7 +150,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 		duk_small_int_t op;
 
 		if (re_ctx->steps_count >= re_ctx->steps_limit) {
-			DUK_ERROR(re_ctx->thr, DUK_ERR_RANGE_ERROR, DUK_STR_REGEXP_EXECUTOR_STEP_LIMIT);
+			DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_EXECUTOR_STEP_LIMIT);
 		}
 		re_ctx->steps_count++;
 
@@ -641,7 +641,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 	return NULL;
 
  internal_error:
-	DUK_ERROR(re_ctx->thr, DUK_ERR_INTERNAL_ERROR, DUK_STR_REGEXP_INTERNAL_ERROR);
+	DUK_ERROR_INTERNAL_DEFMSG(re_ctx->thr);
 	return NULL;  /* never here */
 }
 

--- a/src/duk_strings.c
+++ b/src/duk_strings.c
@@ -31,7 +31,6 @@ DUK_INTERNAL const char *duk_str_sprintf_too_long = "sprintf message too long";
 DUK_INTERNAL const char *duk_str_alloc_failed = "alloc failed";
 DUK_INTERNAL const char *duk_str_pop_too_many = "attempt to pop too many entries";
 DUK_INTERNAL const char *duk_str_wrong_buffer_type = "wrong buffer type";
-DUK_INTERNAL const char *duk_str_failed_to_extend_valstack = "failed to extend valstack";
 DUK_INTERNAL const char *duk_str_encode_failed = "encode failed";
 DUK_INTERNAL const char *duk_str_decode_failed = "decode failed";
 DUK_INTERNAL const char *duk_str_no_sourcecode = "no sourcecode";
@@ -49,7 +48,6 @@ DUK_INTERNAL const char *duk_str_cyclic_input = "cyclic input";
 
 /* Object property access */
 DUK_INTERNAL const char *duk_str_proxy_revoked = "proxy revoked";
-DUK_INTERNAL const char *duk_str_object_resize_failed = "object resize failed";
 DUK_INTERNAL const char *duk_str_invalid_base = "invalid base value";
 DUK_INTERNAL const char *duk_str_strict_caller_read = "attempt to read strict 'caller'";
 DUK_INTERNAL const char *duk_str_proxy_rejected = "proxy rejected";
@@ -87,9 +85,6 @@ DUK_INTERNAL const char *duk_str_invalid_func_name = "invalid function name";
 DUK_INTERNAL const char *duk_str_invalid_getset_name = "invalid getter/setter name";
 DUK_INTERNAL const char *duk_str_func_name_required = "function name required";
 
-/* Executor */
-DUK_INTERNAL const char *duk_str_internal_error_exec_longjmp = "internal error in bytecode executor longjmp handler";
-
 /* Regexp */
 DUK_INTERNAL const char *duk_str_invalid_quantifier_no_atom = "quantifier without preceding atom";
 DUK_INTERNAL const char *duk_str_invalid_quantifier_values = "quantifier values invalid (qmin > qmax)";
@@ -99,15 +94,11 @@ DUK_INTERNAL const char *duk_str_unexpected_end_of_pattern = "unexpected end of 
 DUK_INTERNAL const char *duk_str_unexpected_regexp_token = "unexpected token in regexp";
 DUK_INTERNAL const char *duk_str_invalid_regexp_flags = "invalid regexp flags";
 DUK_INTERNAL const char *duk_str_invalid_backrefs = "invalid backreference(s)";
-DUK_INTERNAL const char *duk_str_regexp_backtrack_failed = "regexp backtrack failed";
-DUK_INTERNAL const char *duk_str_regexp_advance_failed = "regexp advance failed";
-DUK_INTERNAL const char *duk_str_regexp_internal_error = "regexp internal error";
 
 /* Limits */
 DUK_INTERNAL const char *duk_str_valstack_limit = "valstack limit";
 DUK_INTERNAL const char *duk_str_callstack_limit = "callstack limit";
 DUK_INTERNAL const char *duk_str_catchstack_limit = "catchstack limit";
-DUK_INTERNAL const char *duk_str_object_property_limit = "object property limit";
 DUK_INTERNAL const char *duk_str_prototype_chain_limit = "prototype chain limit";
 DUK_INTERNAL const char *duk_str_bound_chain_limit = "function call bound chain limit";
 DUK_INTERNAL const char *duk_str_c_callstack_limit = "C call stack depth limit";
@@ -122,4 +113,3 @@ DUK_INTERNAL const char *duk_str_regexp_executor_recursion_limit = "regexp execu
 DUK_INTERNAL const char *duk_str_regexp_executor_step_limit = "regexp step limit";
 
 /* Misc */
-DUK_INTERNAL const char *duk_str_realloc_failed = "realloc failed";

--- a/src/duk_strings.h
+++ b/src/duk_strings.h
@@ -68,7 +68,6 @@ DUK_INTERNAL_DECL const char *duk_str_not_configurable;
 #define DUK_STR_ALLOC_FAILED duk_str_alloc_failed
 #define DUK_STR_POP_TOO_MANY duk_str_pop_too_many
 #define DUK_STR_WRONG_BUFFER_TYPE duk_str_wrong_buffer_type
-#define DUK_STR_FAILED_TO_EXTEND_VALSTACK duk_str_failed_to_extend_valstack
 #define DUK_STR_ENCODE_FAILED duk_str_encode_failed
 #define DUK_STR_DECODE_FAILED duk_str_decode_failed
 #define DUK_STR_NO_SOURCECODE duk_str_no_sourcecode
@@ -91,7 +90,6 @@ DUK_INTERNAL_DECL const char *duk_str_sprintf_too_long;
 DUK_INTERNAL_DECL const char *duk_str_alloc_failed;
 DUK_INTERNAL_DECL const char *duk_str_pop_too_many;
 DUK_INTERNAL_DECL const char *duk_str_wrong_buffer_type;
-DUK_INTERNAL_DECL const char *duk_str_failed_to_extend_valstack;
 DUK_INTERNAL_DECL const char *duk_str_encode_failed;
 DUK_INTERNAL_DECL const char *duk_str_decode_failed;
 DUK_INTERNAL_DECL const char *duk_str_no_sourcecode;
@@ -116,7 +114,6 @@ DUK_INTERNAL_DECL const char *duk_str_cyclic_input;
 #endif  /* !DUK_SINGLE_FILE */
 
 #define DUK_STR_PROXY_REVOKED duk_str_proxy_revoked
-#define DUK_STR_OBJECT_RESIZE_FAILED duk_str_object_resize_failed
 #define DUK_STR_INVALID_BASE duk_str_invalid_base
 #define DUK_STR_STRICT_CALLER_READ duk_str_strict_caller_read
 #define DUK_STR_PROXY_REJECTED duk_str_proxy_rejected
@@ -130,7 +127,6 @@ DUK_INTERNAL_DECL const char *duk_str_cyclic_input;
 
 #if !defined(DUK_SINGLE_FILE)
 DUK_INTERNAL_DECL const char *duk_str_proxy_revoked;
-DUK_INTERNAL_DECL const char *duk_str_object_resize_failed;
 DUK_INTERNAL_DECL const char *duk_str_invalid_base;
 DUK_INTERNAL_DECL const char *duk_str_strict_caller_read;
 DUK_INTERNAL_DECL const char *duk_str_proxy_rejected;
@@ -195,12 +191,6 @@ DUK_INTERNAL_DECL const char *duk_str_invalid_getset_name;
 DUK_INTERNAL_DECL const char *duk_str_func_name_required;
 #endif  /* !DUK_SINGLE_FILE */
 
-#define DUK_STR_INTERNAL_ERROR_EXEC_LONGJMP duk_str_internal_error_exec_longjmp
-
-#if !defined(DUK_SINGLE_FILE)
-DUK_INTERNAL_DECL const char *duk_str_internal_error_exec_longjmp;
-#endif  /* !DUK_SINGLE_FILE */
-
 #define DUK_STR_INVALID_QUANTIFIER_NO_ATOM duk_str_invalid_quantifier_no_atom
 #define DUK_STR_INVALID_QUANTIFIER_VALUES duk_str_invalid_quantifier_values
 #define DUK_STR_QUANTIFIER_TOO_MANY_COPIES duk_str_quantifier_too_many_copies
@@ -209,9 +199,6 @@ DUK_INTERNAL_DECL const char *duk_str_internal_error_exec_longjmp;
 #define DUK_STR_UNEXPECTED_REGEXP_TOKEN duk_str_unexpected_regexp_token
 #define DUK_STR_INVALID_REGEXP_FLAGS duk_str_invalid_regexp_flags
 #define DUK_STR_INVALID_BACKREFS duk_str_invalid_backrefs
-#define DUK_STR_REGEXP_BACKTRACK_FAILED duk_str_regexp_backtrack_failed
-#define DUK_STR_REGEXP_ADVANCE_FAILED duk_str_regexp_advance_failed
-#define DUK_STR_REGEXP_INTERNAL_ERROR duk_str_regexp_internal_error
 
 #if !defined(DUK_SINGLE_FILE)
 DUK_INTERNAL_DECL const char *duk_str_invalid_quantifier_no_atom;
@@ -222,15 +209,11 @@ DUK_INTERNAL_DECL const char *duk_str_unexpected_end_of_pattern;
 DUK_INTERNAL_DECL const char *duk_str_unexpected_regexp_token;
 DUK_INTERNAL_DECL const char *duk_str_invalid_regexp_flags;
 DUK_INTERNAL_DECL const char *duk_str_invalid_backrefs;
-DUK_INTERNAL_DECL const char *duk_str_regexp_backtrack_failed;
-DUK_INTERNAL_DECL const char *duk_str_regexp_advance_failed;
-DUK_INTERNAL_DECL const char *duk_str_regexp_internal_error;
 #endif  /* !DUK_SINGLE_FILE */
 
 #define DUK_STR_VALSTACK_LIMIT duk_str_valstack_limit
 #define DUK_STR_CALLSTACK_LIMIT duk_str_callstack_limit
 #define DUK_STR_CATCHSTACK_LIMIT duk_str_catchstack_limit
-#define DUK_STR_OBJECT_PROPERTY_LIMIT duk_str_object_property_limit
 #define DUK_STR_PROTOTYPE_CHAIN_LIMIT duk_str_prototype_chain_limit
 #define DUK_STR_BOUND_CHAIN_LIMIT duk_str_bound_chain_limit
 #define DUK_STR_C_CALLSTACK_LIMIT duk_str_c_callstack_limit
@@ -248,7 +231,6 @@ DUK_INTERNAL_DECL const char *duk_str_regexp_internal_error;
 DUK_INTERNAL_DECL const char *duk_str_valstack_limit;
 DUK_INTERNAL_DECL const char *duk_str_callstack_limit;
 DUK_INTERNAL_DECL const char *duk_str_catchstack_limit;
-DUK_INTERNAL_DECL const char *duk_str_object_property_limit;
 DUK_INTERNAL_DECL const char *duk_str_prototype_chain_limit;
 DUK_INTERNAL_DECL const char *duk_str_bound_chain_limit;
 DUK_INTERNAL_DECL const char *duk_str_c_callstack_limit;
@@ -263,11 +245,8 @@ DUK_INTERNAL_DECL const char *duk_str_regexp_executor_recursion_limit;
 DUK_INTERNAL_DECL const char *duk_str_regexp_executor_step_limit;
 #endif  /* !DUK_SINGLE_FILE */
 
-#define DUK_STR_REALLOC_FAILED duk_str_realloc_failed
-
 #if !defined(DUK_SINGLE_FILE)
 DUK_INTERNAL_DECL const char *duk_str_anon;
-DUK_INTERNAL_DECL const char *duk_str_realloc_failed;
 #endif  /* !DUK_SINGLE_FILE */
 
 #endif  /* DUK_ERRMSG_H_INCLUDED */

--- a/src/duk_unicode_support.c
+++ b/src/duk_unicode_support.c
@@ -270,7 +270,7 @@ DUK_INTERNAL duk_ucodepoint_t duk_unicode_decode_xutf8_checked(duk_hthread *thr,
 	if (duk_unicode_decode_xutf8(thr, ptr, ptr_start, ptr_end, &cp)) {
 		return cp;
 	}
-	DUK_ERROR(thr, DUK_ERR_INTERNAL_ERROR, "utf-8 decode failed");
+	DUK_ERROR_INTERNAL(thr, "utf-8 decode failed");  /* XXX: 'internal error' is a bit of a misnomer */
 	DUK_UNREACHABLE();
 	return 0;
 }

--- a/src/duk_util_bufwriter.c
+++ b/src/duk_util_bufwriter.c
@@ -65,7 +65,7 @@ DUK_INTERNAL duk_uint8_t *duk_bw_resize(duk_hthread *thr, duk_bufwriter_ctx *bw_
 	new_sz = curr_off + sz + add_sz;
 	if (new_sz < curr_off) {
 		/* overflow */
-		DUK_ERROR(thr, DUK_ERR_TYPE_ERROR, DUK_STR_BUFFER_TOO_LONG);
+		DUK_ERROR_RANGE(thr, DUK_STR_BUFFER_TOO_LONG);
 		return NULL;  /* not reachable */
 	}
 #if 0  /* for manual torture testing: tight allocation, useful with valgrind */

--- a/tests/api/test-dev-prototype-loop.c
+++ b/tests/api/test-dev-prototype-loop.c
@@ -43,7 +43,7 @@ second gc
 *** test_is_prototype_of (duk_safe_call)
 Object.prototype.isPrototypeOf result: false
 Object.prototype.isPrototypeOf result: true
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 *** test_error_augment (duk_safe_call)
 ret=1
 throw value .foo=123
@@ -51,22 +51,22 @@ throw value .foo=123
 *** test_hasprop (duk_safe_call)
 hasprop foo: 1
 hasprop bar: 1
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 *** test_getprop (duk_safe_call)
 getprop foo: 123
 getprop bar: 321
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 *** test_putprop (duk_safe_call)
 putprop foo done
 putprop bar done
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 *** test_instanceof (duk_safe_call)
 object function
 true
 object function
 true
 object function
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 still here
 ===*/
 

--- a/tests/api/test-get-set-prototype.c
+++ b/tests/api/test-get-set-prototype.c
@@ -40,7 +40,7 @@ set obj0 prototype to obj1
 set obj1 prototype to obj0
 obj0.foo=123
 obj0.bar=123
-==> rc=1, result='Error: prototype chain limit'
+==> rc=1, result='RangeError: prototype chain limit'
 ===*/
 
 /* Multiple basic tests in one: test duk_set_prototype() and duk_get_prototype()

--- a/tests/ecmascript/test-bug-nregs-limit-gh111.js
+++ b/tests/ecmascript/test-bug-nregs-limit-gh111.js
@@ -10,9 +10,9 @@
 
 /*===
 65531
-Error
-Error
-Error
+RangeError
+RangeError
+RangeError
 ===*/
 
 function test(n) {

--- a/tests/ecmascript/test-numconv-parse-explimit.js
+++ b/tests/ecmascript/test-numconv-parse-explimit.js
@@ -9,14 +9,14 @@
 1e-1000000 number 0
 1e1000000000 number Infinity
 1e-1000000000 number 0
-Error
-Error
-Error
-Error
-Error
-Error
-Error
-Error
+RangeError
+RangeError
+RangeError
+RangeError
+RangeError
+RangeError
+RangeError
+RangeError
 ===*/
 
 /* There is an implementation limit for the maximum exponent value


### PR DESCRIPTION
Saves a little bit on footprint because internal call sites will be smaller.

Some error types also changed internally from internal error to range error. This is more consistent with the idea that an internal error indicates an actual error (perhaps a bug) while a range error indicates an internal limit being hit (range error is also used for executor timeouts etc).

Fixes #456.

Tasks:

- [x] Implement the error macros and change call sites
- [x] Remove (now) unused strings
- [x] Rework error macro and helper argument order to avoid 'thr' shuffling
- [x] Remove variadic macros (portability) and vararg function call for non-formatted call sites (vararg call site is larger than non-vararg)
- [x] Pack error code (8-bit) and internal line number into a single argument to remove one unnecessary constant load
- [x] Add automatic regression coverage for all error variants: (1) verbose and paranoid, (2) verbose and non-paranoid, (3) non-verbose
- [x] Fix testcases affected by error code changes
- [x] Check documentation for range error vs. internal error discussion
- [x] Check code issues for log vararg discussion
- [x] Check documentation for macro vararg limitations, e.g. threading (no such issues for internal errors anymore, only for debug macros and public API `__FILE__` and `__LINE__` capture)
- [x] Releases: note on error code changes