### PR TITLE
Check bytecode flags directly without decoding opcode fields

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1839,7 +1839,7 @@ Planned
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for
   Array .length coercion (GH-862); value stack operation optimization
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
-  opcode handler optimizations (GH-903)
+  opcode handler optimizations (GH-903, GH-672)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src/duk_js_bytecode.h
+++ b/src/duk_js_bytecode.h
@@ -459,9 +459,6 @@ typedef duk_uint32_t duk_instr_t;
 #define DUK_BC_TRYCATCH_FLAG_CATCH_BINDING  (1 << 2)
 #define DUK_BC_TRYCATCH_FLAG_WITH_BINDING   (1 << 3)
 
-/* DUK_OP_RETURN flags in A */
-#define DUK_BC_RETURN_FLAG_HAVE_RETVAL      (1 << 0)
-
 /* DUK_OP_DECLVAR flags in A; bottom bits are reserved for propdesc flags (DUK_PROPDESC_FLAG_XXX) */
 #define DUK_BC_DECLVAR_FLAG_UNDEF_VALUE     (1 << 4)  /* use 'undefined' for value automatically */
 #define DUK_BC_DECLVAR_FLAG_FUNC_DECL       (1 << 5)  /* function declaration */


### PR DESCRIPTION
Check opcode flags directly from the instruction without decoding the field first. This has lower footprint, performance impact to be verified.

Also change some `DUK__REGCONSTP(b)` to `DUK__REGCONSTP_B(ins)`, etc.

Tasks:

- [ ] Change flag decoding
- [ ] Releases entry