### PR TITLE
Require callstack index for debug commands

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1720,6 +1720,9 @@ Planned
 * Incompatible change: debug protocol version bumped from 1 to 2 to indicate
   version incompatible protocol changes in the 2.0.0 release (GH-756)
 
+* Incompatible change: make callstack level mandatory for most debugger
+  commands which accept one (GH-747)
+
 * Incompatible change: require a DUK_USE_DEBUG_WRITE() macro for handling
   debug writes when DUK_USE_DEBUG is enabled; this avoids a platform I/O
   dependency and allows debug log filtering and retargeting (GH-782)
@@ -1870,6 +1873,9 @@ Planned
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
   same time provider as seen by Ecmascript code (GH-771)
+
+* Add ability to perform an indirect debugger Eval with non-empty callstack by
+  sending null for the callstack level (GH-747)
 
 * Add a human readable summary of 'new MyConstructor()' constructor call
   target when the target is non-constructable (GH-757)


### PR DESCRIPTION
I remember you saying you wanted to remove the checks in 2.x, so here's a prototype change.  The change is not yet complete however, there were a couple issues:
- What to do for Eval?  If we make the callstack index mandatory, with corresponding sanity check, then it becomes impossible for a client to issue an Eval with nothing on the callstack.  Should we just leave Eval as-is?
- There is a very heavyweight check after the `duk_debug_peek_byte()` in the handler for GetBytecode that I wasn't able to fully decipher: https://github.com/svaarala/duktape/blob/master/src/duk_debugger.c#L1830-L1856.  I left it alone because I didn't want to accidentally break anything.
