### PR TITLE
Add a userdata argument to duk_safe_call()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ CCOPTS_SHARED =
 CCOPTS_SHARED += -D_POSIX_C_SOURCE=200809L  # to avoid linenoise strdup() warnings
 CCOPTS_SHARED += -pedantic -ansi -std=c99 -fstrict-aliasing
 # -Wextra is very picky but catches e.g. signed/unsigned comparisons
-CCOPTS_SHARED += -Wall -Wextra -Wunused-result
+CCOPTS_SHARED += -Wall -Wextra -Wunused-result -Wdeclaration-after-statement
 CCOPTS_SHARED += -Wcast-qual
 CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an error
 # -Wfloat-equal is too picky, there's no apparent way to compare floats

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1593,7 +1593,9 @@ Planned
 2.0.0 (XXXX-XX-XX)
 ------------------
 
+* Incompatible change: add a userdata argument to duk_safe_call() to make it
+  easier to pass C pointers to safe functions (GH-277, GH-727)
+
 * Incompatible change: rename duk_debugger_attach_custom() API call to
   duk_debugger_attach() to eliminate an unnecessary API call variant
   (GH-735, GH-742)
-

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -21,6 +21,18 @@ migrate from 1.5.x to 2.0.0.  There are also bug fixes and other minor
 behavioral changes which may affect some applications, see ``RELEASES.rst``
 for details.
 
+Supporting Duktape 1.x and Duktape 2.x simultaneously
+-----------------------------------------------------
+
+You can use the ``DUK_VERSION`` define to support both Duktape 1.x and 2.x
+in the same application.  For example::
+
+    #if (DUK_VERSION >= 20000)
+    rc = duk_safe_call(ctx, my_safe_call, NULL, 1 /*nargs*/, 1 /*nrets*/);
+    #else
+    rc = duk_safe_call(ctx, my_safe_call, 1 /*nargs*/, 1 /*nrets*/);
+    #endif
+
 DUK_OPT_xxx feature option support removed
 ------------------------------------------
 
@@ -29,7 +41,47 @@ FIXME.
 duk_safe_call() userdata
 ------------------------
 
-FIXME.
+There's a new userdata argument for ``duk_safe_call()``::
+
+    /* Duktape 1.x */
+    typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx);
+    duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, duk_idx_t nargs, duk_idx_t nrets);
+
+    /* Duktape 2.x */
+    typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx, void *udata);
+    duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, void *udata, duk_idx_t nargs, duk_idx_t nrets);
+
+The additional userdata argument makes it easier to pass a C pointer to the
+safe-called function without the need to push a pointer onto the value stack.
+Multiple C values can be passed by packing them into a stack-allocated struct
+and passing a pointer to the struct as the userdata.
+
+To upgrade:
+
+* Add a userdata argument to duk_safe_call() call sites.  If no relevant
+  userdata exists, pass a NULL.
+
+* Add a userdata argument to safe call targets.  If no relevant userdata
+  exists, just ignore the argument.
+
+* If a call site needs to support both Duktape 1.x and Duktape 2.x, use
+  a DUK_VERSION preprocessor check::
+
+      #if (DUK_VERSION >= 20000)
+      duk_ret_t my_safe_call(duk_context *ctx, void *udata) {
+      #else
+      duk_ret_t my_safe_call(duk_context *ctx) {
+      #endif
+          /* Ignore 'udata'. */
+      }
+
+      /* ... */
+
+      #if (DUK_VERSION >= 20000)
+      rc = duk_safe_call(ctx, my_safe_call, NULL, 1 /*nargs*/, 1 /*nrets*/);
+      #else
+      rc = duk_safe_call(ctx, my_safe_call, 1 /*nargs*/, 1 /*nrets*/);
+      #endif
 
 duk_debugger_attach() and duk_debugger_attach_custom() merged
 -------------------------------------------------------------

--- a/examples/cpp-exceptions/cpp_exceptions.cpp
+++ b/examples/cpp-exceptions/cpp_exceptions.cpp
@@ -65,6 +65,10 @@ duk_ret_t test1(duk_context *ctx) {
 
 	return 0;
 }
+duk_ret_t test1_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test1(ctx);
+}
 
 /*
  *  You can use C++ exceptions inside Duktape/C functions for your own
@@ -82,6 +86,10 @@ duk_ret_t test2(duk_context *ctx) {
 
 	return 0;
 }
+duk_ret_t test2_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	test2(ctx);
+}
 
 /*
  *  If you let your own C++ exceptions propagate out of a Duktape/C function
@@ -98,6 +106,10 @@ duk_ret_t test3(duk_context *ctx) {
 	throw 123;  /* ERROR: exception propagated to Duktape */
 
 	return 0;
+}
+duk_ret_t test3_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test3(ctx);
 }
 
 /*
@@ -119,6 +131,10 @@ duk_ret_t test4(duk_context *ctx) {
 
 	return 0;
 }
+duk_ret_t test4_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test4(ctx);
+}
 
 /*
  *  Same as above, but if the exception inherits from std::exception with
@@ -139,6 +155,10 @@ duk_ret_t test5(duk_context *ctx) {
 
 	return 0;
 }
+duk_ret_t test5_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test5(ctx);
+}
 
 int main(int argc, char *argv[]) {
 	duk_context *ctx = duk_create_heap_default();
@@ -154,7 +174,7 @@ int main(int argc, char *argv[]) {
 	printf("\n");
 
 	printf("*** test1 - duk_safe_call()\n");
-	rc = duk_safe_call(ctx, test1, 0, 1);
+	rc = duk_safe_call(ctx, test1_safecall, NULL, 0, 1);
 	printf("--> rc=%ld (%s)\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 	printf("\n");
@@ -178,7 +198,7 @@ int main(int argc, char *argv[]) {
 	printf("\n");
 
 	printf("*** test2 - duk_safe_call()\n");
-	rc = duk_safe_call(ctx, test2, 0, 1);
+	rc = duk_safe_call(ctx, test2_safecall, NULL, 0, 1);
 	printf("--> rc=%ld (%s)\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 	printf("\n");
@@ -202,7 +222,7 @@ int main(int argc, char *argv[]) {
 	printf("\n");
 
 	printf("*** test3 - duk_safe_call()\n");
-	rc = duk_safe_call(ctx, test3, 0, 1);
+	rc = duk_safe_call(ctx, test3_safecall, NULL, 0, 1);
 	printf("--> rc=%ld (%s)\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 	printf("\n");
@@ -226,7 +246,7 @@ int main(int argc, char *argv[]) {
 	printf("\n");
 
 	printf("*** test4 - duk_safe_call()\n");
-	rc = duk_safe_call(ctx, test4, 0, 1);
+	rc = duk_safe_call(ctx, test4_safecall, NULL, 0, 1);
 	printf("--> rc=%ld (%s)\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 	printf("\n");
@@ -250,7 +270,7 @@ int main(int argc, char *argv[]) {
 	printf("\n");
 
 	printf("*** test5 - duk_safe_call()\n");
-	rc = duk_safe_call(ctx, test5, 0, 1);
+	rc = duk_safe_call(ctx, test5_safecall, NULL, 0, 1);
 	printf("--> rc=%ld (%s)\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 	printf("\n");

--- a/examples/eval/eval.c
+++ b/examples/eval/eval.c
@@ -6,12 +6,14 @@
 #include "duktape.h"
 #include <stdio.h>
 
-static int eval_raw(duk_context *ctx) {
+static duk_ret_t eval_raw(duk_context *ctx, void *udata) {
+	(void) udata;
 	duk_eval(ctx);
 	return 1;
 }
 
-static int tostring_raw(duk_context *ctx) {
+static duk_ret_t tostring_raw(duk_context *ctx, void *udata) {
+	(void) udata;
 	duk_to_string(ctx, -1);
 	return 1;
 }
@@ -35,8 +37,8 @@ int main(int argc, char *argv[]) {
 	for (i = 1; i < argc; i++) {
 		printf("=== eval: '%s' ===\n", argv[i]);
 		duk_push_string(ctx, argv[i]);
-		duk_safe_call(ctx, eval_raw, 1 /*nargs*/, 1 /*nrets*/);
-		duk_safe_call(ctx, tostring_raw, 1 /*nargs*/, 1 /*nrets*/);
+		duk_safe_call(ctx, eval_raw, NULL, 1 /*nargs*/, 1 /*nrets*/);
+		duk_safe_call(ctx, tostring_raw, NULL, 1 /*nargs*/, 1 /*nrets*/);
 		res = duk_get_string(ctx, -1);
 		printf("%s\n", res ? res : "null");
 		duk_pop(ctx);

--- a/examples/eventloop/c_eventloop.c
+++ b/examples/eventloop/c_eventloop.c
@@ -254,7 +254,7 @@ static void compact_poll_list(void) {
 	poll_count = j;
 }
 
