### PR TITLE
Bump debug protocol version

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1599,3 +1599,6 @@ Planned
 * Incompatible change: rename duk_debugger_attach_custom() API call to
   duk_debugger_attach() to eliminate an unnecessary API call variant
   (GH-735, GH-742)
+
+* Incompatible change: debug protocol version bumped from 1 to 2 to indicate
+  version incompatible protocol changes in the 2.0.0 release (GH-756)

--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -47,6 +47,7 @@ var UI_MESSAGE_CLIPLEN = 128;
 var LOCALS_CLIPLEN = 64;
 var EVAL_CLIPLEN = 4096;
 var GETVAR_CLIPLEN = 4096;
+var SUPPORTED_DEBUG_PROTOCOL_VERSION = 2;
 
 // Commands initiated by Duktape
 var CMD_STATUS = 0x01;
@@ -1591,7 +1592,8 @@ Debugger.prototype.connectDebugger = function () {
         console.log('Debug version identification:', msg.versionIdentification);
         _this.protocolVersion = ver;
         _this.uiMessage('debugger-info', 'Debug version identification: ' + msg.versionIdentification);
-        if (ver !== 1) {
+        if (ver !== SUPPORTED_DEBUG_PROTOCOL_VERSION) {
+            console.log('Unsupported debug protocol version (got ' + ver + ', support ' + SUPPORTED_DEBUG_PROTOCOL_VERSION + ')');
             _this.uiMessage('debugger-info', 'Protocol version ' + ver + ' unsupported, dropping connection');
             _this.targetStream.destroy();
         } else {

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -657,15 +657,15 @@ as an UTF-8 encoded line of the form::
 
     <protocolversion> <SP (0x20)> <additional text, no LF> <LF (0x0a)>
 
-The current protocol version is "1" and the identification line currently
+The current protocol version is "2" and the identification line currently
 has the form::
 
-    1 <DUK_VERSION> <DUK_GIT_DESCRIBE> <target string> <LF>
+    2 <DUK_VERSION> <DUK_GIT_DESCRIBE> <target string> <LF>
 
 Everything that follows the protocol version number is informative only.
 Example::
 
-    1 10099 v1.0.0-254-g2459e88 duk command built from Duktape repo
+    2 20000 v2.0.0 duk command built from Duktape repo
 
 The debug protocol version is available as a define to the user code
 (defined by ``duktape.h``)::

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -138,6 +138,21 @@ To upgrade:
               detached_cb,
               udata);
 
+Debug protocol version bumped from 1 to 2
+-----------------------------------------
+
+Because there are small incompatible changes in the debug protocol in this
+release, the debug protocol version has been bumped from 1 to 2.  The version
+is provided by the ``DUK_DEBUG_PROTOCOL_VERSION`` constant, and also appears
+in the debug protocol version identification string.
+
+To upgrade:
+
+* Review the debug protocol changes and ensure debug client has corresponding
+  changes.
+
+* Update debug client code to support both versions 1 and 2, or version 2 only.
+
 Known issues
 ============
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -99,7 +99,7 @@ struct duk_number_list_entry {
 #define DUK_GIT_BRANCH                    @GIT_BRANCH_CSTRING@
 
 /* Duktape debug protocol version used by this build. */
-#define DUK_DEBUG_PROTOCOL_VERSION        1
+#define DUK_DEBUG_PROTOCOL_VERSION        2
 
 /* Used to represent invalid index; if caller uses this without checking,
  * this index will map to a non-existent stack entry.  Also used in some


### PR DESCRIPTION
With minor incompatible changes in Duktape 2.x, bump the debug protocol version to 2.

- [x] Update API constant (also controls Duktape version identification line)
- [x] Update debugger documentation for bumped version
- [x] Fix duk_debug.js to use the bumped version
- [x] Releases
- [x] 2.0 migration note