### PR TITLE
Reorder duk_create_heap() arguments, userdata should be last

### DIFF
--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -266,6 +266,9 @@ DUK_EXTERNAL_DECL duk_int_t duk_api_global_line;
  *  Context management
  */
 
+/* FIXME: reorder so that 'heap_udata' is last, as it is also used by
+ * the fatal handler.
+ */
 DUK_EXTERNAL_DECL
 duk_context *duk_create_heap(duk_alloc_function alloc_func,
                              duk_realloc_function realloc_func,


### PR DESCRIPTION
Now that the fatal error handler accepts a (heap) userdata argument, the userdata argument should be last in `duk_create_heap()`. This follows the prevailing convention that when callbacks are registered userdata follows the relevant callback(s) (and when the callbacks are called, userdata is first).