### PR TITLE
Add duk_tval fastint macros even when fastints disabled

### DIFF
--- a/doc/fastint.rst
+++ b/doc/fastint.rst
@@ -182,8 +182,8 @@ necessary information (in a highly fragile manner though).  For instance,
 you can use something like::
 
   /* Fastint tag depends on duk_tval packing */
-  var fastintTag = (Duktape.info(true)[1] === 0xfff5 ?
-                   0xfff2 /* tag for packed duk_tval) :
+  var fastintTag = (Duktape.info(true)[1] >= 0xfff0 ?
+                   0xfff1 /* tag for packed duk_tval) :
                    1 /* tag for unpacked duk_tval */ );
 
   function isFastint(x) {
@@ -352,14 +352,11 @@ that the value is fastint compatible) uses::
   /* 'i' must be in 32-bit signed range */
   DUK_TVAL_SET_FASTINT_I32(tv, i);  /* i is duk_int32_t */
 
-The following macros are available even when fastints are disabled::
-
-  DUK_TVAL_SET_DOUBLE(tv, d);
-  DUK_TVAL_SET_NUMBER_CHKFAST(tv, d);
-
-When fastints are disabled the macros will just write a double with no
-checks or additional overhead.  This is just a convenience to reduce the
-number of ifdefs.
+The macros are also available when fastints are disabled, and will just
+write a double with no checks or additional overhead.  This is just a
+convenience to reduce the number of ifdefs in call sites.  For example,
+``DUK_TVAL_SET_FASTINT_U32`` coerces the uint32 argument to a double
+when fastints are disabled.
 
 In-place double-to-fastint downgrade check
 ------------------------------------------

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -1964,13 +1964,8 @@ DUK_EXTERNAL duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t index) {
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
 	tv = duk_require_tval(ctx, index);
-#if defined(DUK_USE_FASTINT)
 	DUK_TVAL_SET_FASTINT_I32_UPDREF(thr, tv, ret);  /* side effects */
 	return ret;
-#else
-	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, (duk_double_t) ret);  /* side effects */
-	return ret;
-#endif
 }
 
 DUK_EXTERNAL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t index) {
@@ -1986,12 +1981,7 @@ DUK_EXTERNAL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t index) {
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
 	tv = duk_require_tval(ctx, index);
-#if defined(DUK_USE_FASTINT)
 	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv, ret);  /* side effects */
-	return ret;
-#else
-	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, (duk_double_t) ret);  /* side effects */
-#endif
 	return ret;
 }
 
@@ -2008,12 +1998,7 @@ DUK_EXTERNAL duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t index) {
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
 	tv = duk_require_tval(ctx, index);
-#if defined(DUK_USE_FASTINT)
 	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv, ret);  /* side effects */
-	return ret;
-#else
-	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, (duk_double_t) ret);  /* side effects */
-#endif
 	return ret;
 }
 

--- a/src/duk_heaphdr.h
+++ b/src/duk_heaphdr.h
@@ -472,6 +472,9 @@ struct duk_heaphdr_string {
 		DUK_TVAL_SET_FASTINT_U32(tv__dst, (newval)); \
 		DUK_TVAL_DECREF((thr), &tv__tmp);  /* side effects */ \
 	} while (0)
+#else
+#define DUK_TVAL_SET_DOUBLE_CAST_UPDREF(thr,tvptr_dst,newval) \
+	DUK_TVAL_SET_DOUBLE_UPDREF((thr), (tvptr_dst), (duk_double_t) (newval))
 #endif  /* DUK_USE_FASTINT */
 
 #define DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0(thr,tvptr_dst,lf_v,lf_fp,lf_flags) do { \
