### PR TITLE
Add minimal console extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ DUKTAPE_CMDLINE_SOURCES = \
 	dist/examples/alloc-torture/duk_alloc_torture.c \
 	dist/examples/alloc-hybrid/duk_alloc_hybrid.c \
 	dist/examples/debug-trans-socket/duk_trans_socket_unix.c \
-	dist/extras/print-alert/duk_print_alert.c
+	dist/extras/print-alert/duk_print_alert.c \
+	dist/extras/console/duk_console.c
 LINENOISE_SOURCES = \
 	linenoise/linenoise.c
 
@@ -257,6 +258,7 @@ CCOPTS_FEATURES += -DDUK_OPT_FASTINT
 #CCOPTS_FEATURES += -DDUK_OPT_ROM_OBJECTS
 CCOPTS_FEATURES += -DDUK_OPT_JSON_STRINGIFY_FASTPATH
 CCOPTS_FEATURES += -DDUK_CMDLINE_PRINTALERT_SUPPORT
+CCOPTS_FEATURES += -DDUK_CMDLINE_CONSOLE_SUPPORT
 CCOPTS_FEATURES += -DDUK_CMDLINE_FANCY
 CCOPTS_FEATURES += -DDUK_CMDLINE_ALLOC_LOGGING
 CCOPTS_FEATURES += -DDUK_CMDLINE_ALLOC_TORTURE
@@ -280,6 +282,7 @@ CCOPTS_SHARED += -I./dist/examples/alloc-torture
 CCOPTS_SHARED += -I./dist/examples/alloc-hybrid
 CCOPTS_SHARED += -I./dist/examples/debug-trans-socket
 CCOPTS_SHARED += -I./dist/extras/print-alert
+CCOPTS_SHARED += -I./dist/extras/console
 #CCOPTS_SHARED += -I./dist/src-separate
 #CCOPTS_SHARED += -m32                             # force 32-bit compilation on a 64-bit host
 #CCOPTS_SHARED += -mx32                            # force X32 compilation on a 64-bit host
@@ -299,11 +302,11 @@ CCOPTS_DEBUG += -DDUK_OPT_DPRINT
 CCOPTS_DEBUG += -DDUK_OPT_ASSERTIONS
 
 GXXOPTS_NONDEBUG = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -Os -fomit-frame-pointer
-GXXOPTS_NONDEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert
-GXXOPTS_NONDEBUG += -DDUK_OPT_DEBUGGER_SUPPORT -DDUK_OPT_INTERRUPT_COUNTER -DDUK_CMDLINE_PRINTALERT_SUPPORT
+GXXOPTS_NONDEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console
+GXXOPTS_NONDEBUG += -DDUK_OPT_DEBUGGER_SUPPORT -DDUK_OPT_INTERRUPT_COUNTER -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT
 GXXOPTS_DEBUG = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -O0 -g -ggdb
-GXXOPTS_DEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert
-GXXOPTS_DEBUG += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -DDUK_CMDLINE_PRINTALERT_SUPPORT
+GXXOPTS_DEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console
+GXXOPTS_DEBUG += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT
 #GXXOPTS_DEBUG += -DDUK_OPT_DDPRINT -DDUK_OPT_DDDPRINT
 
 CCLIBS	= -lm

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1618,6 +1618,8 @@ Planned
 * Add an extra module providing Duktape 1.x compatible print() and alert()
   bindings (GH-745)
 
+* Add an extra module with a minimal 'console' binding (GH-767)
+
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than
   being declared as actual symbols; this reduces compilation warnings with

--- a/dist-files/Makefile.cmdline
+++ b/dist-files/Makefile.cmdline
@@ -17,6 +17,10 @@ CCLIBS	= -lm
 CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
 CMDLINE_SOURCES += extras/print-alert/duk_print_alert.c
 
