### PR TITLE
Use configurable DUK_USE_DEBUG_WRITE() macro for debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,6 @@ CCOPTS_FEATURES =
 #CCOPTS_FEATURES += -DDUK_OPT_NO_MARK_AND_SWEEP
 #CCOPTS_FEATURES += -DDUK_OPT_NO_VOLUNTARY_GC
 CCOPTS_FEATURES += -DDUK_OPT_SEGFAULT_ON_PANIC       # segfault on panic allows valgrind to show stack trace on panic
-CCOPTS_FEATURES += -DDUK_OPT_DPRINT_COLORS
 #CCOPTS_FEATURES += -DDUK_OPT_NO_FILE_IO
 #CCOPTS_FEATURES += '-DDUK_OPT_PANIC_HANDLER(code,msg)={printf("*** %d:%s\n",(code),(msg));abort();}'
 CCOPTS_FEATURES += -DDUK_OPT_SELF_TESTS
@@ -205,6 +204,7 @@ CCOPTS_FEATURES += -DDUK_OPT_SELF_TESTS
 #CCOPTS_FEATURES += -DDUK_OPT_MARKANDSWEEP_FINALIZER_TORTURE
 #CCOPTS_FEATURES += -DDUK_OPT_NO_MS_RESIZE_STRINGTABLE
 CCOPTS_FEATURES += -DDUK_OPT_DEBUG_BUFSIZE=512
+CCOPTS_FEATURES += '-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)=do {fprintf(stderr, "D%ld %s:%ld (%s): %s\n", (long) (level), (file), (long) (line), (func), (msg));} while(0)'
 #CCOPTS_FEATURES += -DDUK_OPT_NO_STRICT_DECL
 #CCOPTS_FEATURES += -DDUK_OPT_NO_REGEXP_SUPPORT
 #CCOPTS_FEATURES += -DDUK_OPT_NO_OCTAL_SUPPORT
@@ -303,10 +303,12 @@ CCOPTS_DEBUG += -DDUK_OPT_DPRINT
 #CCOPTS_DEBUG += -DDUK_OPT_DDDPRINT
 CCOPTS_DEBUG += -DDUK_OPT_ASSERTIONS
 
-GXXOPTS_NONDEBUG = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -Os -fomit-frame-pointer
+GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result
+GXXOPTS_SHARED += '-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)={fprintf(stderr, "D%ld %s:%ld (%s): %s\n", (long) (level), (file), (long) (line), (func), (msg));}'
+GXXOPTS_NONDEBUG = $(GXXOPTS_SHARED) -Os -fomit-frame-pointer
 GXXOPTS_NONDEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console -I./dist/extras/logging
 GXXOPTS_NONDEBUG += -DDUK_OPT_DEBUGGER_SUPPORT -DDUK_OPT_INTERRUPT_COUNTER -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT -DDUK_CMDLINE_LOGGING_SUPPORT
-GXXOPTS_DEBUG = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -O0 -g -ggdb
+GXXOPTS_DEBUG = $(GXXOPTS_SHARED) -O0 -g -ggdb
 GXXOPTS_DEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console -I./dist/extras/logging
 GXXOPTS_DEBUG += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT -DDUK_CMDLINE_LOGGING_SUPPORT
 #GXXOPTS_DEBUG += -DDUK_OPT_DDPRINT -DDUK_OPT_DDDPRINT

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1612,6 +1612,10 @@ Planned
 * Incompatible change: debug protocol version bumped from 1 to 2 to indicate
   version incompatible protocol changes in the 2.0.0 release (GH-756)
 
+* Incompatible change: require a DUK_USE_DEBUG_WRITE() macro for handling
+  debug writes when DUK_USE_DEBUG is enabled; this avoids a platform I/O
+  dependency and allows debug log filtering and retargeting (GH-782)
+
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
   same time provider as seen by Ecmascript code (GH-771)

