### PR TITLE
Simplify debug level config options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,9 +298,7 @@ CCOPTS_DEBUG = $(CCOPTS_SHARED) $(CCOPTS_FEATURES)
 CCOPTS_DEBUG += -O0
 CCOPTS_DEBUG += -g -ggdb
 CCOPTS_DEBUG += -DDUK_OPT_DEBUG
-CCOPTS_DEBUG += -DDUK_OPT_DPRINT
-#CCOPTS_DEBUG += -DDUK_OPT_DDPRINT
-#CCOPTS_DEBUG += -DDUK_OPT_DDDPRINT
+CCOPTS_DEBUG += -DDUK_OPT_DEBUG_LEVEL=0
 CCOPTS_DEBUG += -DDUK_OPT_ASSERTIONS
 
 GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result
@@ -310,8 +308,8 @@ GXXOPTS_NONDEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/exampl
 GXXOPTS_NONDEBUG += -DDUK_OPT_DEBUGGER_SUPPORT -DDUK_OPT_INTERRUPT_COUNTER -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT -DDUK_CMDLINE_LOGGING_SUPPORT
 GXXOPTS_DEBUG = $(GXXOPTS_SHARED) -O0 -g -ggdb
 GXXOPTS_DEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console -I./dist/extras/logging
-GXXOPTS_DEBUG += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT -DDUK_CMDLINE_LOGGING_SUPPORT
-#GXXOPTS_DEBUG += -DDUK_OPT_DDPRINT -DDUK_OPT_DDDPRINT
+GXXOPTS_DEBUG += -DDUK_OPT_DEBUG -DDUK_OPT_ASSERTIONS -DDUK_OPT_SELF_TESTS -DDUK_CMDLINE_PRINTALERT_SUPPORT -DDUK_CMDLINE_CONSOLE_SUPPORT -DDUK_CMDLINE_LOGGING_SUPPORT
+GXXOPTS_DEBUG += -DDUK_OPT_DEBUG_LEVEL=0
 
 CCLIBS	= -lm
 
@@ -1005,8 +1003,7 @@ CCOPTS_AJDUK += '-DDUK_OPT_EXTSTR_FREE(ud,ptr)=ajsheap_extstr_free_2((ptr))'
 CCOPTS_AJDUK += '-DDUK_OPT_EXEC_TIMEOUT_CHECK(udata)=ajsheap_exec_timeout_check(udata)'
 CCOPTS_AJDUK += '-DDUK_OPT_DECLARE=extern uint8_t *ajsheap_ram; extern duk_uint16_t ajsheap_enc16(void *ud, void *p); extern void *ajsheap_dec16(void *ud, duk_uint16_t x); extern const void *ajsheap_extstr_check_1(const void *ptr, duk_size_t len); extern const void *ajsheap_extstr_check_2(const void *ptr, duk_size_t len); extern const void *ajsheap_extstr_check_3(const void *ptr, duk_size_t len); extern void ajsheap_extstr_free_1(const void *ptr); extern void ajsheap_extstr_free_2(const void *ptr); extern void ajsheap_extstr_free_3(const void *ptr); extern duk_bool_t ajsheap_exec_timeout_check(void *udata);'
 #CCOPTS_AJDUK += -DDUK_OPT_ROM_STRINGS -DDUK_OPT_ROM_OBJECTS -DDUK_OPT_ROM_GLOBAL_INHERIT
-#CCOPTS_AJDUK += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT
-#CCOPTS_AJDUK += -DDUK_OPT_DEBUG -DDUK_OPT_DPRINT -DDUK_OPT_DDPRINT -DDUK_OPT_DDDPRINT
+#CCOPTS_AJDUK += -DDUK_OPT_DEBUG -DDUK_OPT_DEBUG_LEVEL=0
 
 # Command line with Alljoyn.js pool allocator, for low memory testing.
 # The pool sizes only make sense with -m32, so force that.  This forces

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1622,6 +1622,10 @@ Planned
   debug writes when DUK_USE_DEBUG is enabled; this avoids a platform I/O
   dependency and allows debug log filtering and retargeting (GH-782)
 
