### PR TITLE
Fix conditional compilation of default ANSI alloc functions

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1535,6 +1535,11 @@ Planned
   operations wouldn't be overridden by user code and accessed the internal
   value directly (GH-447)
 
+* Fix conditional compilation for default alloc providers (enabled by
+  default using DUK_USE_PROVIDE_DEFAULT_ALLOC_FUNCTIONS) so that if the
+  option is disabled there's no reference to malloc(), realloc(), or
+  free() during compilation (GH-695)
+
 * Remove branch hint from around setjmp() for better portability (GH-605)
 
 * Portability improvement for Atari Mint: avoid fmin/fmax (GH-556)

--- a/src/duk_alloc_default.c
+++ b/src/duk_alloc_default.c
@@ -7,6 +7,7 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_PROVIDE_DEFAULT_ALLOC_FUNCTIONS)
 DUK_INTERNAL void *duk_default_alloc_function(void *udata, duk_size_t size) {
 	void *res;
 	DUK_UNREF(udata);
@@ -30,3 +31,4 @@ DUK_INTERNAL void duk_default_free_function(void *udata, void *ptr) {
 	DUK_UNREF(udata);
 	DUK_ANSI_FREE(ptr);
 }
+#endif  /* DUK_USE_PROVIDE_DEFAULT_ALLOC_FUNCTIONS */

--- a/src/duk_api_heap.c
+++ b/src/duk_api_heap.c
@@ -24,9 +24,14 @@ duk_context *duk_create_heap(duk_alloc_function alloc_func,
 	if (!alloc_func) {
 		DUK_ASSERT(realloc_func == NULL);
 		DUK_ASSERT(free_func == NULL);
+#if defined(DUK_USE_PROVIDE_DEFAULT_ALLOC_FUNCTIONS)
 		alloc_func = duk_default_alloc_function;
 		realloc_func = duk_default_realloc_function;
 		free_func = duk_default_free_function;
+#else
+		DUK_D(DUK_DPRINT("no allocation functions given and no default providers"));
+		return NULL;
+#endif
 	} else {
 		DUK_ASSERT(realloc_func != NULL);
 		DUK_ASSERT(free_func != NULL);


### PR DESCRIPTION
When `DUK_USE_PROVIDE_DEFAULT_ALLOC_FUNCTIONS` was unset, Duktape compilation would still reference `malloc()`, `realloc()`, and `free()` even though they wouldn't actually be called. Fix this by avoiding the references when the config option is unset. This also means `duk_create_heap()` with NULL allocator arguments fails because there are no defaults to fall back to, and `duk_create_heap_default()` fails for a similar reason.

This only affects platforms where ANSI allocation functions are not available.