### PR TITLE
Remove file I/O support from config

### DIFF
--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -11,17 +11,6 @@
 #define DUK_LONGJMP(jb)       siglongjmp((jb), 1)
 #endif
 
-typedef FILE duk_file;
-#if !defined(DUK_STDIN)
-#define DUK_STDIN       stdin
-#endif
-#if !defined(DUK_STDOUT)
-#define DUK_STDOUT      stdout
-#endif
-#if !defined(DUK_STDERR)
-#define DUK_STDERR      stderr
-#endif
-
 /* Special naming to avoid conflict with e.g. DUK_FREE() in duk_heap.h
  * (which is unfortunately named).  May sometimes need replacement, e.g.
  * some compilers don't handle zero length or NULL correctly in realloc().
@@ -88,12 +77,6 @@ typedef FILE duk_file;
 #if !defined(DUK_STRNCMP)
 #define DUK_STRNCMP      strncmp
 #endif
-#if !defined(DUK_PRINTF)
-#define DUK_PRINTF       printf
-#endif
-#if !defined(DUK_FPRINTF)
-#define DUK_FPRINTF      fprintf
-#endif
 #if !defined(DUK_SPRINTF)
 #define DUK_SPRINTF      sprintf
 #endif
@@ -113,30 +96,6 @@ typedef FILE duk_file;
 #endif
 #if !defined(DUK_VSSCANF)
 #define DUK_VSSCANF      vsscanf
-#endif
-#if !defined(DUK_FOPEN)
-#define DUK_FOPEN        fopen
-#endif
-#if !defined(DUK_FCLOSE)
-#define DUK_FCLOSE       fclose
-#endif
-#if !defined(DUK_FREAD)
-#define DUK_FREAD        fread
-#endif
-#if !defined(DUK_FWRITE)
-#define DUK_FWRITE       fwrite
-#endif
-#if !defined(DUK_FSEEK)
-#define DUK_FSEEK        fseek
-#endif
-#if !defined(DUK_FTELL)
-#define DUK_FTELL        ftell
-#endif
-#if !defined(DUK_FFLUSH)
-#define DUK_FFLUSH       fflush
-#endif
-#if !defined(DUK_FPUTC)
-#define DUK_FPUTC        fputc
 #endif
 #if !defined(DUK_MEMZERO)
 #define DUK_MEMZERO(p,n) DUK_MEMSET((p), 0, (n))

--- a/config/other-defines/platform_functions.yaml
+++ b/config/other-defines/platform_functions.yaml
@@ -41,28 +41,11 @@
 - define: DUK_STRNCMP
 
 # String printing and parsing
-- define: DUK_PRINTF
-- define: DUK_FPRINTF
 - define: DUK_SPRINTF
 - define: DUK_SNPRINTF
 - define: DUK_VSNPRINT
 - define: DUK_SSCANF
 - define: DUK_VSSCANF
-
-# File I/O
-- define: DUK_FOPEN
-- define: DUK_FCLOSE
-- define: DUK_FREAD
-- define: DUK_FWRITE
-- define: DUK_FSEEK
-- define: DUK_FTELL
-- define: DUK_FFLUSH
-- define: DUK_FPUTC
-
-# I/O streams
-- define: DUK_STDOUT
-- define: DUK_STDERR
-- define: DUK_STDIN
 
 # These don't need to save/restore signal mask.
 - define: DUK_SETJMP

--- a/src/duk_heap_stringtable.c
+++ b/src/duk_heap_stringtable.c
@@ -843,23 +843,6 @@ DUK_LOCAL duk_hstring *duk__do_intern(duk_heap *heap, const duk_uint8_t *str, du
 	}
 #endif
 
-	/* For manual testing only. */
-#if 0
-	{
-		duk_size_t i;
-		DUK_PRINTF("INTERN: \"");
-		for (i = 0; i < blen; i++) {
-			duk_uint8_t x = str[i];
-			if (x >= 0x20 && x <= 0x7e && x != '"' && x != '\\') {
-				DUK_PRINTF("%c", (int) x);  /* char: use int cast */
-			} else {
-				DUK_PRINTF("\\x%02lx", (long) x);
-			}
-		}
-		DUK_PRINTF("\"\n");
-	}
-#endif
-
 #if defined(DUK_USE_HSTRING_EXTDATA) && defined(DUK_USE_EXTSTR_INTERN_CHECK)
 	extdata = (const duk_uint8_t *) DUK_USE_EXTSTR_INTERN_CHECK(heap->heap_udata, (void *) DUK_LOSE_CONST(str), (duk_size_t) blen);
 #else


### PR DESCRIPTION
Remove file I/O support such as: `duk_file`, `DUK_STDOUT`, `DUK_FWRITE`, etc. The libc sprintf/scanf bindings will remain. This can be merged once all the I/O using call sites have been removed: #781, #782, and #788.