### PR TITLE
Remove experimental status from established API calls

### DIFF
--- a/website/api/duk_config_buffer.yaml
+++ b/website/api/duk_config_buffer.yaml
@@ -19,7 +19,6 @@ example: |
 tags:
   - stack
   - buffer
-  - experimental
 
 seealso:
   - duk_push_external_buffer

--- a/website/api/duk_dump_function.yaml
+++ b/website/api/duk_dump_function.yaml
@@ -23,7 +23,6 @@ example: |
 tags:
   - stack
   - bytecode
-  - experimental
 
 seealso:
   - duk_load_function

--- a/website/api/duk_get_buffer_data.yaml
+++ b/website/api/duk_get_buffer_data.yaml
@@ -57,7 +57,6 @@ tags:
   - stack
   - buffer
   - bufferobject
-  - experimental
 
 seealso:
   - duk_require_buffer_data

--- a/website/api/duk_load_function.yaml
+++ b/website/api/duk_load_function.yaml
@@ -28,7 +28,6 @@ example: |
 tags:
   - stack
   - bytecode
-  - experimental
 
 seealso:
   - duk_dump_function

--- a/website/api/duk_push_buffer_object.yaml
+++ b/website/api/duk_push_buffer_object.yaml
@@ -59,7 +59,6 @@ example: |
 tags:
   - stack
   - bufferobject
-  - experimental
 
 seealso:
   - duk_push_buffer

--- a/website/api/duk_push_external_buffer.yaml
+++ b/website/api/duk_push_external_buffer.yaml
@@ -45,7 +45,6 @@ example: |
 tags:
   - stack
   - buffer
-  - experimental
 
 seealso:
   - duk_config_buffer

--- a/website/api/duk_require_buffer_data.yaml
+++ b/website/api/duk_require_buffer_data.yaml
@@ -22,7 +22,6 @@ tags:
   - stack
   - buffer
   - bufferobject
-  - experimental
 
 seealso:
   - duk_get_buffer_data

--- a/website/api/duk_set_global_object.yaml
+++ b/website/api/duk_set_global_object.yaml
@@ -19,11 +19,6 @@ summary: |
   <a href="https://github.com/svaarala/duktape/blob/master/tests/api/test-set-global-object.c">test-set-global-object.c</a>
   for discussion of detailed behavior after the change.</p>
 
-  <div class="note">
-  This API call is experimental at present, and some of the semantics may
-  change when other sandboxing features are implemented.
-  </div>
-
 example: |
   /* Build a global object with a subset of bindings. */
   duk_eval_string(ctx,
@@ -39,6 +34,5 @@ tags:
   - stack
   - thread
   - sandbox
-  - experimental
 
 introduced: 1.0.0

--- a/website/api/duk_steal_buffer.yaml
+++ b/website/api/duk_steal_buffer.yaml
@@ -60,6 +60,5 @@ example: |
 tags:
   - stack
   - buffer
-  - experimental
 
 introduced: 1.3.0


### PR DESCRIPTION
These API calls have already been in use for some time and because it's possible to make small semantics changes in 2.x, their experimental status is no longer relevant.