### PR TITLE
Avoid circular reference for eval-compiled functions

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1493,6 +1493,11 @@ Planned
 
 * Minor changes to error message strings (GH-661)
 
+* Avoid reference loop for eval() code (previously caused by an automatic
+  .prototype property added for the internal function the eval source
+  compiles to); this allows eval functions to be collected immediately by
+  reference counting rather than by mark-and-sweep (GH-717)
+
 * Fix potentially memory unsafe behavior when a refcount-triggered finalizer
   function rescues an object; the memory unsafe behavior doesn't happen
   immediately which makes the cause of the unsafe behavior difficult to

--- a/src/duk_api_compile.c
+++ b/src/duk_api_compile.c
@@ -139,7 +139,8 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx) {
 	duk_js_push_closure(thr,
 	                   h_templ,
 	                   thr->builtins[DUK_BIDX_GLOBAL_ENV],
-	                   thr->builtins[DUK_BIDX_GLOBAL_ENV]);
+	                   thr->builtins[DUK_BIDX_GLOBAL_ENV],
+	                   1 /*add_auto_proto*/);
 	duk_remove(ctx, -2);   /* -> [ ... closure ] */
 
 	/* [ ... closure ] */

--- a/src/duk_bi_function.c
+++ b/src/duk_bi_function.c
@@ -74,7 +74,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	outer_lex_env = thr->builtins[DUK_BIDX_GLOBAL_ENV];
 	outer_var_env = thr->builtins[DUK_BIDX_GLOBAL_ENV];
 
-	duk_js_push_closure(thr, func, outer_var_env, outer_lex_env);
+	duk_js_push_closure(thr, func, outer_var_env, outer_lex_env, 1 /*add_auto_proto*/);
 
 	/* [ body formals source template closure ] */
 

--- a/src/duk_bi_global.c
+++ b/src/duk_bi_global.c
@@ -536,7 +536,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			outer_lex_env = new_env;
 			outer_var_env = new_env;
 
-			duk_insert(ctx, 0);  /* stash to bottom of value stack to keep new_env reachable */
+			duk_insert(ctx, 0);  /* stash to bottom of value stack to keep new_env reachable for duration of eval */
 
 			/* compiler's responsibility */
 			DUK_ASSERT(DUK_HOBJECT_HAS_NEWENV((duk_hobject *) func));
@@ -561,7 +561,8 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 	}
 	act = NULL;
 
-	duk_js_push_closure(thr, func, outer_var_env, outer_lex_env);
+	/* Eval code doesn't need an automatic .prototype object. */
+	duk_js_push_closure(thr, func, outer_var_env, outer_lex_env, 0 /*add_auto_proto*/);
 
 	/* [ source template closure ] */
 

--- a/src/duk_js.h
+++ b/src/duk_js.h
@@ -84,7 +84,8 @@ DUK_INTERNAL_DECL
 void duk_js_push_closure(duk_hthread *thr,
                          duk_hcompiledfunction *fun_temp,
                          duk_hobject *outer_var_env,
-                         duk_hobject *outer_lex_env);
+                         duk_hobject *outer_lex_env,
+                         duk_bool_t add_auto_proto);
 
 /* call handling */
 DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -2909,7 +2909,8 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			duk_js_push_closure(thr,
 			                    (duk_hcompiledfunction *) fun_temp,
 			                    act->var_env,
-			                    act->lex_env);
+			                    act->lex_env,
+			                    1 /*add_auto_proto*/);
 			duk_replace(ctx, (duk_idx_t) a);
 
 			break;

--- a/src/duk_js_var.c
+++ b/src/duk_js_var.c
@@ -113,7 +113,8 @@ DUK_INTERNAL
 void duk_js_push_closure(duk_hthread *thr,
                          duk_hcompiledfunction *fun_temp,
                          duk_hobject *outer_var_env,
-                         duk_hobject *outer_lex_env) {
+                         duk_hobject *outer_lex_env,
+                         duk_bool_t add_auto_proto) {
 	duk_context *ctx = (duk_context *) thr;
 	duk_hcompiledfunction *fun_clos;
 	duk_small_uint_t i;
@@ -373,11 +374,13 @@ void duk_js_push_closure(duk_hthread *thr,
 
 	/* [ ... closure template ] */
 
-	duk_push_object(ctx);  /* -> [ ... closure template newobj ] */
-	duk_dup(ctx, -3);          /* -> [ ... closure template newobj closure ] */
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* -> [ ... closure template newobj ] */
-	duk_compact(ctx, -1);  /* compact the prototype */
-	duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);     /* -> [ ... closure template ] */
+	if (add_auto_proto) {
+		duk_push_object(ctx);  /* -> [ ... closure template newobj ] */
+		duk_dup(ctx, -3);          /* -> [ ... closure template newobj closure ] */
+		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* -> [ ... closure template newobj ] */
+		duk_compact(ctx, -1);  /* compact the prototype */
+		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);     /* -> [ ... closure template ] */
+	}
 
 	/*
 	 *  "arguments" and "caller" must be mapped to throwers for strict
@@ -444,7 +447,7 @@ void duk_js_push_closure(duk_hthread *thr,
 	DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, &fun_clos->obj) == thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
 	DUK_ASSERT(DUK_HOBJECT_HAS_EXTENSIBLE(&fun_clos->obj));
 	DUK_ASSERT(duk_has_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH) != 0);
-	DUK_ASSERT(duk_has_prop_stridx(ctx, -2, DUK_STRIDX_PROTOTYPE) != 0);
+	DUK_ASSERT(add_auto_proto == 0 || duk_has_prop_stridx(ctx, -2, DUK_STRIDX_PROTOTYPE) != 0);
 	DUK_ASSERT(duk_has_prop_stridx(ctx, -2, DUK_STRIDX_NAME) != 0);  /* non-standard */
 	DUK_ASSERT(!DUK_HOBJECT_HAS_STRICT(&fun_clos->obj) ||
 	           duk_has_prop_stridx(ctx, -2, DUK_STRIDX_CALLER) != 0);


### PR DESCRIPTION
When code is `eval()`'d an internal function is created to represent the eval code. That function had an automatic `.prototype` object which made the eval function part of a reference loop so that it wasn't immediately collected after eval finished (it would be collected in the next mark-and-sweep pass).

Improve this behavior by removing the automatic `.prototype` object which allows eval functions to be collected by reference counting, and also avoids creating the unreferenced `.prototype` object unnecessarily.