### PR TITLE
Add `ctx` argument to debugger detached callback

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1654,6 +1654,9 @@ Planned
   DUK_ERR_API_ERROR and a plain Error for Ecmascript representation) into
   TypeErrors and RangeErrors to match common Ecmascript conventions (GH-827)
 
+* Incompatible change: add a ctx argument to detached_cb to allow easier
+  reattachment in detached callback
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -999,9 +999,7 @@ static duk_idx_t debugger_request(duk_context *ctx, void *udata, duk_idx_t nvalu
 	return -1;
 }
 
-static void debugger_detached(void *udata) {
-	duk_context *ctx = (duk_context *) udata;
-	(void) ctx;
+static void debugger_detached(duk_context *ctx, void *udata) {
 	fprintf(stderr, "Debugger detached, udata: %p\n", (void *) udata);
 	fflush(stderr);
 
@@ -1028,7 +1026,7 @@ static void debugger_detached(void *udata) {
 		                    duk_trans_socket_write_flush_cb,
 		                    debugger_request,
 		                    debugger_detached,
-		                    (void *) ctx);
+		                    NULL);
 	}
 }
 #endif
@@ -1168,7 +1166,7 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 		                    duk_trans_socket_write_flush_cb,
 		                    debugger_request,
 		                    debugger_detached,
-		                    (void *) ctx);
+		                    NULL);
 #else
 		fprintf(stderr, "Warning: option --debugger ignored, no debugger support\n");
 		fflush(stderr);

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -59,7 +59,7 @@ typedef duk_size_t (*duk_debug_peek_function) (void *udata);
 typedef void (*duk_debug_read_flush_function) (void *udata);
 typedef void (*duk_debug_write_flush_function) (void *udata);
 typedef duk_idx_t (*duk_debug_request_function) (duk_context *ctx, void *udata, duk_idx_t nvalues);
-typedef void (*duk_debug_detached_function) (void *udata);
+typedef void (*duk_debug_detached_function) (duk_context *ctx, void *udata);
 
 struct duk_memory_functions {
 	duk_alloc_function alloc_func;

--- a/src/duk_debugger.c
+++ b/src/duk_debugger.c
@@ -88,6 +88,12 @@ DUK_LOCAL void duk__debug_do_detach1(duk_heap *heap, duk_int_t reason) {
 DUK_LOCAL void duk__debug_do_detach2(duk_heap *heap) {
 	duk_debug_detached_function detached_cb;
 	void *detached_udata;
+	duk_hthread *thr;
+	duk_context *ctx;
+
+	thr = heap->heap_thread;
+	DUK_ASSERT(thr != NULL);
+	ctx = (duk_context *) thr;
 
 	/* Safe to call multiple times. */
 
@@ -102,7 +108,7 @@ DUK_LOCAL void duk__debug_do_detach2(duk_heap *heap) {
 		 * inside the callback.
 		 */
 		DUK_D(DUK_DPRINT("detached during message loop, delayed call to detached_cb"));
-		detached_cb(detached_udata);
+		detached_cb(ctx, detached_udata);
 	}
 
 	heap->dbg_detaching = 0;


### PR DESCRIPTION
Immediately reattaching in the detached callback is a supported scenario.  This pull makes that easier by adding a `ctx` argument to detached_cb.