+* Incompatible change: use DUK_USE_DEBUG_LEVEL for debug print level control
+  rather than the previous DUK_USE_DPRINT, DUK_USE_DDPRINT, and
+  DUK_USE_DDDPRINT defines (GH-783)
+
 * Incompatible change: remove the distinction between panic and fatal errors,
   and simplify the fatal error handler function signature to
   ``void my_fatal(void *udata, const char *msg);``  (GH-781)

--- a/config/config-options/DUK_USE_DDDPRINT.yaml
+++ b/config/config-options/DUK_USE_DDDPRINT.yaml
@@ -1,9 +1,10 @@
 define: DUK_USE_DDDPRINT
 feature_enables: DUK_OPT_DDDPRINT
 introduced: 1.0.0
+removed: 2.0.0
 default: false
 tags:
   - debug
 description: >
   Enable even more debug printouts.  Not recommended unless you have
-  grep handy.
+  grep handy.  Replaced by DUK_USE_DEBUG_LEVEL.

--- a/config/config-options/DUK_USE_DDPRINT.yaml
+++ b/config/config-options/DUK_USE_DDPRINT.yaml
@@ -1,8 +1,9 @@
 define: DUK_USE_DDPRINT
 feature_enables: DUK_OPT_DDPRINT
 introduced: 1.0.0
+removed: 2.0.0
 default: false
 tags:
   - debug
 description: >
-  Enable more debug printouts.
+  Enable more debug printouts.  Replaced by DUK_USE_DEBUG_LEVEL.

--- a/config/config-options/DUK_USE_DEBUG.yaml
+++ b/config/config-options/DUK_USE_DEBUG.yaml
@@ -6,4 +6,5 @@ tags:
   - debug
 description: >
   Enable debug code in Duktape internals.  Without this option other
-  debugging options (such as DUK_USE_DPRINT) have no effect.
+  debugging options (such as DUK_USE_DEBUG_LEVEL and DUK_USE_DEBUG_WRITE)
+  have no effect.

--- a/config/config-options/DUK_USE_DEBUG_LEVEL.yaml
+++ b/config/config-options/DUK_USE_DEBUG_LEVEL.yaml
@@ -1,0 +1,14 @@
+define: DUK_USE_DEBUG_LEVEL
+feature_snippet: |
+  #if defined(DUK_OPT_DEBUG_LEVEL)
+  #define DUK_USE_DEBUG_LEVEL DUK_OPT_DEBUG_LEVEL
+  #else
+  #define DUK_USE_DEBUG_LEVEL 0
+  #endif
+introduced: 2.0.0
+default: 0
+tags:
+  - debug
+description: >
+  Set debug print level when DUK_USE_DEBUG is enabled.  The level can be
+  0 (minimal), 1 (verbose), 2 (very verbose).

--- a/config/config-options/DUK_USE_DEBUG_WRITE.yaml
+++ b/config/config-options/DUK_USE_DEBUG_WRITE.yaml
@@ -12,5 +12,9 @@ description: >
   There's no default provider to avoid a dependency on platform I/O calls.
   The macro is called like a function with the following prototype:
   "void DUK_USE_DEBUG_WRITE(long level, const char *file, long line, const char *func, const char *msg)".
+  The "file", "func", and "msg" arguments are non-NULL strings, though NULLs
+  should be handled as good practice (it's ultimately up to duk_config.h
+  whether NULL values are possible).
+
   See http://wiki.duktape.org/HowtoDebugPrints.html for more information
   and examples.

--- a/config/config-options/DUK_USE_DPRINT.yaml
+++ b/config/config-options/DUK_USE_DPRINT.yaml
@@ -1,10 +1,11 @@
 define: DUK_USE_DPRINT
 feature_enables: DUK_OPT_DPRINT
 introduced: 1.0.0