--- a/config/config-options/DUK_USE_DEBUG_WRITE.yaml
+++ b/config/config-options/DUK_USE_DEBUG_WRITE.yaml
@@ -1,0 +1,16 @@
+define: DUK_USE_DEBUG_WRITE
+feature_snippet: |
+  #if defined(DUK_OPT_DEBUG_WRITE)
+  #define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) DUK_OPT_DEBUG_WRITE((level),(file),(line),(func),(msg))
+  #endif
+introduced: 2.0.0
+default: false
+tags:
+  - debug
+description: >
+  Macro used for Duktape debug log writes (when DUK_USE_DEBUG is enabled).
+  There's no default provider to avoid a dependency on platform I/O calls.
+  The macro is called like a function with the following prototype:
+  "void DUK_USE_DEBUG_WRITE(long level, const char *file, long line, const char *func, const char *msg)".
+  See http://wiki.duktape.org/HowtoDebugPrints.html for more information
+  and examples.

--- a/config/config-options/DUK_USE_DPRINT_COLORS.yaml
+++ b/config/config-options/DUK_USE_DPRINT_COLORS.yaml
@@ -1,6 +1,7 @@
 define: DUK_USE_DPRINT_COLORS
 feature_enables: DUK_OPT_DPRINT_COLORS
 introduced: 1.0.0
+removed: 2.0.0
 default: false
 tags:
   - debug

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -252,6 +252,26 @@ To upgrade:
   custom print/alert forwarding by implementing print and alert yourself and
   using AppNotify (``duk_debugger_notify()``) to forward print/alert text.
 