+# Enable console object (console.log() etc) for command line.
+CCOPTS += -DDUK_CMDLINE_CONSOLE_SUPPORT -I./extras/console
+DUKTAPE_CMDLINE_SOURCES += extras/console/duk_console.c
+
 # If you want linenoise, you can enable these.  At the moment linenoise
 # will cause some harmless compilation warnings.
 #CCOPTS += -DDUK_CMDLINE_FANCY -I./linenoise

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -2,6 +2,7 @@
  *  Command line execution tool.  Useful for test cases and manual testing.
  *
  *  To enable print()/alert() bindings, define DUK_CMDLINE_PRINTALERT_SUPPORT.
+ *  To enable console.log() etc, define DUK_CMDLINE_CONSOLE_SUPPORT.
  *
  *  To enable linenoise and other fancy stuff, compile with -DDUK_CMDLINE_FANCY.
  *  It is not the default to maximize portability.  You can also compile in
@@ -44,6 +45,9 @@
 #endif
 #if defined(DUK_CMDLINE_PRINTALERT_SUPPORT)
 #include "duk_print_alert.h"
+#endif
+#if defined(DUK_CMDLINE_CONSOLE_SUPPORT)
+#include "duk_console.h"
 #endif
 #if defined(DUK_CMDLINE_FILEIO)
 #include <errno.h>
@@ -1097,7 +1101,12 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 
 	/* Register print() and alert() (removed in Duktape 2.x). */
 #if defined(DUK_CMDLINE_PRINTALERT_SUPPORT)
-	duk_print_alert_init(ctx);
+	duk_print_alert_init(ctx, 0 /*flags*/);
+#endif
+
+	/* Register console object. */
+#if defined(DUK_CMDLINE_CONSOLE_SUPPORT)
+	duk_console_init(ctx, DUK_CONSOLE_PROXY_WRAPPER /*flags*/);
 #endif
 
 #if defined(DUK_CMDLINE_FILEIO)

--- a/extras/console/Makefile
+++ b/extras/console/Makefile
@@ -1,0 +1,11 @@
+# For manual testing; say 'make' in extras/print-alert and run ./test.
+
+.PHONY: test
+test:
+	gcc -o $@ -I../../src/ -I. ../../src/duktape.c duk_console.c test.c -lm
+	./test 'console.assert(true, "not shown");'
+	./test 'console.assert(false, "shown", { foo: 123 });'
+	./test 'console.log(1, 2, 3, { foo: "bar" });'
+	./test 'a={}; b={}; a.ref=b; console.log(a,b); b.ref=a; console.log(a,b)'  # circular ref
+	./test 'console.trace(1, 2, 3)'
+	./test 'console.dir({ foo: 123, bar: [ "foo", "bar" ]});'

--- a/extras/console/README.rst
+++ b/extras/console/README.rst
@@ -1,0 +1,30 @@
+=========================
+Minimal 'console' binding
+=========================
+
+Duktape doesn't provide a ``console`` binding (for example ``console.log``)
+by default because it would be a portability issue for some targets.  Instead,
+an application should provide its own ``console`` binding.  This directory
+contains an example binding:
+
+* Add ``duk_console.c`` to list of C sources to compile.
+
+* Ensure ``duk_console.h`` is in the include path.
+
+* Include the extra header in calling code::
+
+      #include "duktape.h"
+      #include "duk_console.h"
+
+      /* After initializing the Duktape heap or when creating a new
+       * thread with a new global environment:
+       */
+      duk_console_init(ctx, 0 /*flags*/);
+
+  Use the ``DUK_CONSOLE_PROXY_WRAPPER`` to enable a Proxy wrapper for the
+  console object.  The wrapper allows all undefined methods (for example,
+  ``console.foo``) to be handled as no-ops instead of throwing an error.
+  See ``duk_console.h`` for full flags list.
+
+* After these steps, ``console`` will be registered to the global object
+  and is ready to use.