+removed: 2.0.0
 requires:
   - DUK_USE_DEBUG
 default: false
 tags:
   - debug
 description: >
-  Enable debug printouts.
+  Enable debug printouts.  Replaced by DUK_USE_DEBUG_LEVEL.

--- a/config/config-options/DUK_USE_DPRINT_RDTSC.yaml
+++ b/config/config-options/DUK_USE_DPRINT_RDTSC.yaml
@@ -1,10 +1,9 @@
 define: DUK_USE_DPRINT_RDTSC
 feature_enables: DUK_OPT_DPRINT_RDTSC
 introduced: 1.0.0
+removed: 2.0.0
 default: false
 tags:
   - debug
 description: >
   Print RDTSC cycle count in debug prints if available.
-
-# FIXME: is this really useful?

--- a/config/config-options/DUK_USE_HEAPPTR16.yaml
+++ b/config/config-options/DUK_USE_HEAPPTR16.yaml
@@ -31,6 +31,6 @@ description: >
   implementation.
 
   Current limitation:  Duktape internal debug code enabled with e.g.
-  DUK_USE_DEBUG and DUK_USE_DPRINT doesn't have enough plumbing to be able to
-  decode pointers.  Debug printing cannot currently be enabled when pointer
-  compression is active.
+  DUK_USE_DEBUG and DUK_USE_DEBUG_LEVEL=0 doesn't have enough plumbing to be
+  able to decode pointers.  Debug printing cannot currently be enabled when
+  pointer compression is active.

--- a/config/examples/enable_debug_print0.yaml
+++ b/config/examples/enable_debug_print0.yaml
@@ -1,0 +1,3 @@
+# Enable debug level 0.
+DUK_USE_DEBUG: true
+DUK_USE_DEBUG_LEVEL: 0

--- a/config/examples/enable_debug_print1.yaml
+++ b/config/examples/enable_debug_print1.yaml
@@ -1,3 +1,3 @@
 # Enable debug level 1.
 DUK_USE_DEBUG: true
-DUK_USE_DPRINT: true
+DUK_USE_DEBUG_LEVEL: 1

--- a/config/examples/enable_debug_print2.yaml
+++ b/config/examples/enable_debug_print2.yaml
@@ -1,4 +1,3 @@
 # Enable debug level 2.
 DUK_USE_DEBUG: true
-DUK_USE_DPRINT: true
-DUK_USE_DDPRINT: true
+DUK_USE_DEBUG_LEVEL: 2

--- a/config/examples/enable_debug_print3.yaml
+++ b/config/examples/enable_debug_print3.yaml
@@ -1,5 +1,0 @@
-# Enable debug level 3.
-DUK_USE_DEBUG: true
-DUK_USE_DPRINT: true
-DUK_USE_DDPRINT: true
-DUK_USE_DDDPRINT: true

--- a/dist-files/Makefile.cmdline
+++ b/dist-files/Makefile.cmdline
@@ -34,7 +34,8 @@ CMDLINE_SOURCES += extras/logging/duk_logging.c
 # Optional feature defines, see: http://duktape.org/guide.html#compiling
 CCOPTS += -DDUK_OPT_SELF_TESTS
 #CCOPTS += -DDUK_OPT_DEBUG
