### PR TITLE
Improve error message for non-constructable target for 'new'

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1605,3 +1605,6 @@ Planned
 
 * Incompatible change: debug protocol version bumped from 1 to 2 to indicate
   version incompatible protocol changes in the 2.0.0 release (GH-756)
+
+* Add a human readable summary of 'new MyConstructor()' constructor call
+  target when the target is non-constructable (GH-757)

--- a/src/duk_api_call.c
+++ b/src/duk_api_call.c
@@ -404,7 +404,15 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 	return;
 
  not_constructable:
-	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONSTRUCTABLE);
+#if defined(DUK_USE_VERBOSE_ERRORS)
+#if defined(DUK_USE_PARANOID_ERRORS)
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "%s not constructable", duk_get_type_name(ctx, -1));
+#else
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "%s not constructable", duk_push_string_readable(ctx, -1));
+#endif
+#else
+	DUK_ERROR_TYPE(thr, "not constructable");
+#endif
 }
 
 DUK_LOCAL duk_ret_t duk__pnew_helper(duk_context *ctx, void *udata) {

--- a/src/duk_strings.c
+++ b/src/duk_strings.c
@@ -12,7 +12,6 @@
 DUK_INTERNAL const char *duk_str_internal_error = "internal error";
 DUK_INTERNAL const char *duk_str_invalid_count = "invalid count";
 DUK_INTERNAL const char *duk_str_invalid_call_args = "invalid call args";
-DUK_INTERNAL const char *duk_str_not_constructable = "not constructable";
 DUK_INTERNAL const char *duk_str_not_callable = "not callable";
 DUK_INTERNAL const char *duk_str_not_extensible = "not extensible";
 DUK_INTERNAL const char *duk_str_not_writable = "not writable";

--- a/src/duk_strings.h
+++ b/src/duk_strings.h
@@ -24,7 +24,7 @@
 #define DUK_STR_INTERNAL_ERROR duk_str_internal_error
 #define DUK_STR_INVALID_COUNT duk_str_invalid_count
 #define DUK_STR_INVALID_CALL_ARGS duk_str_invalid_call_args
-#define DUK_STR_NOT_CONSTRUCTABLE duk_str_not_constructable
+#define DUK_STR_NOT_CONSTRUCTABLE "not constructable"
 #define DUK_STR_NOT_CALLABLE duk_str_not_callable
 #define DUK_STR_NOT_EXTENSIBLE duk_str_not_extensible
 #define DUK_STR_NOT_WRITABLE duk_str_not_writable
@@ -34,7 +34,6 @@
 DUK_INTERNAL_DECL const char *duk_str_internal_error;
 DUK_INTERNAL_DECL const char *duk_str_invalid_count;
 DUK_INTERNAL_DECL const char *duk_str_invalid_call_args;
-DUK_INTERNAL_DECL const char *duk_str_not_constructable;
 DUK_INTERNAL_DECL const char *duk_str_not_callable;
 DUK_INTERNAL_DECL const char *duk_str_not_extensible;
 DUK_INTERNAL_DECL const char *duk_str_not_writable;

--- a/tests/api/test-new.c
+++ b/tests/api/test-new.c
@@ -14,7 +14,7 @@ final top: 0
 ==> rc=0, result='undefined'
 *** test_pnew_2 (duk_safe_call)
 pnew returned: 1
-result: TypeError: not constructable
+result: TypeError: null not constructable
 final top: 0
 ==> rc=0, result='undefined'
 ===*/


### PR DESCRIPTION
Current behavior:

```
((o) Duktape [linenoise] 1.99.99 (v1.5.0-37-gf2be963)
duk> x = new undefined()
TypeError: not constructable
    at [anon] (duk_api_call.c:407) internal
    at global (input:1) preventsyield
```

Improve error message to e.g.

    TypeError: undefined not constructable