### PR TITLE
Document stable v1-maintenance branch, branch policies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ This repository is **intended for Duktape developers only**, and contains
 Duktape internals: test cases, internal documentation, sources for the
 duktape.org web site, etc.
 
-Current branch policy: the "master" branch is used for active development,
-other branches are frequently rebased feature branches (so you should not
-fork off them), and tags are used for releases.  Master is quite stable,
-but may be broken from time to time so use it with care.
-
 Getting started: end user
 -------------------------
 
@@ -101,6 +96,34 @@ Getting started: other development (Linux only)
 Other development stuff, such as building the website and running test cases,
 is based on a `Makefile` **intended for Linux only**.  See detailed
 instructions in http://wiki.duktape.org/DevelopmentSetup.html.
+
+Branch policy
+-------------
+
+* The `master` branch is used for active development.  While pull requests
+  are tested before merging, master may be broken from time to time.  When
+  development on a new major release starts, master will also get API
+  incompatible changes without warning.  For these reasons **you should
+  generally not depend on the master branch** for building your project; use
+  a release tag or a release maintenance branch instead.
+
+* Pull requests and their related branches are frequently rebased so you
+  should not fork off them.  Pull requests may be open for a while for
+  testing and discussion.
+
+* Release tags like `v1.4.1` are used for releases and match the released
+  distributables.  These are stable once the release is complete.
+
+* Maintenance branches are used for backporting fixes and features for
+  maintenance releases.  Documentation changes go to master for maintenance
+  releases too.  For example, `v1.5-maintenance` was created for the 1.5.0
+  release and is used for 1.5.x maintenance releases.
+
+* A maintenance branch is also created for a major release when master moves
+  on to active development of the next major release.  For example,
+  `v1-maintenance` was created when 1.5.0 was released (last planned 1.x
+  release) and development of 2.0.0 (with API incompatible changes) started
+  on master.  If a 1.6.0 is made, it will be made from `v1-maintenance`.
 
 Versioning
 ----------

--- a/doc/git-conventions.rst
+++ b/doc/git-conventions.rst
@@ -86,6 +86,10 @@ Maintenance branches:
   before an initial zero patch level release.  Release prepping should be done
   in master so that there's no need to backport release notes and such.
 
+* ``vN-maintenance``: Maintenance branch for a certain major version (e.g. 1.x)
+  which is created when master moves on for development of the next major
+  version.
+
 Release tags:
 
 * ``vN.N.N``: Release tags.  All releases are created from a maintenance


### PR DESCRIPTION
Add more explicit branch policies in README (and not only in internal documentation); in particular, `master` is unstable and project builds should generally avoid depending on it.

**With the master now used for 2.0.0 development which includes API incompatible changes, any projects relying on "latest 1.x" (rather than a specific release, e.g. `v1.5.0`) should depend on `v1-maintenance` rather than master.**