--- a/extras/console/duk_console.c
+++ b/extras/console/duk_console.c
@@ -1,0 +1,157 @@
+/*
+ *  Minimal 'console' binding.
+ *
+ *  https://github.com/DeveloperToolsWG/console-object/blob/master/api.md
+ *  https://developers.google.com/web/tools/chrome-devtools/debug/console/console-reference
+ *  https://developer.mozilla.org/en/docs/Web/API/console
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "duktape.h"
+#include "duk_console.h"
+
+/* XXX: Add some form of log level filtering. */
+
+/* XXX: For now logs everything to stdout, V8/Node.js logs debug/info level
+ * to stdout, warn and above to stderr.  Should this extra do the same?
+ */
+
+/* XXX: Should all output be written via e.g. console.write(formattedMsg)?
+ * This would make it easier for user code to redirect all console output
+ * to a custom backend.
+ */
+
+/* XXX: For now output is not flushed, add a flush flag, or maybe add flush
+ * to info level and above only.
+ */
+
+/* XXX: Init console object using duk_def_prop() when that call is available. */
+
+static duk_ret_t duk__console_log_helper(duk_context *ctx, const char *error_name) {
+	duk_idx_t i, n;
+
+	n = duk_get_top(ctx);
+
+	duk_get_global_string(ctx, "console");
+	duk_get_prop_string(ctx, -1, "format");
+
+	for (i = 0; i < n; i++) {
+		if (duk_check_type_mask(ctx, i, DUK_TYPE_MASK_OBJECT)) {
+			/* Slow path formatting. */
+			duk_dup(ctx, -1);  /* console.format */
+			duk_dup(ctx, i);
+			duk_call(ctx, 1);
+			duk_replace(ctx, i);  /* arg[i] = console.format(arg[i]); */
+		}
+	}
+
+	duk_pop_2(ctx);
+
+	duk_push_string(ctx, " ");
+	duk_insert(ctx, 0);
+	duk_join(ctx, n);
+
+	if (error_name) {
+		duk_push_error_object(ctx, DUK_ERR_ERROR, "%s", duk_require_string(ctx, -1));
+		duk_push_string(ctx, "name");
+		duk_push_string(ctx, error_name);
+		duk_def_prop(ctx, -3, DUK_DEFPROP_FORCE | DUK_DEFPROP_HAVE_VALUE);  /* to get e.g. 'Trace: 1 2 3' */
+		duk_get_prop_string(ctx, -1, "stack");
+	}
+
+	printf("%s\n", duk_to_string(ctx, -1));
+	return 0;
+}
+
+static duk_ret_t duk__console_assert(duk_context *ctx) {
+	if (duk_to_boolean(ctx, 0)) {
+		return 0;
+	}
+	duk_remove(ctx, 0);
+
+	return duk__console_log_helper(ctx, "AssertionError");
+}
+
+static duk_ret_t duk__console_log(duk_context *ctx) {
+	return duk__console_log_helper(ctx, NULL);
+}
+
+static duk_ret_t duk__console_trace(duk_context *ctx) {
+	return duk__console_log_helper(ctx, "Trace");
+}
+
+static duk_ret_t duk__console_info(duk_context *ctx) {
+	return duk__console_log_helper(ctx, NULL);
+}
+
+static duk_ret_t duk__console_warn(duk_context *ctx) {
+	return duk__console_log_helper(ctx, NULL);
+}
+
+static duk_ret_t duk__console_error(duk_context *ctx) {
+	return duk__console_log_helper(ctx, "Error");
+}
+
+static duk_ret_t duk__console_dir(duk_context *ctx) {
+	/* For now, just share the formatting of .log() */
+	return duk__console_log_helper(ctx, 0);
+}
+
+static void duk__console_reg_vararg_func(duk_context *ctx, duk_c_function func, const char *name) {
+	duk_push_c_function(ctx, func, DUK_VARARGS);
+	duk_push_string(ctx, name);
+	duk_put_prop_string(ctx, -2, "name");  /* Improve stacktraces by displaying function name */
+	duk_put_prop_string(ctx, -2, name);
+}
+
+void duk_console_init(duk_context *ctx, duk_uint_t flags) {
+	duk_push_object(ctx);
+
+	/* Custom function to format objects; user can replace.
+	 * For now, try JX-formatting and if that fails, fall back
+	 * to ToString(v).
+	 */
+	duk_eval_string(ctx,
+		"(function format(v) {\n"
+		"    try {\n"
+		"        return Duktape.enc('jx', v);\n"
+		"    } catch (e) {\n"
+		"        return String(v);\n"
+		"    }\n"
+		"})");
+	duk_put_prop_string(ctx, -2, "format");
+
+	duk__console_reg_vararg_func(ctx, duk__console_assert, "assert");
+	duk__console_reg_vararg_func(ctx, duk__console_log, "log");
+	duk__console_reg_vararg_func(ctx, duk__console_log, "debug");  /* alias to console.log */
+	duk__console_reg_vararg_func(ctx, duk__console_trace, "trace");
+	duk__console_reg_vararg_func(ctx, duk__console_info, "info");
+	duk__console_reg_vararg_func(ctx, duk__console_warn, "warn");
+	duk__console_reg_vararg_func(ctx, duk__console_error, "error");
+	duk__console_reg_vararg_func(ctx, duk__console_error, "exception");  /* alias to console.error */
+	duk__console_reg_vararg_func(ctx, duk__console_dir, "dir");
+
+	duk_put_global_string(ctx, "console");
+
+	/* Proxy wrapping: ensures any undefined console method calls are
+	 * ignored silently.  This is required specifically by the
+	 * DeveloperToolsWG proposal (and is implemented also by Firefox:
+	 * https://bugzilla.mozilla.org/show_bug.cgi?id=629607).
+	 */
+
+	if (flags & DUK_CONSOLE_PROXY_WRAPPER) {
+		duk_eval_string_noresult(ctx,
+			"(function () {\n"
+			"    var orig = console;\n"
+			"    var dummy = function () {};\n"
+			"    console = new Proxy(orig, {\n"
+			"        get: function (targ, key, recv) {\n"
+			"            var v = targ[key];\n"
+			"            return typeof v === 'function' ? v : dummy;\n"
+			"        }\n"
+			"    });\n"
+			"})();"
+		);
+	}
+}

