### PR TITLE
Remove node.js 'wrench' dependencies

### DIFF
--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -27,8 +27,8 @@ var util = require('util');
 var readline = require('readline');
 var sprintf = require('sprintf').sprintf;
 var utf8 = require('utf8');
-var wrench = require('wrench');  // https://github.com/ryanmcgrath/wrench-js
 var yaml = require('yamljs');
+var recursiveReadSync = require('recursive-readdir-sync');
 
 // Command line options (defaults here, overwritten if necessary)
 var optTargetHost = '127.0.0.1';
@@ -445,7 +445,7 @@ SourceFileManager.prototype.scan = function () {
     this.directories.forEach(function (dir) {
         console.log('Scanning source files: ' + dir);
         try {
-            wrench.readdirSyncRecursive(dir).forEach(function (fn) {
+            recursiveReadSync(dir).forEach(function (fn) {
                 var absFn = path.normalize(path.join(dir, fn));   // './foo/bar.js' -> 'foo/bar.js'
                 var ent;
 

--- a/debugger/package.json
+++ b/debugger/package.json
@@ -8,20 +8,20 @@
   },
   "dependencies": {
     "bluebird": "~2.6.4",
-    "minimist": "~1.1.0",
-    "express": "~4.10.1",
     "body-parser": "~1.9.3",
-    "socket.io": "~1.2.1",
-    "utf8": "~2.0.0",
-    "wrench": "~1.5.8",
-    "sprintf": "~0.1.5",
+    "byline": "~4.2.1",
     "events": "~1.0.2",
-    "stream": "0.0.2",
-    "readline": "0.0.5",
-    "util": "~0.10.3",
+    "express": "~4.10.1",
     "http": "0.0.0",
-    "yamljs": "~0.2.1",
-    "byline": "~4.2.1"
+    "minimist": "~1.1.0",
+    "readline": "0.0.5",
+    "recursive-readdir-sync": "^1.0.6",
+    "socket.io": "~1.2.1",
+    "sprintf": "~0.1.5",
+    "stream": "0.0.2",
+    "utf8": "~2.0.0",
+    "util": "~0.10.3",
+    "yamljs": "~0.2.1"
   },
   "main": "duk_debug.js"
 }


### PR DESCRIPTION
The wrench module is deprecated, use e.g. https://github.com/jprichardson/node-fs-extra.