### PR TITLE
Add Kraken benchmark support files

### DIFF
--- a/tests/google-v8-benchmark-v7/README.rst
+++ b/tests/google-v8-benchmark-v7/README.rst
@@ -1,0 +1,11 @@
+===================
+Google V8 benchmark
+===================
+
+Create a combined test file::
+
+    $ make
+
+Run the combined test file e.g. as::
+
+    $ time ./duk combined.js

--- a/tests/kraken-benchmark/README.rst
+++ b/tests/kraken-benchmark/README.rst
@@ -1,0 +1,14 @@
+================
+Kraken benchmark
+================
+
+Download a Kraken snapshot and unpack it, for example:
+
+* http://hg.mozilla.org/projects/kraken/file/e119421cb325
+
+Then use ``kraken_duk.py`` as the test driver; for now::
+
+    $ cd kraken-e119421cb325
+    $ cp ../kraken_duk.py ../kraken_harness.js .   # some path assumptions
+    $ cp /path/to/my/duk duk    # hardcoded assumption in kraken_duk.py now
+    $ ./sunspider --shell ./kraken_duk.py --suite kraken-1.0 --runs 10

--- a/tests/kraken-benchmark/kraken_duk.py
+++ b/tests/kraken-benchmark/kraken_duk.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+import subprocess
+
+DUK_COMMAND = './duk'
+LOG_FILE = '/tmp/kraken_duk.log'
+HARNESS_FILE = './kraken_harness.js'
+
+def parse_opts():
+    res = []
+    opt = None
+    for i in sys.argv[1:]:
+        if opt is not None:
+            if i[0] == '-':
+                raise Exception('invalid argument: ' + repr(i))
+            res.append(i)
+            opt = None
+        else:
+            if i == '-f':
+                opt = i
+            else:
+                raise Exception('invalid option: ' + repr(i))
+    return res
+
+def main():
+    logfile = open(LOG_FILE, 'ab')
+
+    logfile.write('\n*** Running: ' + repr(sys.argv) + '\n\n')
+    logfile.flush()
+
+    files = parse_opts()
+    cmd = [ DUK_COMMAND, HARNESS_FILE ] + files
+
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ret = proc.communicate(input='')
+    logfile.write(ret[0])
+    logfile.write(ret[1])
+    logfile.flush()
+    sys.stdout.write(ret[0])
+    sys.stderr.write(ret[1])
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.exit(proc.returncode)
+
+if __name__ == '__main__':
+    main()

--- a/tests/kraken-benchmark/kraken_harness.js
+++ b/tests/kraken-benchmark/kraken_harness.js
@@ -1,0 +1,25 @@
+/*
+ *  Harness / glue functions for running Kraken
+ *
+ *  Don't print() anything here because it's used by the 'sunspider' command
+ *  to build loadable source files for result analysis.
+ */
+
+function load(filename) {
+    alert('Load: ' + filename);
+    if (typeof readFile !== 'function') {
+        throw new Error('expecting "duk" to provide file i/o bindings');
+    }
+    try {
+        var indirectEval = eval;  // use indirect eval to ensure 'var xxx = ...' gets registered to global variables
+        var data = readFile(filename);
+        return indirectEval('' + data);
+    } catch (e) {
+        alert(e.stack || e);  // may fail on purpose if file not found, just log
+        return;
+    }
+}
+
+function gc() {
+    Duktape.gc();
+}


### PR DESCRIPTION
Minimal Kraken support:

- Add a "shell" which accepts Kraken `sunspider` command argument format and runs `duk` with converted arguments.
- Add `kraken_harness.js` to provide a few bindings expected by Kraken

No Makefile or runner files etc.