--- a/extras/console/duk_console.h
+++ b/extras/console/duk_console.h
@@ -1,0 +1,11 @@
+#if !defined(DUK_CONSOLE_H_INCLUDED)
+#define DUK_CONSOLE_H_INCLUDED
+
+#include "duktape.h"
+
+/* Use a proxy wrapper to make undefined methods (console.foo()) no-ops. */
+#define DUK_CONSOLE_PROXY_WRAPPER  (1 << 0)
+
+extern void duk_console_init(duk_context *ctx, duk_uint_t flags);
+
+#endif  /* DUK_CONSOLE_H_INCLUDED */

--- a/extras/console/test.c
+++ b/extras/console/test.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include "duktape.h"
+#include "duk_console.h"
+
+int main(int argc, char *argv[]) {
+	duk_context *ctx;
+	int i;
+
+	ctx = duk_create_heap_default();
+	if (!ctx) {
+		return 1;
+	}
+
+	duk_console_init(ctx, DUK_CONSOLE_PROXY_WRAPPER /*flags*/);
+
+	for (i = 1; i < argc; i++) {
+		printf("Evaling: %s\n", argv[i]);
+		(void) duk_peval_string(ctx, argv[i]);
+		printf("--> %s\n", duk_safe_to_string(ctx, -1));
+		duk_pop(ctx);
+	}
+
+	printf("Done\n");
+	duk_destroy_heap(ctx);
+	return 0;
+}

--- a/extras/print-alert/README.rst
+++ b/extras/print-alert/README.rst
@@ -19,7 +19,9 @@ print() and alert() bindings:
       /* After initializing the Duktape heap or when creating a new
        * thread with a new global environment:
        */