-int eventloop_run(duk_context *ctx) {
+duk_ret_t eventloop_run(duk_context *ctx, void *udata) {
 	ev_timer *t;
 	double now;
 	double diff;
@@ -263,6 +263,8 @@ int eventloop_run(duk_context *ctx) {
 	int i, n;
 	int idx_eventloop;
 	int idx_fd_handler;
+
+	(void) udata;
 
 	/* The Ecmascript poll handler is passed through EventLoop.fdPollHandler
 	 * which c_eventloop.js sets before we come here.

--- a/examples/eventloop/main.c
+++ b/examples/eventloop/main.c
@@ -19,7 +19,7 @@ extern void ncurses_register(duk_context *ctx);
 extern void socket_register(duk_context *ctx);
 extern void fileio_register(duk_context *ctx);
 extern void eventloop_register(duk_context *ctx);
-extern int eventloop_run(duk_context *ctx);  /* Duktape/C function, safe called */
+extern duk_ret_t eventloop_run(duk_context *ctx, void *udata);
 
 static int c_evloop = 0;
 
@@ -54,9 +54,11 @@ static void print_error(duk_context *ctx, FILE *f) {
 	duk_pop(ctx);
 }
 
-int wrapped_compile_execute(duk_context *ctx) {
+duk_ret_t wrapped_compile_execute(duk_context *ctx, void *udata) {
 	int comp_flags = 0;
 	int rc;
+
+	(void) udata;
 
 	/* Compile input and place it into global _USERCODE */
 	duk_compile(ctx, comp_flags);
@@ -82,7 +84,7 @@ int wrapped_compile_execute(duk_context *ctx) {
 	if (c_evloop) {
 		fprintf(stderr, "calling eventloop_run()\n");
 		fflush(stderr);
-		rc = duk_safe_call(ctx, eventloop_run, 0 /*nargs*/, 1 /*nrets*/);
+		rc = duk_safe_call(ctx, eventloop_run, NULL, 0 /*nargs*/, 1 /*nrets*/);
 		if (rc != 0) {
 			fprintf(stderr, "eventloop_run() failed: %s\n", duk_to_string(ctx, -1));
 			fflush(stderr);
@@ -125,7 +127,7 @@ int handle_fh(duk_context *ctx, FILE *f, const char *filename) {
 	free(buf);
 	buf = NULL;
 
-	rc = duk_safe_call(ctx, wrapped_compile_execute, 2 /*nargs*/, 1 /*nret*/);
+	rc = duk_safe_call(ctx, wrapped_compile_execute, NULL, 2 /*nargs*/, 1 /*nret*/);
 	if (rc != DUK_EXEC_SUCCESS) {
 		print_error(ctx, stderr);
 		goto error;

--- a/examples/jxpretty/jxpretty.c
+++ b/examples/jxpretty/jxpretty.c
@@ -6,10 +6,12 @@
 #include <stdlib.h>
 #include "duktape.h"
 
-static duk_ret_t do_jxpretty(duk_context *ctx) {
+static duk_ret_t do_jxpretty(duk_context *ctx, void *udata) {
 	FILE *f = stdin;
 	char buf[4096];
 	size_t ret;
+
+	(void) udata;
 
 	for (;;) {
 		if (ferror(f)) {
@@ -51,7 +53,7 @@ int main(int argc, char *argv[]) {
 
 	ctx = duk_create_heap_default();
 
-	rc = duk_safe_call(ctx, do_jxpretty, 0 /*nargs*/, 1 /*nrets*/);
+	rc = duk_safe_call(ctx, do_jxpretty, NULL, 0 /*nargs*/, 1 /*nrets*/);
 	if (rc) {
 		fprintf(stderr, "ERROR: %s\n", duk_safe_to_string(ctx, -1));
 		fflush(stderr);

--- a/examples/sandbox/sandbox.c
+++ b/examples/sandbox/sandbox.c
@@ -144,11 +144,13 @@ static void sandbox_free(void *udata, void *ptr) {
  *  Sandbox setup and test
  */
 
-static duk_ret_t do_sandbox_test(duk_context *ctx) {
+static duk_ret_t do_sandbox_test(duk_context *ctx, void *udata) {
 	FILE *f;
 	char buf[4096];
 	size_t ret;
 	const char *globobj;
+
+	(void) udata;
 
 	/*
 	 *  Setup sandbox
@@ -236,7 +238,7 @@ int main(int argc, char *argv[]) {
 	                      sandbox_fatal);
 
 	duk_push_string(ctx, argv[1]);
-	rc = duk_safe_call(ctx, do_sandbox_test, 1 /*nargs*/, 1 /*nrets*/);
+	rc = duk_safe_call(ctx, do_sandbox_test, NULL, 1 /*nargs*/, 1 /*nrets*/);
 	if (rc) {
 		fprintf(stderr, "ERROR: %s\n", duk_safe_to_string(ctx, -1));
 		fflush(stderr);

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -269,7 +269,7 @@ function executeTest(options, callback) {
                 '-L.',
                 '-Idist/src',
                 '-Wl,-rpath,.',
-                '-pedantic', '-ansi', '-std=c99', '-Wall', '-fstrict-aliasing', '-D__POSIX_C_SOURCE=200809L', '-D_GNU_SOURCE', '-D_XOPEN_SOURCE', '-Os', '-fomit-frame-pointer',
+                '-pedantic', '-ansi', '-std=c99', '-Wall', '-Wdeclaration-after-statement', '-fstrict-aliasing', '-D__POSIX_C_SOURCE=200809L', '-D_GNU_SOURCE', '-D_XOPEN_SOURCE', '-Os', '-fomit-frame-pointer',
                 '-g', '-ggdb',
                 '-Werror',
                 //'-m32',

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -370,7 +370,7 @@ var API_TEST_HEADER =
     "\t\tduk_ret_t _rc; \\\n" +
     "\t\tprintf(\"*** %s (duk_safe_call)\\n\", #func); \\\n" +
     "\t\tfflush(stdout); \\\n" +
-    "\t\t_rc = duk_safe_call(ctx, (func), 0, 1); \\\n" +
+    "\t\t_rc = duk_safe_call(ctx, (func), NULL, 0, 1); \\\n" +
     "\t\tprintf(\"==> rc=%d, result='%s'\\n\", (int) _rc, duk_safe_to_string(ctx, -1)); \\\n" +
     "\t\tfflush(stdout); \\\n" +
     "\t\tduk_pop(ctx); \\\n" +

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -50,7 +50,7 @@ typedef void (*duk_free_function) (void *udata, void *ptr);
 typedef void (*duk_fatal_function) (duk_context *ctx, duk_errcode_t code, const char *msg);
 typedef void (*duk_decode_char_function) (void *udata, duk_codepoint_t codepoint);
 typedef duk_codepoint_t (*duk_map_char_function) (void *udata, duk_codepoint_t codepoint);
-typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx);
+typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx, void *udata);
 typedef duk_size_t (*duk_debug_read_function) (void *udata, char *buffer, duk_size_t length);
 typedef duk_size_t (*duk_debug_write_function) (void *udata, const char *buffer, duk_size_t length);
 typedef duk_size_t (*duk_debug_peek_function) (void *udata);
@@ -160,9 +160,7 @@ struct duk_number_list_entry {
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 << 5)    /* enumerate a proxy object itself without invoking proxy behavior */
 
 /* Compilation flags for duk_compile() and duk_eval() */
-/* DUK_COMPILE_xxx bits 0-2 are reserved for an internal 'nargs' argument
- * (the nargs value passed is direct stack arguments + 1 to account for an
- * internal extra argument).
+/* DUK_COMPILE_xxx bits 0-2 are reserved for an internal 'nargs' argument.
  */
 #define DUK_COMPILE_EVAL                  (1 << 3)    /* compile eval code (instead of global code) */
 #define DUK_COMPILE_FUNCTION              (1 << 4)    /* compile function code (instead of global code) */
@@ -774,7 +772,7 @@ DUK_EXTERNAL_DECL duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs);
 DUK_EXTERNAL_DECL void duk_new(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_pnew(duk_context *ctx, duk_idx_t nargs);
-DUK_EXTERNAL_DECL duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, duk_idx_t nargs, duk_idx_t nrets);
+DUK_EXTERNAL_DECL duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, void *udata, duk_idx_t nargs, duk_idx_t nrets);
 
 /*
  *  Thread management
@@ -793,103 +791,103 @@ DUK_EXTERNAL_DECL duk_int_t duk_compile_raw(duk_context *ctx, const char *src_bu
 
 /* plain */
 #define duk_eval(ctx)  \
-	((void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), NULL, 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_noresult(ctx)  \
-	((void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), NULL, 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval(ctx)  \
-	(duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), NULL, 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_noresult(ctx)  \
-	(duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), NULL, 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile(ctx,flags)  \
-	((void) duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags)))
+	((void) duk_compile_raw((ctx), NULL, 0, 2 /*args*/ | (flags)))
 
 #define duk_pcompile(ctx,flags)  \
-	(duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags) | DUK_COMPILE_SAFE))
+	(duk_compile_raw((ctx), NULL, 0, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE))
 
 /* string */
 #define duk_eval_string(ctx,src)  \
-	((void) duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), (src), 0, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_string_noresult(ctx,src)  \
-	((void) duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), (src), 0, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_string(ctx,src)  \
-	(duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), (src), 0, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_string_noresult(ctx,src)  \
-	(duk_eval_raw((ctx), (src), 0, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), (src), 0, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_string(ctx,flags,src)  \
-	((void) duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
+	((void) duk_compile_raw((ctx), (src), 0, 0 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_string_filename(ctx,flags,src)  \
-	((void) duk_compile_raw((ctx), (src), 0, 2 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	((void) duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
 
 #define duk_pcompile_string(ctx,flags,src)  \
-	(duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
+	(duk_compile_raw((ctx), (src), 0, 0 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN | DUK_COMPILE_NOFILENAME))
 
 #define duk_pcompile_string_filename(ctx,flags,src)  \
-	(duk_compile_raw((ctx), (src), 0, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
+	(duk_compile_raw((ctx), (src), 0, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN))
 
 /* lstring */
 #define duk_eval_lstring(ctx,buf,len)  \
-	((void) duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), buf, len, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_eval_lstring_noresult(ctx,buf,len)  \
-	((void) duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	((void) duk_eval_raw((ctx), buf, len, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_lstring(ctx,buf,len)  \
-	(duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), buf, len, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NOSOURCE | DUK_COMPILE_SAFE | DUK_COMPILE_NOFILENAME))
 
 #define duk_peval_lstring_noresult(ctx,buf,len)  \
-	(duk_eval_raw((ctx), buf, len, 1 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
+	(duk_eval_raw((ctx), buf, len, 0 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NORESULT | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_lstring(ctx,flags,buf,len)  \
-	((void) duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
+	((void) duk_compile_raw((ctx), buf, len, 0 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_compile_lstring_filename(ctx,flags,buf,len)  \
-	((void) duk_compile_raw((ctx), buf, len, 2 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE))
+	((void) duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_NOSOURCE))
 
 #define duk_pcompile_lstring(ctx,flags,buf,len)  \
-	(duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
+	(duk_compile_raw((ctx), buf, len, 0 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE | DUK_COMPILE_NOFILENAME))
 
 #define duk_pcompile_lstring_filename(ctx,flags,buf,len)  \
-	(duk_compile_raw((ctx), buf, len, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE))
+	(duk_compile_raw((ctx), buf, len, 1 /*args*/ | (flags) | DUK_COMPILE_SAFE | DUK_COMPILE_NOSOURCE))
 
 /* file */
 #define duk_eval_file(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL))
+	 (void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL))
 
 #define duk_eval_file_noresult(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT))
+	 (void) duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_NORESULT))
 
 #define duk_peval_file(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE))
+	 duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE))
 
 #define duk_peval_file_noresult(ctx,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_eval_raw((ctx), NULL, 0, 3 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT))
+	 duk_eval_raw((ctx), NULL, 0, 2 /*args*/ | DUK_COMPILE_EVAL | DUK_COMPILE_SAFE | DUK_COMPILE_NORESULT))
 
 #define duk_compile_file(ctx,flags,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), 0), \
 	 (void) duk_push_string((ctx), (path)), \
-	 (void) duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags)))
+	 (void) duk_compile_raw((ctx), NULL, 0, 2 /*args*/ | (flags)))
 
 #define duk_pcompile_file(ctx,flags,path)  \
 	((void) duk_push_string_file_raw((ctx), (path), DUK_STRING_PUSH_SAFE), \
 	 (void) duk_push_string((ctx), (path)), \
-	 duk_compile_raw((ctx), NULL, 0, 3 /*args*/ | (flags) | DUK_COMPILE_SAFE))
+	 duk_compile_raw((ctx), NULL, 0, 2 /*args*/ | (flags) | DUK_COMPILE_SAFE))
 
 /*
  *  Bytecode load/dump

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -2046,8 +2046,9 @@ DUK_EXTERNAL const char *duk_to_lstring(duk_context *ctx, duk_idx_t index, duk_s
 	return duk_require_lstring(ctx, index, out_len);
 }
 
-DUK_LOCAL duk_ret_t duk__safe_to_string_raw(duk_context *ctx) {
+DUK_LOCAL duk_ret_t duk__safe_to_string_raw(duk_context *ctx, void *udata) {
 	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_UNREF(udata);
 
 	duk_to_string(ctx, -1);
 	return 1;
@@ -2064,10 +2065,10 @@ DUK_EXTERNAL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, 
 	 */
 
 	duk_dup(ctx, index);
-	(void) duk_safe_call(ctx, duk__safe_to_string_raw, 1 /*nargs*/, 1 /*nrets*/);
+	(void) duk_safe_call(ctx, duk__safe_to_string_raw, NULL /*udata*/, 1 /*nargs*/, 1 /*nrets*/);
 	if (!duk_is_string(ctx, -1)) {
 		/* Error: try coercing error to string once. */
-		(void) duk_safe_call(ctx, duk__safe_to_string_raw, 1 /*nargs*/, 1 /*nrets*/);
+		(void) duk_safe_call(ctx, duk__safe_to_string_raw, NULL /*udata*/, 1 /*nargs*/, 1 /*nrets*/);
 		if (!duk_is_string(ctx, -1)) {
 			/* Double error */
 			duk_pop(ctx);

--- a/src/duk_bi_json.c
+++ b/src/duk_bi_json.c
@@ -2647,14 +2647,14 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 	return 0;  /* unreachable */
 }
 
-DUK_LOCAL duk_ret_t duk__json_stringify_fast(duk_context *ctx) {
+DUK_LOCAL duk_ret_t duk__json_stringify_fast(duk_context *ctx, void *udata) {
 	duk_json_enc_ctx *js_ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT(ctx != NULL);
-	tv = DUK_GET_TVAL_NEGIDX(ctx, -2);
-	DUK_ASSERT(DUK_TVAL_IS_POINTER(tv));
-	js_ctx = (duk_json_enc_ctx *) DUK_TVAL_GET_POINTER(tv);
+	DUK_ASSERT(udata != NULL);
+
+	js_ctx = (duk_json_enc_ctx *) udata;
 	DUK_ASSERT(js_ctx != NULL);
 
 	tv = DUK_GET_TVAL_NEGIDX(ctx, -1);
@@ -3009,7 +3009,6 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 		 * limited loop detection).
 		 */
 
-		duk_push_pointer(ctx, (void *) js_ctx);
 		duk_dup(ctx, idx_value);
 
 #if defined(DUK_USE_MARK_AND_SWEEP)
@@ -3020,7 +3019,7 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 		        DUK_MS_FLAG_NO_OBJECT_COMPACTION;   /* avoid attempt to compact any objects */
 #endif
 
-		pcall_rc = duk_safe_call(ctx, duk__json_stringify_fast, 2 /*nargs*/, 0 /*nret*/);
+		pcall_rc = duk_safe_call(ctx, duk__json_stringify_fast, (void *) js_ctx /*udata*/, 1 /*nargs*/, 0 /*nret*/);
 
 #if defined(DUK_USE_MARK_AND_SWEEP)
 		thr->heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;

--- a/src/duk_heap_markandsweep.c
+++ b/src/duk_heap_markandsweep.c
@@ -932,10 +932,12 @@ DUK_LOCAL void duk__run_object_finalizers(duk_heap *heap, duk_small_uint_t flags
  *  Compaction is assumed to never throw an error.
  */
 
-DUK_LOCAL int duk__protected_compact_object(duk_context *ctx) {
+DUK_LOCAL int duk__protected_compact_object(duk_context *ctx, void *udata) {
+	duk_hobject *obj;
 	/* XXX: for threads, compact value stack, call stack, catch stack? */
 
-	duk_hobject *obj = duk_get_hobject(ctx, -1);
+	DUK_UNREF(udata);
+	obj = duk_get_hobject(ctx, -1);
 	DUK_ASSERT(obj != NULL);
 	duk_hobject_compact_props((duk_hthread *) ctx, obj);
 	return 0;
@@ -972,7 +974,7 @@ DUK_LOCAL void duk__compact_object_list(duk_heap *heap, duk_hthread *thr, duk_he
 		DUK_DD(DUK_DDPRINT("compact object: %p", (void *) obj));
 		duk_push_hobject((duk_context *) thr, obj);
 		/* XXX: disable error handlers for duration of compaction? */
-		duk_safe_call((duk_context *) thr, duk__protected_compact_object, 1, 0);
+		duk_safe_call((duk_context *) thr, duk__protected_compact_object, NULL, 1, 0);
 
 #ifdef DUK_USE_DEBUG
 		new_size = DUK_HOBJECT_P_COMPUTE_SIZE(DUK_HOBJECT_GET_ESIZE(obj),

--- a/src/duk_hobject_finalizer.c
+++ b/src/duk_hobject_finalizer.c
@@ -17,11 +17,12 @@
 
 #include "duk_internal.h"
 
-DUK_LOCAL duk_ret_t duk__finalize_helper(duk_context *ctx) {
+DUK_LOCAL duk_ret_t duk__finalize_helper(duk_context *ctx, void *udata) {
 	duk_hthread *thr;
 
 	DUK_ASSERT(ctx != NULL);
 	thr = (duk_hthread *) ctx;
+	DUK_UNREF(udata);
 
 	DUK_DDD(DUK_DDDPRINT("protected finalization helper running"));
 
@@ -94,7 +95,7 @@ DUK_INTERNAL void duk_hobject_run_finalizer(duk_hthread *thr, duk_hobject *obj) 
 
 	DUK_DDD(DUK_DDDPRINT("-> finalizer found, calling wrapped finalize helper"));
 	duk_push_hobject(ctx, obj);  /* this also increases refcount by one */
-	rc = duk_safe_call(ctx, duk__finalize_helper, 0 /*nargs*/, 1 /*nrets*/);  /* -> [... obj retval/error] */
+	rc = duk_safe_call(ctx, duk__finalize_helper, NULL /*udata*/, 0 /*nargs*/, 1 /*nrets*/);  /* -> [... obj retval/error] */
 	DUK_ASSERT_TOP(ctx, entry_top + 2);  /* duk_safe_call discipline */
 
 	if (rc != DUK_EXEC_SUCCESS) {

--- a/src/duk_js.h
+++ b/src/duk_js.h
@@ -90,7 +90,7 @@ void duk_js_push_closure(duk_hthread *thr,
 /* call handling */
 DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL void duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
-DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
+DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, void *udata, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
 DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 
 /* bytecode execution */

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -42,6 +42,7 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
                                       duk_jmpbuf *old_jmpbuf_ptr);
 DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_safe_call_function func,
+                                           void *udata,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
@@ -1871,6 +1872,7 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
 
 DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
                                             duk_safe_call_function func,
+                                            void *udata,
                                             duk_idx_t num_stack_args,
                                             duk_idx_t num_stack_rets) {
 	duk_context *ctx = (duk_context *) thr;
@@ -1943,6 +1945,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 
 		duk__handle_safe_call_inner(thr,
 		                            func,
+		                            udata,
 		                            idx_retbase,
 		                            num_stack_rets,
 		                            entry_valstack_bottom_index,
@@ -2037,6 +2040,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 
 DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_safe_call_function func,
+                                           void *udata,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
@@ -2108,7 +2112,7 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 	 *  Make the C call
 	 */
 
-	rc = func(ctx);
+	rc = func(ctx, udata);
 
 	DUK_DDD(DUK_DDDPRINT("safe_call, func rc=%ld", (long) rc));
 

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -15,7 +15,9 @@ dummy - return here
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_func(duk_context *ctx) {
+static duk_ret_t test_func(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	if (ctx) {
 		printf("dummy - return here\n"); fflush(stdout);
 		return 0;
@@ -254,7 +256,7 @@ static duk_ret_t test_func(duk_context *ctx) {
 	(void) duk_require_undefined(ctx, 0);
 	(void) duk_require_valid_index(ctx, 0);
 	(void) duk_resize_buffer(ctx, 0, 0);
-	(void) duk_safe_call(ctx, NULL, 0, 0);
+	(void) duk_safe_call(ctx, NULL, NULL, 0, 0);
 	(void) duk_safe_to_lstring(ctx, 0, NULL);
 	(void) duk_safe_to_string(ctx, 0);
 	(void) duk_set_finalizer(ctx, 0);

--- a/tests/api/test-base64.c
+++ b/tests/api/test-base64.c
@@ -11,7 +11,9 @@ top after: 2
 ==> rc=1, result='TypeError: decode failed'
 ===*/
 
-static duk_ret_t test_encode(duk_context *ctx) {
+static duk_ret_t test_encode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "foo");
 	duk_push_int(ctx, 123);  /* dummy */
@@ -20,7 +22,9 @@ static duk_ret_t test_encode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode(duk_context *ctx) {
+static duk_ret_t test_decode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "dGVzdCBzdHJpbmc=");
 	duk_push_int(ctx, 321);  /* dummy */
@@ -31,7 +35,9 @@ static duk_ret_t test_decode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode_invalid_char(duk_context *ctx) {
+static duk_ret_t test_decode_invalid_char(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "dGVzdCBzdHJ@bmc=");
 	duk_push_int(ctx, 321);  /* dummy */

--- a/tests/api/test-bufferobject-dynamic-safety.c
+++ b/tests/api/test-bufferobject-dynamic-safety.c
@@ -431,7 +431,9 @@ static void shared_read_write_index(duk_context *ctx, duk_size_t resize_to) {
 }
 
 /* Duktape.Buffer */
-static duk_ret_t test_duktape_buffer_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_duktape_buffer_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 100);
 	setup_duktape_buffer(ctx, -1);
 	shared_read_write_index(ctx, 95);
@@ -441,7 +443,9 @@ static duk_ret_t test_duktape_buffer_indexed_1a(duk_context *ctx) {
 }
 
 /* Node.js Buffer, "full slice" */
-static duk_ret_t test_nodejs_buffer_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 100);
 	setup_nodejs_buffer(ctx, -1);
 	shared_read_write_index(ctx, 95);
@@ -451,7 +455,9 @@ static duk_ret_t test_nodejs_buffer_indexed_1a(duk_context *ctx) {
 }
 
 /* Node.js Buffer, "partial slice" */
-static duk_ret_t test_nodejs_buffer_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 150);
 	setup_nodejs_buffer_slice(ctx, -1, 30, 130);
 	shared_read_write_index(ctx, 30 + 95);
@@ -461,7 +467,9 @@ static duk_ret_t test_nodejs_buffer_indexed_1b(duk_context *ctx) {
 }
 
 /* ArrayBuffer, "full slice" */
-static duk_ret_t test_arraybuffer_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_arraybuffer_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 100);
 	setup_arraybuffer(ctx, -1);
 	shared_read_write_index(ctx, 95);
@@ -473,7 +481,9 @@ static duk_ret_t test_arraybuffer_indexed_1a(duk_context *ctx) {
 /* Can't create slices for ArrayBuffer directly. */
 
 /* Uint8Array, "full slice" */
-static duk_ret_t test_uint8array_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_uint8array_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 100);
 	setup_typedarray(ctx, -1, "Uint8Array");
 	shared_read_write_index(ctx, 95);
@@ -483,7 +493,9 @@ static duk_ret_t test_uint8array_indexed_1a(duk_context *ctx) {
 }
 
 /* Uint8Array, "partial slice" */
-static duk_ret_t test_uint8array_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_uint8array_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 150);
 	setup_typedarray_slice(ctx, -1, "Uint8Array", 30, 100);
 	shared_read_write_index(ctx, 30 + 95);
@@ -493,7 +505,9 @@ static duk_ret_t test_uint8array_indexed_1b(duk_context *ctx) {
 }
 
 /* Uint16Array, "full slice" */
-static duk_ret_t test_uint16array_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_uint16array_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 200);
 	setup_typedarray(ctx, -1, "Uint16Array");
 	shared_read_write_index(ctx, 95 * 2);
@@ -503,7 +517,9 @@ static duk_ret_t test_uint16array_indexed_1a(duk_context *ctx) {
 }
 
 /* Uint16Array, "partial slice" */
-static duk_ret_t test_uint16array_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_uint16array_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 300);
 	setup_typedarray_slice(ctx, -1, "Uint16Array", 60, 100);
 	shared_read_write_index(ctx, 60 + 95 * 2);
@@ -513,7 +529,9 @@ static duk_ret_t test_uint16array_indexed_1b(duk_context *ctx) {
 }
 
 /* Uint32Array, "full slice" */
-static duk_ret_t test_uint32array_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_uint32array_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 400);
 	setup_typedarray(ctx, -1, "Uint32Array");
 	shared_read_write_index(ctx, 95 * 4);
@@ -523,7 +541,9 @@ static duk_ret_t test_uint32array_indexed_1a(duk_context *ctx) {
 }
 
 /* Uint32Array, "partial slice" */
-static duk_ret_t test_uint32array_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_uint32array_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 600);
 	setup_typedarray_slice(ctx, -1, "Uint32Array", 120, 100);
 	shared_read_write_index(ctx, 120 + 95 * 4);
@@ -533,7 +553,9 @@ static duk_ret_t test_uint32array_indexed_1b(duk_context *ctx) {
 }
 
 /* Float32Array, "full slice" */
-static duk_ret_t test_float32array_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_float32array_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 400);
 	setup_typedarray(ctx, -1, "Float32Array");
 	shared_read_write_index(ctx, 95 * 4);
@@ -543,7 +565,9 @@ static duk_ret_t test_float32array_indexed_1a(duk_context *ctx) {
 }
 
 /* Float32Array, "partial slice" */
-static duk_ret_t test_float32array_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_float32array_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 600);
 	setup_typedarray_slice(ctx, -1, "Float32Array", 120, 100);
 	shared_read_write_index(ctx, 120 + 95 * 4);
@@ -553,7 +577,9 @@ static duk_ret_t test_float32array_indexed_1b(duk_context *ctx) {
 }
 
 /* Float64Array, "full slice" */
-static duk_ret_t test_float64array_indexed_1a(duk_context *ctx) {
+static duk_ret_t test_float64array_indexed_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 800);
 	setup_typedarray(ctx, -1, "Float64Array");
 	shared_read_write_index(ctx, 95 * 8);
@@ -563,7 +589,9 @@ static duk_ret_t test_float64array_indexed_1a(duk_context *ctx) {
 }
 
 /* Float64Array, "partial slice" */
-static duk_ret_t test_float64array_indexed_1b(duk_context *ctx) {
+static duk_ret_t test_float64array_indexed_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 1200);
 	setup_typedarray_slice(ctx, -1, "Float64Array", 240, 100);
 	shared_read_write_index(ctx, 240 + 95 * 8);
@@ -641,10 +669,12 @@ final top: 2
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_json_serialize_1(duk_context *ctx) {
+static duk_ret_t test_json_serialize_1(duk_context *ctx, void *udata) {
 	unsigned char *data;
 	int i;
 	duk_uarridx_t arridx = 0;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 20);
 	for (i = 0; i < 20; i++) {
@@ -717,9 +747,11 @@ final top: 2
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_typedarray_constructor_copy_1(duk_context *ctx) {
+static duk_ret_t test_typedarray_constructor_copy_1(duk_context *ctx, void *udata) {
 	int i;
 	unsigned char *data;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 10);  /* index 0 */
 	for (i = 0; i < 10; i++) {
@@ -1050,9 +1082,11 @@ final top: 6
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_typedarray_set_1(duk_context *ctx) {
+static duk_ret_t test_typedarray_set_1(duk_context *ctx, void *udata) {
 	int i, dst, src;
 	unsigned char *data;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 10);  /* index 0 */
 	for (i = 0; i < 10; i++) {
@@ -1457,9 +1491,11 @@ final top: 5
 ==> rc=0, result='undefined'
 ===*/
 
-static int test_nodejs_buffer_compare_1(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_compare_1(duk_context *ctx, void *udata) {
 	int i, dst, src;
 	unsigned char *data;
+
+	(void) udata;
 
 	/* There are two relevant methods: Buffer.compare and Buffer.prototype.compare() */
 
@@ -1677,9 +1713,11 @@ final top: 9
 ==> rc=0, result='undefined'
 ===*/
 
-static int test_nodejs_buffer_write_1(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_write_1(duk_context *ctx, void *udata) {
 	int i, dst, src;
 	unsigned char *data;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 10);  /* index 0 */
 	for (i = 0; i < 10; i++) {
@@ -1907,9 +1945,11 @@ final top: 5
 ==> rc=0, result='undefined'
 ===*/
 
-static int test_nodejs_buffer_copy_1(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_copy_1(duk_context *ctx, void *udata) {
 	int i, dst, src;
 	unsigned char *data;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 10);  /* index 0 */
 	for (i = 0; i < 10; i++) {
@@ -1981,9 +2021,11 @@ final top: 6
 ==> rc=0, result='undefined'
 ===*/
 
-static int test_nodejs_buffer_concat_1(duk_context *ctx) {
+static duk_ret_t test_nodejs_buffer_concat_1(duk_context *ctx, void *udata) {
 	int i;
 	unsigned char *data;
+
+	(void) udata;
 
 	data = (unsigned char *) duk_push_dynamic_buffer(ctx, 10);  /* index 0 */
 	for (i = 0; i < 10; i++) {

--- a/tests/api/test-bufferobject-initial.c
+++ b/tests/api/test-bufferobject-initial.c
@@ -19,10 +19,12 @@ final top: 8
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_to_buffer_1(duk_context *ctx) {
+static duk_ret_t test_to_buffer_1(duk_context *ctx, void *udata) {
 	int i, j;
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "new Buffer('foobar')");
 	duk_eval_string(ctx,

--- a/tests/api/test-bug-is-fixed-dynamic-buffer-nullptr.c
+++ b/tests/api/test-bug-is-fixed-dynamic-buffer-nullptr.c
@@ -11,7 +11,9 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* These would segfault or at least cause valgrind issues. */
 	printf("duk_is_dynamic_buffer(-1): %d\n", (int) duk_is_dynamic_buffer(ctx, -1));
 	printf("duk_is_fixed_buffer(-1): %d\n", (int) duk_is_fixed_buffer(ctx, -1));

--- a/tests/api/test-bug-is-primitive-invalid-index-gh337.c
+++ b/tests/api/test-bug-is-primitive-invalid-index-gh337.c
@@ -21,21 +21,27 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%ld\n", (long) duk_is_primitive(ctx, -1));
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%ld\n", (long) duk_is_primitive(ctx, DUK_INVALID_INDEX));
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_null(ctx);
 
 	printf("%ld\n", (long) duk_is_primitive(ctx, 0));  /* valid */

--- a/tests/api/test-bug-multithread-valgrind.c
+++ b/tests/api/test-bug-multithread-valgrind.c
@@ -17,8 +17,10 @@ top: 1
 ==> rc=1, result='ReferenceError: identifier 'zork' undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_context *ctx2;
+
+	(void) udata;
 
 	duk_push_thread(ctx);
 	ctx2 = duk_require_context(ctx, -1);
@@ -29,8 +31,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_context *ctx2;
+
+	(void) udata;
 
 	duk_push_thread_new_globalenv(ctx);
 	ctx2 = duk_require_context(ctx, -1);

--- a/tests/api/test-bug-object-binding-proxy.c
+++ b/tests/api/test-bug-object-binding-proxy.c
@@ -17,8 +17,10 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_eval_string(ctx,
 		"new Proxy(new Function('return this')() /* global object */, {\n"

--- a/tests/api/test-bug-peval-pcompile-nofile.c
+++ b/tests/api/test-bug-peval-pcompile-nofile.c
@@ -25,8 +25,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_peval_file(duk_context *ctx) {
+static duk_ret_t test_peval_file(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	rc = duk_peval_file(ctx, NONEXISTENT_FILE);
 	printf("rc: %ld\n", (long) rc);
@@ -36,8 +38,10 @@ static duk_ret_t test_peval_file(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_peval_file_noresult(duk_context *ctx) {
+static duk_ret_t test_peval_file_noresult(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	rc = duk_peval_file_noresult(ctx, NONEXISTENT_FILE);
 	printf("rc: %ld\n", (long) rc);
@@ -46,8 +50,10 @@ static duk_ret_t test_peval_file_noresult(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pcompile_file(duk_context *ctx) {
+static duk_ret_t test_pcompile_file(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	rc = duk_pcompile_file(ctx, 0, NONEXISTENT_FILE);
 	printf("rc: %ld\n", (long) rc);

--- a/tests/api/test-bug-push-buffer-maxsize.c
+++ b/tests/api/test-bug-push-buffer-maxsize.c
@@ -23,8 +23,10 @@ dynamic size buffer, maximum size_t - 8 (should fail)
  * size to the requested size (this is done now).
  */
 
-static int test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -36,8 +38,10 @@ static int test_1a(duk_context *ctx) {
 	return 0;
 }
 
-static int test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -49,8 +53,10 @@ static int test_1b(duk_context *ctx) {
 	return 0;
 }
 
-static int test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -63,8 +69,10 @@ static int test_2a(duk_context *ctx) {
 }
 
 /* This test actually succeeds even with the bug. */
-static int test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 

--- a/tests/api/test-bug-push-string-maxsize.c
+++ b/tests/api/test-bug-push-string-maxsize.c
@@ -24,8 +24,10 @@ push string with maximum size_t - 8 (should fail)
 
 const char dummy[4] = { 'f', 'o', 'o', '\0' };
 
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	const char *p;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -37,8 +39,10 @@ static duk_ret_t test_1a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	const char *p;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 

--- a/tests/api/test-bug-refzero-rescue-queue.c
+++ b/tests/api/test-bug-refzero-rescue-queue.c
@@ -61,9 +61,11 @@ static duk_ret_t inspect_badger(duk_context *ctx);
 static void *cached_badger_1 = NULL;
 static void *cached_badger_2 = NULL;
 
-static duk_ret_t test_badgers(duk_context *ctx) {
+static duk_ret_t test_badgers(duk_context *ctx, void *udata) {
 	cached_badger_1 = create_badger(ctx, "badger1");
 	cached_badger_2 = create_badger(ctx, "badger2");
+
+	(void) udata;
 
 	printf("first call\n");
 

--- a/tests/api/test-bug-set-cfunc-name.c
+++ b/tests/api/test-bug-set-cfunc-name.c
@@ -30,7 +30,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Check that Function.prototype.name is writable. */
 	duk_eval_string_noresult(ctx,
 		"var pd = Object.getOwnPropertyDescriptor(Function.prototype, 'name');\n"

--- a/tests/api/test-bug-set-top-wrap.c
+++ b/tests/api/test-bug-set-top-wrap.c
@@ -7,7 +7,9 @@ top=0
 ==> rc=1, result='Error: invalid stack index 357913942'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("top=%ld\n", (long) duk_get_top(ctx));
 
 	/* duk_set_top() uses pointer arithmetic internally, and because
@@ -28,7 +30,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("top=%ld\n", (long) duk_get_top(ctx));
 
 	/* On a 32-bit platform and 12-byte values there is no zero-

--- a/tests/api/test-bug-tailcall-preventyield-assert.c
+++ b/tests/api/test-bug-tailcall-preventyield-assert.c
@@ -41,7 +41,9 @@ result: 123
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* This test would trigger the assertion failure in Duktape 0.10.0. */
 
 	duk_eval_string(ctx, "function g() { print('g'); return 123; };\n"

--- a/tests/api/test-c-constructor.c
+++ b/tests/api/test-c-constructor.c
@@ -9,7 +9,9 @@ static duk_ret_t my_constructor(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_global_object(ctx);
 	duk_push_c_function(ctx, my_constructor, 0);   /* constructor (function) */
 	duk_push_object(ctx);                          /* prototype object -> [ global cons proto ] */

--- a/tests/api/test-call-method.c
+++ b/tests/api/test-call-method.c
@@ -29,7 +29,9 @@ static duk_ret_t my_adder(duk_context *ctx) {
 	return 1;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_c_function(ctx, my_adder, 3 /*nargs*/);
@@ -48,7 +50,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_c_function(ctx, my_adder, 3 /*nargs*/);

--- a/tests/api/test-call-prop.c
+++ b/tests/api/test-call-prop.c
@@ -16,7 +16,9 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_eval_string(ctx, "({ myfunc: function(x,y,z) { print(this); return x+y+z; } })");
@@ -40,7 +42,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_eval_string(ctx, "({ myfunc: function(x,y,z) { print(this); throw new Error('my error'); } })");
@@ -66,7 +70,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 }
 
 /* test this coercion in strict/non-strict functions */
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	/* Use Number.prototype to stash new functions, and call "through" a

--- a/tests/api/test-call.c
+++ b/tests/api/test-call.c
@@ -29,7 +29,9 @@ static duk_ret_t my_adder(duk_context *ctx) {
 	return 1;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_c_function(ctx, my_adder, 3 /*nargs*/);
@@ -47,7 +49,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_c_function(ctx, my_adder, 3 /*nargs*/);

--- a/tests/api/test-charcodeat.c
+++ b/tests/api/test-charcodeat.c
@@ -24,8 +24,10 @@ i=18, n=19, charcode=0
 ==> rc=1, result='TypeError: string required, found 123 (stack index -1)'
 ===*/
 
-static int test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_size_t i, n;
+
+	(void) udata;
 
 	/* Simple test, intentional out-of-bounds access at the end. */
 
@@ -40,7 +42,9 @@ static int test_1(duk_context *ctx) {
 	return 0;
 }
 
-static int test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* TypeError for invalid arg type */
 
 	duk_push_int(ctx, 123);

--- a/tests/api/test-check-require-stack-top.c
+++ b/tests/api/test-check-require-stack-top.c
@@ -23,8 +23,10 @@ final top: 1000
 ===*/
 
 /* demonstrate how pushing too many elements causes an error */
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		duk_push_int(ctx, 123);
@@ -37,9 +39,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 /* demonstrate how using one large duk_check_stack_top() before such
  * a loop works.
  */
-static duk_ret_t check_1(duk_context *ctx) {
+static duk_ret_t check_1(duk_context *ctx, void *udata) {
 	int i;
 	duk_ret_t rc;
+
+	(void) udata;
 
 	rc = duk_check_stack_top(ctx, 1000);
 	printf("rc=%d\n", (int) rc);
@@ -53,9 +57,11 @@ static duk_ret_t check_1(duk_context *ctx) {
 }
 
 /* same test but with one element checks, once per loop */
-static duk_ret_t check_2(duk_context *ctx) {
+static duk_ret_t check_2(duk_context *ctx, void *udata) {
 	int i;
 	duk_ret_t rc;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		rc = duk_check_stack_top(ctx, i + 1);
@@ -70,8 +76,10 @@ static duk_ret_t check_2(duk_context *ctx) {
 }
 
 /* try to extend value stack too much with duk_check_stack_top */
-static duk_ret_t check_3(duk_context *ctx) {
+static duk_ret_t check_3(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	rc = duk_check_stack_top(ctx, 1000*1000*1000);
 	printf("rc=%d\n", (int) rc);  /* should print 0: fail */
@@ -81,8 +89,10 @@ static duk_ret_t check_3(duk_context *ctx) {
 }
 
 /* same as check_1 but with duk_require_stack_top() */
-static duk_ret_t require_1(duk_context *ctx) {
+static duk_ret_t require_1(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	duk_require_stack_top(ctx, 1000);
 
@@ -95,8 +105,10 @@ static duk_ret_t require_1(duk_context *ctx) {
 }
 
 /* same as check_2 but with duk_require_stack_top() */
-static duk_ret_t require_2(duk_context *ctx) {
+static duk_ret_t require_2(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		duk_require_stack_top(ctx, i + 1);
@@ -108,7 +120,9 @@ static duk_ret_t require_2(duk_context *ctx) {
 }
 
 /* same as check_3 but with duk_require_stack_top */
-static duk_ret_t require_3(duk_context *ctx) {
+static duk_ret_t require_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_stack_top(ctx, 1000*1000*1000);
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));

--- a/tests/api/test-check-require-stack.c
+++ b/tests/api/test-check-require-stack.c
@@ -23,8 +23,10 @@ final top: 1000
 ===*/
 
 /* demonstrate how pushing too many elements causes an error */
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		duk_push_int(ctx, 123);
@@ -37,9 +39,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 /* demonstrate how using one large duk_check_stack() before such
  * a loop works.
  */
-static duk_ret_t check_1(duk_context *ctx) {
+static duk_ret_t check_1(duk_context *ctx, void *udata) {
 	int i;
 	duk_ret_t rc;
+
+	(void) udata;
 
 	rc = duk_check_stack(ctx, 1000);
 	printf("rc=%d\n", (int) rc);
@@ -53,9 +57,11 @@ static duk_ret_t check_1(duk_context *ctx) {
 }
 
 /* same test but with one element checks, once per loop */
-static duk_ret_t check_2(duk_context *ctx) {
+static duk_ret_t check_2(duk_context *ctx, void *udata) {
 	int i;
 	duk_ret_t rc;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		rc = duk_check_stack(ctx, 1);
@@ -70,8 +76,10 @@ static duk_ret_t check_2(duk_context *ctx) {
 }
 
 /* try to extend value stack too much with duk_check_stack */
-static duk_ret_t check_3(duk_context *ctx) {
+static duk_ret_t check_3(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	rc = duk_check_stack(ctx, 1000*1000*1000);
 	printf("rc=%d\n", (int) rc);  /* should print 0: fail */
@@ -81,8 +89,10 @@ static duk_ret_t check_3(duk_context *ctx) {
 }
 
 /* same as check_1 but with duk_require_stack() */
-static duk_ret_t require_1(duk_context *ctx) {
+static duk_ret_t require_1(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	duk_require_stack(ctx, 1000);
 
@@ -95,8 +105,10 @@ static duk_ret_t require_1(duk_context *ctx) {
 }
 
 /* same as check_2 but with duk_require_stack() */
-static duk_ret_t require_2(duk_context *ctx) {
+static duk_ret_t require_2(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = 0; i < 1000; i++) {
 		duk_require_stack(ctx, 1);
@@ -108,7 +120,9 @@ static duk_ret_t require_2(duk_context *ctx) {
 }
 
 /* same as check_3 but with duk_require_stack */
-static duk_ret_t require_3(duk_context *ctx) {
+static duk_ret_t require_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_stack(ctx, 1000*1000*1000);
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));

--- a/tests/api/test-compile-file.c
+++ b/tests/api/test-compile-file.c
@@ -35,10 +35,12 @@ static void write_file(const char *filename, const char *data) {
 	}
 }
 
-static duk_ret_t test_raw(duk_context *ctx) {
+static duk_ret_t test_raw(duk_context *ctx, void *udata) {
 	const char *data1 = "print('Hello world from a file!'); 123;";
 	const char *data2 = "print('Hello world from a file, with syntax error'); obj = {";
 	duk_ret_t rc;
+
+	(void) udata;
 
 	write_file(TMPFILE, data1);
 	duk_compile_file(ctx, 0, TMPFILE);

--- a/tests/api/test-compile-filename.c
+++ b/tests/api/test-compile-filename.c
@@ -13,8 +13,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	rc = duk_pcompile_string(ctx, 0, "\n\naiee");
 	printf("rc: %ld\n", (long) rc);

--- a/tests/api/test-compile-string.c
+++ b/tests/api/test-compile-string.c
@@ -29,8 +29,10 @@ top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_string(duk_context *ctx) {
+static duk_ret_t test_string(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	/* Normal compile */
 	duk_compile_string(ctx, 0, "print('program code'); 123");
@@ -69,11 +71,13 @@ static duk_ret_t test_string(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_lstring(duk_context *ctx) {
+static duk_ret_t test_lstring(duk_context *ctx, void *udata) {
 	duk_int_t rc;
 	const char *src1 = "print('program code'); 123@";
 	const char *src2 = "print(Duktape.act(-2).function.fileName); 234@";
 	const char *src3 = "print('program code'); 123; obj={@";
+
+	(void) udata;
 
 	/* Normal compile */
 	duk_compile_lstring(ctx, 0, src1, strlen(src1) - 1);

--- a/tests/api/test-compile.c
+++ b/tests/api/test-compile.c
@@ -18,7 +18,9 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_string(ctx, "print('program');\n"
@@ -34,7 +36,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_string(ctx, "2+3");
@@ -48,7 +52,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_string(ctx, "function (x,y) { return x+y; }");
@@ -64,8 +70,10 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 

--- a/tests/api/test-copy.c
+++ b/tests/api/test-copy.c
@@ -35,8 +35,10 @@ static void prep(duk_context *ctx) {
 	duk_push_string(ctx, "foo");  /* -> [ 123 234 345 "foo" ] */
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	prep(ctx);
 	duk_copy(ctx, -4, 2);         /* -> [ 123 234 123 "foo" ] */
@@ -49,8 +51,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	prep(ctx);
 	duk_copy(ctx, -3, -3);  /* nop */
@@ -63,43 +67,57 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, -5, 2);  /* source index too low */
 	return 0;
 }
 
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, 5, 2);  /* source index too high */
 	return 0;
 }
 
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, DUK_INVALID_INDEX, 2);  /* source index invalid */
 	return 0;
 }
 
-static duk_ret_t test_3d(duk_context *ctx) {
+static duk_ret_t test_3d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, 2, -5);  /* source index too low */
 	return 0;
 }
 
-static duk_ret_t test_3e(duk_context *ctx) {
+static duk_ret_t test_3e(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, 2, 5);  /* source index too high */
 	return 0;
 }
 
-static duk_ret_t test_3f(duk_context *ctx) {
+static duk_ret_t test_3f(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_copy(ctx, 2, DUK_INVALID_INDEX);  /* source index invalid */
 	return 0;
 }
 
-static duk_ret_t test_3g(duk_context *ctx) {
+static duk_ret_t test_3g(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	/* indices both invalid and equal: would be nop, but still not allowed for invalid indices */
 	duk_copy(ctx, 10, 10);

--- a/tests/api/test-debugger-notify.c
+++ b/tests/api/test-debugger-notify.c
@@ -12,7 +12,9 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_notify_not_attached(duk_context *ctx) {
+static duk_ret_t test_notify_not_attached(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Not attached, ignored; no arguments. */
 	duk_debugger_notify(ctx, 0);
 	printf("top: %ld\n", (long) duk_get_top(ctx));
@@ -40,7 +42,9 @@ static duk_ret_t test_notify_not_attached(duk_context *ctx) {
 ==> rc=1, result='Error: not enough stack values for notify'
 ===*/
 
-static duk_ret_t test_notify_invalid_count1(duk_context *ctx) {
+static duk_ret_t test_notify_invalid_count1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "DummyNotify");
 	duk_debugger_notify(ctx, 2);
 
@@ -53,7 +57,9 @@ static duk_ret_t test_notify_invalid_count1(duk_context *ctx) {
 ==> rc=1, result='Error: invalid count'
 ===*/
 
-static duk_ret_t test_notify_invalid_count2(duk_context *ctx) {
+static duk_ret_t test_notify_invalid_count2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "DummyNotify");
 	duk_debugger_notify(ctx, -1);
 

--- a/tests/api/test-def-prop-convenience.c
+++ b/tests/api/test-def-prop-convenience.c
@@ -25,7 +25,9 @@ static void dump_prop(duk_context *ctx) {
 	duk_pop(ctx);
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "prop");

--- a/tests/api/test-def-prop.c
+++ b/tests/api/test-def-prop.c
@@ -258,7 +258,9 @@ static void push_setter_lightfunc(duk_context *ctx) {
 }
 
 /* Define new property, value only.  Other attributes get defaults. */
-static duk_ret_t test_value_only(duk_context *ctx) {
+static duk_ret_t test_value_only(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 	duk_push_string(ctx, "dummy");
 	duk_push_string(ctx, "my_key");
@@ -273,7 +275,9 @@ static duk_ret_t test_value_only(duk_context *ctx) {
 }
 
 /* Try to re-define a value for a non-configurable property. */
-static duk_ret_t test_value_redefine(duk_context *ctx) {
+static duk_ret_t test_value_redefine(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Define new property, value only.  Other attributes will have
 	 * default values (false).
 	 */
@@ -315,8 +319,10 @@ static duk_ret_t test_value_redefine(duk_context *ctx) {
 }
 
 /* Define a property with a value and all attribute combinations. */
-static duk_ret_t test_value_attr_combinations(duk_context *ctx) {
+static duk_ret_t test_value_attr_combinations(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	duk_push_object(ctx);
 
@@ -345,7 +351,9 @@ static duk_ret_t test_value_attr_combinations(duk_context *ctx) {
 /* Test presence of value and attributes; exercises the "tri-state"
  * nature of attributes.
  */
-static duk_ret_t test_value_attr_presence(duk_context *ctx) {
+static duk_ret_t test_value_attr_presence(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	/* First set the property to have all attributes true. */
@@ -412,7 +420,9 @@ static duk_ret_t test_value_attr_presence(duk_context *ctx) {
 /* Test property creation with setter, getter, or both.  Use a few attribute
  * combinations at the same time (including not present = default).
  */
-static duk_ret_t test_setget_only(duk_context *ctx) {
+static duk_ret_t test_setget_only(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	/* Getter only. */
@@ -450,7 +460,9 @@ static duk_ret_t test_setget_only(duk_context *ctx) {
 /* Test an invalid call where we "have" a value, a getter, and a setter.
  * This is an invalid property descriptor.
  */
-static duk_ret_t test_value_and_setget(duk_context *ctx) {
+static duk_ret_t test_value_and_setget(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "my_key_1");
@@ -470,7 +482,9 @@ static duk_ret_t test_value_and_setget(duk_context *ctx) {
 /* Test an invalid call where we "have" writable (implies plain property)
  * and setter (implies accessor property).
  */
-static duk_ret_t test_writable_and_set(duk_context *ctx) {
+static duk_ret_t test_writable_and_set(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "my_key_1");
@@ -487,7 +501,9 @@ static duk_ret_t test_writable_and_set(duk_context *ctx) {
 /* Test a valid call where setter and getter are undefined.  This causes
  * them to be removed from the property.
  */
-static duk_ret_t test_setget_undefined(duk_context *ctx) {
+static duk_ret_t test_setget_undefined(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	/* First setup a setter and a getter. */
@@ -522,7 +538,9 @@ static duk_ret_t test_setget_undefined(duk_context *ctx) {
 }
 
 /* Test an invalid call where getter is a non-object (but not undefined). */
-static duk_ret_t test_getter_nonobject(duk_context *ctx) {
+static duk_ret_t test_getter_nonobject(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	/* First setup a setter and a getter. */
@@ -549,7 +567,9 @@ static duk_ret_t test_getter_nonobject(duk_context *ctx) {
 }
 
 /* Test an invalid call where setter is a non-object (but not undefined). */
-static duk_ret_t test_setter_nonobject(duk_context *ctx) {
+static duk_ret_t test_setter_nonobject(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	/* First setup a setter and a getter. */
@@ -576,7 +596,9 @@ static duk_ret_t test_setter_nonobject(duk_context *ctx) {
 }
 
 /* Test an invalid call where getter is a non-callable object. */
-static duk_ret_t test_getter_noncallable(duk_context *ctx) {
+static duk_ret_t test_getter_noncallable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "my_key_1");
@@ -591,7 +613,9 @@ static duk_ret_t test_getter_noncallable(duk_context *ctx) {
 }
 
 /* Test an invalid call where setter is a non-callable object. */
-static duk_ret_t test_setter_noncallable(duk_context *ctx) {
+static duk_ret_t test_setter_noncallable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "my_key_1");
@@ -608,7 +632,9 @@ static duk_ret_t test_setter_noncallable(duk_context *ctx) {
 /* Test that lightfuncs work as setter and getter.  They get coerced to
  * a full function in the process though.
  */
-static duk_ret_t test_setget_lightfunc(duk_context *ctx) {
+static duk_ret_t test_setget_lightfunc(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 
 	duk_push_string(ctx, "my_key_1");
@@ -645,10 +671,14 @@ static duk_ret_t test_force_nonextensible_raw(duk_context *ctx, duk_bool_t force
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_nonextensible(duk_context *ctx) {
+static duk_ret_t test_fail_nonextensible(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_nonextensible_raw(ctx, 0);
 }
-static duk_ret_t test_force_nonextensible(duk_context *ctx) {
+static duk_ret_t test_force_nonextensible(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_nonextensible_raw(ctx, 1);
 }
 
@@ -672,10 +702,14 @@ static duk_ret_t test_force_set_configurable_raw(duk_context *ctx, duk_bool_t fo
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_set_configurable(duk_context *ctx) {
+static duk_ret_t test_fail_set_configurable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_configurable_raw(ctx, 0);
 }
-static duk_ret_t test_force_set_configurable(duk_context *ctx) {
+static duk_ret_t test_force_set_configurable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_configurable_raw(ctx, 1);
 }
 
@@ -699,10 +733,14 @@ static duk_ret_t test_force_set_enumerable_raw(duk_context *ctx, duk_bool_t forc
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_set_enumerable(duk_context *ctx) {
+static duk_ret_t test_fail_set_enumerable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_enumerable_raw(ctx, 0);
 }
-static duk_ret_t test_force_set_enumerable(duk_context *ctx) {
+static duk_ret_t test_force_set_enumerable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_enumerable_raw(ctx, 1);
 }
 
@@ -726,10 +764,14 @@ static duk_ret_t test_force_set_writable_raw(duk_context *ctx, duk_bool_t forced
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_set_writable(duk_context *ctx) {
+static duk_ret_t test_fail_set_writable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_writable_raw(ctx, 0);
 }
-static duk_ret_t test_force_set_writable(duk_context *ctx) {
+static duk_ret_t test_force_set_writable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_writable_raw(ctx, 1);
 }
 
@@ -754,10 +796,14 @@ static duk_ret_t test_force_set_value_raw(duk_context *ctx, duk_bool_t forced) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_set_value(duk_context *ctx) {
+static duk_ret_t test_fail_set_value(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_value_raw(ctx, 0);
 }
-static duk_ret_t test_force_set_value(duk_context *ctx) {
+static duk_ret_t test_force_set_value(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_value_raw(ctx, 1);
 }
 
@@ -786,16 +832,24 @@ static duk_ret_t test_force_set_setget_raw(duk_context *ctx, duk_bool_t setter, 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_set_getter(duk_context *ctx) {
+static duk_ret_t test_fail_set_getter(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_setget_raw(ctx, 0, 0);
 }
-static duk_ret_t test_force_set_getter(duk_context *ctx) {
+static duk_ret_t test_force_set_getter(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_setget_raw(ctx, 0, 1);
 }
-static duk_ret_t test_fail_set_setter(duk_context *ctx) {
+static duk_ret_t test_fail_set_setter(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_setget_raw(ctx, 1, 0);
 }
-static duk_ret_t test_force_set_setter(duk_context *ctx) {
+static duk_ret_t test_force_set_setter(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_set_setget_raw(ctx, 1, 1);
 }
 
@@ -825,10 +879,14 @@ static duk_ret_t test_force_data2accessor_raw(duk_context *ctx, duk_bool_t force
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_data2accessor(duk_context *ctx) {
+static duk_ret_t test_fail_data2accessor(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_data2accessor_raw(ctx, 0);
 }
-static duk_ret_t test_force_data2accessor(duk_context *ctx) {
+static duk_ret_t test_force_data2accessor(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_data2accessor_raw(ctx, 1);
 }
 
@@ -856,10 +914,14 @@ static duk_ret_t test_force_accessor2data_raw(duk_context *ctx, duk_bool_t force
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_accessor2data(duk_context *ctx) {
+static duk_ret_t test_fail_accessor2data(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_accessor2data_raw(ctx, 0);
 }
-static duk_ret_t test_force_accessor2data(duk_context *ctx) {
+static duk_ret_t test_force_accessor2data(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_accessor2data_raw(ctx, 1);
 }
 
@@ -897,16 +959,24 @@ static duk_ret_t test_force_array_smaller_raw(duk_context *ctx, duk_bool_t lengt
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_array_smaller(duk_context *ctx) {
+static duk_ret_t test_fail_array_smaller(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_array_smaller_raw(ctx, 1, 0);
 }
-static duk_ret_t test_force_array_smaller(duk_context *ctx) {
+static duk_ret_t test_force_array_smaller(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_array_smaller_raw(ctx, 1, 1);
 }
-static duk_ret_t test_fail_array_smaller_nonwritablelength(duk_context *ctx) {
+static duk_ret_t test_fail_array_smaller_nonwritablelength(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_array_smaller_raw(ctx, 0, 0);
 }
-static duk_ret_t test_force_array_smaller_nonwritablelength(duk_context *ctx) {
+static duk_ret_t test_force_array_smaller_nonwritablelength(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_array_smaller_raw(ctx, 0, 1);
 }
 
@@ -942,10 +1012,14 @@ static duk_ret_t test_force_nondeletable_raw(duk_context *ctx, duk_bool_t forced
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_fail_nondeletable(duk_context *ctx) {
+static duk_ret_t test_fail_nondeletable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_nondeletable_raw(ctx, 0);
 }
-static duk_ret_t test_force_nondeletable(duk_context *ctx) {
+static duk_ret_t test_force_nondeletable(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return test_force_nondeletable_raw(ctx, 1);
 }
 

--- a/tests/api/test-del-prop.c
+++ b/tests/api/test-del-prop.c
@@ -1,5 +1,5 @@
 /*===
-*** test_1a (duk_safe_call)
+*** test_1a_safecall (duk_safe_call)
 delete obj.foo -> rc=1
 delete obj.nonexistent -> rc=1
 delete obj[123] -> rc=1
@@ -9,31 +9,31 @@ final object: {"bar":"barval"}
 final array: ["foo","bar",null]
 final top: 3
 ==> rc=0, result='undefined'
-*** test_1b (duk_safe_call)
+*** test_1b_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_1b (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_1c (duk_safe_call)
+*** test_1c_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_1c (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_1d (duk_safe_call)
+*** test_1d_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_1d (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_1e (duk_safe_call)
+*** test_1e_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index 234'
 *** test_1e (duk_pcall)
 ==> rc=1, result='Error: invalid stack index 234'
-*** test_1f (duk_safe_call)
+*** test_1f_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index -2147483648'
 *** test_1f (duk_pcall)
 ==> rc=1, result='Error: invalid stack index -2147483648'
-*** test_1g (duk_safe_call)
+*** test_1g_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: cannot delete property 'foo' of null'
 *** test_1g (duk_pcall)
 ==> rc=1, result='TypeError: cannot delete property 'foo' of null'
-*** test_2a (duk_safe_call)
+*** test_2a_safecall (duk_safe_call)
 delete obj.foo -> rc=1
 delete obj.nonexistent -> rc=1
 delete obj['123'] -> rc=1
@@ -43,31 +43,31 @@ final object: {"bar":"barval"}
 final array: ["foo","bar",null]
 final top: 3
 ==> rc=0, result='undefined'
-*** test_2b (duk_safe_call)
+*** test_2b_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_2b (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_2c (duk_safe_call)
+*** test_2c_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_2c (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_2d (duk_safe_call)
+*** test_2d_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_2d (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_2e (duk_safe_call)
+*** test_2e_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index 234'
 *** test_2e (duk_pcall)
 ==> rc=1, result='Error: invalid stack index 234'
-*** test_2f (duk_safe_call)
+*** test_2f_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index -2147483648'
 *** test_2f (duk_pcall)
 ==> rc=1, result='Error: invalid stack index -2147483648'
-*** test_2g (duk_safe_call)
+*** test_2g_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: cannot delete property 'foo' of null'
 *** test_2g (duk_pcall)
 ==> rc=1, result='TypeError: cannot delete property 'foo' of null'
-*** test_3a (duk_safe_call)
+*** test_3a_safecall (duk_safe_call)
 delete obj[31337] -> rc=1
 delete obj[123] -> rc=1
 delete arr[31337] -> rc=1
@@ -76,15 +76,15 @@ final object: {"foo":"fooval","bar":"barval"}
 final array: ["foo","bar",null]
 final top: 3
 ==> rc=0, result='undefined'
-*** test_3b (duk_safe_call)
+*** test_3b_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_3b (duk_pcall)
 ==> rc=1, result='TypeError: not configurable'
-*** test_3c (duk_safe_call)
+*** test_3c_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index 234'
 *** test_3c (duk_pcall)
 ==> rc=1, result='Error: invalid stack index 234'
-*** test_3d (duk_safe_call)
+*** test_3d_safecall (duk_safe_call)
 ==> rc=1, result='Error: invalid stack index -2147483648'
 *** test_3d (duk_pcall)
 ==> rc=1, result='Error: invalid stack index -2147483648'
@@ -106,8 +106,10 @@ static void prep(duk_context *ctx) {
 }
 
 /* duk_del_prop(), success cases */
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a_safecall(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -151,7 +153,6 @@ static duk_ret_t test_1a(duk_context *ctx) {
  */
 static duk_ret_t test_1b(duk_context *ctx) {
 	duk_ret_t rc;
-
 	prep(ctx);
 
 	duk_push_string(ctx, "length");
@@ -160,6 +161,10 @@ static duk_ret_t test_1b(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_1b_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1b(ctx);
 }
 
 /* duk_del_prop(), non-configurable virtual property of a plain string.
@@ -177,6 +182,10 @@ static duk_ret_t test_1c(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_1c_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1c(ctx);
+}
 
 /* duk_del_prop(), non-configurable virtual property of a plain string.
  * Same behavior when called inside/outside of a Duktape/C activation.
@@ -193,6 +202,10 @@ static duk_ret_t test_1d(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_1d_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1d(ctx);
+}
 
 /* duk_del_prop(), invalid index */
 static duk_ret_t test_1e(duk_context *ctx) {
@@ -206,6 +219,10 @@ static duk_ret_t test_1e(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_1e_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1e(ctx);
 }
 
 /* duk_del_prop(), DUK_INVALID_INDEX */
@@ -221,6 +238,10 @@ static duk_ret_t test_1f(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_1f_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1f(ctx);
+}
 
 /* duk_del_prop(), not object coercible */
 static duk_ret_t test_1g(duk_context *ctx) {
@@ -235,10 +256,16 @@ static duk_ret_t test_1g(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_1g_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_1g(ctx);
+}
 
 /* duk_del_prop_string(), success cases */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a_safecall(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -280,6 +307,10 @@ static duk_ret_t test_2b(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_2b_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2b(ctx);
+}
 
 /* duk_del_prop_string(), non-configurable virtual property of a plain string.
  * Same behavior when called inside/outside of a Duktape/C activation.
@@ -294,6 +325,10 @@ static duk_ret_t test_2c(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_2c_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2c(ctx);
 }
 
 /* duk_del_prop_string(), non-configurable virtual property of a plain string.
@@ -310,6 +345,10 @@ static duk_ret_t test_2d(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_2d_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2d(ctx);
+}
 
 /* duk_del_prop_string(), invalid index */
 static duk_ret_t test_2e(duk_context *ctx) {
@@ -322,6 +361,10 @@ static duk_ret_t test_2e(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_2e_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2e(ctx);
 }
 
 /* duk_del_prop_string(), DUK_INVALID_INDEX */
@@ -336,6 +379,10 @@ static duk_ret_t test_2f(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_2f_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2f(ctx);
+}
 
 /* duk_del_prop_string(), not object coercible */
 static duk_ret_t test_2g(duk_context *ctx) {
@@ -349,10 +396,16 @@ static duk_ret_t test_2g(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_2g_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2g(ctx);
+}
 
 /* duk_del_prop_index(), success cases */
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a_safecall(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -391,6 +444,10 @@ static duk_ret_t test_3b(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_3b_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_3b(ctx);
+}
 
 /* duk_del_prop_index(), invalid index */
 static duk_ret_t test_3c(duk_context *ctx) {
@@ -403,6 +460,10 @@ static duk_ret_t test_3c(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_3c_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_3c(ctx);
 }
 
 /* duk_del_prop_index(), DUK_INVALID_INDEX */
@@ -417,41 +478,45 @@ static duk_ret_t test_3d(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_3d_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_3d(ctx);
+}
 
 void test(duk_context *ctx) {
-	TEST_SAFE_CALL(test_1a);
-	TEST_SAFE_CALL(test_1b);
+	TEST_SAFE_CALL(test_1a_safecall);
+	TEST_SAFE_CALL(test_1b_safecall);
 	TEST_PCALL(test_1b);
-	TEST_SAFE_CALL(test_1c);
+	TEST_SAFE_CALL(test_1c_safecall);
 	TEST_PCALL(test_1c);
-	TEST_SAFE_CALL(test_1d);
+	TEST_SAFE_CALL(test_1d_safecall);
 	TEST_PCALL(test_1d);
-	TEST_SAFE_CALL(test_1e);
+	TEST_SAFE_CALL(test_1e_safecall);
 	TEST_PCALL(test_1e);
-	TEST_SAFE_CALL(test_1f);
+	TEST_SAFE_CALL(test_1f_safecall);
 	TEST_PCALL(test_1f);
-	TEST_SAFE_CALL(test_1g);
+	TEST_SAFE_CALL(test_1g_safecall);
 	TEST_PCALL(test_1g);
 
-	TEST_SAFE_CALL(test_2a);
-	TEST_SAFE_CALL(test_2b);
+	TEST_SAFE_CALL(test_2a_safecall);
+	TEST_SAFE_CALL(test_2b_safecall);
 	TEST_PCALL(test_2b);
-	TEST_SAFE_CALL(test_2c);
+	TEST_SAFE_CALL(test_2c_safecall);
 	TEST_PCALL(test_2c);
-	TEST_SAFE_CALL(test_2d);
+	TEST_SAFE_CALL(test_2d_safecall);
 	TEST_PCALL(test_2d);
-	TEST_SAFE_CALL(test_2e);
+	TEST_SAFE_CALL(test_2e_safecall);
 	TEST_PCALL(test_2e);
-	TEST_SAFE_CALL(test_2f);
+	TEST_SAFE_CALL(test_2f_safecall);
 	TEST_PCALL(test_2f);
-	TEST_SAFE_CALL(test_2g);
+	TEST_SAFE_CALL(test_2g_safecall);
 	TEST_PCALL(test_2g);
 
-	TEST_SAFE_CALL(test_3a);
-	TEST_SAFE_CALL(test_3b);
+	TEST_SAFE_CALL(test_3a_safecall);
+	TEST_SAFE_CALL(test_3b_safecall);
 	TEST_PCALL(test_3b);
-	TEST_SAFE_CALL(test_3c);
+	TEST_SAFE_CALL(test_3c_safecall);
 	TEST_PCALL(test_3c);
-	TEST_SAFE_CALL(test_3d);
+	TEST_SAFE_CALL(test_3d_safecall);
 	TEST_PCALL(test_3d);
 }

--- a/tests/api/test-dev-api-verbose-error-messages-gh441.c
+++ b/tests/api/test-dev-api-verbose-error-messages-gh441.c
@@ -150,56 +150,80 @@ done
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_normalize_index(ctx, -3);
 	return 0;
 }
 
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_valid_index(ctx, -3);
 	return 0;
 }
 
-static duk_ret_t test_1c(duk_context *ctx) {
+static duk_ret_t test_1c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_top_index(ctx);
 	return 0;
 }
 
 static duk_ret_t dummy_func(duk_context *ctx) {
 	(void) ctx;
+
 	return 0;
 }
 
-static duk_ret_t test__undefined(duk_context *ctx) {
+static duk_ret_t test__undefined(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_undefined(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__null(duk_context *ctx) {
+static duk_ret_t test__null(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_require_null(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__boolean(duk_context *ctx) {
+static duk_ret_t test__boolean(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_require_boolean(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__number(duk_context *ctx) {
+static duk_ret_t test__number(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_require_number(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__string(duk_context *ctx) {
+static duk_ret_t test__string(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_require_string(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__buffer(duk_context *ctx) {
+static duk_ret_t test__buffer(duk_context *ctx, void *udata) {
 	duk_size_t sz;
+
+	(void) udata;
+
 	(void) duk_require_buffer(ctx, -3, &sz);
 	return 0;
 }
-static duk_ret_t test__pointer(duk_context *ctx) {
+static duk_ret_t test__pointer(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_require_pointer(ctx, -3);
 	return 0;
 }
-static duk_ret_t test__c_function(duk_context *ctx) {
+static duk_ret_t test__c_function(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_require_c_function(ctx, -3);
 	return 0;
 }
@@ -209,7 +233,7 @@ static duk_ret_t test__c_function(duk_context *ctx) {
 		duk_dup(ctx, 0); \
 		duk_push_null(ctx); \
 		duk_push_null(ctx); \
-		rc = duk_safe_call(ctx, (fn), 3, 3); \
+		rc = duk_safe_call(ctx, (fn), NULL, 3, 3); \
 		if (rc != 0) { \
 			duk_eval_string(ctx, "(function (v) { print(String(v).replace(/\\(0x.*?\\)/g, '(PTR)')" \
 			                     ".replace(/light_[0-9a-fA-F_]+/g, 'LFUNC')); })"); \
@@ -237,9 +261,11 @@ static void test__require_calls(duk_context *ctx) {
 	/* No duk_require_object(), duk_require_array(), duk_require_c_lightfunc(), etc. */
 }
 
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Test first with nothing on stack index -3. */
-	duk_safe_call(ctx, test__null, 0, 1); printf("%s\n", duk_safe_to_string(ctx, 0));
+	duk_safe_call(ctx, test__null, NULL, 0, 1); printf("%s\n", duk_safe_to_string(ctx, 0));
 	duk_pop(ctx);
 
 	duk_set_top(ctx, 0); duk_push_undefined(ctx); test__require_calls(ctx);

--- a/tests/api/test-dev-cfunc-name.c
+++ b/tests/api/test-dev-cfunc-name.c
@@ -31,7 +31,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return DUK_RET_URI_ERROR;
 }
 
-static duk_ret_t test_without_name(duk_context *ctx) {
+static duk_ret_t test_without_name(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_function(ctx, my_func, 0);
 	duk_put_global_string(ctx, "MyFunc");
 
@@ -45,7 +47,9 @@ static duk_ret_t test_without_name(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_with_name(duk_context *ctx) {
+static duk_ret_t test_with_name(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_get_global_string(ctx, "MyFunc");
 	duk_push_string(ctx, "my_func");
 	duk_put_prop_string(ctx, -2, "name");

--- a/tests/api/test-dev-cmodule-guide.c
+++ b/tests/api/test-dev-cmodule-guide.c
@@ -52,8 +52,10 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_use_module(duk_context *ignored_ctx) {
+static duk_ret_t test_use_module(duk_context *ignored_ctx, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	ctx = duk_create_heap_default();
 	if (!ctx) {
@@ -106,8 +108,10 @@ static duk_ret_t my_modsearch(duk_context *ctx) {
 	return 0;  /* return undefined, no Ecmascript source code */
 }
 
-static duk_ret_t test_modsearch_module(duk_context *ignored_ctx) {
+static duk_ret_t test_modsearch_module(duk_context *ignored_ctx, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	ctx = duk_create_heap_default();
 	if (!ctx) {

--- a/tests/api/test-dev-error-fileline-blame-gh455.c
+++ b/tests/api/test-dev-error-fileline-blame-gh455.c
@@ -193,6 +193,10 @@ static duk_ret_t my_thrower_1(duk_context *ctx) {
 	duk_call(ctx, 0);
 	return 0;
 }
+static duk_ret_t my_thrower_1_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return my_thrower_1(ctx);
+}
 
 static duk_ret_t my_thrower_2(duk_context *ctx) {
 	/* When an error is thrown using duk_error(), the __FILE__ and __LINE__
@@ -202,6 +206,10 @@ static duk_ret_t my_thrower_2(duk_context *ctx) {
 #line 1234 "dummy.c"
 	duk_error(ctx, DUK_ERR_RANGE_ERROR, "user error");
 	return 0;
+}
+static duk_ret_t my_thrower_2_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return my_thrower_2(ctx);
 }
 
 static duk_ret_t my_thrower_3(duk_context *ctx) {
@@ -213,6 +221,10 @@ static duk_ret_t my_thrower_3(duk_context *ctx) {
 	duk_throw(ctx);
 	return 0;
 }
+static duk_ret_t my_thrower_3_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return my_thrower_3(ctx);
+}
 
 static duk_ret_t my_thrower_4(duk_context *ctx) {
 	/* When an error is thrown from inside Duktape (which is always
@@ -223,15 +235,19 @@ static duk_ret_t my_thrower_4(duk_context *ctx) {
 	duk_require_string(ctx, -1);
 	return 0;
 }
+static duk_ret_t my_thrower_4_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return my_thrower_4(ctx);
+}
 
 /*
  *  Empty callstack
  */
 
-static duk_ret_t empty_helper(duk_context *ctx, duk_c_function target_func) {
+static duk_ret_t empty_helper(duk_context *ctx, duk_safe_call_function target_func) {
 	duk_int_t rc;
 
-	rc = duk_safe_call(ctx, target_func, 0, 1);
+	rc = duk_safe_call(ctx, target_func, NULL, 0, 1);
 	(void) rc;
 
 	duk_eval_string(ctx, "(function (e) { print(e.fileName, e.lineNumber); if (PRINT_STACK) { print(e.stack); } })");
@@ -243,20 +259,28 @@ static duk_ret_t empty_helper(duk_context *ctx, duk_c_function target_func) {
 	return 0;
 }
 
-static duk_ret_t test_empty_1(duk_context *ctx) {
-	return empty_helper(ctx, my_thrower_1);
+static duk_ret_t test_empty_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	return empty_helper(ctx, my_thrower_1_safecall);
 }
 
-static duk_ret_t test_empty_2(duk_context *ctx) {
-	return empty_helper(ctx, my_thrower_2);
+static duk_ret_t test_empty_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	return empty_helper(ctx, my_thrower_2_safecall);
 }
 
-static duk_ret_t test_empty_3(duk_context *ctx) {
-	return empty_helper(ctx, my_thrower_3);
+static duk_ret_t test_empty_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	return empty_helper(ctx, my_thrower_3_safecall);
 }
 
-static duk_ret_t test_empty_4(duk_context *ctx) {
-	return empty_helper(ctx, my_thrower_4);
+static duk_ret_t test_empty_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	return empty_helper(ctx, my_thrower_4_safecall);
 }
 
 /*
@@ -296,19 +320,27 @@ static duk_ret_t nofile_helper(duk_context *ctx, duk_c_function target_func) {
 	return 0;
 }
 
-static duk_ret_t test_nofile_1(duk_context *ctx) {
+static duk_ret_t test_nofile_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return nofile_helper(ctx, my_thrower_1);
 }
 
-static duk_ret_t test_nofile_2(duk_context *ctx) {
+static duk_ret_t test_nofile_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return nofile_helper(ctx, my_thrower_2);
 }
 
-static duk_ret_t test_nofile_3(duk_context *ctx) {
+static duk_ret_t test_nofile_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return nofile_helper(ctx, my_thrower_3);
 }
 
-static duk_ret_t test_nofile_4(duk_context *ctx) {
+static duk_ret_t test_nofile_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return nofile_helper(ctx, my_thrower_4);
 }
 
@@ -349,19 +381,27 @@ static duk_ret_t havefile1_helper(duk_context *ctx, duk_c_function target_func) 
 	return 0;
 }
 
-static duk_ret_t test_havefile1_1(duk_context *ctx) {
+static duk_ret_t test_havefile1_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile1_helper(ctx, my_thrower_1);
 }
 
-static duk_ret_t test_havefile1_2(duk_context *ctx) {
+static duk_ret_t test_havefile1_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile1_helper(ctx, my_thrower_2);
 }
 
-static duk_ret_t test_havefile1_3(duk_context *ctx) {
+static duk_ret_t test_havefile1_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile1_helper(ctx, my_thrower_3);
 }
 
-static duk_ret_t test_havefile1_4(duk_context *ctx) {
+static duk_ret_t test_havefile1_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile1_helper(ctx, my_thrower_4);
 }
 
@@ -406,19 +446,27 @@ static duk_ret_t havefile2_helper(duk_context *ctx, duk_c_function target_func) 
 	return 0;
 }
 
-static duk_ret_t test_havefile2_1(duk_context *ctx) {
+static duk_ret_t test_havefile2_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile2_helper(ctx, my_thrower_1);
 }
 
-static duk_ret_t test_havefile2_2(duk_context *ctx) {
+static duk_ret_t test_havefile2_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile2_helper(ctx, my_thrower_2);
 }
 
-static duk_ret_t test_havefile2_3(duk_context *ctx) {
+static duk_ret_t test_havefile2_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile2_helper(ctx, my_thrower_3);
 }
 
-static duk_ret_t test_havefile2_4(duk_context *ctx) {
+static duk_ret_t test_havefile2_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return havefile2_helper(ctx, my_thrower_4);
 }
 
@@ -469,55 +517,87 @@ static duk_ret_t deep_helper(duk_context *ctx, duk_c_function target_func, int d
 	return 0;
 }
 
-static duk_ret_t test_deep_1a(duk_context *ctx) {
+static duk_ret_t test_deep_1a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_1, 9);
 }
-static duk_ret_t test_deep_1b(duk_context *ctx) {
+static duk_ret_t test_deep_1b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_1, 10);
 }
-static duk_ret_t test_deep_1c(duk_context *ctx) {
+static duk_ret_t test_deep_1c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_1, 11);
 }
-static duk_ret_t test_deep_1d(duk_context *ctx) {
+static duk_ret_t test_deep_1d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_1, 50);
 }
 
-static duk_ret_t test_deep_2a(duk_context *ctx) {
+static duk_ret_t test_deep_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_2, 9);
 }
-static duk_ret_t test_deep_2b(duk_context *ctx) {
+static duk_ret_t test_deep_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_2, 10);
 }
-static duk_ret_t test_deep_2c(duk_context *ctx) {
+static duk_ret_t test_deep_2c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_2, 11);
 }
-static duk_ret_t test_deep_2d(duk_context *ctx) {
+static duk_ret_t test_deep_2d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_2, 50);
 }
 
-static duk_ret_t test_deep_3a(duk_context *ctx) {
+static duk_ret_t test_deep_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_3, 9);
 }
-static duk_ret_t test_deep_3b(duk_context *ctx) {
+static duk_ret_t test_deep_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_3, 10);
 }
-static duk_ret_t test_deep_3c(duk_context *ctx) {
+static duk_ret_t test_deep_3c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_3, 11);
 }
-static duk_ret_t test_deep_3d(duk_context *ctx) {
+static duk_ret_t test_deep_3d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_3, 50);
 }
 
-static duk_ret_t test_deep_4a(duk_context *ctx) {
+static duk_ret_t test_deep_4a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_4, 9);
 }
-static duk_ret_t test_deep_4b(duk_context *ctx) {
+static duk_ret_t test_deep_4b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_4, 10);
 }
-static duk_ret_t test_deep_4c(duk_context *ctx) {
+static duk_ret_t test_deep_4c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_4, 11);
 }
-static duk_ret_t test_deep_4d(duk_context *ctx) {
+static duk_ret_t test_deep_4d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	return deep_helper(ctx, my_thrower_4, 50);
 }
 

--- a/tests/api/test-dev-finalizer-rerun.c
+++ b/tests/api/test-dev-finalizer-rerun.c
@@ -17,8 +17,10 @@ heap destroyed
  * Object has been finalized but not yet rescued, and should not be
  * finalized again on destruction.
  */
-static duk_ret_t test_heap_destruction(duk_context *ignored_ctx) {
+static duk_ret_t test_heap_destruction(duk_context *ignored_ctx, void *udata) {
 	duk_context *my_ctx;
+
+	(void) udata;
 
 	printf("creating heap\n"); fflush(stdout);
 	my_ctx = duk_create_heap_default();

--- a/tests/api/test-dev-finalizer-rescue-unwind.c
+++ b/tests/api/test-dev-finalizer-rescue-unwind.c
@@ -21,7 +21,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string_noresult(ctx,
 		"this.myFinalizer = function myfin(o) {\n"
 		"    print('finalizer, rescuing object', JSON.stringify(o));\n"

--- a/tests/api/test-dev-func-tostring.c
+++ b/tests/api/test-dev-func-tostring.c
@@ -17,7 +17,9 @@ static duk_ret_t dummy_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Lightfunc, must sanitize the address for the expect string. */
 	duk_eval_string(ctx,
 		"(function (v) {\n"

--- a/tests/api/test-dev-internal-key-access.c
+++ b/tests/api/test-dev-internal-key-access.c
@@ -14,7 +14,9 @@ final top: 2
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx, "new Date(123456)");
 	duk_push_string(ctx, "\xffValue");
 	duk_get_prop(ctx, -2);

--- a/tests/api/test-dev-internal-property-basics.c
+++ b/tests/api/test-dev-internal-property-basics.c
@@ -9,7 +9,9 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx, "(function (x) { print(Duktape.enc('jx', x)); })");
 
 	duk_push_object(ctx);

--- a/tests/api/test-dev-lightfunc-toobject-varargs.c
+++ b/tests/api/test-dev-lightfunc-toobject-varargs.c
@@ -21,7 +21,9 @@ static duk_ret_t my_lightfunc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* First test: lightfunc without varargs. */
 
 	duk_push_c_lightfunc(ctx, my_lightfunc, 12 /*nargs*/, 3 /*length*/, 0 /*magic*/);
@@ -39,7 +41,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Second test: lightfunc with varargs. */
 
 	duk_push_c_lightfunc(ctx, my_lightfunc, DUK_VARARGS /*nargs*/, 3 /*length*/, 0 /*magic*/);

--- a/tests/api/test-dev-lightfunc.c
+++ b/tests/api/test-dev-lightfunc.c
@@ -36,8 +36,10 @@ static duk_ret_t my_dummy_func(duk_context *ctx) {
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_is_lightfunc(duk_context *ctx) {
+static duk_ret_t test_is_lightfunc(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	/* Just a few spot checks. */
 
@@ -72,8 +74,10 @@ final top: 3
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_simple_push(duk_context *ctx) {
+static duk_ret_t test_simple_push(duk_context *ctx, void *udata) {
 	duk_idx_t ret;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);  /* dummy padding */
@@ -615,21 +619,25 @@ i=256, res=Error: invalid call args
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_magic_raw(duk_context *ctx) {
+static duk_ret_t test_magic_raw(duk_context *ctx, void *udata) {
 	int i = duk_require_int(ctx, -1);
 	duk_idx_t ret;
+
+	(void) udata;
 
 	ret = duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, 3 /*length*/, i /*magic*/);
 	duk_push_int(ctx, (duk_int_t) ret);
 	return 1;
 }
 
-static duk_ret_t test_magic(duk_context *ctx) {
+static duk_ret_t test_magic(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = -256; i <= 256; i++) {
 		duk_push_int(ctx, i);
-		duk_safe_call(ctx, test_magic_raw, 1, 1);
+		duk_safe_call(ctx, test_magic_raw, NULL, 1, 1);
 		printf("i=%ld, res=%s\n", (long) i, duk_safe_to_string(ctx, -1));
 		duk_pop(ctx);
 	}
@@ -674,21 +682,25 @@ i=16, res=Error: invalid call args
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_length_raw(duk_context *ctx) {
+static duk_ret_t test_length_raw(duk_context *ctx, void *udata) {
 	int i = duk_require_int(ctx, -1);
 	duk_idx_t ret;
+
+	(void) udata;
 
 	ret = duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, i /*length*/, 0x42 /*magic*/);
 	duk_push_int(ctx, (duk_int_t) ret);
 	return 1;
 }
 
-static duk_ret_t test_length_values(duk_context *ctx) {
+static duk_ret_t test_length_values(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	for (i = -16; i <= 16; i++) {
 		duk_push_int(ctx, i);
-		duk_safe_call(ctx, test_length_raw, 1, 1);
+		duk_safe_call(ctx, test_length_raw, NULL, 1, 1);
 		printf("i=%ld, res=%s\n", (long) i, duk_safe_to_string(ctx, -1));
 		duk_pop(ctx);
 	}
@@ -736,19 +748,23 @@ i=18, nargs=18, res=Error: invalid call args
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_nargs_raw(duk_context *ctx) {
+static duk_ret_t test_nargs_raw(duk_context *ctx, void *udata) {
 	int i = duk_require_int(ctx, -1);
 	duk_idx_t ret;
+
+	(void) udata;
 
 	ret = duk_push_c_lightfunc(ctx, my_addtwo_lfunc, i /*nargs*/, 2 /*length*/, 0x42 /*magic*/);
 	duk_push_int(ctx, (duk_int_t) ret);
 	return 1;
 }
 
-static duk_ret_t test_nargs_values(duk_context *ctx) {
+static duk_ret_t test_nargs_values(duk_context *ctx, void *udata) {
 	int i;
 	int nargs;
 	int is_vararg;
+
+	(void) udata;
 
 	for (i = -16; i <= 18; i++) {
 		if (i == 17) {
@@ -758,7 +774,7 @@ static duk_ret_t test_nargs_values(duk_context *ctx) {
 		}
 		nargs = duk_get_int(ctx, -1);
 		is_vararg =  (nargs == DUK_VARARGS);
-		duk_safe_call(ctx, test_nargs_raw, 1, 1);
+		duk_safe_call(ctx, test_nargs_raw, NULL, 1, 1);
 		printf("i=%ld, nargs=%ld%s, res=%s\n",
 		       (long) i, (long) nargs, (is_vararg ? " (varargs)" : ""),
 		       duk_safe_to_string(ctx, -1));
@@ -796,7 +812,9 @@ top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_enum(duk_context *ctx) {
+static duk_ret_t test_enum(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, 3 /*length*/, 0x42 /*magic*/);
 
 	printf("enum defaults\n");
@@ -846,8 +864,10 @@ final top: 2
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_get_length(duk_context *ctx) {
+static duk_ret_t test_get_length(duk_context *ctx, void *udata) {
 	duk_size_t len;
+
+	(void) udata;
 
 	/*
 	 *  Lightfunc length is its virtual 'length' property, same as for
@@ -882,7 +902,9 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_to_object(duk_context *ctx) {
+static duk_ret_t test_to_object(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	(void) duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, 3 /*length*/, 0x42 /*magic*/);
 
 	printf("tag before: %ld\n", (long) duk_get_type(ctx, -1));
@@ -911,9 +933,11 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_to_buffer(duk_context *ctx) {
+static duk_ret_t test_to_buffer(duk_context *ctx, void *udata) {
 	duk_size_t sz;
 	unsigned char *p;
+
+	(void) udata;
 
 	(void) duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, 3 /*length*/, 0x42 /*magic*/);
 
@@ -958,8 +982,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_to_pointer(duk_context *ctx) {
+static duk_ret_t test_to_pointer(duk_context *ctx, void *udata) {
 	void *p;
+
+	(void) udata;
 
 	(void) duk_push_c_lightfunc(ctx, my_addtwo_lfunc, 2 /*nargs*/, 3 /*length*/, 0x42 /*magic*/);
 
@@ -989,7 +1015,9 @@ final top: 1
  * because duk_is_object() is 0 for lightfuncs.
  */
 
-static duk_ret_t test_is_primitive(duk_context *ctx) {
+static duk_ret_t test_is_primitive(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_lightfunc(ctx, my_dummy_func, 0, 0, 0);
 	printf("is_primitive: %ld\n", (long) duk_is_primitive(ctx, -1));
 
@@ -1006,7 +1034,9 @@ final top: 1
 
 /* Lightfuncs are not objects (they're primitive). */
 
-static duk_ret_t test_is_object(duk_context *ctx) {
+static duk_ret_t test_is_object(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_lightfunc(ctx, my_dummy_func, 0, 0, 0);
 	printf("is_object: %ld\n", (long) duk_is_object(ctx, -1));
 
@@ -1022,7 +1052,9 @@ final top: 1
 
 /* Lightfuncs are object coercible. */
 
-static duk_ret_t test_is_object_coercible(duk_context *ctx) {
+static duk_ret_t test_is_object_coercible(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_lightfunc(ctx, my_dummy_func, 0, 0, 0);
 	printf("is_object_coercible: %ld\n", (long) duk_is_object_coercible(ctx, -1));
 

--- a/tests/api/test-dev-prototype-loop.c
+++ b/tests/api/test-dev-prototype-loop.c
@@ -90,7 +90,9 @@ static void prep(duk_context *ctx) {
 	 */
 }
 
-static duk_ret_t test_gc(duk_context *ctx) {
+static duk_ret_t test_gc(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 
 	/* Both objects are now in a prototype loop.  Force garbage
@@ -113,7 +115,9 @@ static duk_ret_t test_gc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_is_prototype_of(duk_context *ctx) {
+static duk_ret_t test_is_prototype_of(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 
 	/* obj0.isPrototypeOf(dummy) -> false, traverses prototype chain of dummy */
@@ -143,13 +147,17 @@ static duk_ret_t test_is_prototype_of(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t augment_raw(duk_context *ctx) {
+static duk_ret_t augment_raw(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_throw(ctx);
 	return 0;
 }
 
-static duk_ret_t test_error_augment(duk_context *ctx) {
+static duk_ret_t test_error_augment(duk_context *ctx, void *udata) {
 	duk_int_t ret;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -169,7 +177,7 @@ static duk_ret_t test_error_augment(duk_context *ctx) {
 	 */
 
 	duk_dup(ctx, 0);
-	ret = duk_safe_call(ctx, augment_raw, 0 /*nargs*/, 1 /*nrets*/);
+	ret = duk_safe_call(ctx, augment_raw, NULL, 0 /*nargs*/, 1 /*nrets*/);
 	printf("ret=%d\n", (int) ret);
 	duk_get_prop_string(ctx, -1, "foo");
 	printf("throw value .foo=%d\n", duk_get_int(ctx, -1));
@@ -178,8 +186,10 @@ static duk_ret_t test_error_augment(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_hasprop(duk_context *ctx) {
+static duk_ret_t test_hasprop(duk_context *ctx, void *udata) {
 	duk_bool_t ret;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -198,7 +208,9 @@ static duk_ret_t test_hasprop(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_getprop(duk_context *ctx) {
+static duk_ret_t test_getprop(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 
 	/* Property exists, own property */
@@ -219,7 +231,9 @@ static duk_ret_t test_getprop(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_putprop(duk_context *ctx) {
+static duk_ret_t test_putprop(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 
 	/* Property exists, own property */
@@ -240,7 +254,9 @@ static duk_ret_t test_putprop(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_instanceof(duk_context *ctx) {
+static duk_ret_t test_instanceof(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 
 	/* For 'a instanceof b', the [[HasInstance]] algorithm looks up

--- a/tests/api/test-dev-return-types.c
+++ b/tests/api/test-dev-return-types.c
@@ -35,7 +35,9 @@ final top: 0
 ===*/
 
 /* Normal call from a duk_safe_call() wrapper, implicit return value. */
-static duk_ret_t test_basic_implicit(duk_context *ctx) {
+static duk_ret_t test_basic_implicit(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    print('inside func');\n"
@@ -49,7 +51,9 @@ static duk_ret_t test_basic_implicit(duk_context *ctx) {
 }
 
 /* Normal call from a duk_safe_call() wrapper, explicit return value. */
-static duk_ret_t test_basic_explicit(duk_context *ctx) {
+static duk_ret_t test_basic_explicit(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    print('inside func');\n"
@@ -66,7 +70,9 @@ static duk_ret_t test_basic_explicit(duk_context *ctx) {
 /* Ecmascript finally captures return and the return is propagated
  * onwards after finally finishes.
  */
-static duk_ret_t test_endfin_return(duk_context *ctx) {
+static duk_ret_t test_endfin_return(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    try {\n"

--- a/tests/api/test-dev-rom-builtins-1.c
+++ b/tests/api/test-dev-rom-builtins-1.c
@@ -20,7 +20,9 @@
  * different from setPrototypeOf() because the C API does not care if
  * the object is non-extensible.
  */
-static duk_ret_t test_set_prototype(duk_context *ctx) {
+static duk_ret_t test_set_prototype(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx, "Math");
 	duk_push_object(ctx);  /* dummy */
 	duk_set_prototype(ctx, -2);

--- a/tests/api/test-dev-valstack-checked-size-call.c
+++ b/tests/api/test-dev-valstack-checked-size-call.c
@@ -89,14 +89,18 @@ static duk_ret_t my_func_error2(duk_context *ctx) {
 	return DUK_RET_URI_ERROR;
 }
 
-static duk_ret_t my_safe_func_success(duk_context *ctx) {
+static duk_ret_t my_safe_func_success(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("hello from my_safe_func_success\n");
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 234);
 	return 2;  /* caller wants 1 ret only, so 123 is effective */
 }
 
-static duk_ret_t my_safe_func_error1(duk_context *ctx) {
+static duk_ret_t my_safe_func_error1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("hello from my_safe_func_error1\n");
 	duk_error(ctx, 123, "error thrown by my_safe_func_error1");
 	duk_push_int(ctx, 123);
@@ -104,15 +108,19 @@ static duk_ret_t my_safe_func_error1(duk_context *ctx) {
 	return 2;  /* caller wants 1 ret only, so 123 is effective */
 }
 
-static duk_ret_t my_safe_func_error2(duk_context *ctx) {
+static duk_ret_t my_safe_func_error2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("hello from my_safe_func_error2\n");
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 234);
 	return DUK_RET_URI_ERROR;
 }
 
-static duk_ret_t test_ecma_call_success(duk_context *ctx) {
+static duk_ret_t test_ecma_call_success(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	/* Ensure stack space for a lot of elements. */
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
@@ -139,8 +147,10 @@ static duk_ret_t test_ecma_call_success(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_ecma_call_error(duk_context *ctx) {
+static duk_ret_t test_ecma_call_error(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -156,9 +166,11 @@ static duk_ret_t test_ecma_call_error(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_ecma_pcall_success(duk_context *ctx) {
+static duk_ret_t test_ecma_pcall_success(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -174,9 +186,11 @@ static duk_ret_t test_ecma_pcall_success(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_ecma_pcall_error(duk_context *ctx) {
+static duk_ret_t test_ecma_pcall_error(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -192,8 +206,10 @@ static duk_ret_t test_ecma_pcall_error(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_call_success(duk_context *ctx) {
+static duk_ret_t test_c_call_success(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -209,8 +225,10 @@ static duk_ret_t test_c_call_success(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_call_error1(duk_context *ctx) {
+static duk_ret_t test_c_call_error1(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -226,8 +244,10 @@ static duk_ret_t test_c_call_error1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_call_error2(duk_context *ctx) {
+static duk_ret_t test_c_call_error2(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -243,9 +263,11 @@ static duk_ret_t test_c_call_error2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_pcall_success(duk_context *ctx) {
+static duk_ret_t test_c_pcall_success(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -261,9 +283,11 @@ static duk_ret_t test_c_pcall_success(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_pcall_error1(duk_context *ctx) {
+static duk_ret_t test_c_pcall_error1(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -279,9 +303,11 @@ static duk_ret_t test_c_pcall_error1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_c_pcall_error2(duk_context *ctx) {
+static duk_ret_t test_c_pcall_error2(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
@@ -297,13 +323,15 @@ static duk_ret_t test_c_pcall_error2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_safe_call_success(duk_context *ctx) {
+static duk_ret_t test_safe_call_success(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
 
+	(void) udata;
+
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
-	rc = duk_safe_call(ctx, my_safe_func_success, 0 /*nargs*/, 1 /*nrets*/);
+	rc = duk_safe_call(ctx, my_safe_func_success, NULL, 0 /*nargs*/, 1 /*nrets*/);
 	printf("duk_safe_call: rc=%ld, value: %s\n", (long) rc, duk_safe_to_string(ctx, -1));
 
 	for (i = 0; i < STACK_REQUIRE; i++) {
@@ -314,13 +342,15 @@ static duk_ret_t test_safe_call_success(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_safe_call_error1(duk_context *ctx) {
+static duk_ret_t test_safe_call_error1(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
 
+	(void) udata;
+
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
-	rc = duk_safe_call(ctx, my_safe_func_error1, 0 /*nargs*/, 1 /*nrets*/);
+	rc = duk_safe_call(ctx, my_safe_func_error1, NULL, 0 /*nargs*/, 1 /*nrets*/);
 	printf("duk_safe_call: rc=%ld, value: %s\n", (long) rc, duk_safe_to_string(ctx, -1));
 
 	for (i = 0; i < STACK_REQUIRE; i++) {
@@ -331,13 +361,15 @@ static duk_ret_t test_safe_call_error1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_safe_call_error2(duk_context *ctx) {
+static duk_ret_t test_safe_call_error2(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	duk_int_t rc;
 
+	(void) udata;
+
 	duk_require_stack(ctx, STACK_REQUIRE + 1);
 
-	rc = duk_safe_call(ctx, my_safe_func_error2, 0 /*nargs*/, 1 /*nrets*/);
+	rc = duk_safe_call(ctx, my_safe_func_error2, NULL, 0 /*nargs*/, 1 /*nrets*/);
 	printf("duk_safe_call: rc=%ld, value: %s\n", (long) rc, duk_safe_to_string(ctx, -1));
 
 	for (i = 0; i < STACK_REQUIRE; i++) {

--- a/tests/api/test-dump-context.c
+++ b/tests/api/test-dump-context.c
@@ -5,7 +5,9 @@ final top: 4
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_int(ctx, 123);
 	duk_eval_string(ctx, "'foo\\u1234bar'");
 	duk_eval_string(ctx, "({ foo: 123, bar: [ 1, 2, 3 ]})");

--- a/tests/api/test-dump-load-basic.c
+++ b/tests/api/test-dump-load-basic.c
@@ -53,9 +53,11 @@ final top: 1
  * function.  Hex dumping the bytecode provides an exact test case dependency
  * to the dump format so that any accidental changes break the test.
  */
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	duk_size_t i, sz;
+
+	(void) udata;
 
 	/* Integer constants generate LDINT now so also use a fractional
 	 * constant to exercise number constants.
@@ -126,9 +128,11 @@ final top: 1
 ===*/
 
 /* Dump/load mandelbrot.  No inner functions but a bit more code. */
-static duk_ret_t test_mandel(duk_context *ctx) {
+static duk_ret_t test_mandel(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	duk_size_t i, sz;
+
+	(void) udata;
 
 	printf("Mandelbrot source length: %ld\n", (long) strlen(MANDELBROT));
 
@@ -163,7 +167,9 @@ final top: 1
 ===*/
 
 /* Test dumping of a large function to exercise buffer resizes. */
-static duk_ret_t test_large_func(duk_context *ctx) {
+static duk_ret_t test_large_func(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var res = [];\n"
@@ -204,7 +210,9 @@ final top: 0
 ===*/
 
 /* Properties and property attributes of a loaded function. */
-static duk_ret_t test_properties(duk_context *ctx) {
+static duk_ret_t test_properties(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Compile explicitly to force fileName. */
 	duk_push_string(ctx,
 		"(function () {\n"
@@ -258,7 +266,9 @@ final top: 0
  * - Bindings established via Eval code are not configurable
  *   (E5 Section 10.5 step 2).
  */
-static duk_ret_t test_program_code(duk_context *ctx) {
+static duk_ret_t test_program_code(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Demonstrate behavior without dump/load. */
 	duk_compile_string(ctx, 0,
 		"var testProgram1 = 123;"
@@ -302,7 +312,9 @@ final top: 0
  * Here we bytecode dump an eval function that is then loaded and executed
  * in the global scope.
  */
-static duk_ret_t test_eval_code(duk_context *ctx) {
+static duk_ret_t test_eval_code(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Demonstrate behavior without dump/load. */
 	duk_compile_string(ctx, DUK_COMPILE_EVAL,
 		"var testEval1 = 123;"
@@ -338,7 +350,9 @@ final top: 0
 ===*/
 
 /* Strictness status is preserved. */
-static duk_ret_t test_strict(duk_context *ctx) {
+static duk_ret_t test_strict(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_compile_string(ctx, DUK_COMPILE_FUNCTION,
 		"function () {\n"
 		"    var strict = (function () { return !this; })();\n"
@@ -373,7 +387,9 @@ final top: 0
 ===*/
 
 /* _Varmap is preserved if function needs it. */
-static duk_ret_t test_varmap(duk_context *ctx) {
+static duk_ret_t test_varmap(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Get access to _Varmap by creating a function that provides
 	 * an 'eval service' in a function scope.
 	 */
@@ -418,7 +434,9 @@ final top: 0
 ===*/
 
 /* Arguments object still works after dump/load, relies on e.g. _Formals. */
-static duk_ret_t test_arguments_object(duk_context *ctx) {
+static duk_ret_t test_arguments_object(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var f = function test(x,y) {\n"
@@ -456,7 +474,9 @@ final top: 0
 ===*/
 
 /* _Pc2line is preserved, check by traceback line numbers. */
-static duk_ret_t test_pc2line(duk_context *ctx) {
+static duk_ret_t test_pc2line(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var f = function test() {\n"
@@ -505,7 +525,9 @@ final top: 0
 /* Name binding for function expressions is preserved, it is important
  * for recursive functions.
  */
-static duk_ret_t test_name_binding_funcexpr(duk_context *ctx) {
+static duk_ret_t test_name_binding_funcexpr(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var f = function test() { print('i am a ' + typeof test); };\n"
@@ -552,7 +574,9 @@ final top: 1
  * we dump/load the function, only the function object is resurrected while the
  * global binding is not.
  */
-static duk_ret_t test_name_binding_funcdecl(duk_context *ctx) {
+static duk_ret_t test_name_binding_funcdecl(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_compile_string(ctx, 0 /*flags: program*/,
 		"function declaredTest() {\n"
 		"    print('i am a ' + typeof declaredTest);\n"
@@ -582,7 +606,9 @@ dummythis x-arg y-arg
 ===*/
 
 /* Bound functions are rejected with TypeError. */
-static duk_ret_t test_bound_rejected(duk_context *ctx) {
+static duk_ret_t test_bound_rejected(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* XXX: Perhaps rework bound function support so that the final non-bound
 	 * function is serialized instead?
 	 */
@@ -615,7 +641,9 @@ final top: 0
 ===*/
 
 /* Custom external prototype is lost during a dump/load. */
-static duk_ret_t test_external_prototype_lost(duk_context *ctx) {
+static duk_ret_t test_external_prototype_lost(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var f = function test() {};\n"
@@ -656,7 +684,9 @@ final top: 0
 ===*/
 
 /* Custom internal prototype is lost during a dump/load. */
-static duk_ret_t test_internal_prototype_lost(duk_context *ctx) {
+static duk_ret_t test_internal_prototype_lost(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx,
 		"(function () {\n"
 		"    var f = function test() {};\n"

--- a/tests/api/test-dump-load-fastint.c
+++ b/tests/api/test-dump-load-fastint.c
@@ -18,7 +18,9 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* copied from polyfills/duktape-isfastint.js */
 	duk_eval_string_noresult(ctx,
 		"Object.defineProperty(Duktape, 'fastintTag', {\n"

--- a/tests/api/test-dup.c
+++ b/tests/api/test-dup.c
@@ -16,8 +16,10 @@ final top: 4
 ==> rc=1, result='Error: invalid stack index -1'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -35,7 +37,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -46,7 +50,9 @@ static duk_ret_t test_2a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -57,7 +63,9 @@ static duk_ret_t test_2b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -68,7 +76,9 @@ static duk_ret_t test_2c(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_dup_top(ctx);  /* empty */

--- a/tests/api/test-enum.c
+++ b/tests/api/test-enum.c
@@ -39,7 +39,9 @@ final top: 0
 ===*/
 
 /* basic enum success cases */
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	printf("object with own properties only, enum with get_value=0\n");

--- a/tests/api/test-errhandler.c
+++ b/tests/api/test-errhandler.c
@@ -22,7 +22,9 @@ static void remove_handlers(duk_context *ctx) {
 	duk_pop(ctx);
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	remove_handlers(ctx);
@@ -38,7 +40,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	remove_handlers(ctx);
@@ -53,7 +57,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	/* Causes a ReferenceError when error handler runs.  The
@@ -70,7 +76,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	remove_handlers(ctx);
@@ -87,7 +95,9 @@ static duk_ret_t test_4(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_5(duk_context *ctx) {
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	remove_handlers(ctx);

--- a/tests/api/test-error.c
+++ b/tests/api/test-error.c
@@ -6,7 +6,7 @@ name: RangeError
 message: range error: 123
 code: undefined
 fileName is a string: 1
-lineNumber: 43
+lineNumber: 45
 isNative: undefined
 *** test_2 (duk_pcall)
 ==> rc=1
@@ -15,7 +15,7 @@ name: Error
 message: arbitrary error code
 code: undefined
 fileName is a string: 1
-lineNumber: 52
+lineNumber: 56
 isNative: undefined
 *** test_3 (duk_pcall)
 ==> rc=1
@@ -24,7 +24,7 @@ name: TypeError
 message: 105
 code: undefined
 fileName is a string: 1
-lineNumber: 62
+lineNumber: 68
 isNative: undefined
 *** test_4 (duk_pcall)
 ==> rc=1
@@ -33,11 +33,13 @@ name: RangeError
 message: my error 123 234 foobar
 code: undefined
 fileName is a string: 1
-lineNumber: 73
+lineNumber: 79
 isNative: undefined
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_error(ctx, DUK_ERR_RANGE_ERROR, "range error: %d", 123);
@@ -46,7 +48,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_error(ctx, 1234567, "arbitrary error code");
@@ -55,7 +59,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	/* error code replaces message automatically now if message is NULL */
@@ -74,7 +80,9 @@ static void my_error(duk_context *ctx, duk_errcode_t errcode, const char *fmt, .
 	va_end(ap);
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	my_error(ctx, DUK_ERR_RANGE_ERROR, "my error %d %d %s", 123, 234, "foobar");
@@ -118,7 +126,7 @@ void dump_error(duk_context *ctx) {
 /* use custom helper because of dump_error() */
 #define  TEST(func)  do {  \
 		printf("*** %s (duk_pcall)\n", #func); \
-		rc = duk_safe_call(ctx, (func), 0, 1); \
+		rc = duk_safe_call(ctx, (func), NULL, 0, 1); \
 		printf("==> rc=%d\n", (int) rc); \
 		dump_error(ctx); \
 		duk_pop(ctx); \

--- a/tests/api/test-eval-file.c
+++ b/tests/api/test-eval-file.c
@@ -48,11 +48,13 @@ static void write_file(const char *filename, const char *data) {
 	}
 }
 
-static int test_raw(duk_context *ctx) {
+static duk_ret_t test_raw(duk_context *ctx, void *udata) {
 	const char *data1 = "print('Hello world from a file!'); 123;";
 	const char *data2 = "print('Hello world from a file, with exception'); throw new Error('eval error');";
 	const char *data3 = "print('Hello world from a file, with syntax error'); obj = {";
 	duk_ret_t rc;
+
+	(void) udata;
 
 	write_file(TMPFILE, data1);
 

--- a/tests/api/test-eval-filename.c
+++ b/tests/api/test-eval-filename.c
@@ -12,8 +12,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	rc = duk_peval_string(ctx, "\n\naiee");
 	printf("rc: %ld\n", (long) rc);

--- a/tests/api/test-eval-strictness.c
+++ b/tests/api/test-eval-strictness.c
@@ -43,8 +43,10 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	const char *str;
+
+	(void) udata;
 
 	/* Eval happens outside of a Duktape/C activation.  The eval code was
 	 * executed in non-strict mode also in Duktape 0.11.0 and prior.
@@ -75,8 +77,10 @@ static duk_ret_t test_2_inner(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	const char *str;
+
+	(void) udata;
 
 	printf("context is strict: %d\n", duk_is_strict_call(ctx));
 

--- a/tests/api/test-eval-string.c
+++ b/tests/api/test-eval-string.c
@@ -35,8 +35,10 @@ top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_string(duk_context *ctx) {
+static duk_ret_t test_string(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "print('Hello world!'); 123;");
 	printf("return value is: %lf\n", duk_get_number(ctx, -1));
@@ -75,13 +77,15 @@ static duk_ret_t test_string(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_lstring(duk_context *ctx) {
+static duk_ret_t test_lstring(duk_context *ctx, void *udata) {
 	duk_int_t rc;
 	const char *src1 = "print('Hello world!'); 123;@";
 	const char *src2 = "'testString'.toUpperCase()@";
 	const char *src3 = "throw new Error('eval error');@";
 	const char *src4 = "throw new Error('eval error'); obj = {@";
 	const char *src5 = "print('Hello world!'); obj = {@";
+
+	(void) udata;
 
 	duk_eval_lstring(ctx, src1, strlen(src1) - 1);
 	printf("return value is: %lf\n", duk_get_number(ctx, -1));

--- a/tests/api/test-eval-this-binding.c
+++ b/tests/api/test-eval-this-binding.c
@@ -16,7 +16,9 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* For non-strict eval code the 'this' binding was effectively
 	 * the global object even before fixing GH-164: an undefined
 	 * 'this' binding gets promoted to the global object by the

--- a/tests/api/test-external-buffer.c
+++ b/tests/api/test-external-buffer.c
@@ -26,10 +26,12 @@ final top: 0
 
 unsigned char global_buffer[256];
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t len;
 	int i;
+
+	(void) udata;
 
 	for (i = 0; i < sizeof(global_buffer); i++) {
 		if ((i / 3) & 2) {
@@ -82,7 +84,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 }
 
 /* Attempt to set external buffer for wrong buffer type. */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 1024);
 	duk_config_buffer(ctx, -1, (void *) global_buffer, sizeof(global_buffer));
 
@@ -90,7 +94,9 @@ static duk_ret_t test_2a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_dynamic_buffer(ctx, 1024);
 	duk_config_buffer(ctx, -1, (void *) global_buffer, sizeof(global_buffer));
 
@@ -99,7 +105,9 @@ static duk_ret_t test_2b(duk_context *ctx) {
 }
 
 /* Attempt to set external buffer for wrong type altogether. */
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 	duk_config_buffer(ctx, -1, (void *) global_buffer, sizeof(global_buffer));
 
@@ -108,8 +116,10 @@ static duk_ret_t test_3(duk_context *ctx) {
 }
 
 /* Check Duktape.info() for external buffers. */
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	unsigned char buf[16];
+
+	(void) udata;
 
 	/* Censor refcount too because e.g. in shuffle torture test the
 	 * refcount will be different than otherwise.

--- a/tests/api/test-fatal.c
+++ b/tests/api/test-fatal.c
@@ -10,7 +10,9 @@ void my_fatal_handler(duk_context *ctx, duk_errcode_t code, const char *msg) {
 	exit(0);
 }
 
-static duk_ret_t my_func(duk_context *ctx) {
+static duk_ret_t my_func(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("my_func\n");
 	duk_fatal(ctx, 123456, "reason");
 	printf("never here\n");
@@ -21,6 +23,6 @@ void test(duk_context *ctx) {
 	duk_context *new_ctx;
 
 	new_ctx = duk_create_heap(NULL, NULL, NULL, NULL, my_fatal_handler);
-	duk_safe_call(new_ctx, my_func, 0, 1);
+	duk_safe_call(new_ctx, my_func, NULL, 0, 1);
 	printf("duk_safe_call() returned, should not happen\n");
 }

--- a/tests/api/test-get-buffer-data.c
+++ b/tests/api/test-get-buffer-data.c
@@ -23,8 +23,10 @@ final top: 18
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_push_undefined(ctx);
 	duk_push_null(ctx);
@@ -73,8 +75,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_null_ptr(duk_context *ctx) {
+static duk_ret_t test_null_ptr(duk_context *ctx, void *udata) {
 	void *p;
+
+	(void) udata;
 
 	duk_eval_string(ctx,
 		"(function () {\n"
@@ -114,10 +118,12 @@ final top: 1
  * is correctly offsetted.  Avoid endianness by using initializers
  * which have the same memory representation in either case.
  */
-static duk_ret_t test_slice(duk_context *ctx) {
+static duk_ret_t test_slice(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	duk_size_t sz;
 	duk_size_t i;
+
+	(void) udata;
 
 	duk_eval_string(ctx,
 		"(function () {\n"
@@ -152,9 +158,11 @@ final top: 2
 ===*/
 
 /* Underlying buffer doesn't cover logical slice. */
-static duk_ret_t test_uncovered_buffer(duk_context *ctx) {
+static duk_ret_t test_uncovered_buffer(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_push_dynamic_buffer(ctx, 64);  /* 16x4 elements */
 
@@ -206,9 +214,11 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_invalid_index(duk_context *ctx) {
+static duk_ret_t test_invalid_index(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	sz = (duk_size_t) 0xdeadbeefUL;
 	p = duk_get_buffer_data(ctx, -1, &sz);

--- a/tests/api/test-get-buffer.c
+++ b/tests/api/test-get-buffer.c
@@ -23,8 +23,10 @@ final top: 18
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_push_undefined(ctx);
 	duk_push_null(ctx);
@@ -73,8 +75,10 @@ final top: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_null_ptr(duk_context *ctx) {
+static duk_ret_t test_null_ptr(duk_context *ctx, void *udata) {
 	void *p;
+
+	(void) udata;
 
 	duk_push_fixed_buffer(ctx, 1024);
 
@@ -96,9 +100,11 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_invalid_index(duk_context *ctx) {
+static duk_ret_t test_invalid_index(duk_context *ctx, void *udata) {
 	void *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	sz = (duk_size_t) 0xdeadbeefUL;
 	p = duk_get_buffer(ctx, -1, &sz);
@@ -118,9 +124,11 @@ p is NULL
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_buffer_object(duk_context *ctx) {
+static duk_ret_t test_buffer_object(duk_context *ctx, void *udata) {
 	void *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	/* duk_get_buffer_data() doesn't accept a buffer object */
 

--- a/tests/api/test-get-context.c
+++ b/tests/api/test-get-context.c
@@ -10,8 +10,10 @@ new_ctx is NULL: 1
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	(void) duk_push_thread(ctx);
@@ -33,8 +35,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	/* non-thread value */
 	duk_set_top(ctx, 0);

--- a/tests/api/test-get-error-code-is-error.c
+++ b/tests/api/test-get-error-code-is-error.c
@@ -48,8 +48,10 @@ static duk_ret_t my_error_thrower(duk_context *ctx) {
 	return DUK_RET_INTERNAL_ERROR;
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	/*
 	 *  Test values
@@ -112,7 +114,9 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_protoloop_code(duk_context *ctx) {
+static duk_ret_t test_protoloop_code(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/*
 	 *  A prototype loop currently results in a DUK_ERR_NONE
 	 *  instead of an error.
@@ -130,7 +134,9 @@ static duk_ret_t test_protoloop_code(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_protoloop_iserror(duk_context *ctx) {
+static duk_ret_t test_protoloop_iserror(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);  /* 0 */
 	duk_push_object(ctx);  /* 1 */
 

--- a/tests/api/test-get-global-string.c
+++ b/tests/api/test-get-global-string.c
@@ -13,8 +13,10 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_bool_t ret;
+
+	(void) udata;
 
 	printf("top: %ld\n", (long) duk_get_top(ctx));
 	ret = duk_get_global_string(ctx, "encodeURIComponent");

--- a/tests/api/test-get-prop.c
+++ b/tests/api/test-get-prop.c
@@ -66,8 +66,10 @@ static void prep(duk_context *ctx) {
 }
 
 /* duk_get_prop(), success cases */
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -116,8 +118,10 @@ static duk_ret_t test_1a(duk_context *ctx) {
 }
 
 /* duk_get_prop(), invalid index */
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -131,8 +135,10 @@ static duk_ret_t test_1b(duk_context *ctx) {
 }
 
 /* duk_get_prop(), DUK_INVALID_INDEX */
-static duk_ret_t test_1c(duk_context *ctx) {
+static duk_ret_t test_1c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -146,8 +152,10 @@ static duk_ret_t test_1c(duk_context *ctx) {
 }
 
 /* duk_get_prop(), test in API doc (more or less) */
-static duk_ret_t test_1d(duk_context *ctx) {
+static duk_ret_t test_1d(duk_context *ctx, void *udata) {
 	int cfg_idx;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -182,8 +190,10 @@ static duk_ret_t test_1d(duk_context *ctx) {
 }
 
 /* duk_get_prop(), not object coercible */
-static duk_ret_t test_1e(duk_context *ctx) {
+static duk_ret_t test_1e(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -198,8 +208,10 @@ static duk_ret_t test_1e(duk_context *ctx) {
 }
 
 /* duk_get_prop_string(), success cases */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -240,8 +252,10 @@ static duk_ret_t test_2a(duk_context *ctx) {
 }
 
 /* duk_get_prop_string(), invalid index */
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -254,8 +268,10 @@ static duk_ret_t test_2b(duk_context *ctx) {
 }
 
 /* duk_get_prop_string(), DUK_INVALID_INDEX */
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -268,8 +284,10 @@ static duk_ret_t test_2c(duk_context *ctx) {
 }
 
 /* duk_get_prop_index(), success cases */
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -298,8 +316,10 @@ static duk_ret_t test_3a(duk_context *ctx) {
 }
 
 /* duk_get_prop_index(), invalid index */
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -312,8 +332,10 @@ static duk_ret_t test_3b(duk_context *ctx) {
 }
 
 /* duk_get_prop_index(), DUK_INVALID_INDEX */
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 

--- a/tests/api/test-get-require-push-heapptr.c
+++ b/tests/api/test-get-require-push-heapptr.c
@@ -40,9 +40,11 @@ final top: 2
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t raw_require_heapptr(duk_context *ctx) {
+static duk_ret_t raw_require_heapptr(duk_context *ctx, void *udata) {
 	duk_idx_t i;
 	void *ptr;
+
+	(void) udata;
 
 	i = duk_require_uint(ctx, -1);
 	duk_pop(ctx);
@@ -55,11 +57,13 @@ static duk_ret_t raw_require_heapptr(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
 	void *ptr;
 	void *p1, *p2, *p3;
 	duk_int_t ret;
+
+	(void) udata;
 
 	duk_push_undefined(ctx);
 	duk_push_null(ctx);
@@ -83,7 +87,7 @@ static duk_ret_t test_basic(duk_context *ctx) {
 		       (long) i, (long) duk_get_type(ctx, i), (ptr ? "non-NULL" : "NULL"));
 
 		duk_push_uint(ctx, (duk_uint_t) i);
-		ret = duk_safe_call(ctx, raw_require_heapptr, 1 /*nargs*/, 1 /*nrets*/);
+		ret = duk_safe_call(ctx, raw_require_heapptr, NULL, 1 /*nargs*/, 1 /*nrets*/);
 		if (ret == DUK_EXEC_SUCCESS) {
 			;
 		} else {
@@ -150,8 +154,10 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_api_example(duk_context *ctx) {
+static duk_ret_t test_api_example(duk_context *ctx, void *udata) {
 	void *ptr;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "({ foo: 'bar' })");
 	ptr = duk_get_heapptr(ctx, -1);

--- a/tests/api/test-get-require-top-index.c
+++ b/tests/api/test-get-require-top-index.c
@@ -15,7 +15,9 @@ final top: 3
 ==> rc=1, result='Error: invalid stack index -1'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 123);
@@ -25,14 +27,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("top: %ld, top index is DUK_INVALID: %d\n", (long) duk_get_top(ctx), duk_get_top_index(ctx) == DUK_INVALID_INDEX ? 1 : 0);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 123);
@@ -42,7 +48,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("top: %ld, top index: %ld\n", (long) duk_get_top(ctx), (long) duk_require_top_index(ctx));
 	printf("final top: %ld\n", (long) duk_get_top(ctx));

--- a/tests/api/test-get-set-finalizer.c
+++ b/tests/api/test-get-set-finalizer.c
@@ -41,7 +41,9 @@ static duk_ret_t basic_finalizer(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Object to be finalized, special toString() */
 	duk_push_object(ctx);
 	duk_eval_string(ctx, "(function() { return 'target object'; })");
@@ -84,7 +86,9 @@ static duk_ret_t c_finalizer(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_recursive_finalizer(duk_context *ctx) {
+static duk_ret_t test_recursive_finalizer(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Object to be finalized */
 	duk_push_object(ctx);
 	duk_push_int(ctx, 123);
@@ -153,14 +157,18 @@ static duk_ret_t test_recursive_finalizer(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_get_nonobject(duk_context *ctx) {
+static duk_ret_t test_get_nonobject(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_int(ctx, 123);
 	duk_get_finalizer(ctx, -1);
 	printf("read finalizer: %s\n", duk_safe_to_string(ctx, -1));
 	return 0;
 }
 
-static duk_ret_t test_set_nonobject(duk_context *ctx) {
+static duk_ret_t test_set_nonobject(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 321);
 	duk_set_finalizer(ctx, -2);
@@ -168,7 +176,9 @@ static duk_ret_t test_set_nonobject(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_finalizer_loop(duk_context *ctx) {
+static duk_ret_t test_finalizer_loop(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Setup a finalizer loop: the finalizer of a finalizer is the
 	 * finalizer itself.  The finalizer won't be called recursively.
 	 */

--- a/tests/api/test-get-set-magic.c
+++ b/tests/api/test-get-set-magic.c
@@ -38,7 +38,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_function(ctx, my_func, 0);
 	duk_push_undefined(ctx);  /* dummy filler */
 
@@ -71,7 +73,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* duk_get_magic() is strict: incorrect target type throws an error.
 	 * This minimizes compiled function size and magic manipulation is
 	 * rare.
@@ -81,7 +85,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* duk_set_magic() is similarly strict. */
 	duk_eval_string(ctx, "(function () {})");
 	duk_set_magic(ctx, -1, 0x4321);
@@ -108,7 +114,9 @@ static duk_ret_t guide_example(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_function(ctx, guide_example, 1);
 	duk_set_magic(ctx, -1, 0);  /* INFO */
 

--- a/tests/api/test-get-set-prototype.c
+++ b/tests/api/test-get-set-prototype.c
@@ -47,7 +47,9 @@ obj0.bar=123
  * stack top changes, and object/undefined for duk_set_prototype().  Also checks
  * how a naked object works.
  */
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Prototype object: { foo: 123 }, internal prototype is null. */
 	duk_push_object(ctx);
 	duk_push_undefined(ctx);
@@ -120,7 +122,9 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_loop(duk_context *ctx) {
+static duk_ret_t test_loop(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 	duk_push_int(ctx, 123);
 	duk_put_prop_string(ctx, -2, "foo");

--- a/tests/api/test-get-set-top.c
+++ b/tests/api/test-get-set-top.c
@@ -93,7 +93,9 @@ static void prep(duk_context *ctx) {
 	print_stack(ctx);
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test_1\n");
 	prep(ctx);
 
@@ -112,7 +114,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test_2\n");
 	prep(ctx);
 
@@ -123,7 +127,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test_3\n");
 	prep(ctx);
 
@@ -134,7 +140,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test_4\n");
 	prep(ctx);
 
@@ -145,7 +153,9 @@ static duk_ret_t test_4(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_5(duk_context *ctx) {
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test_5\n");
 	prep(ctx);
 

--- a/tests/api/test-get-string.c
+++ b/tests/api/test-get-string.c
@@ -36,8 +36,10 @@ index 9: null
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_get_string(duk_context *ctx) {
+static duk_ret_t test_get_string(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_push_undefined(ctx);
 	duk_push_null(ctx);
@@ -86,8 +88,10 @@ index 9: null
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_get_lstring(duk_context *ctx) {
+static duk_ret_t test_get_lstring(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_push_undefined(ctx);
 	duk_push_null(ctx);

--- a/tests/api/test-get-var.c
+++ b/tests/api/test-get-var.c
@@ -1,5 +1,5 @@
 /*===
-*** test_1 (duk_safe_call)
+*** test_1_safecall (duk_safe_call)
 strict: 1
 Math.PI = 3.141592653589793
 final top: 0
@@ -9,19 +9,19 @@ strict: 1
 Math.PI = 3.141592653589793
 final top: 0
 ==> rc=0, result='undefined'
-*** test_2 (duk_safe_call)
+*** test_2_safecall (duk_safe_call)
 strict: 1
 ==> rc=1, result='ReferenceError: identifier 'no-such-property' undefined'
 *** test_2 (duk_pcall)
 strict: 1
 ==> rc=1, result='ReferenceError: identifier 'no-such-property' undefined'
-*** test_3 (duk_safe_call)
+*** test_3_safecall (duk_safe_call)
 strict: 1
 ==> rc=1, result='TypeError: string required, found 123 (stack index -1)'
 *** test_3 (duk_pcall)
 strict: 1
 ==> rc=1, result='TypeError: string required, found 123 (stack index -1)'
-*** test_4 (duk_safe_call)
+*** test_4_safecall (duk_safe_call)
 strict: 1
 ==> rc=1, result='TypeError: string required, found 123 (stack index -1)'
 *** test_4 (duk_pcall)
@@ -44,6 +44,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_1_safecall(duk_context *ctx, void *udata) {
+	return test_1(ctx);
+}
 
 /* Nonexistent -> throw */
 static duk_ret_t test_2(duk_context *ctx) {
@@ -59,6 +62,10 @@ static duk_ret_t test_2(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_2_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_2(ctx);
+}
 
 /* Variable name is not a string */
 static duk_ret_t test_3(duk_context *ctx) {
@@ -72,6 +79,10 @@ static duk_ret_t test_3(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_3_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_3(ctx);
 }
 
 /* Value stack is empty (no varname at all) */
@@ -87,14 +98,18 @@ static duk_ret_t test_4(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_4_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_4(ctx);
+}
 
 void test(duk_context *ctx) {
-	TEST_SAFE_CALL(test_1);
+	TEST_SAFE_CALL(test_1_safecall);
 	TEST_PCALL(test_1);
-	TEST_SAFE_CALL(test_2);
+	TEST_SAFE_CALL(test_2_safecall);
 	TEST_PCALL(test_2);
-	TEST_SAFE_CALL(test_3);
+	TEST_SAFE_CALL(test_3_safecall);
 	TEST_PCALL(test_3);
-	TEST_SAFE_CALL(test_4);
+	TEST_SAFE_CALL(test_4_safecall);
 	TEST_PCALL(test_4);
 }

--- a/tests/api/test-has-prop.c
+++ b/tests/api/test-has-prop.c
@@ -58,8 +58,10 @@ static void prep(duk_context *ctx) {
 }
 
 /* duk_has_prop(), success cases */
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -92,8 +94,10 @@ static duk_ret_t test_1a(duk_context *ctx) {
 }
 
 /* duk_has_prop(), invalid index */
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -106,8 +110,10 @@ static duk_ret_t test_1b(duk_context *ctx) {
 }
 
 /* duk_has_prop(), DUK_INVALID_INDEX */
-static duk_ret_t test_1c(duk_context *ctx) {
+static duk_ret_t test_1c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -120,8 +126,10 @@ static duk_ret_t test_1c(duk_context *ctx) {
 }
 
 /* duk_has_prop(), not an object */
-static duk_ret_t test_1d(duk_context *ctx) {
+static duk_ret_t test_1d(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -135,8 +143,10 @@ static duk_ret_t test_1d(duk_context *ctx) {
 }
 
 /* duk_has_prop(), not an object */
-static duk_ret_t test_1e(duk_context *ctx) {
+static duk_ret_t test_1e(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -150,8 +160,10 @@ static duk_ret_t test_1e(duk_context *ctx) {
 }
 
 /* duk_has_prop_string(), success cases */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -178,8 +190,10 @@ static duk_ret_t test_2a(duk_context *ctx) {
 }
 
 /* duk_has_prop_string(), invalid index */
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -191,8 +205,10 @@ static duk_ret_t test_2b(duk_context *ctx) {
 }
 
 /* duk_has_prop_string(), DUK_INVALID_INDEX */
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -204,8 +220,10 @@ static duk_ret_t test_2c(duk_context *ctx) {
 }
 
 /* duk_has_prop_index(), success cases */
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -226,8 +244,10 @@ static duk_ret_t test_3a(duk_context *ctx) {
 }
 
 /* duk_has_prop_index(), invalid index */
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 
@@ -239,8 +259,10 @@ static duk_ret_t test_3b(duk_context *ctx) {
 }
 
 /* duk_has_prop_index(), DUK_INVALID_INDEX */
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	prep(ctx);
 

--- a/tests/api/test-hex.c
+++ b/tests/api/test-hex.c
@@ -13,7 +13,9 @@ top after: 2
 ==> rc=1, result='TypeError: decode failed'
 ===*/
 
-static duk_ret_t test_encode(duk_context *ctx) {
+static duk_ret_t test_encode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "foo");
 	duk_push_int(ctx, 123);  /* dummy */
@@ -22,7 +24,9 @@ static duk_ret_t test_encode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode(duk_context *ctx) {
+static duk_ret_t test_decode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "7465737420737472696e67");
 	duk_push_int(ctx, 321);  /* dummy */
@@ -33,7 +37,9 @@ static duk_ret_t test_decode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode_odd_length(duk_context *ctx) {
+static duk_ret_t test_decode_odd_length(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "7465737420737472696e6");  /* odd length */
 	duk_push_int(ctx, 321);  /* dummy */
@@ -44,7 +50,9 @@ static duk_ret_t test_decode_odd_length(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode_invalid_char(duk_context *ctx) {
+static duk_ret_t test_decode_invalid_char(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "7465737420737g72696e67");  /* invalid char */
 	duk_push_int(ctx, 321);  /* dummy */

--- a/tests/api/test-insert.c
+++ b/tests/api/test-insert.c
@@ -25,8 +25,10 @@ static void prep(duk_context *ctx) {
 	duk_push_string(ctx, "foo");  /* -> [ 123 234 345 "foo" ] */
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	prep(ctx);
 	duk_insert(ctx, -3);          /* -> [ 123 "foo" 234 345 ] */
@@ -38,7 +40,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_insert(ctx, 3);           /* -> [ 123 234 345 "foo" ]  (legal, keep top) */
 	printf("insert at 3 ok\n");
@@ -49,7 +53,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_insert(ctx, 0);           /* -> [ "foo" 123 234 345 ]  (legal) */
 	printf("insert at 0 ok\n");
@@ -60,7 +66,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_insert(ctx, DUK_INVALID_INDEX);  /* (illegal: invalid index) */
 	printf("insert at DUK_INVALID_INDEX ok\n");

--- a/tests/api/test-instanceof.c
+++ b/tests/api/test-instanceof.c
@@ -26,8 +26,10 @@ final top: 6
 ===*/
 
 /* Basic test. */
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	int i;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "new RangeError('test error')");  /* 0 */
 	duk_eval_string(ctx, "Error");  /* 1 */
@@ -49,7 +51,9 @@ static duk_ret_t test_1(duk_context *ctx) {
  * to do the equivalent of: "new Error() instanceof new Error()" is a TypeError
  * because the rval is a non-callable object.
  */
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx, "new Error('test error')");
 
 	duk_instanceof(ctx, 0, 0);  /* -> TypeError */
@@ -61,27 +65,37 @@ static duk_ret_t test_2(duk_context *ctx) {
 /* Strict behavior is also used for indices to match the strictness of
  * instanceof.  (This differs from e.g. duk_equals() on purpose.)
  */
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%d\n", duk_instanceof(ctx, -1, 0));  /* -1 is out of stack */
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%d\n", duk_instanceof(ctx, 0, -1));  /* -1 is out of stack */
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%d\n", duk_instanceof(ctx, 1, 0));  /* 1 is out of stack */
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_3d(duk_context *ctx) {
+static duk_ret_t test_3d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%d\n", duk_instanceof(ctx, 0, 1));  /* 1 is out of stack */
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_3e(duk_context *ctx) {
+static duk_ret_t test_3e(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("%d\n", duk_instanceof(ctx, DUK_INVALID_INDEX, DUK_INVALID_INDEX));
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;

--- a/tests/api/test-is-calls.c
+++ b/tests/api/test-is-calls.c
@@ -31,8 +31,10 @@ static duk_ret_t my_c_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	/*
 	 *  push test values

--- a/tests/api/test-is-constructor-call.c
+++ b/tests/api/test-is-constructor-call.c
@@ -10,7 +10,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_function(ctx, my_func, 0);
 
 	duk_dup(ctx, 0);   /* -> [ func func ] */

--- a/tests/api/test-json-fastpath.c
+++ b/tests/api/test-json-fastpath.c
@@ -9,7 +9,9 @@ final top: 4
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Bufferobject without cover. */
 	duk_push_fixed_buffer(ctx, 4);
 	duk_push_buffer_object(ctx, 0, 0, 100, DUK_BUFOBJ_UINT8ARRAY);

--- a/tests/api/test-json.c
+++ b/tests/api/test-json.c
@@ -22,7 +22,9 @@ top after: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_encode(duk_context *ctx) {
+static duk_ret_t test_encode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 	duk_push_int(ctx, 123);
 	duk_put_prop_string(ctx, -2, "foo");
@@ -35,7 +37,9 @@ static duk_ret_t test_encode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_encode_apidoc(duk_context *ctx) {
+static duk_ret_t test_encode_apidoc(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_object(ctx);
 	duk_push_int(ctx, 42);
 	duk_put_prop_string(ctx, -2, "meaningOfLife");
@@ -46,7 +50,9 @@ static duk_ret_t test_encode_apidoc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode(duk_context *ctx) {
+static duk_ret_t test_decode(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "{\"foo\":\"bar\"}");
 	duk_push_int(ctx, 321);  /* dummy */
 	duk_json_decode(ctx, -2);
@@ -57,7 +63,9 @@ static duk_ret_t test_decode(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode_apidoc(duk_context *ctx) {
+static duk_ret_t test_decode_apidoc(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "{\"meaningOfLife\":42}");
 	duk_json_decode(ctx, -1);
 	duk_get_prop_string(ctx, -1, "meaningOfLife");
@@ -68,19 +76,23 @@ static duk_ret_t test_decode_apidoc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_decode_error_raw(duk_context *ctx) {
+static duk_ret_t test_decode_error_raw(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_json_decode(ctx, -1);
 	return 1;
 }
 
-static duk_ret_t test_decode_error(duk_context *ctx) {
+static duk_ret_t test_decode_error(duk_context *ctx, void *udata) {
 	/* The JSON.parse() error message includes a byte offset, so we need to
 	 * normalize it.
 	 */
 	duk_int_t ret;
 
+	(void) udata;
+
 	duk_push_string(ctx, "{\"meaningOfLife\":,42}");
-	ret = duk_safe_call(ctx, test_decode_error_raw, 1 /*nargs*/, 1 /*nrets*/);
+	ret = duk_safe_call(ctx, test_decode_error_raw, NULL, 1 /*nargs*/, 1 /*nrets*/);
 	printf("ret: %ld\n", (long) ret);
 
 	duk_eval_string(ctx, "(function (x) { print(x.replace(/at offset \\d+/, 'at offset N')); })");

--- a/tests/api/test-logging.c
+++ b/tests/api/test-logging.c
@@ -22,7 +22,9 @@ TIMESTAMP FTL C: fatal error: 123 quux
 	"long long long long long long long long long long " \
 	"long long long long long long long long long long "
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Force log level to output all logs. */
 	duk_eval_string(ctx, "Duktape.Logger.clog.l = 0;");
 	duk_pop(ctx);
@@ -72,7 +74,9 @@ static void my_log_write(duk_context *ctx, duk_int_t level, const char *fmt, ...
 	va_end(ap);
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Rely on the log "censoring" set up in test_1(). */
 
 	my_log_write(ctx, DUK_LOG_FATAL, "fatal error: %d %s", 123, "quux");

--- a/tests/api/test-magic-modify-during-call.c
+++ b/tests/api/test-magic-modify-during-call.c
@@ -27,7 +27,9 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_c_function(ctx, my_func, 2 /*nargs*/);
 	duk_set_magic(ctx, -1, 345);
 

--- a/tests/api/test-map-string.c
+++ b/tests/api/test-map-string.c
@@ -19,7 +19,9 @@ static duk_codepoint_t map_char_1(void *udata, duk_codepoint_t codepoint) {
 	return codepoint;
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	printf("test 1\n");
 	duk_push_string(ctx, "test_string");
 	duk_map_string(ctx, -1, map_char_1, NULL);
@@ -53,9 +55,11 @@ static duk_codepoint_t map_char_2(void *udata, duk_codepoint_t codepoint) {
 	return codepoint + 0x1234;
 }
 
-static duk_ret_t test_vary_size(duk_context *ctx) {
+static duk_ret_t test_vary_size(duk_context *ctx, void *udata) {
 	duk_size_t i;
 	unsigned char buf[1024];
+
+	(void) udata;
 
 	for (i = 0; i < 1024; i++) {
 		buf[i] = (duk_uint8_t) (i & 0x7f);

--- a/tests/api/test-new.c
+++ b/tests/api/test-new.c
@@ -49,7 +49,9 @@ static duk_ret_t my_func_2(duk_context *ctx) {
 	return 1;
 }
 
-static duk_ret_t test_new(duk_context *ctx) {
+static duk_ret_t test_new(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Create a constructor (function object).  Its "prototype" property
 	 * controls the internal prototype of created instances.
 	 */
@@ -81,8 +83,10 @@ static duk_ret_t test_new(duk_context *ctx) {
 }
 
 /* Successful duk_pnew(). */
-static duk_ret_t test_pnew_1(duk_context *ctx) {
+static duk_ret_t test_pnew_1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "Error");  /* constructor */
 	duk_push_string(ctx, "my error message");
@@ -96,8 +100,10 @@ static duk_ret_t test_pnew_1(duk_context *ctx) {
 }
 
 /* Failed duk_pnew(). */
-static duk_ret_t test_pnew_2(duk_context *ctx) {
+static duk_ret_t test_pnew_2(duk_context *ctx, void *udata) {
 	duk_int_t rc;
+
+	(void) udata;
 
 	duk_eval_string(ctx, "null");  /* constructor: not callable */
 	duk_push_string(ctx, "whatever");

--- a/tests/api/test-normalize-index.c
+++ b/tests/api/test-normalize-index.c
@@ -34,9 +34,11 @@ req_norm_idx: top 3 after popping arg
 idx=5 -> duk_require_normalize_index -> Error: invalid stack index 5
 ===*/
 
-static duk_ret_t req_norm_idx(duk_context *ctx) {
+static duk_ret_t req_norm_idx(duk_context *ctx, void *udata) {
 	duk_idx_t idx = (duk_idx_t) duk_get_int(ctx, -1);
 	duk_idx_t norm_idx;
+
+	(void) udata;
 
 	duk_pop(ctx);
 	printf("req_norm_idx: top %ld after popping arg\n", (long) duk_get_top(ctx));
@@ -66,7 +68,7 @@ void test(duk_context *ctx) {
 
 	for (idx = -5; idx <= 5; idx++) {
 		duk_push_int(ctx, idx);
-		duk_safe_call(ctx, req_norm_idx, 1, 1);
+		duk_safe_call(ctx, req_norm_idx, NULL, 1, 1);
 		printf("idx=%ld -> duk_require_normalize_index -> %s\n", (long) idx, duk_to_string(ctx, -1));
 		duk_pop(ctx);
 	}

--- a/tests/api/test-pcall-prop.c
+++ b/tests/api/test-pcall-prop.c
@@ -31,8 +31,10 @@ rc=1, result='TypeError: undefined not callable'
 final top: 0
 ===*/
 
-static int test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* basic success case: own property */
 	duk_eval_string(ctx, "({ name: 'me', foo: function (x,y) { print(this.name); return x+y; } })");  /* idx 1 */
@@ -47,8 +49,10 @@ static int test_1(duk_context *ctx) {
 	return 0;
 }
 
-static int test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* use plain number as 'this', add function to Number.prototype; non-strict handler
 	 * causes this to be coerced to Number.
@@ -67,8 +71,10 @@ static int test_2(duk_context *ctx) {
 	return 0;
 }
 
-static int test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* use plain number as 'this', add function to Number.prototype; strict handler
 	 * causes this to remain a plain number.
@@ -87,8 +93,10 @@ static int test_3(duk_context *ctx) {
 	return 0;
 }
 
-static int test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* basic error case */
 	duk_eval_string(ctx, "({ name: 'me', foo: function (x,y) { throw new Error('my error'); } })");  /* idx 1 */
@@ -103,8 +111,10 @@ static int test_4(duk_context *ctx) {
 	return 0;
 }
 
-static int test_5(duk_context *ctx) {
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* property lookup fails: base value does not allow property lookup */
 	duk_push_undefined(ctx);
@@ -119,8 +129,10 @@ static int test_5(duk_context *ctx) {
 	return 0;
 }
 
-static int test_6(duk_context *ctx) {
+static duk_ret_t test_6(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* property lookup fails: getter throws */
 	duk_eval_string(ctx, "({ get prop() { throw new RangeError('getter error'); } })");
@@ -135,8 +147,10 @@ static int test_6(duk_context *ctx) {
 	return 0;
 }
 
-static int test_7(duk_context *ctx) {
+static duk_ret_t test_7(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* invalid object index */
 	duk_eval_string(ctx, "({ foo: 1, bar: 2 })");
@@ -151,8 +165,10 @@ static int test_7(duk_context *ctx) {
 	return 0;
 }
 
-static int test_8(duk_context *ctx) {
+static duk_ret_t test_8(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* invalid arg count, causes 'key' to be identified with the object in the stack */
 	duk_eval_string(ctx, "({ foo: function () { print('foo called'); } })");
@@ -167,8 +183,10 @@ static int test_8(duk_context *ctx) {
 	return 0;
 }
 
-static int test_9(duk_context *ctx) {
+static duk_ret_t test_9(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	/* Invalid arg count, 'key' would be below start of stack.  This
 	 * results in an actual (uncaught) error at the moment, and matches
@@ -188,7 +206,6 @@ static int test_9(duk_context *ctx) {
 }
 
 void test(duk_context *ctx) {
-
 	/* dummy just to offset the object index from 0 */
 	duk_push_string(ctx, "foo");
 

--- a/tests/api/test-poppers.c
+++ b/tests/api/test-poppers.c
@@ -36,7 +36,9 @@ top: 1
 #define  SETUP(n)    do { duk_set_top(ctx, (n)); } while (0)
 #define  PRINTTOP()  do { printf("top: %ld\n", (long) duk_get_top(ctx)); } while (0)
 
-static duk_ret_t test_pop_a(duk_context *ctx) {
+static duk_ret_t test_pop_a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop(ctx);
 	PRINTTOP();
 	duk_pop(ctx);
@@ -44,7 +46,9 @@ static duk_ret_t test_pop_a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_b(duk_context *ctx) {
+static duk_ret_t test_pop_b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop(ctx);
 	PRINTTOP();
 	duk_pop(ctx);
@@ -56,7 +60,9 @@ static duk_ret_t test_pop_b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_2a(duk_context *ctx) {
+static duk_ret_t test_pop_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_2(ctx);
 	PRINTTOP();
 	duk_pop_2(ctx);
@@ -64,7 +70,9 @@ static duk_ret_t test_pop_2a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_2b(duk_context *ctx) {
+static duk_ret_t test_pop_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_2(ctx);
 	PRINTTOP();
 	duk_pop_2(ctx);
@@ -76,7 +84,9 @@ static duk_ret_t test_pop_2b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_3a(duk_context *ctx) {
+static duk_ret_t test_pop_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_3(ctx);
 	PRINTTOP();
 	duk_pop_3(ctx);
@@ -84,7 +94,9 @@ static duk_ret_t test_pop_3a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_3b(duk_context *ctx) {
+static duk_ret_t test_pop_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_3(ctx);
 	PRINTTOP();
 	duk_pop_3(ctx);
@@ -96,7 +108,9 @@ static duk_ret_t test_pop_3b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_na(duk_context *ctx) {
+static duk_ret_t test_pop_na(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_n(ctx, 0);
 	PRINTTOP();
 
@@ -109,7 +123,9 @@ static duk_ret_t test_pop_na(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_pop_nb(duk_context *ctx) {
+static duk_ret_t test_pop_nb(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_pop_n(ctx, -1);
 	PRINTTOP();
 	return 0;
@@ -121,42 +137,42 @@ void test(duk_context *ctx) {
 	/* Custom test macro, prints top after call. */
 
 	SETUP(2); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_a, 2, 1);
+	rc = duk_safe_call(ctx, test_pop_a, NULL, 2, 1);
 	printf("test_pop_1 -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(2); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_b, 2, 1);
+	rc = duk_safe_call(ctx, test_pop_b, NULL, 2, 1);
 	printf("test_pop_b -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(5); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_2a, 5, 1);
+	rc = duk_safe_call(ctx, test_pop_2a, NULL, 5, 1);
 	printf("test_pop_2a -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(5); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_2b, 5, 1);
+	rc = duk_safe_call(ctx, test_pop_2b, NULL, 5, 1);
 	printf("test_pop_2b -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(7); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_3a, 7, 1);
+	rc = duk_safe_call(ctx, test_pop_3a, NULL, 7, 1);
 	printf("test_pop_3a -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(7); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_3b, 7, 1);
+	rc = duk_safe_call(ctx, test_pop_3b, NULL, 7, 1);
 	printf("test_pop_3b -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(11); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_na, 11, 1);
+	rc = duk_safe_call(ctx, test_pop_na, NULL, 11, 1);
 	printf("test_pop_na -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 
 	SETUP(11); PRINTTOP();
-	rc = duk_safe_call(ctx, test_pop_nb, 11, 1);
+	rc = duk_safe_call(ctx, test_pop_nb, NULL, 11, 1);
 	printf("test_pop_nb -> top=%ld, rc=%d, ret='%s'\n",
 	       (long) duk_get_top(ctx), (int) rc, duk_to_string(ctx, -1));
 

--- a/tests/api/test-print-replacement.c
+++ b/tests/api/test-print-replacement.c
@@ -22,7 +22,9 @@ static duk_ret_t my_print(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_global_object(ctx);
 	duk_push_c_function(ctx, my_print, DUK_VARARGS);
 	duk_put_prop_string(ctx, -2, "print");

--- a/tests/api/test-proxy-basic.c
+++ b/tests/api/test-proxy-basic.c
@@ -137,8 +137,10 @@ static void setup_proxy(duk_context *ctx) {
 	/* -> [ proxy_object ] */
 }
 
-static duk_ret_t test_get1(duk_context *ctx) {
+static duk_ret_t test_get1(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 
@@ -152,8 +154,10 @@ static duk_ret_t test_get1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_get2(duk_context *ctx) {
+static duk_ret_t test_get2(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 
@@ -168,8 +172,10 @@ static duk_ret_t test_get2(duk_context *ctx) {
 }
 
 
-static duk_ret_t test_set1(duk_context *ctx) {
+static duk_ret_t test_set1(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 
@@ -183,8 +189,10 @@ static duk_ret_t test_set1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_set2(duk_context *ctx) {
+static duk_ret_t test_set2(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 
@@ -198,8 +206,10 @@ static duk_ret_t test_set2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_delete1(duk_context *ctx) {
+static duk_ret_t test_delete1(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 
@@ -212,8 +222,10 @@ static duk_ret_t test_delete1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_delete2(duk_context *ctx) {
+static duk_ret_t test_delete2(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
+
+	(void) udata;
 
 	setup_proxy(ctx);
 

--- a/tests/api/test-push-buffer-object.c
+++ b/tests/api/test-push-buffer-object.c
@@ -88,7 +88,7 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_uint_t test[] = {
 		DUK_BUFOBJ_DUKTAPE_BUFFER,
 		DUK_BUFOBJ_NODEJS_BUFFER,
@@ -106,6 +106,8 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	};
 	int i;
 	unsigned char extbuf[256];
+
+	(void) udata;
 
 	for (i = 0; i < sizeof(test) / sizeof(duk_uint_t); i++) {
 		switch (i % 3) {
@@ -168,8 +170,10 @@ final top: 1
  * Test the .buffer reference in more detail: check that property
  * attributes are correct, check that it backs to the same slice, etc.
  */
-static duk_ret_t test_view_buffer_prop(duk_context *ctx) {
+static duk_ret_t test_view_buffer_prop(duk_context *ctx, void *udata) {
 	unsigned char extbuf[256];
+
+	(void) udata;
 
 	duk_push_external_buffer(ctx);
 	duk_config_buffer(ctx, -1, (void *) extbuf, 256);
@@ -220,7 +224,9 @@ final top: 0
  * of the element size (e.g. 4 bytes for Uint32Array) and that the slice ends
  * evenly.  The C API doesn't pose such restrictions.
  */
-static duk_ret_t test_unaligned(duk_context *ctx) {
+static duk_ret_t test_unaligned(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -1, 7, 64, DUK_BUFOBJ_UINT32ARRAY);
 
@@ -252,7 +258,9 @@ final top: 0
  * .byteLength is 63 here, which means that .length x .BYTES_PER_ELEMENT
  * won't match .byteLength in this case.
  */
-static duk_ret_t test_unaligned_uneven(duk_context *ctx) {
+static duk_ret_t test_unaligned_uneven(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* Start at an unaligned offset, with slice length NOT a multiple
 	 * of 4.
 	 */
@@ -284,7 +292,9 @@ final top: 0
  * and external buffers at run time anyway.  In any case, no memory
  * unsafe behavior happens.
  */
-static duk_ret_t test_uncovered(duk_context *ctx) {
+static duk_ret_t test_uncovered(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -1, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 
@@ -315,14 +325,18 @@ static duk_ret_t test_uncovered(duk_context *ctx) {
 ==> rc=1, result='TypeError: buffer required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_invalid_index1(duk_context *ctx) {
+static duk_ret_t test_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -2, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_invalid_index2(duk_context *ctx) {
+static duk_ret_t test_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, DUK_INVALID_INDEX, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -341,7 +355,9 @@ static duk_ret_t test_invalid_index2(duk_context *ctx) {
 /* A bufferobject is -not- accepted as the underlying buffer.  This also
  * prevents issues like a slice being applied to a sliced view.
  */
-static duk_ret_t test_invalid_bufferobject(duk_context *ctx) {
+static duk_ret_t test_invalid_bufferobject(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_eval_string(ctx, "new Uint16Array(123);");
 	duk_push_buffer_object(ctx, -1, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -349,14 +365,18 @@ static duk_ret_t test_invalid_bufferobject(duk_context *ctx) {
 }
 
 /* A string is not allowed (although this might be useful). */
-static duk_ret_t test_invalid_string(duk_context *ctx) {
+static duk_ret_t test_invalid_string(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "foobar");
 	duk_push_buffer_object(ctx, -1, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_invalid_null(duk_context *ctx) {
+static duk_ret_t test_invalid_null(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_null(ctx);
 	duk_push_buffer_object(ctx, -1, 7, 512, DUK_BUFOBJ_UINT32ARRAY);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -376,14 +396,18 @@ final top: 2
 /* If 'flags' is given as zero, it will match a DUK_BUFOBJ_DUKTAPEBUFFER.
  * So this test succeeds which is intentional.
  */
-static duk_ret_t test_invalid_flags1(duk_context *ctx) {
+static duk_ret_t test_invalid_flags1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -1, 7, 512, 0 /* no type given, but matches DUK_BUFOBJ_DUKTAPEBUFFER */);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
-static duk_ret_t test_invalid_flags2(duk_context *ctx) {
+static duk_ret_t test_invalid_flags2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -1, 7, 512, (duk_uint_t) 0xdeadbeef /* ERROR: bogus type */);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -391,7 +415,9 @@ static duk_ret_t test_invalid_flags2(duk_context *ctx) {
 }
 
 /* Boundary case. */
-static duk_ret_t test_invalid_flags3(duk_context *ctx) {
+static duk_ret_t test_invalid_flags3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx, -1, 7, 512, (duk_uint_t) (DUK_BUFOBJ_FLOAT64ARRAY + 1) /* ERROR: bogus type, right after last defined */);
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -406,7 +432,9 @@ static duk_ret_t test_invalid_flags3(duk_context *ctx) {
 ===*/
 
 /* Byte offset + byte length wrap. */
-static duk_ret_t test_invalid_offlen_wrap1(duk_context *ctx) {
+static duk_ret_t test_invalid_offlen_wrap1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx,
 	                       -1,
@@ -418,7 +446,9 @@ static duk_ret_t test_invalid_offlen_wrap1(duk_context *ctx) {
 }
 
 /* Byte offset + byte length wrap, just barely */
-static duk_ret_t test_invalid_offlen_wrap2(duk_context *ctx) {
+static duk_ret_t test_invalid_offlen_wrap2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx,
 	                       -1,
@@ -442,7 +472,9 @@ final top: 1
  * wrap.  This works and doesn't cause a ~4G allocation because the conceptual
  * size (~4G) is unrelated to the underlying buffer size (256 bytes here).
  */
-static duk_ret_t test_allowed_offlen_nowrap1(duk_context *ctx) {
+static duk_ret_t test_allowed_offlen_nowrap1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_fixed_buffer(ctx, 256);
 	duk_push_buffer_object(ctx,
 	                       -1,

--- a/tests/api/test-push-buffer.c
+++ b/tests/api/test-push-buffer.c
@@ -62,8 +62,10 @@ static void rw_test(unsigned char *p, size_t sz) {
 }
 
 /* Basic success test. */
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -90,8 +92,10 @@ static duk_ret_t test_1a(duk_context *ctx) {
 }
 
 /* Same test, using shortcut functions. */
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -123,8 +127,10 @@ static duk_ret_t test_1b(duk_context *ctx) {
  * other trouble (separate bug testcase exists for that:
  * test-bug-push-buffer-maxsize.c).
  */
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -136,8 +142,10 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	void *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 

--- a/tests/api/test-push-duktape-buffer.c
+++ b/tests/api/test-push-duktape-buffer.c
@@ -12,9 +12,11 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	int i;
+
+	(void) udata;
 
 	p = (unsigned char *) duk_push_fixed_buffer(ctx, 256);
 	for (i = 0; i < 256; i++) {

--- a/tests/api/test-push-error-object.c
+++ b/tests/api/test-push-error-object.c
@@ -14,8 +14,10 @@ final top: 3
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t err_idx;
+
+	(void) udata;
 
 	/* dummy values */
 	duk_push_int(ctx, 123);
@@ -64,7 +66,9 @@ static void push_1(duk_context *ctx, duk_errcode_t errcode, const char *fmt, ...
 	va_end(ap);
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* dummy values */
 	duk_push_int(ctx, 123);
 	duk_push_int(ctx, 123);

--- a/tests/api/test-push-sprintf.c
+++ b/tests/api/test-push-sprintf.c
@@ -9,10 +9,12 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	char buf[65536 + 1024];
 	duk_size_t fmt_len, i;
 	double len_sum = 0.0;
+
+	(void) udata;
 
 	for (fmt_len = 0;
 	     fmt_len <= 65536;

--- a/tests/api/test-push-thread.c
+++ b/tests/api/test-push-thread.c
@@ -14,9 +14,11 @@ context b: undefined
 ===*/
 
 /* Some basic tests. */
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t thr_idx;
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	duk_push_int(ctx, 123);  /* dummy */
 
@@ -40,9 +42,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 }
 
 /* Thread with shared and fresh globals. */
-static int test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_context *ctx_a;
 	duk_context *ctx_b;
+
+	(void) udata;
 
 	duk_eval_string_noresult(ctx, "this.globalFoo = 'bar';");
 

--- a/tests/api/test-push-vsprintf.c
+++ b/tests/api/test-push-vsprintf.c
@@ -34,8 +34,10 @@ static void test_1(duk_context *ctx, int fmt_len, ...) {
 	va_end(ap);
 }
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_size_t fmt_len;
+
+	(void) udata;
 
 	/* Note: don't reuse 'ap' in multiple calls, so the fmt_len loop
 	 * is here.

--- a/tests/api/test-put-func-num-list.c
+++ b/tests/api/test-put-func-num-list.c
@@ -53,7 +53,9 @@ static const duk_number_list_entry my_consts[] = {
 	{ NULL, 0.0 }
 };
 
-int test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* This becomes our module. */
 	duk_push_object(ctx);
 	duk_push_string(ctx, "dummy");  /* just for offset */

--- a/tests/api/test-put-global-string.c
+++ b/tests/api/test-put-global-string.c
@@ -11,8 +11,10 @@ top: 0
 ==> rc=1, result='TypeError: not writable'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_bool_t ret;
+
+	(void) udata;
 
 	printf("top: %ld\n", (long) duk_get_top(ctx));
 	duk_push_string(ctx, "1.2.3");
@@ -26,8 +28,10 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_nonwritable(duk_context *ctx) {
+static duk_ret_t test_nonwritable(duk_context *ctx, void *udata) {
 	duk_bool_t ret;
+
+	(void) udata;
 
 	duk_eval_string_noresult(ctx,
 		"Object.defineProperty(this, 'nonWritable', "

--- a/tests/api/test-put-prop-primbase.c
+++ b/tests/api/test-put-prop-primbase.c
@@ -1,11 +1,11 @@
 /*===
-*** test_put (duk_safe_call)
+*** test_put_safecall (duk_safe_call)
 ==> rc=1, result='TypeError: cannot write property 'foo' of 0'
 *** test_put (duk_pcall)
 ==> rc=1, result='TypeError: cannot write property 'foo' of 0'
 ===*/
 
-duk_ret_t test_put(duk_context *ctx) {
+static duk_ret_t test_put(duk_context *ctx) {
 	duk_ret_t rc;
 
 	/* In Ecmascript, '(0).foo = "bar"' should work and evaluate to "bar"
@@ -23,11 +23,15 @@ duk_ret_t test_put(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_put_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_put(ctx);
+}
 
 void test(duk_context *ctx) {
 	/* Since Duktape 0.12.0, a Duktape/C context is considered strict
 	 * both inside and outside of Duktape/C calls.
 	 */
-	TEST_SAFE_CALL(test_put);  /* outside: strict (non-strict before 0.12.0) */
+	TEST_SAFE_CALL(test_put_safecall);  /* outside: strict (non-strict before 0.12.0) */
 	TEST_PCALL(test_put);      /* inside: strict */
 }

--- a/tests/api/test-put-prop.c
+++ b/tests/api/test-put-prop.c
@@ -1,5 +1,5 @@
 /*===
-*** test_ex_writable (duk_safe_call)
+*** test_ex_writable_safecall (duk_safe_call)
 strict: 1
 put rc=1
 result: {"foo":"bar"}
@@ -11,7 +11,7 @@ put rc=1
 result: {"foo":"bar"}
 final top: 1
 ==> rc=0, result='undefined'
-*** test_ex_nonwritable (duk_safe_call)
+*** test_ex_nonwritable_safecall (duk_safe_call)
 strict: 1
 get Math -> rc=1
 Math.PI=3.141592653589793
@@ -21,7 +21,7 @@ strict: 1
 get Math -> rc=1
 Math.PI=3.141592653589793
 ==> rc=1, result='TypeError: not writable'
-*** test_ex_accessor_wo_setter (duk_safe_call)
+*** test_ex_accessor_wo_setter_safecall (duk_safe_call)
 strict: 1
 eval:
 (function () {
@@ -51,7 +51,7 @@ eval:
 })()
 top after eval: 1
 ==> rc=1, result='TypeError: setter undefined'
-*** test_ex_setter_throws (duk_safe_call)
+*** test_ex_setter_throws_safecall (duk_safe_call)
 strict: 1
 eval:
 (function () {
@@ -83,7 +83,7 @@ eval:
 top after eval: 1
 setter, throw error
 ==> rc=1, result='setter error'
-*** test_new_extensible (duk_safe_call)
+*** test_new_extensible_safecall (duk_safe_call)
 strict: 1
 put rc=1
 result: {"foo":1,"bar":"quux"}
@@ -95,7 +95,7 @@ put rc=1
 result: {"foo":1,"bar":"quux"}
 final top: 1
 ==> rc=0, result='undefined'
-*** test_new_not_extensible (duk_safe_call)
+*** test_new_not_extensible_safecall (duk_safe_call)
 strict: 1
 eval:
 (function () { var o = { foo: 1 }; Object.preventExtensions(o); return o; })()
@@ -158,6 +158,10 @@ static duk_ret_t test_ex_writable(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_ex_writable_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_ex_writable(ctx);
+}
 
 /* strict: error
  * (non-strict: return 0)
@@ -189,6 +193,10 @@ static duk_ret_t test_ex_nonwritable(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_ex_nonwritable_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_ex_nonwritable(ctx);
 }
 
 /* strict: error
@@ -227,6 +235,10 @@ static duk_ret_t test_ex_accessor_wo_setter(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_ex_accessor_wo_setter_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_ex_accessor_wo_setter(ctx);
 }
 
 /* strict: setter error propagates
@@ -271,6 +283,10 @@ static duk_ret_t test_ex_setter_throws(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_ex_setter_throws_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_ex_setter_throws(ctx);
+}
 
 /* success */
 static duk_ret_t test_new_extensible(duk_context *ctx) {
@@ -292,6 +308,10 @@ static duk_ret_t test_new_extensible(duk_context *ctx) {
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+static duk_ret_t test_new_extensible_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_new_extensible(ctx);
 }
 
 /* strict: error
@@ -322,9 +342,13 @@ static duk_ret_t test_new_not_extensible(duk_context *ctx) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
+static duk_ret_t test_new_not_extensible_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_new_not_extensible(ctx);
+}
 
 #define  TEST(func)  do { \
-		TEST_SAFE_CALL(func); \
+		TEST_SAFE_CALL(func ## _safecall); \
 		TEST_PCALL(func); \
 	} while (0)
 

--- a/tests/api/test-remove.c
+++ b/tests/api/test-remove.c
@@ -22,8 +22,10 @@ static void prep(duk_context *ctx) {
 	duk_push_int(ctx, 345);       /* -> [ 123 234 345 ] */
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	prep(ctx);
 	duk_remove(ctx, -2);          /* -> [ 123 345 ] */
@@ -35,7 +37,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_remove(ctx, 2);   /* -> [ 123 234 ]  (legal) */
 	printf("remove at 2 ok\n");
@@ -46,7 +50,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_remove(ctx, 0);   /* -> [ 234 345 ]  (legal) */
 	printf("remove at 0 ok\n");
@@ -57,7 +63,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_remove(ctx, DUK_INVALID_INDEX);  /* (illegal) */
 	printf("remove at DUK_INVALID_INDEX ok\n");

--- a/tests/api/test-replace.c
+++ b/tests/api/test-replace.c
@@ -22,8 +22,10 @@ static void prep(duk_context *ctx) {
 	duk_push_string(ctx, "foo");  /* -> [ 123 234 345 "foo" ] */
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	prep(ctx);
 	duk_replace(ctx, -3);         /* -> [ 123 "foo" 345 ] */
@@ -35,7 +37,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_replace(ctx, 3);          /* -> [ 123 234 "foo" ]  (legal) */
 	printf("replace at 3 ok\n");
@@ -44,7 +48,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_replace(ctx, -4);         /* -> [ "foo" 234 345 ]  (legal) */
 	printf("replace at -4 ok\n");
@@ -53,7 +59,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	prep(ctx);
 	duk_replace(ctx, DUK_INVALID_INDEX);  /* (illegal: invalid index) */
 	printf("replace at DUK_INVALID_INDEX ok\n");

--- a/tests/api/test-require-boolean.c
+++ b/tests/api/test-require-boolean.c
@@ -11,7 +11,9 @@ boolean: 0
 ==> rc=1, result='TypeError: boolean required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_true(ctx);
 	duk_push_false(ctx);
@@ -20,20 +22,26 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	printf("boolean: %d\n", (int) duk_require_boolean(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("boolean: %d\n", (int) duk_require_boolean(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("boolean: %d\n", (int) duk_require_boolean(ctx, DUK_INVALID_INDEX));
 	return 0;

--- a/tests/api/test-require-buffer-data.c
+++ b/tests/api/test-require-buffer-data.c
@@ -19,10 +19,12 @@ buffer
 ==> rc=1, result='TypeError: buffer required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
 	int i;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_fixed_buffer(ctx, 1024);
@@ -46,9 +48,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
@@ -58,9 +62,11 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	sz = (duk_size_t) 0xdeadbeefUL;
@@ -69,9 +75,11 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	sz = (duk_size_t) 0xdeadbeefUL;

--- a/tests/api/test-require-buffer.c
+++ b/tests/api/test-require-buffer.c
@@ -19,10 +19,12 @@ buffer
 ==> rc=1, result='TypeError: buffer required, found [object ArrayBuffer] (stack index -1)'
 ===*/
 
-static duk_ret_t test_basic(duk_context *ctx) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
 	int i;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_fixed_buffer(ctx, 1024);
@@ -45,9 +47,11 @@ static duk_ret_t test_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_invalid_type(duk_context *ctx) {
+static duk_ret_t test_invalid_type(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
@@ -57,9 +61,11 @@ static duk_ret_t test_invalid_type(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_invalid_index1(duk_context *ctx) {
+static duk_ret_t test_invalid_index1(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	sz = (duk_size_t) 0xdeadbeefUL;
@@ -68,9 +74,11 @@ static duk_ret_t test_invalid_index1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_invalid_index2(duk_context *ctx) {
+static duk_ret_t test_invalid_index2(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	sz = (duk_size_t) 0xdeadbeefUL;
@@ -79,9 +87,11 @@ static duk_ret_t test_invalid_index2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_buffer_object(duk_context *ctx) {
+static duk_ret_t test_buffer_object(duk_context *ctx, void *udata) {
 	void *ptr;
 	duk_size_t sz;
+
+	(void) udata;
 
 	/* duk_require_buffer() doesn't accept a buffer object */
 

--- a/tests/api/test-require-c-function.c
+++ b/tests/api/test-require-c-function.c
@@ -13,8 +13,10 @@ static duk_ret_t my_func(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_c_function funcptr;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_c_function(ctx, my_func, 1 /*nargs*/);
@@ -25,8 +27,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_c_function funcptr;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_c_function(ctx, my_func, 1 /*nargs*/);
@@ -37,8 +41,10 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	duk_c_function funcptr;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_c_function(ctx, my_func, 1 /*nargs*/);

--- a/tests/api/test-require-context.c
+++ b/tests/api/test-require-context.c
@@ -11,8 +11,10 @@ still here
 ==> rc=1, result='TypeError: thread required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	(void) duk_push_thread(ctx);
@@ -34,8 +36,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	/* non-thread value */
 	duk_set_top(ctx, 0);
@@ -45,8 +49,10 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	/* invalid index */
 	duk_set_top(ctx, 0);
@@ -56,8 +62,10 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	duk_context *new_ctx;
+
+	(void) udata;
 
 	/* invalid index */
 	duk_set_top(ctx, 0);

--- a/tests/api/test-require-int.c
+++ b/tests/api/test-require-int.c
@@ -14,8 +14,10 @@ number: inf -> int: DUK_INT_MAX
 ==> rc=1, result='TypeError: number required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_int(ctx, 123);
@@ -41,20 +43,26 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	printf("int: %ld\n", (long) duk_require_int(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("int: %ld\n", (long) duk_require_int(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("int: %ld\n", (long) duk_require_int(ctx, DUK_INVALID_INDEX));
 	return 0;

--- a/tests/api/test-require-lstring.c
+++ b/tests/api/test-require-lstring.c
@@ -21,9 +21,11 @@ static void dump_string_size(const char *p, duk_size_t sz) {
 	printf("string:%s%s (%ld)\n", (strlen(p) == 0 ? "" : " "), p, (long) sz);
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_lstring(ctx, "foo\0bar", 7);
@@ -47,9 +49,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
@@ -59,9 +63,11 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -70,9 +76,11 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 

--- a/tests/api/test-require-null.c
+++ b/tests/api/test-require-null.c
@@ -9,28 +9,36 @@
 ==> rc=1, result='TypeError: null required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	duk_require_null(ctx, 0);
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
 	duk_require_null(ctx, 0);
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_require_null(ctx, 0);
 	printf("require 0 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_require_null(ctx, DUK_INVALID_INDEX);
 	printf("require DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-require-number.c
+++ b/tests/api/test-require-number.c
@@ -11,7 +11,9 @@ number: nan
 ==> rc=1, result='TypeError: number required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_int(ctx, 123);
 	duk_push_nan(ctx);
@@ -20,20 +22,26 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	printf("number: %lf\n", (double) duk_require_number(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("number: %lf\n", (double) duk_require_number(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("number: %lf\n", (double) duk_require_number(ctx, DUK_INVALID_INDEX));
 	return 0;

--- a/tests/api/test-require-pointer.c
+++ b/tests/api/test-require-pointer.c
@@ -11,7 +11,9 @@ pointer: (nil)
 ==> rc=1, result='TypeError: pointer required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_pointer(ctx, (void *) 0xdeadbeef);
 	duk_push_pointer(ctx, (void *) NULL);
@@ -20,20 +22,26 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	printf("pointer: %p\n", duk_require_pointer(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("pointer: %p\n", duk_require_pointer(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	printf("pointer: %p\n", duk_require_pointer(ctx, DUK_INVALID_INDEX));
 	return 0;

--- a/tests/api/test-require-string.c
+++ b/tests/api/test-require-string.c
@@ -15,7 +15,9 @@ static void dump_string(const char *p) {
 	printf("string:%s%s\n", (strlen(p) == 0 ? "" : " "), p);
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "foo");
 	duk_push_string(ctx, "");
@@ -24,20 +26,26 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	dump_string(duk_require_string(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	dump_string(duk_require_string(ctx, 0));
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	dump_string(duk_require_string(ctx, DUK_INVALID_INDEX));
 	return 0;

--- a/tests/api/test-require-undefined.c
+++ b/tests/api/test-require-undefined.c
@@ -9,28 +9,36 @@
 ==> rc=1, result='TypeError: undefined required, found none (stack index -2147483648)'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
 	duk_require_undefined(ctx, 0);
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	duk_require_undefined(ctx, 0);
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_require_undefined(ctx, 0);
 	printf("require 0 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_require_undefined(ctx, DUK_INVALID_INDEX);
 	printf("require DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-resize-buffer.c
+++ b/tests/api/test-resize-buffer.c
@@ -41,8 +41,10 @@ static void dump_buffer(duk_context *ctx) {
 	printf("\n");
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	unsigned char *p;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -70,8 +72,10 @@ static duk_ret_t test_1(duk_context *ctx) {
 }
 
 /* fixed buffer */
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	unsigned char *p;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -91,7 +95,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 }
 
 /* non-buffer */
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	printf("non-buffer\n");
@@ -105,7 +111,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 }
 
 /* invalid index */
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	printf("non-buffer\n");
@@ -119,7 +127,9 @@ static duk_ret_t test_4(duk_context *ctx) {
 }
 
 /* DUK_INVALID_INDEX */
-static duk_ret_t test_5(duk_context *ctx) {
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	printf("non-buffer\n");

--- a/tests/api/test-safe-call.c
+++ b/tests/api/test-safe-call.c
@@ -5,8 +5,10 @@ error: Error: test_2 error
 final top: 1
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	double a, b, c;
+
+	(void) udata;
 
 	a = duk_get_number(ctx, -3);
 	b = duk_get_number(ctx, -2);
@@ -18,7 +20,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 1;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_error(ctx, DUK_ERR_INTERNAL_ERROR, "test_2 error");
 	return 0;
 }
@@ -34,7 +38,7 @@ void test(duk_context *ctx) {
 	duk_push_int(ctx, 10);
 	duk_push_int(ctx, 11);
 	duk_push_int(ctx, 12);
-	rc = duk_safe_call(ctx, test_1, 3 /*nargs*/, 2 /*nrets*/);
+	rc = duk_safe_call(ctx, test_1, NULL /*udata*/, 3 /*nargs*/, 2 /*nrets*/);
 	if (rc == DUK_EXEC_SUCCESS) {
 		printf("1st return value: %s\n", duk_to_string(ctx, -2));  /* 21 */
 		printf("2nd return value: %s\n", duk_to_string(ctx, -1));  /* undefined */
@@ -47,7 +51,7 @@ void test(duk_context *ctx) {
 	duk_push_int(ctx, 10);
 	duk_push_int(ctx, 11);
 	duk_push_int(ctx, 12);
-	rc = duk_safe_call(ctx, test_2, 3 /*nargs*/, 2 /*nrets*/);
+	rc = duk_safe_call(ctx, test_2, NULL /*udata*/, 3 /*nargs*/, 2 /*nrets*/);
 	if (rc == DUK_EXEC_SUCCESS) {
 		printf("1st return value: %s\n", duk_to_string(ctx, -2));  /* 21 */
 		printf("2nd return value: %s\n", duk_to_string(ctx, -1));  /* undefined */

--- a/tests/api/test-safe-to-string.c
+++ b/tests/api/test-safe-to-string.c
@@ -55,8 +55,10 @@ static void init_test_values(duk_context *ctx) {
 	/* XXX: add an infinite loop and timeout case */
 }
 
-static int test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	/* duk_safe_to_string() */
 	init_test_values(ctx);

--- a/tests/api/test-set-global-object.c
+++ b/tests/api/test-set-global-object.c
@@ -157,8 +157,10 @@ static void dump_global_object_keys(duk_context *ctx) {
 		"})()\n");
 }
 
-static duk_ret_t test_invalid_index(duk_context *ctx_root) {
+static duk_ret_t test_invalid_index(duk_context *ctx_root, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx = duk_require_context(ctx_root, -1);
@@ -168,8 +170,10 @@ static duk_ret_t test_invalid_index(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_invalid_target(duk_context *ctx_root) {
+static duk_ret_t test_invalid_target(duk_context *ctx_root, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx = duk_require_context(ctx_root, -1);
@@ -179,8 +183,10 @@ static duk_ret_t test_invalid_target(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_basic(duk_context *ctx_root) {
+static duk_ret_t test_basic(duk_context *ctx_root, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx = duk_require_context(ctx_root, -1);
@@ -237,8 +243,10 @@ static duk_ret_t test_basic(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_noeval(duk_context *ctx_root) {
+static duk_ret_t test_noeval(duk_context *ctx_root, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx = duk_require_context(ctx_root, -1);
@@ -281,8 +289,10 @@ static duk_ret_t test_noeval(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_regexp_literals(duk_context *ctx_root) {
+static duk_ret_t test_regexp_literals(duk_context *ctx_root, void *udata) {
 	duk_context *ctx;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx = duk_require_context(ctx_root, -1);
@@ -316,9 +326,11 @@ static duk_ret_t test_regexp_literals(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_regexp_prototype_shared(duk_context *ctx_root) {
+static duk_ret_t test_regexp_prototype_shared(duk_context *ctx_root, void *udata) {
 	duk_context *ctx1;
 	duk_context *ctx2;
+
+	(void) udata;
 
 	/*
 	 *  The RegExp constructor (built-in) is shared between two
@@ -396,9 +408,11 @@ static duk_ret_t test_regexp_prototype_shared(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_set_after_thread_create(duk_context *ctx_root) {
+static duk_ret_t test_set_after_thread_create(duk_context *ctx_root, void *udata) {
 	duk_context *ctx1;
 	duk_context *ctx2;
+
+	(void) udata;
 
 	duk_push_thread(ctx_root);
 	ctx1 = duk_require_context(ctx_root, -1);
@@ -470,10 +484,12 @@ static duk_ret_t test_set_after_thread_create(duk_context *ctx_root) {
 	return 0;
 }
 
-static duk_ret_t test_set_before_thread_create(duk_context *ctx_root) {
+static duk_ret_t test_set_before_thread_create(duk_context *ctx_root, void *udata) {
 	duk_context *ctx1;
 	duk_context *ctx2;
 	duk_context *ctx3;
+
+	(void) udata;
 
 	/*
 	 *  Creating a new thread using duk_push_thread() after setting

--- a/tests/api/test-steal-buffer.c
+++ b/tests/api/test-steal-buffer.c
@@ -35,11 +35,13 @@ static void dump_buffer(duk_context *ctx) {
 	printf("\n");
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	unsigned char *buf;
 	duk_size_t sz;
 	int i;
+
+	(void) udata;
 
 	duk_push_dynamic_buffer(ctx, 0);
 	dump_buffer(ctx);

--- a/tests/api/test-substring.c
+++ b/tests/api/test-substring.c
@@ -33,7 +33,7 @@ static void dump_string(duk_context *ctx) {
 	duk_pop(ctx);
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	/*
 	 *  Test with a string containing non-ASCII to ensure indices are
 	 *  treated correctly as char indices.
@@ -42,6 +42,8 @@ static duk_ret_t test_1(duk_context *ctx) {
 	 *  '666f6fe188b46172'
 	 */
 	const char *teststr = "666f6fe188b46172";
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -76,7 +78,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 }
 
 /* non-string -> error */
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123456);
@@ -87,7 +91,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 }
 
 /* invalid index */
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_string(ctx, "foobar");
@@ -98,7 +104,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 }
 
 /* invalid index */
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_string(ctx, "foobar");

--- a/tests/api/test-swap.c
+++ b/tests/api/test-swap.c
@@ -34,7 +34,9 @@ static void dump_stack(duk_context *ctx) {
 	printf(" ]\n");
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -64,7 +66,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -75,7 +79,9 @@ static duk_ret_t test_2a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -86,7 +92,9 @@ static duk_ret_t test_2b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -97,7 +105,9 @@ static duk_ret_t test_2c(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2d(duk_context *ctx) {
+static duk_ret_t test_2d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -108,7 +118,9 @@ static duk_ret_t test_2d(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_swap_top(ctx, 0);  /* empty stack */
@@ -117,7 +129,9 @@ static duk_ret_t test_3a(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -128,7 +142,9 @@ static duk_ret_t test_3b(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);

--- a/tests/api/test-throw.c
+++ b/tests/api/test-throw.c
@@ -3,7 +3,9 @@
 ==> rc=1, result='throw me'
 ===*/
 
-int test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_push_string(ctx, "throw me");
 	duk_throw(ctx);
 	return 0;

--- a/tests/api/test-to-boolean.c
+++ b/tests/api/test-to-boolean.c
@@ -26,8 +26,10 @@ index 17, boolean: 1
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -58,14 +60,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_boolean(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_boolean(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-buffer.c
+++ b/tests/api/test-to-buffer.c
@@ -66,9 +66,11 @@ static void dump_buffer(duk_context *ctx) {
 	printf("\n");
 }
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_size_t i, n;
 	char *buf;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -127,14 +129,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	(void) duk_to_buffer(ctx, 3, NULL);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	(void) duk_to_buffer(ctx, DUK_INVALID_INDEX, NULL);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-defaultvalue.c
+++ b/tests/api/test-to-defaultvalue.c
@@ -18,8 +18,10 @@ index 2, type 6 -> 3, result: true
  * Ecmascript tests.
  */
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_object(ctx);
@@ -43,7 +45,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	/* non-object input */
 	duk_set_top(ctx, 0);
 	duk_push_int(ctx, 123);
@@ -53,14 +57,18 @@ static duk_ret_t test_2(duk_context *ctx) {
 
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_defaultvalue(ctx, 3, DUK_HINT_NONE);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_defaultvalue(ctx, DUK_INVALID_INDEX, DUK_HINT_NONE);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-fixed-dynamic-buffer.c
+++ b/tests/api/test-to-fixed-dynamic-buffer.c
@@ -88,10 +88,12 @@ static void dump_buffer(duk_context *ctx) {
 }
 
 /* source: dynamic buffer, target: fixed buffer */
-static duk_ret_t test_1a(duk_context *ctx) {
+static duk_ret_t test_1a(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	void *q, *r;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -118,10 +120,12 @@ static duk_ret_t test_1a(duk_context *ctx) {
 }
 
 /* source: fixed buffer, target: dynamic buffer */
-static duk_ret_t test_1b(duk_context *ctx) {
+static duk_ret_t test_1b(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	void *q, *r;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -148,10 +152,12 @@ static duk_ret_t test_1b(duk_context *ctx) {
 }
 
 /* source: fixed buffer, target: fixed buffer */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -171,10 +177,12 @@ static duk_ret_t test_2a(duk_context *ctx) {
 }
 
 /* source: dynamic buffer, target: dynamic buffer */
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
 	unsigned char *p;
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -194,9 +202,11 @@ static duk_ret_t test_2b(duk_context *ctx) {
 }
 
 /* source: non-buffer, target: fixed buffer */
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "foo");
@@ -211,9 +221,11 @@ static duk_ret_t test_3a(duk_context *ctx) {
 }
 
 /* source: non-buffer, target: dynamic buffer */
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_string(ctx, "foo");
@@ -228,9 +240,11 @@ static duk_ret_t test_3b(duk_context *ctx) {
 }
 
 /* invalid index, target: fixed buffer */
-static duk_ret_t test_4a(duk_context *ctx) {
+static duk_ret_t test_4a(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -243,9 +257,11 @@ static duk_ret_t test_4a(duk_context *ctx) {
 }
 
 /* invalid index, target: dynamic buffer */
-static duk_ret_t test_4b(duk_context *ctx) {
+static duk_ret_t test_4b(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -258,9 +274,11 @@ static duk_ret_t test_4b(duk_context *ctx) {
 }
 
 /* DUK_INVALID_INDEX, target: fixed buffer */
-static duk_ret_t test_5a(duk_context *ctx) {
+static duk_ret_t test_5a(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -273,9 +291,11 @@ static duk_ret_t test_5a(duk_context *ctx) {
 }
 
 /* DUK_INVALID_INDEX, target: dynamic buffer */
-static duk_ret_t test_5b(duk_context *ctx) {
+static duk_ret_t test_5b(duk_context *ctx, void *udata) {
 	void *q;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -290,11 +310,13 @@ static duk_ret_t test_5b(duk_context *ctx) {
 /* When converting from an external buffer to a fixed buffer a copy is
  * always made.
  */
-static duk_ret_t test_6a(duk_context *ctx) {
+static duk_ret_t test_6a(duk_context *ctx, void *udata) {
 	unsigned char buf[16];
 	int i;
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	for (i = 0; i < 16; i++) {
 		buf[i] = (unsigned char) i;
@@ -317,11 +339,13 @@ static duk_ret_t test_6a(duk_context *ctx) {
 /* When converting from an external buffer to a dynamic buffer a copy
  * is always made.
  */
-static duk_ret_t test_6b(duk_context *ctx) {
+static duk_ret_t test_6b(duk_context *ctx, void *udata) {
 	unsigned char buf[16];
 	int i;
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	for (i = 0; i < 16; i++) {
 		buf[i] = (unsigned char) i;
@@ -344,11 +368,13 @@ static duk_ret_t test_6b(duk_context *ctx) {
 /* When converting from an external buffer to a "don't care" buffer,
  * an external buffer is kept as is.
  */
-static duk_ret_t test_6c(duk_context *ctx) {
+static duk_ret_t test_6c(duk_context *ctx, void *udata) {
 	unsigned char buf[16];
 	int i;
 	unsigned char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	for (i = 0; i < 16; i++) {
 		buf[i] = (unsigned char) i;

--- a/tests/api/test-to-int-uint.c
+++ b/tests/api/test-to-int-uint.c
@@ -78,8 +78,10 @@ index 32, uint: 1, number before: nan, number after: 1.000000
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -170,28 +172,36 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_int(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_int(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-int32-uint32-uint16.c
+++ b/tests/api/test-to-int32-uint32-uint16.c
@@ -145,8 +145,10 @@ index 42, uint16: 1, number before: nan, number after: 1.000000
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -234,42 +236,54 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_int32(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint32(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint16(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3a(duk_context *ctx) {
+static duk_ret_t test_3a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_int32(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3b(duk_context *ctx) {
+static duk_ret_t test_3b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint32(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3c(duk_context *ctx) {
+static duk_ret_t test_3c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_uint16(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-lstring.c
+++ b/tests/api/test-to-lstring.c
@@ -48,9 +48,11 @@ index 19, string: '0xdeadbeef'
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_int_t i, j, n;
 	char *ptr;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -110,9 +112,11 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	p = duk_to_lstring(ctx, 3, &sz);
@@ -120,9 +124,11 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
 	const char *p;
 	duk_size_t sz;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	p = duk_to_lstring(ctx, DUK_INVALID_INDEX, &sz);

--- a/tests/api/test-to-null.c
+++ b/tests/api/test-to-null.c
@@ -26,8 +26,10 @@ index 17, is-null: 1
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -59,14 +61,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_null(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_null(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-number.c
+++ b/tests/api/test-to-number.c
@@ -37,8 +37,10 @@ index 28, number: 1.000000
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -83,14 +85,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_number(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_number(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-object.c
+++ b/tests/api/test-to-object.c
@@ -40,8 +40,10 @@ index 0 OK
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_true(ctx);
@@ -72,14 +74,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 }
 
 /* Non-coercible types */
-static duk_ret_t test_2a(duk_context *ctx) {
+static duk_ret_t test_2a(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2b(duk_context *ctx) {
+static duk_ret_t test_2b(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_null(ctx);
 	duk_to_object(ctx, 0);
@@ -88,42 +94,53 @@ static duk_ret_t test_2b(duk_context *ctx) {
 }
 
 /* Buffers and pointers are coercible */
-static duk_ret_t test_2c(duk_context *ctx) {
+static duk_ret_t test_2c(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_fixed_buffer(ctx, 0);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2d(duk_context *ctx) {
+static duk_ret_t test_2d(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_fixed_buffer(ctx, 1024);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2e(duk_context *ctx) {
+static duk_ret_t test_2e(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_dynamic_buffer(ctx, 0);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2f(duk_context *ctx) {
+static duk_ret_t test_2f(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_dynamic_buffer(ctx, 1024);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2g(duk_context *ctx) {
+static duk_ret_t test_2g(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_push_pointer(ctx, (void *) NULL);
 	duk_to_object(ctx, 0);
 	printf("index 0 OK\n");
 	return 0;
 }
-static duk_ret_t test_2h(duk_context *ctx) {
+static duk_ret_t test_2h(duk_context *ctx, void *udata) {
+	(void) udata;
 	duk_set_top(ctx, 0);
 	duk_push_pointer(ctx, (void *) 0xdeadbeef);
 	duk_to_object(ctx, 0);
@@ -131,14 +148,18 @@ static duk_ret_t test_2h(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_boolean(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_boolean(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-pointer.c
+++ b/tests/api/test-to-pointer.c
@@ -28,8 +28,10 @@ pointer: 0xdeadbeef
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -72,14 +74,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_pointer(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_pointer(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-primitive.c
+++ b/tests/api/test-to-primitive.c
@@ -31,8 +31,10 @@ index 18, ToString(result): '0xdeadbeef', type: 8 -> 8
  * They are indirectly covered by Ecmascript tests to some extent, though.
  */
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -72,14 +74,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_primitive(ctx, 3, DUK_HINT_NONE);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_primitive(ctx, DUK_INVALID_INDEX, DUK_HINT_NONE);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-string.c
+++ b/tests/api/test-to-string.c
@@ -28,9 +28,11 @@ index 19, string: '0xdeadbeef'
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_int_t i, n;
 	char *ptr;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -69,14 +71,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_string(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_string(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-to-undefined.c
+++ b/tests/api/test-to-undefined.c
@@ -26,8 +26,10 @@ index 17, is-undefined: 1
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 	duk_push_undefined(ctx);
@@ -59,14 +61,18 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_undefined(ctx, 3);
 	printf("index 3 OK\n");
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 	duk_to_undefined(ctx, DUK_INVALID_INDEX);
 	printf("index DUK_INVALID_INDEX OK\n");

--- a/tests/api/test-trim.c
+++ b/tests/api/test-trim.c
@@ -12,8 +12,10 @@ final top: 2
 ==> rc=1, result='Error: invalid stack index -2147483648'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx) {
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_idx_t i, n;
+
+	(void) udata;
 
 	duk_set_top(ctx, 0);
 
@@ -47,7 +49,9 @@ static duk_ret_t test_1(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx) {
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -58,7 +62,9 @@ static duk_ret_t test_2(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx) {
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);
@@ -69,7 +75,9 @@ static duk_ret_t test_3(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_4(duk_context *ctx) {
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
 	duk_set_top(ctx, 0);
 
 	duk_push_int(ctx, 123);

--- a/tests/api/test-typedarray-set-overlap.c
+++ b/tests/api/test-typedarray-set-overlap.c
@@ -62,10 +62,12 @@ final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
-static duk_ret_t test_basic_overlap(duk_context *ctx) {
+static duk_ret_t test_basic_overlap(duk_context *ctx, void *udata) {
 	unsigned char buf[16];
 	int offset;
 	int i;
+
+	(void) udata;
 
 	for (offset = 0; offset <= 8; offset++) {
 		printf("offset: %d\n", offset);
@@ -224,10 +226,12 @@ final top: 0
  *  check in the implementation.
  */
 
-static duk_ret_t test_expand_overlap(duk_context *ctx) {
+static duk_ret_t test_expand_overlap(duk_context *ctx, void *udata) {
 	unsigned char buf[48];
 	int offset;
 	int i;
+
+	(void) udata;
 
 	for (offset = 0; offset < 16; offset++) {  /* dst offset */
 		printf("offset: %d\n", offset);

--- a/tests/api/test-validate-index.c
+++ b/tests/api/test-validate-index.c
@@ -34,8 +34,10 @@ req_valid_idx: top 3 after popping arg
 idx=5, duk_require_valid_index -> Error: invalid stack index 5
 ===*/
 
-static duk_ret_t req_valid_idx(duk_context *ctx) {
+static duk_ret_t req_valid_idx(duk_context *ctx, void *udata) {
 	duk_idx_t idx = duk_get_int(ctx, -1);
+
+	(void) udata;
 
 	duk_pop(ctx);
 	printf("req_valid_idx: top %ld after popping arg\n", (long) duk_get_top(ctx));
@@ -60,7 +62,7 @@ void test(duk_context *ctx) {
 
 	for (idx = -5; idx <= 5; idx++) {
 		duk_push_int(ctx, idx);
-		duk_safe_call(ctx, req_valid_idx, 1, 1);
+		duk_safe_call(ctx, req_valid_idx, NULL, 1, 1);
 		printf("idx=%ld, duk_require_valid_index -> %s\n",
 		       (long) idx, duk_to_string(ctx, -1));
 		duk_pop(ctx);

--- a/tests/api/test-xcopy-xmove.c
+++ b/tests/api/test-xcopy-xmove.c
@@ -309,8 +309,10 @@ static void unwind_logged(duk_context *ctx, const char *name) {
 	}
 }
 
-static duk_ret_t test_xcopy_top_basic(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_basic(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -331,8 +333,10 @@ static duk_ret_t test_xcopy_top_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_large(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_large(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_large(ctx, &ctx1, &ctx2);
 
@@ -346,8 +350,10 @@ static duk_ret_t test_xcopy_top_large(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_refcount(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_refcount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_finalizers(ctx, &ctx1, &ctx2);
 
@@ -379,8 +385,10 @@ static duk_ret_t test_xcopy_top_refcount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_samectx(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_samectx(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -393,8 +401,10 @@ static duk_ret_t test_xcopy_top_samectx(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_negcount(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_negcount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -407,8 +417,10 @@ static duk_ret_t test_xcopy_top_negcount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_verylargecount(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_verylargecount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -425,8 +437,10 @@ static duk_ret_t test_xcopy_top_verylargecount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_notenoughsrc(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_notenoughsrc(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -439,9 +453,11 @@ static duk_ret_t test_xcopy_top_notenoughsrc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xcopy_top_notenoughdst(duk_context *ctx) {
+static duk_ret_t test_xcopy_top_notenoughdst(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
 	int i;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 	duk_require_stack(ctx2, 1000);
@@ -461,8 +477,10 @@ static duk_ret_t test_xcopy_top_notenoughdst(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_basic(duk_context *ctx) {
+static duk_ret_t test_xmove_top_basic(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -480,8 +498,10 @@ static duk_ret_t test_xmove_top_basic(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_large(duk_context *ctx) {
+static duk_ret_t test_xmove_top_large(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_large(ctx, &ctx1, &ctx2);
 
@@ -495,8 +515,10 @@ static duk_ret_t test_xmove_top_large(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_refcount(duk_context *ctx) {
+static duk_ret_t test_xmove_top_refcount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_finalizers(ctx, &ctx1, &ctx2);
 
@@ -520,8 +542,10 @@ static duk_ret_t test_xmove_top_refcount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_samectx(duk_context *ctx) {
+static duk_ret_t test_xmove_top_samectx(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -534,8 +558,10 @@ static duk_ret_t test_xmove_top_samectx(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_negcount(duk_context *ctx) {
+static duk_ret_t test_xmove_top_negcount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -548,8 +574,10 @@ static duk_ret_t test_xmove_top_negcount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_verylargecount(duk_context *ctx) {
+static duk_ret_t test_xmove_top_verylargecount(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -562,8 +590,10 @@ static duk_ret_t test_xmove_top_verylargecount(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_notenoughsrc(duk_context *ctx) {
+static duk_ret_t test_xmove_top_notenoughsrc(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 
@@ -576,9 +606,11 @@ static duk_ret_t test_xmove_top_notenoughsrc(duk_context *ctx) {
 	return 0;
 }
 
-static duk_ret_t test_xmove_top_notenoughdst(duk_context *ctx) {
+static duk_ret_t test_xmove_top_notenoughdst(duk_context *ctx, void *udata) {
 	duk_context *ctx1, *ctx2;
 	int i;
+
+	(void) udata;
 
 	prep_plain(ctx, &ctx1, &ctx2);
 	duk_require_stack(ctx2, 1000);

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -55,7 +55,7 @@ typedef void (*duk_free_function) (void *udata, void *ptr);
 typedef void (*duk_fatal_function) (duk_context *ctx, duk_errcode_t code, const char *msg);
 typedef void (*duk_decode_char_function) (void *udata, duk_codepoint_t codepoint);
 typedef duk_codepoint_t (*duk_map_char_function) (void *udata, duk_codepoint_t codepoint);
-typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx);
+typedef duk_ret_t (*duk_safe_call_function) (duk_context *ctx, void *udata);
 typedef duk_size_t (*duk_debug_read_function) (void *udata, char *buffer, duk_size_t length);
 typedef duk_size_t (*duk_debug_write_function) (void *udata, const char *buffer, duk_size_t length);
 typedef duk_size_t (*duk_debug_peek_function) (void *udata);

--- a/website/api/duk_safe_call.yaml
+++ b/website/api/duk_safe_call.yaml
@@ -1,16 +1,23 @@
 name: duk_safe_call
 
 proto: |
-  duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, duk_idx_t nargs, duk_idx_t nrets);
+  duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, void *udata, duk_idx_t nargs, duk_idx_t nrets);
 
 stack: |
   [ ... arg1! ...! argN! ] -> [ ... ret1! ...! retN! ]
 
 summary: |
-  <p>Perform a protected pure C function call inside the current value stack frame
-  (the call is not visible on the call stack).  <code>nargs</code> topmost values in the
-  current value stack frame are identified as call arguments, and <code>nrets</code>
-  return values are provided after the call returns.</p>
+  <p>Perform a protected pure C function call inside the current value stack
+  frame (the call is not visible on the call stack).  <code>nargs</code>
+  topmost values in the current value stack frame are identified as call
+  arguments, and <code>nrets</code> return values are provided after the call
+  returns.  The <code>udata</code> (userdata) pointer is passed on to
+  <code>func</code> as is, and makes it easy to pass one or more C values to
+  the target function without using the value stack.  Multiple values can be
+  passed by packing them into a stack-allocated C struct and passing a pointer
+  to the struct as userdata.  The userdata argument is not interpreted by
+  Duktape; if it isn't needed simply pass a <code>NULL</code> and ignore the
+  udata argument in the safe call target.</p>
 
   <p>The return value is:</p>
   <ul>
@@ -29,8 +36,7 @@ summary: |
   </div>
 
   <p>Because this call operates on the current value stack frame, stack behavior
-  differs a bit from other call types.  Although the target function signature
-  matches Duktape/C functions, value stack and return code policies are different.</p>
+  and return code handling differ a bit from other call types.</p>
 
   <p>The top <code>nargs</code> elements of the stack top are identified as arguments to
   <code>func</code> establishing a "base index" for the return stack as:</p>
@@ -54,8 +60,8 @@ summary: |
   top will equal the "base index"), so calling this function with <code>nrets</code> as 0
   is not very useful.</p>
 
-  <p>Example with <code>nargs = 3</code>, <code>nrets = 2</code>, <code>func</code> returns 4.
-  Pipe chars indicate logical boundaries:</p>
+  <p>Example value stack behavior with <code>nargs = 3</code>, <code>nrets = 2</code>,
+  <code>func</code> returns 4.  Pipe chars indicate logical value stack boundaries:</p>
 
   <pre>
         .--- frame bottom
@@ -74,18 +80,31 @@ summary: |
   </pre>
 
   <div class="note">
-  Note that <code>func</code> uses caller stack frame, so bottom-based references
-  are dangerous within 'func'.
+  Note that <code>func</code> uses the caller's stack frame, so bottom-based
+  references are dangerous within 'func' unless the calling context is known.
+  </div>
+
+  <div class="note">
+  The userdata argument was added in Duktape 2.x.
   </div>
 
 example: |
-  duk_ret_t my_func(duk_context *ctx) {
-      double a, b, c;
+  typedef struct {
+    int floor;
+  } my_safe_args;
+
+  duk_ret_t my_safe_func(duk_context *ctx, void *udata) {
+      my_safe_args *args = (my_safe_args *) udata;
+      double a, b, c, t;
 
       a = duk_get_number(ctx, -3);
       b = duk_get_number(ctx, -2);
       c = duk_get_number(ctx, -1);  /* ignored on purpose */
-      duk_push_number(ctx, a + b);
+      t = a + b;
+      if (args->floor) {
+          t = floor(t);
+      }
+      duk_push_number(ctx, t;
 
       /* Indicates that there is only one return value.  Because the caller
        * requested two (nrets == 2), Duktape will automatically add an
@@ -94,12 +113,14 @@ example: |
       return 1;
   }
 
+  my_safe_args args;  /* C struct whose pointer is passed as userdata */
   duk_int_t rc;
 
+  args.floor = 1;
   duk_push_int(ctx, 10);
   duk_push_int(ctx, 11);
   duk_push_int(ctx, 12);
-  rc = duk_safe_call(ctx, my_func, 3 /*nargs*/, 2 /*nrets*/);
+  rc = duk_safe_call(ctx, my_func, (void *) &args, 3 /*nargs*/, 2 /*nrets*/);
   if (rc == DUK_EXEC_SUCCESS) {
       printf("1st return value: %s\n", duk_to_string(ctx, -2));  /* 21 */
       printf("2nd return value: %s\n", duk_to_string(ctx, -1));  /* undefined */
@@ -112,4 +133,5 @@ tags:
   - call
   - protected
 
-introduced: 1.0.0
+# Introduced in 1.0.0 but incompatible change in 2.0.0.
+introduced: 2.0.0

--- a/website/guide/programming.html
+++ b/website/guide/programming.html
@@ -639,8 +639,11 @@ duk_pop(ctx);
  * but is a bit more verbose.
  */
 
-static duk_ret_t unsafe_code(duk_context *ctx) {
+static duk_ret_t unsafe_code(duk_context *ctx, void *udata) {
     /* Here we can use unprotected calls freely. */
+
+    (void) udata;  /* 'udata' may be used to pass e.g. a struct pointer */
+
     duk_eval_file_noresult(ctx, "myscript.js");
 
     /* ... */
@@ -650,7 +653,7 @@ static duk_ret_t unsafe_code(duk_context *ctx) {
 
 /* elsewhere: */
 
-if (duk_safe_call(ctx, unsafe_code, 0 /*nargs*/, 1 /*nrets */) != 0) {
+if (duk_safe_call(ctx, unsafe_code, NULL /*udata*/, 0 /*nargs*/, 1 /*nrets */) != 0) {
     /* The 'nrets' argument should be at least 1 so that an error value
      * is left on the stack if an error occurs.  To avoid further errors,
      * use duk_safe_to_string() for safe error printing.


### PR DESCRIPTION
- [x] Add a userdata argument to duk_safe_call()
- [x] Fix internal call sites
- [x] Fix API testcases
- [x] Fix examples
- [x] Grep all duk_safe_call() strings and check they've been updated
- [x] Update API documentation
- [x] Update website
- [x] Release notes migration instructions
- [x] Releases entry

Fixes #277.