-#CCOPTS += -DDUK_OPT_DPRINT
+#CCOPTS += '-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)=do {fprintf(stderr, "D%ld %s:%ld (%s): %s\n", (long) (level), (file), (long) (line), (func), (msg));} while(0)'
+#CCOPTS += -DDUK_OPT_DEBUG_LEVEL=0
 # ...
 
 duk:	$(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -57,7 +57,7 @@ Checklist for ordinary releases
 * Compilation tests:
 
   - Clean compile for command line tool with (a) no options and (b) common
-    debug options (DUK_USE_DEBUG, DUK_USE_DPRINT, DUK_USE_SELF_TESTS,
+    debug options (DUK_USE_DEBUG, DUK_USE_DEBUG_LEVEL=0, DUK_USE_SELF_TESTS,
     DUK_USE_ASSERTIONS)
 
   - Compile both from ``src`` and ``src-separate``.

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -311,6 +311,29 @@ Debug print related config options were reworked as follows:
 
   See http://wiki.duktape.org/HowtoDebugPrints.html for more information.
 
+* Debug level options ``DUK_USE_DPRINT``, ``DUK_USE_DDPRINT``, and
+  ``DUK_DDDPRINT`` were replaced with a single config option
+  ``DUK_USE_DEBUG_LEVEL`` with a numeric value:
+
+  - 0 is minimal logging (matches ``DUK_USE_DPRINT``)
+
+  - 1 is verbose logging (matches ``DUK_USE_DDPRINT``)
+
+  - 2 is very verbose logging (matches ``DUK_USE_DDDPRINT``)
+
+To upgrade:
+
+* If you're not using debug prints, no action is needed.
+
+* If you're using debug prints:
+
+  - Add a ``DUK_USE_DEBUG_WRITE()`` to your ``duk_config.h``.  By itself it
+    won't enable debug prints so it's safe to add even when debug prints are
+    disabled.
+
+  - Convert debug level options from ``DUK_USE_{D,DD,DDD}PRINT`` to the
+    equivalent ``DUK_USE_DEBUG_LEVEL`` (0, 1, or 2).
+
 Fatal error and panic handling reworked
 ---------------------------------------
 

--- a/src/duk_bi_array.c
+++ b/src/duk_bi_array.c
@@ -567,7 +567,7 @@ DUK_LOCAL void duk__array_sort_swap(duk_context *ctx, duk_int_t l, duk_int_t r) 
 	}
 }
 