-      duk_print_alert_init(ctx);
+      duk_print_alert_init(ctx, 0 /*flags*/);
+
+  See ``duk_print_alert.h`` for available flags.
 
 * After these steps, ``print()`` and ``alert()`` will be registered to the
   global object and are ready to use.

--- a/extras/print-alert/duk_print_alert.c
+++ b/extras/print-alert/duk_print_alert.c
@@ -112,7 +112,9 @@ static duk_ret_t duk__alert(duk_context *ctx) {
 	return duk__print_alert_helper(ctx, stderr);
 }
 
-void duk_print_alert_init(duk_context *ctx) {
+void duk_print_alert_init(duk_context *ctx, duk_uint_t flags) {
+	(void) flags;  /* unused at the moment */
+
 	/* XXX: use duk_def_prop_list(). */
 	duk_push_global_object(ctx);
 	duk_push_string(ctx, "print");

--- a/extras/print-alert/duk_print_alert.h
+++ b/extras/print-alert/duk_print_alert.h
@@ -3,6 +3,8 @@
 
 #include "duktape.h"
 
-extern void duk_print_alert_init(duk_context *ctx);
+/* No flags at the moment. */
+
+extern void duk_print_alert_init(duk_context *ctx, duk_uint_t flags);
 
 #endif /* DUK_PRINT_ALERT_H_INCLUDED */

--- a/extras/print-alert/test.c
+++ b/extras/print-alert/test.c
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	duk_print_alert_init(ctx);
+	duk_print_alert_init(ctx, 0 /*flags*/);
 
 	for (i = 1; i < argc; i++) {
 		printf("Evaling: %s\n", argv[i]);

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -156,6 +156,7 @@ def create_dist_directories(dist):
 	mkdir(os.path.join(dist, 'extras'))
 	mkdir(os.path.join(dist, 'extras', 'duk-v1-compat'))
 	mkdir(os.path.join(dist, 'extras', 'print-alert'))
+	mkdir(os.path.join(dist, 'extras', 'console'))
 	mkdir(os.path.join(dist, 'polyfills'))
 	#mkdir(os.path.join(dist, 'doc'))  # Empty, so omit
 	mkdir(os.path.join(dist, 'licenses'))
@@ -583,6 +584,14 @@ copy_files([
 	'test.c',
 	'Makefile'
 ], os.path.join('extras', 'print-alert'), os.path.join(dist, 'extras', 'print-alert'))
+
+copy_files([
+	'README.rst',
+	'duk_console.c',
+	'duk_console.h',
+	'test.c',
+	'Makefile'
+], os.path.join('extras', 'console'), os.path.join(dist, 'extras', 'console'))
 
 copy_files([
 	'Makefile.cmdline',


### PR DESCRIPTION
Add a minimal (optional) console extra with:

- console.trace
- console.log (= console.debug)
- console.info
- console.warn
- console.error (= console.exception)
- console.assert
- console.dir

Object formatting is handled through `console.format` which uses JX by default, falling back to `ToString(v)` if JX serialization fails (e.g. due to a looped object). User code can easily replace `console.format` with something more appropriate.

Tasks:

- [x] Proxy semantics (required by specification to avoid errors on missing functions; not implemented like that by Node.js though)
- [x] Make Proxy semantics optional (init parameter)
- [x] Dense and multiline object formatting, maybe use multiline for console.dir() => Skip, Node.js also uses single line formatting
- [x] Dukweb console object
- [x] Add `DUK_CMDLINE_CONSOLE_SUPPORT` to enable console bindings for `duk`
- [x] Website: suggestion for I/O bindings (suggest where print/alert is mentioned)

These were marked as future work (XXX note in source):

- [x] Minimal level filtering
- [x] Compile time selection of stdout/stderr output, flushing behavior
- [x] Compare stdout/stderr behavior to Node (seems to use stderr for >= warn and trace, stdout for info and log)
- [x] Initialize using `duk_def_prop()`