@@ -559,6 +562,10 @@ struct duk_heaphdr_string {
 #define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_FASTINT_UPDREF_ALT0
 #define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0
 #define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0
+#else
+#define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_DOUBLE_CAST_UPDREF  /* XXX: fast int-to-double */
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_DOUBLE_CAST_UPDREF
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_DOUBLE_CAST_UPDREF
 #endif  /* DUK_USE_FASTINT */
 #define DUK_TVAL_SET_LIGHTFUNC_UPDREF         DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0
 #define DUK_TVAL_SET_STRING_UPDREF            DUK_TVAL_SET_STRING_UPDREF_ALT0
@@ -669,6 +676,9 @@ struct duk_heaphdr_string {
 		DUK_TVAL_SET_FASTINT_U32(tv__dst, (newval)); \
 		DUK_UNREF((thr)); \
 	} while (0)
+#else
+#define DUK_TVAL_SET_DOUBLE_CAST_UPDREF(thr,tvptr_dst,newval) \
+	DUK_TVAL_SET_DOUBLE_UPDREF((thr), (tvptr_dst), (duk_double_t) (newval))
 #endif  /* DUK_USE_FASTINT */
 
 #define DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0(thr,tvptr_dst,lf_v,lf_fp,lf_flags) do { \
@@ -720,6 +730,10 @@ struct duk_heaphdr_string {
 #define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_FASTINT_UPDREF_ALT0
 #define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_FASTINT_I32_UPDREF_ALT0
 #define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_FASTINT_U32_UPDREF_ALT0
+#else
+#define DUK_TVAL_SET_FASTINT_UPDREF           DUK_TVAL_SET_DOUBLE_CAST_UPDREF  /* XXX: fast-int-to-double */
+#define DUK_TVAL_SET_FASTINT_I32_UPDREF       DUK_TVAL_SET_DOUBLE_CAST_UPDREF
+#define DUK_TVAL_SET_FASTINT_U32_UPDREF       DUK_TVAL_SET_DOUBLE_CAST_UPDREF
 #endif  /* DUK_USE_FASTINT */
 #define DUK_TVAL_SET_LIGHTFUNC_UPDREF         DUK_TVAL_SET_LIGHTFUNC_UPDREF_ALT0
 #define DUK_TVAL_SET_STRING_UPDREF            DUK_TVAL_SET_STRING_UPDREF_ALT0

--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -2083,11 +2083,7 @@ DUK_LOCAL duk_bool_t duk__putprop_shallow_fastpath_array_tval(duk_hthread *thr, 
 		/* No resize has occurred so temp_desc->e_idx is still OK */
 		tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, temp_desc->e_idx);
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
-#if defined(DUK_USE_FASTINT)
 		DUK_TVAL_SET_FASTINT_U32(tv, new_len);  /* no need for decref/incref because value is a number */
-#else
-		DUK_TVAL_SET_NUMBER(tv, (duk_double_t) new_len);  /* no need for decref/incref because value is a number */
-#endif
 	} else {
 		;
 	}
@@ -3179,11 +3175,7 @@ DUK_LOCAL duk_bool_t duk__handle_put_array_length(duk_hthread *thr, duk_hobject 
 		tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, desc.e_idx);
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		/* no decref needed for a number */
-#if defined(DUK_USE_FASTINT)
 		DUK_TVAL_SET_FASTINT_U32(tv, new_len);
-#else
-		DUK_TVAL_SET_NUMBER(tv, (duk_double_t) new_len);
-#endif
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		return 1;
 	}
@@ -3206,11 +3198,7 @@ DUK_LOCAL duk_bool_t duk__handle_put_array_length(duk_hthread *thr, duk_hobject 
 	tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, desc.e_idx);
 	DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 	/* no decref needed for a number */
-#if defined(DUK_USE_FASTINT)
 	DUK_TVAL_SET_FASTINT_U32(tv, result_len);
-#else
-	DUK_TVAL_SET_NUMBER(tv, (duk_double_t) result_len);
-#endif
 	DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 
 	/* XXX: shrink array allocation or entries compaction here? */
@@ -4026,11 +4014,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, orig, desc.e_idx);
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
 		/* no need for decref/incref because value is a number */
-#if defined(DUK_USE_FASTINT)
 		DUK_TVAL_SET_FASTINT_U32(tv, new_array_length);
-#else
-		DUK_TVAL_SET_NUMBER(tv, (duk_double_t) new_array_length);
-#endif
 	}
 
 	/*
@@ -5695,11 +5679,7 @@ void duk_hobject_define_property_helper(duk_context *ctx,
 			tmp = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, curr.e_idx);
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tmp));
 			/* no need for decref/incref because value is a number */
-#if defined(DUK_USE_FASTINT)
 			DUK_TVAL_SET_FASTINT_U32(tmp, arridx_new_array_length);
