### PR TITLE
Forced stack reallocs in finalizer torture

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2634,7 +2634,7 @@ Planned
   (GH-1408)
 
 * More assertion and torture test coverage for GC, finalizers, and error
-  handling (GH-1411, GH-1427)
+  handling (GH-1411, GH-1427, GH-709)
 
 * Avoid relying on the value stack when handling a double error (error which
   happened during handling of a previous error); this is cleaner but relying

--- a/src-input/duk_heap_finalize.c
+++ b/src-input/duk_heap_finalize.c
@@ -17,9 +17,12 @@ DUK_LOCAL duk_ret_t duk__fake_global_finalizer(duk_context *ctx) {
 	/* Require a lot of stack to force a value stack grow/shrink. */
 	duk_require_stack(ctx, 100000);
 
-	/* XXX: do something to force a callstack grow/shrink, perhaps
-	 * just a manual forced resize or a forced relocating realloc?
+	/* Force a reallocation with pointer change for value, call, and
+	 * catch stacks to maximize side effects.
 	 */
+	duk_hthread_valstack_torture_realloc((duk_hthread *) ctx);
+	duk_hthread_callstack_torture_realloc((duk_hthread *) ctx);
+	duk_hthread_catchstack_torture_realloc((duk_hthread *) ctx);
 
 	/* Inner function call, error throw. */
 	duk_eval_string_noresult(ctx,

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -386,6 +386,12 @@ DUK_INTERNAL_DECL void duk_hthread_catchstack_shrink_check(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_hthread_catchstack_unwind_norz(duk_hthread *thr, duk_size_t new_top);
 DUK_INTERNAL_DECL void duk_hthread_catchstack_unwind(duk_hthread *thr, duk_size_t new_top);
 
+#if defined(DUK_USE_FINALIZER_TORTURE)
+DUK_INTERNAL_DECL void duk_hthread_valstack_torture_realloc(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_hthread_callstack_torture_realloc(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_hthread_catchstack_torture_realloc(duk_hthread *thr);
+#endif
+
 DUK_INTERNAL_DECL void *duk_hthread_get_valstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */
 DUK_INTERNAL_DECL void *duk_hthread_get_callstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */
 DUK_INTERNAL_DECL void *duk_hthread_get_catchstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */


### PR DESCRIPTION
- [x] Add helpers to force realloc (to same size) for value stack, call stack, and catch stack
- [x] Include stack reallocs in finalizer torture (both refcount and mark-and-sweep)
