### PR TITLE
Release preparation fixes for 1.5.0 release

### DIFF
--- a/dist-files/Makefile.sharedlibrary
+++ b/dist-files/Makefile.sharedlibrary
@@ -24,8 +24,8 @@
 # convention is to set soname version to (100*MAJOR + MINOR), e.g. 104 for
 # Duktape 1.4.x, so that it gets automatically bumped for major and minor
 # releases (potentially binary incompatible), but not for patch releases.
-DUK_VERSION=10400
-SONAME_VERSION=104
+DUK_VERSION=10500
+SONAME_VERSION=105
 REAL_VERSION=$(SONAME_VERSION).$(DUK_VERSION)
 
 # Change to actual path for actual distribution packaging.

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -32,6 +32,9 @@ Checklist for ordinary releases
 
   - Verify by running Duktape cmdline and evaluating ``Duktape.version``
 
+  - Check dist-files/Makefile.sharedlibrary; currently duplicates version
+    number and needs to be fixed manually
+
 * Check dist-files/README.rst
 
 * Ensure LICENSE.txt is up-to-date
@@ -217,6 +220,13 @@ Checklist for ordinary releases
 
     - make luajstest
 
+* Debugger test
+
+  - Test Makefile.dukdebug + debugger/duk_debug.js to ensure all files
+    are included (easy to forget e.g. YAML metadata files)
+
+  - Test JSON proxy
+
 * Release notes (``doc/release-notes-*.rst``)
 
   - Write new release notes for release; needs known issues output from at
@@ -270,9 +280,6 @@ Checklist for ordinary releases
 
   - Trivial compile test for separate sources (important because
     it's easy to forget to add files in make_dist.sh)
-
-  - Test Makefile.dukdebug + debugger/duk_debug.js to ensure all files
-    are included (easy to forget e.g. YAML metadata files)
 
 * Store binaries to duktape-releases repo
 
@@ -347,6 +354,9 @@ Checklist for maintenance releases
   the maintenance branch.
 
 * Bump DUK_VERSION in maintenance branch.
+
+* Check dist-files/Makefile.sharedlibrary; currently duplicates version
+  number and needs to be fixed manually.
 
 * Review diff between previous release and new patch release.
 

--- a/src/duktape.h.in
+++ b/src/duktape.h.in
@@ -1,5 +1,6 @@
 /*
  *  Duktape public API for Duktape @DUK_VERSION_FORMATTED@.
+ *
  *  See the API reference for documentation on call semantics.
  *  The exposed API is inside the DUK_API_PUBLIC_H_INCLUDED
  *  include guard.  Other parts of the header are Duktape

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -155,7 +155,7 @@ def create_dist_directories(dist):
 	mkdir(os.path.join(dist, 'config'))
 	mkdir(os.path.join(dist, 'extras'))
 	mkdir(os.path.join(dist, 'polyfills'))
-	mkdir(os.path.join(dist, 'doc'))
+	#mkdir(os.path.join(dist, 'doc'))  # Empty, so omit
 	mkdir(os.path.join(dist, 'licenses'))
 	mkdir(os.path.join(dist, 'debugger'))
 	mkdir(os.path.join(dist, 'debugger', 'static'))


### PR DESCRIPTION
- Release checklist updates
- Fix Makefile.sharedlibrary version number
- duktape.h header title readability fix
- Omit empty 'doc' directory from dist