### PR TITLE
Use single shift+mask in executor reg/const access

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1693,6 +1693,9 @@ Planned
 * Fix -Wshift-sign-overflow warnings on some Clang versions for signed left
   shifts whose result was used as unsigned (GH-812, GH-813)
 
+* Internal performance improvement: avoid one extra shift when computing
+  reg/const pointers in the bytecode executor (GH-674)
+
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than
   being declared as actual symbols; this reduces compilation warnings with

--- a/config/config-options/DUK_USE_EXEC_REGCONST_OPTIMIZE.yaml
+++ b/config/config-options/DUK_USE_EXEC_REGCONST_OPTIMIZE.yaml
@@ -1,0 +1,11 @@
+define: DUK_USE_EXEC_REGCONST_OPTIMIZE
+introduced: 2.0.0
+default: true
+tags:
+  - performance
+  - execution
+description: >
+  Use an internal optimization to access registers and constants in the
+  bytecode executor.  The optimization avoids unnecessary shifts when computing
+  addresses but assumes sizeof(duk_tval) is 8 or 16.  This is almost always the
+  case, but when it isn't, disable this option.

--- a/src/duk_heap_alloc.c
+++ b/src/duk_heap_alloc.c
@@ -746,11 +746,30 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	/*
 	 *  If selftests enabled, run them as early as possible.
 	 */
+
 #if defined(DUK_USE_SELF_TESTS)
 	if (duk_selftest_run_tests() > 0) {
 		fatal_func(heap_udata, "self test(s) failed");
 	}
 #endif
+
+	/*
+	 *  Important assert-like checks that should be enabled even
+	 *  when assertions are otherwise not enabled.
+	 */
+
+#if defined(DUK_USE_EXEC_REGCONST_OPTIMIZE)
+	/* Can't check sizeof() using preprocessor so explicit check.
+	 * This will be optimized away in practice.
+	 */
+#if defined(DUK_USE_PACKED_TVAL)
+	if (sizeof(duk_tval) != 8) {
+#else
+	if (sizeof(duk_tval) != 16) {
+#endif
+		fatal_func(heap_udata, "sizeof(duk_tval) not 8 or 16, cannot use DUK_USE_EXEC_REGCONST_OPTIMIZE option");
+	}
+#endif  /* DUK_USE_EXEC_REGCONST_OPTIMIZE */
 
 	/*
 	 *  Computed values (e.g. INFINITY)

--- a/src/duk_js_bytecode.h
+++ b/src/duk_js_bytecode.h
@@ -31,6 +31,17 @@
 
 typedef duk_uint32_t duk_instr_t;
 
+#define DUK_BC_SHIFT_OP             0
+#define DUK_BC_SHIFT_A              6
+#define DUK_BC_SHIFT_B              14
+#define DUK_BC_SHIFT_C              23
+
+#define DUK_BC_UNSHIFTED_MASK_OP    0x3fUL
+#define DUK_BC_UNSHIFTED_MASK_A     0xffUL
+#define DUK_BC_UNSHIFTED_MASK_B     0x1ffUL
+#define DUK_BC_UNSHIFTED_MASK_C     0x1ffUL
+#define DUK_BC_UNSHIFTED_MASK_BC    0x3ffffUL
+
 #define DUK_DEC_OP(x)               ((x) & 0x3fUL)
 #define DUK_DEC_A(x)                (((x) >> 6) & 0xffUL)
 #define DUK_DEC_B(x)                (((x) >> 14) & 0x1ffUL)


### PR DESCRIPTION
Instead of decoding a field (say A) and then computing DUK__REGP which involves further shifting of the value, add macros such as DUK__REGP_A(ins) which operate directly on the 32-bit 'ins' and use a single shift+mask to get the byte offset (rather than element offset) for the target reg/const. Performance and footprint impact not yet evaluated.

- [x] Config option DUK_USE_EXEC_REGCONST_OPTIMIZE for enabling/disabling the optimization; it assumes sizeof(duk_tval) is 8 or 16 which is almost always (but not always) the case
- [x] Heap alloc check for sizeof() assumption (even with assertions disabled) because sizeof() cannot be detected by preprocessor
- [x] Unit test coverage for DUK_USE_EXEC_REGCONST_OPTIMIZE, otherwise cold macro path
- [x] Releases entry