-#if defined(DUK_USE_DDDPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 /* Debug print which visualizes the qsort partitioning process. */
 DUK_LOCAL void duk__debuglog_qsort_state(duk_context *ctx, duk_int_t lo, duk_int_t hi, duk_int_t pivot) {
 	char buf[4096];
@@ -688,7 +688,7 @@ DUK_LOCAL void duk__array_qsort(duk_context *ctx, duk_int_t lo, duk_int_t hi) {
 	DUK_DDD(DUK_DDDPRINT("before final pivot swap: %!T", (duk_tval *) duk_get_tval(ctx, 1)));
 	duk__array_sort_swap(ctx, lo, r);
 
-#if defined(DUK_USE_DDDPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	duk__debuglog_qsort_state(ctx, lo, hi, r);
 #endif
 

--- a/src/duk_debug.h
+++ b/src/duk_debug.h
@@ -23,21 +23,21 @@
 #ifndef DUK_DEBUG_H_INCLUDED
 #define DUK_DEBUG_H_INCLUDED
 
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 
-#if defined(DUK_USE_DPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 0)
 #define DUK_D(x) x
 #else
 #define DUK_D(x) do { } while (0) /* omit */
 #endif
 
-#if defined(DUK_USE_DDPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 1)
 #define DUK_DD(x) x
 #else
 #define DUK_DD(x) do { } while (0) /* omit */
 #endif
 
-#if defined(DUK_USE_DDDPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 #define DUK_DDD(x) x
 #else
 #define DUK_DDD(x) do { } while (0) /* omit */
@@ -47,22 +47,26 @@
  *  Exposed debug macros: debugging enabled
  */
 
-#ifdef DUK_USE_VARIADIC_MACROS
+#if defined(DUK_USE_VARIADIC_MACROS)
 
 /* Note: combining __FILE__, __LINE__, and __func__ into fmt would be
  * possible compile time, but waste some space with shared function names.
  */
 #define DUK__DEBUG_LOG(lev,...)  duk_debug_log((duk_int_t) (lev), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, DUK_FUNC_MACRO, __VA_ARGS__);
 
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 0)
 #define DUK_DPRINT(...)          DUK__DEBUG_LOG(DUK_LEVEL_DEBUG, __VA_ARGS__)
+#else
+#define DUK_DPRINT(...)
+#endif
 
-#ifdef DUK_USE_DDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 1)
 #define DUK_DDPRINT(...)         DUK__DEBUG_LOG(DUK_LEVEL_DDEBUG, __VA_ARGS__)
 #else
 #define DUK_DDPRINT(...)
 #endif
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 #define DUK_DDDPRINT(...)        DUK__DEBUG_LOG(DUK_LEVEL_DDDEBUG, __VA_ARGS__)
 #else
 #define DUK_DDDPRINT(...)
@@ -84,19 +88,19 @@
  * statement from the compiler.
  */
 
-#ifdef DUK_USE_DPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 0)
 #define DUK_DPRINT  DUK__DEBUG_STASH(DUK_LEVEL_DEBUG), (void) duk_debug_log  /* args go here in parens */
 #else
 #define DUK_DPRINT  0 && /* args go here as a comma expression in parens */
 #endif
 
-#ifdef DUK_USE_DDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 1)
 #define DUK_DDPRINT  DUK__DEBUG_STASH(DUK_LEVEL_DDEBUG), (void) duk_debug_log  /* args go here in parens */
 #else
 #define DUK_DDPRINT  0 && /* args */
 #endif
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 #define DUK_DDDPRINT  DUK__DEBUG_STASH(DUK_LEVEL_DDDEBUG), (void) duk_debug_log  /* args go here in parens */
 #else
 #define DUK_DDDPRINT  0 && /* args */
@@ -114,7 +118,7 @@
 #define DUK_DD(x) do { } while (0) /* omit */
 #define DUK_DDD(x) do { } while (0) /* omit */
 
-#ifdef DUK_USE_VARIADIC_MACROS
+#if defined(DUK_USE_VARIADIC_MACROS)
 
 #define DUK_DPRINT(...)
 #define DUK_DDPRINT(...)
@@ -134,7 +138,7 @@
  *  Structs
  */
 
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 struct duk_fixedbuffer {
 	duk_uint8_t *buffer;
 	duk_size_t length;
@@ -147,7 +151,7 @@ struct duk_fixedbuffer {
  *  Prototypes
  */
 
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 DUK_INTERNAL_DECL duk_int_t duk_debug_vsnprintf(char *str, duk_size_t size, const char *format, va_list ap);
 #if 0  /*unused*/
 DUK_INTERNAL_DECL duk_int_t duk_debug_snprintf(char *str, duk_size_t size, const char *format, ...);

--- a/src/duk_heap_alloc.c
+++ b/src/duk_heap_alloc.c
@@ -691,6 +691,7 @@ DUK_LOCAL void duk__dump_misc_options(void) {
 	DUK_D(DUK_DPRINT("OS string: %s", DUK_USE_OS_STRING));
 	DUK_D(DUK_DPRINT("architecture string: %s", DUK_USE_ARCH_STRING));
 	DUK_D(DUK_DPRINT("compiler string: %s", DUK_USE_COMPILER_STRING));
+	DUK_D(DUK_DPRINT("debug level: %ld", (long) DUK_USE_DEBUG_LEVEL));
 #if defined(DUK_USE_PACKED_TVAL)
 	DUK_D(DUK_DPRINT("DUK_USE_PACKED_TVAL: yes"));
 #else

--- a/src/duk_heap_stringcache.c
+++ b/src/duk_heap_stringcache.c
@@ -131,7 +131,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	use_cache = (DUK_HSTRING_GET_CHARLEN(h) > DUK_HEAP_STRINGCACHE_NOCACHE_LIMIT);
 
 	if (use_cache) {
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache before char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
 			duk_strcache *c = heap->strcache + i;
@@ -280,7 +280,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 
 			/* 'sce' points to the wrong entry here, but is no longer used */
 		}
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache after char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
 			duk_strcache *c = heap->strcache + i;

--- a/src/duk_heap_stringtable.c
+++ b/src/duk_heap_stringtable.c
@@ -657,7 +657,7 @@ DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t n
 	DUK_UNREF(old_used);  /* unused with some debug level combinations */
 #endif
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	DUK_DDD(DUK_DDDPRINT("attempt to resize stringtable: %ld entries, %ld bytes, %ld used, %ld%% load -> %ld entries, %ld bytes, %ld used, %ld%% load",
 	                     (long) old_size, (long) (sizeof(duk_hstring *) * old_size), (long) old_used,
 	                     (long) (((double) old_used) / ((double) old_size) * 100.0),
@@ -733,7 +733,7 @@ DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t n
 		duk__insert_hstring_probe(heap, new_entries, new_size, &new_used, e);
 	}
 
-#ifdef DUK_USE_DDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 1)
 	DUK_DD(DUK_DDPRINT("resized stringtable: %ld entries, %ld bytes, %ld used, %ld%% load -> %ld entries, %ld bytes, %ld used, %ld%% load",
 	                   (long) old_size, (long) (sizeof(duk_hstring *) * old_size), (long) old_used,
 	                   (long) (((double) old_used) / ((double) old_size) * 100.0),

--- a/src/duk_hobject_enum.c
+++ b/src/duk_hobject_enum.c
@@ -75,7 +75,7 @@ DUK_LOCAL void duk__sort_array_indices(duk_hthread *thr, duk_hobject *h_obj) {
 	DUK_DDD(DUK_DDDPRINT("keys=%p, p_end=%p (after skipping enum props)",
 	                     (void *) keys, (void *) p_end));
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	{
 		duk_uint_fast32_t i;
 		for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(h_obj); i++) {
@@ -145,7 +145,7 @@ DUK_LOCAL void duk__sort_array_indices(duk_hthread *thr, duk_hobject *h_obj) {
 		/* keep val_highest */
 	}
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	{
 		duk_uint_fast32_t i;
 		for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(h_obj); i++) {

--- a/src/duk_hthread_builtins.c
+++ b/src/duk_hthread_builtins.c
@@ -808,7 +808,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 	DUK_D(DUK_DPRINT("INITBUILTINS END"));
 
-#ifdef DUK_USE_DDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 1)
 	for (i = 0; i < DUK_NUM_ALL_BUILTINS; i++) {
 		DUK_DD(DUK_DDPRINT("built-in object %ld after initialization and compacting: %!@iO",
 		                   (long) i, (duk_heaphdr *) duk_require_hobject(ctx, i)));

--- a/src/duk_js_compiler.c
+++ b/src/duk_js_compiler.c
@@ -941,7 +941,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 	 *  Debug dumping
 	 */
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	{
 		duk_hcompfunc *h;
 		duk_instr_t *p, *p_start, *p_end;

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -4439,10 +4439,10 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 			case DUK_EXTRAOP_ENDLABEL: {
 				duk_catcher *cat;
-#if defined(DUK_USE_DDDPRINT) || defined(DUK_USE_ASSERTIONS)
+#if (defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)) || defined(DUK_USE_ASSERTIONS)
 				duk_uint_fast_t bc = DUK_DEC_BC(ins);
 #endif
-#if defined(DUK_USE_DDDPRINT)
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 				DUK_DDD(DUK_DDDPRINT("ENDLABEL %ld", (long) bc));
 #endif
 

--- a/src/duk_js_var.c
+++ b/src/duk_js_var.c
@@ -298,7 +298,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_INT_VARENV, DUK_PROPDESC_FLAGS_WC);
 		}
 	}
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_INT_VARENV);
 	duk_get_prop_stridx(ctx, -3, DUK_STRIDX_INT_LEXENV);
 	DUK_DDD(DUK_DDDPRINT("closure varenv -> %!ipT, lexenv -> %!ipT",
@@ -543,7 +543,7 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr,
 	DUK_ASSERT(env != NULL);
 
 	DUK_DDD(DUK_DDDPRINT("created delayed fresh env: %!ipO", (duk_heaphdr *) env));
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	{
 		duk_hobject *p = env;
 		while (p) {

--- a/src/duk_numconv.c
+++ b/src/duk_numconv.c
@@ -73,7 +73,7 @@ DUK_LOCAL const duk__exp_limits duk__str2num_exp_limits[] = {
  */
 #define DUK__BI_MAX_PARTS  37  /* 37x32 = 1184 bits */
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 #define DUK__BI_PRINT(name,x)  duk__bi_print((name),(x))
 #else
 #define DUK__BI_PRINT(name,x)
@@ -85,7 +85,7 @@ typedef struct {
 	duk_uint32_t v[DUK__BI_MAX_PARTS];  /* low to high */
 } duk__bigint;
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 DUK_LOCAL void duk__bi_print(const char *name, duk__bigint *x) {
 	/* Overestimate required size; debug code so not critical to be tight. */
 	char buf[DUK__BI_MAX_PARTS * 9 + 64];
@@ -1097,7 +1097,7 @@ DUK_LOCAL void duk__dragon4_generate(duk__numconv_stringify_ctx *nc_ctx) {
 
 	DUK_DDD(DUK_DDDPRINT("generate finished"));
 
-#ifdef DUK_USE_DDDPRINT
+#if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 	{
 		duk_uint8_t buf[2048];
 		duk_small_int_t i, t;

--- a/util/example_rombuild.sh
+++ b/util/example_rombuild.sh
@@ -23,13 +23,13 @@ $PYTHON config/genconfig.py \
 	-DDUK_USE_ROM_STRINGS \
 	-DDUK_USE_ROM_OBJECTS \
 	-DDUK_USE_ROM_GLOBAL_INHERIT \
-	-DDUK_USE_DEBUG -DDUK_USE_DPRINT \
+	-DDUK_USE_DEBUG -DDUK_USE_DEBUG_LEVEL=0 \
 	--option-yaml 'DUK_USE_DEBUG_WRITE: { "verbatim": "#define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) do {fprintf(stderr, \"%ld %s:%ld (%s): %s\\n\", (long) (level), (file), (long) (line), (func), (msg)); } while(0)" }' \
 	-DDUK_USE_ASSERTIONS \
 	autodetect-header
 cp dist/src/duk_config.h dist/src-separate/
 #gcc -std=c99 -Wall -Wextra -Os -Idist/src-separate/ -Idist/examples/cmdline dist/src-separate/*.c dist/examples/cmdline/duk_cmdline.c -o _duk -lm
-make duk dukd
+make duk dukd  # XXX: currently fails to start, DUK_CMDLINE_LOGGING_SUPPORT modifies Duktape object (doesn't work with ROM built-ins)
 
 # Ajduk depends on 'make ajduk' and uses DUK_OPT_xxx feature options.
 # This would ideally be done directly using genconfig.py without


### PR DESCRIPTION
Simplify the debug level macros: replace `DUK_USE_DPRINT`, `DUK_USE_DDPRINT`, and `DUK_USE_DDDPRINT` with `DUK_USE_DEBUG_LEVEL` ranging from 0 to 2.

Tasks:

- [x] Config option changes
- [x] Change internal debug macros to match
- [x] Documentation changes
- [x] Website changes
- [x] Document whether file, line, func can be NULL
- [x] Ensure wiki debug print howto covers the issue - https://github.com/svaarala/duktape-wiki/pull/115
- [x] Grep and fix for occurrences of the old macros
- [x] What about DUK_USE_DEBUG; is it needed or should enabling DUK_USE_DEBUG_WRITE enable debugging automatically? => Keep separate for now.
- [x] 2.0 migration note
- [x] Test all levels with and without variadic macros manually
- [x] Releases entry