-#else
-			DUK_TVAL_SET_NUMBER(tmp, (duk_double_t) arridx_new_array_length);
-#endif
 		}
 		if (key == DUK_HTHREAD_STRING_LENGTH(thr) && arrlen_new_len < arrlen_old_len) {
 			/*
@@ -5731,11 +5711,7 @@ void duk_hobject_define_property_helper(duk_context *ctx,
 			tmp = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, curr.e_idx);
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tmp));
 			/* no decref needed for a number */
-#if defined(DUK_USE_FASTINT)
 			DUK_TVAL_SET_FASTINT_U32(tmp, result_len);
-#else
-			DUK_TVAL_SET_NUMBER(tmp, (duk_double_t) result_len);
-#endif
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tmp));
 
 			if (pending_write_protect) {

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -654,11 +654,7 @@ DUK_LOCAL void duk__set_catcher_regs(duk_hthread *thr, duk_size_t cat_idx, duk_t
 	tv1 = thr->valstack + thr->catchstack[cat_idx].idx_base + 1;
 	DUK_ASSERT(tv1 < thr->valstack_top);
 
-#if defined(DUK_USE_FASTINT)
 	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) lj_type);  /* side effects */
-#else
-	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) lj_type);  /* side effects */
-#endif
 }
 
 DUK_LOCAL void duk__handle_catch(duk_hthread *thr, duk_size_t cat_idx, duk_tval *tv_val_unstable, duk_small_uint_t lj_type) {
@@ -1267,11 +1263,7 @@ DUK_LOCAL void duk__handle_break_or_continue(duk_hthread *thr,
 
 			cat_idx = (duk_size_t) (cat - thr->catchstack);  /* get before side effects */
 
-#if defined(DUK_USE_FASTINT)
 			DUK_TVAL_SET_FASTINT_U32(&tv_tmp, (duk_uint32_t) label_id);
-#else
-			DUK_TVAL_SET_NUMBER(&tv_tmp, (duk_double_t) label_id);
-#endif
 			duk__handle_finally(thr, cat_idx, &tv_tmp, lj_type);
 
 			DUK_DD(DUK_DDPRINT("-> break/continue caught by 'finally', restart execution"));
@@ -4113,11 +4105,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base + 1;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-#if defined(DUK_USE_FASTINT)
 					DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
-#else
-					DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
-#endif
 					tv1 = NULL;
 
 					DUK_CAT_CLEAR_FINALLY_ENABLED(cat);
@@ -4171,11 +4159,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 					tv1 = thr->valstack + cat->idx_base + 1;
 					DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);
-#if defined(DUK_USE_FASTINT)
 					DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv1, (duk_uint32_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
-#else
-					DUK_TVAL_SET_NUMBER_UPDREF(thr, tv1, (duk_double_t) DUK_LJ_TYPE_NORMAL);  /* side effects */
-#endif
 					tv1 = NULL;
 
 					DUK_CAT_CLEAR_FINALLY_ENABLED(cat);

--- a/src/duk_tval.h
+++ b/src/duk_tval.h
@@ -26,7 +26,7 @@
 #error unsupported: cannot determine byte order variant
 #endif
 
-#ifdef DUK_USE_PACKED_TVAL
+#if defined(DUK_USE_PACKED_TVAL)
 /* ======================================================================== */
 
 /*
@@ -58,8 +58,8 @@ typedef union duk_double_union duk_tval;
 #define DUK_XTAG_BOOLEAN_TRUE     0xfff50001UL
 
 /* two casts to avoid gcc warning: "warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]" */
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_64BIT_OPS)
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK__TVAL_SET_TAGGEDPOINTER(v,h,tag)  do { \
 		(v)->ull[DUK_DBL_IDX_ULL0] = (((duk_uint64_t) (tag)) << 16) | (((duk_uint64_t) (duk_uint32_t) (h)) << 32); \
 	} while (0)
@@ -75,9 +75,9 @@ typedef union duk_double_union duk_tval;
 	} while (0)
 #endif  /* DUK_USE_64BIT_OPS */
 