+Debug print config options changed
+----------------------------------
+
+Debug print related config options were reworked as follows:
+
+* Debug prints no longer automatically go to ``stderr``.  Instead, an
+  application must define ``DUK_USE_DEBUG_WRITE()`` in ``duk_config.h``
+  when ``DUK_USE_DEBUG`` is enabled.  The macro is called to write debug log
+  lines; there's no default provider to avoid platform I/O dependencies.
+  Using a user-provided macro removes a dependency on platform I/O and also
+  allows debug logs to be filtered and redirected in whatever manner is most
+  useful for the application.  Example provider::
+
+      #define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) do { \
+              fprintf(stderr, "D%ld %s:%ld (%s): %s\n", \
+                      (long) (level), (file), (long) (line), (func), (msg)); \
+          } while (0)
+
+  See http://wiki.duktape.org/HowtoDebugPrints.html for more information.
+
 Known issues
 ============
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -247,6 +247,11 @@ struct duk_time_components {
 #define DUK_EXEC_SUCCESS                  0
 #define DUK_EXEC_ERROR                    1
 
+/* Debug levels for DUK_USE_DEBUG_WRITE(). */
+#define DUK_LEVEL_DEBUG                   0
+#define DUK_LEVEL_DDEBUG                  1
+#define DUK_LEVEL_DDDEBUG                 2
+
 /*
  *  If no variadic macros, __FILE__ and __LINE__ are passed through globals
  *  which is ugly and not thread safe.

--- a/src/duk_debug.h
+++ b/src/duk_debug.h
@@ -47,16 +47,12 @@
  *  Exposed debug macros: debugging enabled
  */
 
-#define DUK_LEVEL_DEBUG    1
-#define DUK_LEVEL_DDEBUG   2
-#define DUK_LEVEL_DDDEBUG  3
-
 #ifdef DUK_USE_VARIADIC_MACROS
 
 /* Note: combining __FILE__, __LINE__, and __func__ into fmt would be
  * possible compile time, but waste some space with shared function names.
  */
-#define DUK__DEBUG_LOG(lev,...)  duk_debug_log((duk_small_int_t) (lev), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, DUK_FUNC_MACRO, __VA_ARGS__);
+#define DUK__DEBUG_LOG(lev,...)  duk_debug_log((duk_int_t) (lev), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, DUK_FUNC_MACRO, __VA_ARGS__);
 
 #define DUK_DPRINT(...)          DUK__DEBUG_LOG(DUK_LEVEL_DEBUG, __VA_ARGS__)
 
@@ -76,11 +72,10 @@
 
 #define DUK__DEBUG_STASH(lev)    \
 	(void) DUK_SNPRINTF(duk_debug_file_stash, DUK_DEBUG_STASH_SIZE, "%s", (const char *) DUK_FILE_MACRO), \
-	duk_debug_file_stash[DUK_DEBUG_STASH_SIZE - 1] = (char) 0; \
-	(void) DUK_SNPRINTF(duk_debug_line_stash, DUK_DEBUG_STASH_SIZE, "%ld", (long) DUK_LINE_MACRO), \
-	duk_debug_line_stash[DUK_DEBUG_STASH_SIZE - 1] = (char) 0; \
+	(void) (duk_debug_file_stash[DUK_DEBUG_STASH_SIZE - 1] = (char) 0), \
+	(void) (duk_debug_line_stash = (duk_int_t) DUK_LINE_MACRO), \
 	(void) DUK_SNPRINTF(duk_debug_func_stash, DUK_DEBUG_STASH_SIZE, "%s", (const char *) DUK_FUNC_MACRO), \
-	duk_debug_func_stash[DUK_DEBUG_STASH_SIZE - 1] = (char) 0; \
+	(void) (duk_debug_func_stash[DUK_DEBUG_STASH_SIZE - 1] = (char) 0), \
 	(void) (duk_debug_level_stash = (lev))
 
 /* Without variadic macros resort to comma expression trickery to handle debug
@@ -160,15 +155,15 @@ DUK_INTERNAL_DECL duk_int_t duk_debug_snprintf(char *str, duk_size_t size, const
 DUK_INTERNAL_DECL void duk_debug_format_funcptr(char *buf, duk_size_t buf_size, duk_uint8_t *fptr, duk_size_t fptr_size);
 
 #ifdef DUK_USE_VARIADIC_MACROS
-DUK_INTERNAL_DECL void duk_debug_log(duk_small_int_t level, const char *file, duk_int_t line, const char *func, const char *fmt, ...);
+DUK_INTERNAL_DECL void duk_debug_log(duk_int_t level, const char *file, duk_int_t line, const char *func, const char *fmt, ...);
 #else  /* DUK_USE_VARIADIC_MACROS */
 /* parameter passing, not thread safe */
 #define DUK_DEBUG_STASH_SIZE  128
 #if !defined(DUK_SINGLE_FILE)
 DUK_INTERNAL_DECL char duk_debug_file_stash[DUK_DEBUG_STASH_SIZE];
-DUK_INTERNAL_DECL char duk_debug_line_stash[DUK_DEBUG_STASH_SIZE];
+DUK_INTERNAL_DECL duk_int_t duk_debug_line_stash;
 DUK_INTERNAL_DECL char duk_debug_func_stash[DUK_DEBUG_STASH_SIZE];
-DUK_INTERNAL_DECL duk_small_int_t duk_debug_level_stash;
+DUK_INTERNAL_DECL duk_int_t duk_debug_level_stash;
 #endif
 DUK_INTERNAL_DECL void duk_debug_log(const char *fmt, ...);
 #endif  /* DUK_USE_VARIADIC_MACROS */

--- a/src/duk_debug_macros.c
+++ b/src/duk_debug_macros.c
@@ -4,7 +4,7 @@
 
 #include "duk_internal.h"
 
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 
 /*
  *  Debugging enabled
@@ -14,91 +14,34 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#if !defined(DUK_USE_DEBUG_WRITE)
+#error debugging enabled (DUK_USE_DEBUG) but DUK_USE_DEBUG_WRITE not defined
+#endif
+
 #define DUK__DEBUG_BUFSIZE  DUK_USE_DEBUG_BUFSIZE
-DUK_LOCAL char duk__debug_buf[DUK__DEBUG_BUFSIZE];
 
-DUK_LOCAL const char *duk__get_level_string(duk_small_int_t level) {
-	switch ((int) level) {
-	case DUK_LEVEL_DEBUG:
-		return "D";
-	case DUK_LEVEL_DDEBUG:
-		return "DD";
-	case DUK_LEVEL_DDDEBUG:
-		return "DDD";
-	}
-	return "???";
-}
+#if defined(DUK_USE_VARIADIC_MACROS)
 
-#ifdef DUK_USE_DPRINT_COLORS
-
-/* http://en.wikipedia.org/wiki/ANSI_escape_code */
-#define DUK__TERM_REVERSE  "\x1b[7m"
-#define DUK__TERM_BRIGHT   "\x1b[1m"
-#define DUK__TERM_RESET    "\x1b[0m"
-#define DUK__TERM_BLUE     "\x1b[34m"
-#define DUK__TERM_RED      "\x1b[31m"
-
-DUK_LOCAL const char *duk__get_term_1(duk_small_int_t level) {
-	DUK_UNREF(level);
-	return (const char *) DUK__TERM_RED;
-}
-
-DUK_LOCAL const char *duk__get_term_2(duk_small_int_t level) {
-	switch ((int) level) {
-	case DUK_LEVEL_DEBUG:
-		return (const char *) (DUK__TERM_RESET DUK__TERM_BRIGHT);
-	case DUK_LEVEL_DDEBUG:
-		return (const char *) (DUK__TERM_RESET);
-	case DUK_LEVEL_DDDEBUG:
-		return (const char *) (DUK__TERM_RESET DUK__TERM_BLUE);
-	}
-	return (const char *) DUK__TERM_RESET;
-}
-
-DUK_LOCAL const char *duk__get_term_3(duk_small_int_t level) {
-	DUK_UNREF(level);
-	return (const char *) DUK__TERM_RESET;
-}
-
-#else
-
-DUK_LOCAL const char *duk__get_term_1(duk_small_int_t level) {
-	DUK_UNREF(level);
-	return (const char *) "";
-}
-
-DUK_LOCAL const char *duk__get_term_2(duk_small_int_t level) {
-	DUK_UNREF(level);
-	return (const char *) "";
-}
-
-DUK_LOCAL const char *duk__get_term_3(duk_small_int_t level) {
-	DUK_UNREF(level);
-	return (const char *) "";
-}
-
-#endif  /* DUK_USE_DPRINT_COLORS */
-
-#ifdef DUK_USE_VARIADIC_MACROS
-
-DUK_INTERNAL void duk_debug_log(duk_small_int_t level, const char *file, duk_int_t line, const char *func, const char *fmt, ...) {
+DUK_INTERNAL void duk_debug_log(duk_int_t level, const char *file, duk_int_t line, const char *func, const char *fmt, ...) {
 	va_list ap;
+	long arg_level;
+	const char *arg_file;
+	long arg_line;
+	const char *arg_func;
+	const char *arg_msg;
+	char buf[DUK__DEBUG_BUFSIZE];
 
 	va_start(ap, fmt);
 
-	DUK_MEMZERO((void *) duk__debug_buf, (size_t) DUK__DEBUG_BUFSIZE);
-	duk_debug_vsnprintf(duk__debug_buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
+	DUK_MEMZERO((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
+	duk_debug_vsnprintf(buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
 
-	DUK_FPRINTF(DUK_STDERR, "%s[%s] %s:%ld (%s):%s %s%s\n",
-	            (const char *) duk__get_term_1(level),
-	            (const char *) duk__get_level_string(level),
-	            (const char *) file,
-	            (long) line,
-	            (const char *) func,
-	            (const char *) duk__get_term_2(level),
-	            (const char *) duk__debug_buf,
-	            (const char *) duk__get_term_3(level));
-	DUK_FFLUSH(DUK_STDERR);
+	arg_level = (long) level;
+	arg_file = (const char *) file;
+	arg_line = (long) line;
+	arg_func = (const char *) func;
+	arg_msg = (const char *) buf;
+	DUK_USE_DEBUG_WRITE(arg_level, arg_file, arg_line, arg_func, arg_msg);
 
 	va_end(ap);
 }
@@ -106,29 +49,30 @@ DUK_INTERNAL void duk_debug_log(duk_small_int_t level, const char *file, duk_int
 #else  /* DUK_USE_VARIADIC_MACROS */
 
 DUK_INTERNAL char duk_debug_file_stash[DUK_DEBUG_STASH_SIZE];
-DUK_INTERNAL char duk_debug_line_stash[DUK_DEBUG_STASH_SIZE];
+DUK_INTERNAL duk_int_t duk_debug_line_stash;
 DUK_INTERNAL char duk_debug_func_stash[DUK_DEBUG_STASH_SIZE];
-DUK_INTERNAL duk_small_int_t duk_debug_level_stash;
+DUK_INTERNAL duk_int_t duk_debug_level_stash;
 
 DUK_INTERNAL void duk_debug_log(const char *fmt, ...) {
 	va_list ap;
-	duk_small_int_t level = duk_debug_level_stash;
+	long arg_level;
+	const char *arg_file;
+	long arg_line;
+	const char *arg_func;
+	const char *arg_msg;
+	char buf[DUK__DEBUG_BUFSIZE];
 
 	va_start(ap, fmt);
 
-	DUK_MEMZERO((void *) duk__debug_buf, (size_t) DUK__DEBUG_BUFSIZE);
-	duk_debug_vsnprintf(duk__debug_buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
+	DUK_MEMZERO((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
+	duk_debug_vsnprintf(buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
 
-	DUK_FPRINTF(DUK_STDERR, "%s[%s] %s:%s (%s):%s %s%s\n",
-	            (const char *) duk__get_term_1(level),
-	            (const char *) duk__get_level_string(duk_debug_level_stash),
-	            (const char *) duk_debug_file_stash,
-	            (const char *) duk_debug_line_stash,
-	            (const char *) duk_debug_func_stash,
-	            (const char *) duk__get_term_2(level),
-	            (const char *) duk__debug_buf,
-	            (const char *) duk__get_term_3(level));
-	DUK_FFLUSH(DUK_STDERR);
+	arg_level = (long) duk_debug_level_stash;
+	arg_file = (const char *) duk_debug_file_stash;
+	arg_line = (long) duk_debug_line_stash;
+	arg_func = (const char *) duk_debug_func_stash;
+	arg_msg = (const char *) buf;
+	DUK_USE_DEBUG_WRITE(arg_level, arg_file, arg_line, arg_func, arg_msg);
 
 	va_end(ap);
 }

--- a/testrunner/client-simple-node/run_commit_test.py
+++ b/testrunner/client-simple-node/run_commit_test.py
@@ -445,6 +445,7 @@ def context_linux_x64_duk_dddprint():
 		'gcc', '-oduk',
 		'-DDUK_OPT_ASSERTIONS', '-DDUK_OPT_SELF_TESTS',
 		'-DDUK_OPT_DEBUG', '-DDUK_OPT_DPRINT', '-DDUK_OPT_DDPRINT', '-DDUK_OPT_DDDPRINT',
+		'-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)=do {fprintf(stderr, "%ld %s:%ld (%s): %s\\n", (long) (level), (file), (long) (line), (func), (msg));} while(0)',
 		'-DDUK_CMDLINE_PRINTALERT_SUPPORT',
 		'-I' + os.path.join(cwd, 'dist', 'src'),
 		'-I' + os.path.join(cwd, 'dist', 'extras', 'print-alert'),

--- a/util/example_rombuild.sh
+++ b/util/example_rombuild.sh
@@ -23,7 +23,9 @@ $PYTHON config/genconfig.py \
 	-DDUK_USE_ROM_STRINGS \
 	-DDUK_USE_ROM_OBJECTS \
 	-DDUK_USE_ROM_GLOBAL_INHERIT \
-	-DDUK_USE_DEBUG -DDUK_USE_DPRINT -DDUK_USE_ASSERTIONS \
+	-DDUK_USE_DEBUG -DDUK_USE_DPRINT \
+	--option-yaml 'DUK_USE_DEBUG_WRITE: { "verbatim": "#define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) do {fprintf(stderr, \"%ld %s:%ld (%s): %s\\n\", (long) (level), (file), (long) (line), (func), (msg)); } while(0)" }' \
+	-DDUK_USE_ASSERTIONS \
 	autodetect-header
 cp dist/src/duk_config.h dist/src-separate/
 #gcc -std=c99 -Wall -Wextra -Os -Idist/src-separate/ -Idist/examples/cmdline dist/src-separate/*.c dist/examples/cmdline/duk_cmdline.c -o _duk -lm

--- a/util/matrix_compile.py
+++ b/util/matrix_compile.py
@@ -323,7 +323,6 @@ def create_matrix(fn_duk):
 		'-DDUK_OPT_SHUFFLE_TORTURE',
 		'-DDUK_OPT_NO_VOLUNTARY_GC',
 		'-DDUK_OPT_SEGFAULT_ON_PANIC',
-		'-DDUK_OPT_DPRINT_COLORS',
 		'-DDUK_OPT_NO_PACKED_TVAL',
 		Select([ '', '-DDUK_OPT_FORCE_ALIGN=4', '-DDUK_OPT_FORCE_ALIGN=8' ]),
 		'-DDUK_OPT_NO_TRACEBACKS',
@@ -355,7 +354,7 @@ def create_matrix(fn_duk):
 		'''-DDUK_OPT_USER_INITJS="Math.MEANING_OF_LIFE=42"''',
 		'-DDUK_OPT_LIGHTFUNC_BUILTINS',
 		'-DDUK_OPT_ASSERTIONS',
-		[ '-DDUK_OPT_DEBUG', '-DDUK_OPT_DPRINT', '-DDUK_OPT_DDDPRINT' ],
+		[ '-DDUK_OPT_DEBUG', '-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)=do {fprintf(stderr, "%ld %s %ld %s %s\\n", (long) (level), (file), (long) (line), (func), (msg));} while(0)', '-DDUK_OPT_DPRINT', '-DDUK_OPT_DDDPRINT' ],
 		'-DDUK_OPT_SELF_TESTS',
 		[ '-DDUK_OPT_STRTAB_CHAIN', '-DDUK_OPT_STRTAB_CHAIN_SIZE=64' ],
 
@@ -386,7 +385,7 @@ def create_matrix(fn_duk):
 		gcc_gxx_warning_options,
 		gcc_gxx_optimization_options,
 		duktape_options,
-		[ '-Isrc', 'src/duktape.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
+		[ '-DDUK_CMDLINE_PRINTALERT_SUPPORT', '-Isrc', '-Iextras/print-alert', 'src/duktape.c', 'extras/print-alert/duk_print_alert.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
 	])
 
 	gxx_cmd_matrix = Combine([
@@ -395,7 +394,7 @@ def create_matrix(fn_duk):
 		gcc_gxx_warning_options,
 		gcc_gxx_optimization_options,
 		duktape_options,
-		[ '-Isrc', 'src/duktape.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
+		[ '-DDUK_CMDLINE_PRINTALERT_SUPPORT', '-Isrc', '-Iextras/print-alert', 'src/duktape.c', 'extras/print-alert/duk_print_alert.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
 	])
 
 	clang_cmd_matrix = Combine([
@@ -404,7 +403,7 @@ def create_matrix(fn_duk):
 		clang_warning_options,
 		clang_optimization_options,
 		duktape_options,
-		[ '-Isrc', 'src/duktape.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
+		[ '-DDUK_CMDLINE_PRINTALERT_SUPPORT', '-Isrc', '-Iextras/print-alert', 'src/duktape.c', 'extras/print-alert/duk_print_alert.c', 'examples/cmdline/duk_cmdline.c', '-o', fn_duk, '-lm' ]
 	])
 
 	matrix = Select([ gcc_cmd_matrix, gxx_cmd_matrix, clang_cmd_matrix ])


### PR DESCRIPTION
Use `DUK_USE_DEBUG_WRITE()` macro, provided by `duk_config.h`, for emitting debug log writes. This avoids a dependence on standard I/O which is a portability issue. Log entry formatting is also postponed to the user macro; only the body of the message is formatted but file, line, level, etc are given as arguments so that it can implement coloring and/or filtering as it sees fit.

Tasks:

- [x] Remove DUK_USE_DPRINT_COLORS
- [x] Add DUK_USE_DEBUG_WRITE() usage for log write call sites
- [x] Fix Makefile, examples, etc
- [x] Internal documentation update
- [x] Website update
- [x] Wiki howto for enabling debug printouts - https://github.com/svaarala/duktape-wiki/pull/115
- [x] Could DUK_USE_DPRINT, DUK_USE_DDPRINT, etc be deprecated? - #783
- [x] 2.0 migration notes
- [x] Releases entry