### PR TITLE
Suppress some harmless scanbuild warnings, cmdline realloc() leak fix

### DIFF
--- a/examples/alloc-logging/duk_alloc_logging.c
+++ b/examples/alloc-logging/duk_alloc_logging.c
@@ -90,8 +90,8 @@ void *duk_realloc_logging(void *udata, void *ptr, duk_size_t size) {
 		old_size = hdr->u.sz;
 
 		if (size == 0) {
-			free((void *) hdr);
 			write_log("R %p %ld NULL 0\n", ptr, (long) old_size);
+			free((void *) hdr);
 			return NULL;
 		} else {
 			t = realloc((void *) hdr, size + sizeof(alloc_hdr));

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -318,14 +318,16 @@ static int handle_fh(duk_context *ctx, FILE *f, const char *filename, const char
 		avail = bufsz - bufoff;
 		if (avail < 1024) {
 			size_t newsz;
+			char *buf_new;
 #if 0
 			fprintf(stderr, "resizing read buffer: %ld -> %ld\n", (long) bufsz, (long) (bufsz * 2));
 #endif
 			newsz = bufsz + (bufsz >> 2) + 1024;  /* +25% and some extra */
-			buf = (char *) realloc(buf, newsz);
-			if (!buf) {
+			buf_new = (char *) realloc(buf, newsz);
+			if (!buf_new) {
 				goto error;
 			}
+			buf = buf_new;
 			bufsz = newsz;
 		}
 
@@ -411,6 +413,7 @@ static int handle_fh(duk_context *ctx, FILE *f, const char *filename, const char
  cleanup:
 	if (buf) {
 		free(buf);
+		buf = NULL;
 	}
 	return retval;
 

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -2101,7 +2101,7 @@ DUK_EXTERNAL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, 
 }
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)  /* only needed by debugger for now */
-DUK_EXTERNAL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t index) {
 	(void) duk_safe_to_string(ctx, index);
 	DUK_ASSERT(duk_is_string(ctx, index));
 	DUK_ASSERT(duk_get_hstring(ctx, index) != NULL);
@@ -2184,10 +2184,12 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index,
 	} else {
 		res = (duk_int_t) d;
 	}
+	DUK_UNREF(d);  /* SCANBUILD: with suitable dmin/dmax limits 'd' is unused */
 	/* 'd' and 'res' agree here */
 
 	/* Relookup in case duk_js_tointeger() ends up e.g. coercing an object. */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_get_tval(ctx, index);
+	DUK_ASSERT(tv != NULL);  /* not popped by side effect */
 	DUK_TVAL_SET_TVAL(&tv_tmp, tv);
 #if defined(DUK_USE_FASTINT)
 #if (DUK_INT_MAX <= 0x7fffffffL)

--- a/src/duk_bi_date_unix.c
+++ b/src/duk_bi_date_unix.c
@@ -129,8 +129,6 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 	t = (time_t) (d / 1000.0);
 	DUK_DDD(DUK_DDDPRINT("timeval: %lf -> time_t %ld", (double) d, (long) t));
 
-	t1 = t;
-
 	DUK_MEMZERO((void *) tms, sizeof(struct tm) * 2);
 
 #if defined(DUK_USE_DATE_TZO_GMTIME_R)

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -1375,6 +1375,7 @@ DUK_LOCAL void duk__debug_handle_get_call_stack(duk_hthread *thr, duk_heap *heap
 	duk_uint_fast32_t line;
 	duk_size_t i;
 
+	DUK_ASSERT(thr != NULL);
 	DUK_UNREF(heap);
 
 	duk_debug_write_reply(thr);
@@ -1413,6 +1414,9 @@ DUK_LOCAL void duk__debug_handle_get_call_stack(duk_hthread *thr, duk_heap *heap
 		}
 		curr_thr = curr_thr->resumer;
 	}
+	/* SCANBUILD: warning about 'thr' potentially being NULL here,
+	 * warning is incorrect because thr != NULL always here.
+	 */
 	duk_debug_write_eom(thr);
 }
 

--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -4937,7 +4937,6 @@ void duk_hobject_prepare_property_descriptor(duk_context *ctx,
 		duk_tval *tv = duk_require_tval(ctx, -1);
 		duk_hobject *h_set;
 
-		is_acc_desc = 1;
 		if (DUK_TVAL_IS_UNDEFINED(tv)) {
 			/* undefined is accepted */
 			DUK_ASSERT(setter == NULL);

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -1744,6 +1744,7 @@ DUK_LOCAL duk_small_uint_t duk__executor_interrupt(duk_hthread *thr) {
 		 */
 		duk__interrupt_handle_debugger(thr, &immediate, &retval);
 		act = thr->callstack + thr->callstack_top - 1;  /* relookup if changed */
+		DUK_UNREF(act);  /* 'act' is no longer accessed, scanbuild fix */
 	}
 #endif  /* DUK_USE_DEBUGGER_SUPPORT */
 
@@ -3506,6 +3507,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 					/* must relookup act in case of side effects */
 					duk_js_init_activation_environment_records_delayed(thr, act);
 					act = thr->callstack + thr->callstack_top - 1;
+					DUK_UNREF(act);  /* 'act' is no longer accessed, scanbuild fix */
 				}
 				DUK_ASSERT(act->lex_env != NULL);
 				DUK_ASSERT(act->var_env != NULL);


### PR DESCRIPTION
Fix duk_cmdline.c incorrect realloc() error handling where original buffer being reallocated might leak. Other scanbuild warnings are harmless; there are a few remaining issues which are intentional and harmless (e.g. intentional segfault on panic).