-#ifdef DUK_USE_64BIT_OPS
+#if defined(DUK_USE_64BIT_OPS)
 /* Double casting for pointer to avoid gcc warning (cast from pointer to integer of different size) */
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK__TVAL_SET_LIGHTFUNC(v,fp,flags)  do { \
 		(v)->ull[DUK_DBL_IDX_ULL0] = (((duk_uint64_t) DUK_TAG_LIGHTFUNC) << 16) | \
 		                             ((duk_uint64_t) (flags)) | \
@@ -99,7 +99,7 @@ typedef union duk_double_union duk_tval;
 
 #if defined(DUK_USE_FASTINT)
 /* Note: masking is done for 'i' to deal with negative numbers correctly */
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK__TVAL_SET_FASTINT(v,i)  do { \
 		(v)->ui[DUK_DBL_IDX_UI0] = ((duk_uint32_t) DUK_TAG_FASTINT) << 16 | (((duk_uint32_t) ((i) >> 32)) & 0x0000ffffUL); \
 		(v)->ui[DUK_DBL_IDX_UI1] = (duk_uint32_t) (i); \
@@ -123,7 +123,7 @@ typedef union duk_double_union duk_tval;
 	} while (0)
 
 /* XXX: clumsy sign extend and masking of 16 topmost bits */
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK__TVAL_GET_FASTINT(v)      (((duk_int64_t) ((((duk_uint64_t) (v)->ui[DUK_DBL_IDX_UI0]) << 32) | ((duk_uint64_t) (v)->ui[DUK_DBL_IDX_UI1]))) << 16 >> 16)
 #else
 #define DUK__TVAL_GET_FASTINT(v)      ((((duk_int64_t) (v)->ull[DUK_DBL_IDX_ULL0]) << 16) >> 16)
@@ -175,6 +175,9 @@ typedef union duk_double_union duk_tval;
 		DUK_ASSERT_DOUBLE_IS_NORMALIZED(duk__dblval); \
 		DUK_DBLUNION_SET_DOUBLE((v), duk__dblval); \
 	} while (0)
+#define DUK_TVAL_SET_FASTINT(v,i)           DUK_TVAL_SET_DOUBLE((v), (duk_double_t) (i))  /* XXX: fast int-to-double */
+#define DUK_TVAL_SET_FASTINT_I32(v,i)       DUK_TVAL_SET_DOUBLE((v), (duk_double_t) (i))
+#define DUK_TVAL_SET_FASTINT_U32(v,i)       DUK_TVAL_SET_DOUBLE((v), (duk_double_t) (i))
 #define DUK_TVAL_SET_NUMBER_CHKFAST(v,d)    DUK_TVAL_SET_DOUBLE((v), (d))
 #define DUK_TVAL_SET_NUMBER(v,d)            DUK_TVAL_SET_DOUBLE((v), (d))
 #define DUK_TVAL_CHKFAST_INPLACE(v)  do { } while (0)
@@ -350,13 +353,19 @@ struct duk_tval_struct {
 		} \
 	} while (0)
 #else
+#define DUK_TVAL_SET_DOUBLE(tv,d) \
+	DUK_TVAL_SET_NUMBER((tv), (d))
+#define DUK_TVAL_SET_FASTINT(tv,val) \
+	DUK_TVAL_SET_NUMBER((tv), (duk_double_t) (val))  /* XXX: fast int-to-double */
+#define DUK_TVAL_SET_FASTINT_U32(tv,val) \
+	DUK_TVAL_SET_NUMBER((tv), (duk_double_t) (val))
+#define DUK_TVAL_SET_FASTINT_I32(tv,val) \
+	DUK_TVAL_SET_NUMBER((tv), (duk_double_t) (val))
 #define DUK_TVAL_SET_NUMBER(tv,val)  do { \
 		(tv)->t = DUK__TAG_NUMBER; \
 		(tv)->v.d = (val); \
 	} while (0)
 #define DUK_TVAL_SET_NUMBER_CHKFAST(tv,d) \
-	DUK_TVAL_SET_NUMBER((tv), (d))
-#define DUK_TVAL_SET_DOUBLE(v,d) \
 	DUK_TVAL_SET_NUMBER((tv), (d))
 #define DUK_TVAL_CHKFAST_INPLACE(v)  do { } while (0)
 #endif  /* DUK_USE_FASTINT */


### PR DESCRIPTION
This allows calling code to e.g. `DUK_TVAL_SET_FASTINT_U32()`, compiled into a cast-to-double when fastints are disabled, which reduces ifdefs in call sites.