### PR TITLE
Add a Node.js-like module loader extra

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1669,6 +1669,9 @@ Planned
 * Add an extra module (extras/console) providing a minimal 'console' binding
   (GH-767)
 
+* Add an extra module (extras/module-node) providing a Node.js-like module
+  loading framework supporting require.cache, module.loaded, etc.
+
 * Add an extra module (extras/minimal-printf) providing minimal,
   Duktape-optimized sprintf(), snprintf(), vsnprintf(), and sscanf()
   implementations; the extra compiles to less than 1kB of code which is

--- a/extras/module-node/Makefile
+++ b/extras/module-node/Makefile
@@ -1,0 +1,16 @@
+# For manual testing; say 'make' in extras/module-node and run ./test.
+
+.PHONY: test
+test:
+	gcc -o $@ -I../../src/ -I. ../../src/duktape.c duk_module_node.c test.c -lm
+	@printf '\n'
+	./test 'typeof require("pig") === "string" ? "require() OK" : "require() FAILED";'
+	./test 'require("cow").indexOf("pig") !== -1 ? "nested require() OK" : "nested require() FAILED";'
+	./test 'var ape1 = require("ape"); var ape2 = require("ape"); ape1 === ape2 ? "caching OK" : "caching FAILED";'
+	./test 'var ape1 = require("ape"); var inCache = "ape.js" in require.cache; delete require.cache["ape.js"]; var ape2 = require("ape"); inCache && ape2 !== ape1 ? "require.cache OK" : "require.cache FAILED";'
+	./test 'var ape = require("ape"); typeof ape.module.require === "function" ? "module.require OK" : "module.require FAILED";'
+	./test 'var ape = require("ape"); ape.module.exports === ape ? "module.exports OK" : "module.exports FAILED";'
+	./test 'var ape = require("ape"); ape.module.id === "ape.js" && ape.module.id === ape.module.filename ? "module.id OK" : "module.id FAILED";'
+	./test 'var ape = require("ape"); ape.module.filename === "ape.js" ? "module.filename OK" : "module.filename FAILED";'
+	./test 'var ape = require("ape"); ape.module.loaded === true && ape.wasLoaded === false ? "module.loaded OK" : "module.loaded FAILED";'
+	./test 'var ape = require("ape"); ape.__filename === "ape.js" ? "__filename OK" : "__filename FAILED";'

--- a/extras/module-node/README.rst
+++ b/extras/module-node/README.rst
@@ -1,0 +1,84 @@
+=====================================
+Node.js-like module loading framework
+=====================================
+
+This directory contains an example module resolution and loading framework and
+``require`` implementation based on the Node.js module system:
+
+* https://nodejs.org/api/modules.html
+
+The application needs only to provide the module resolution and loading logic:
+
+* Add ``duk_module_node.c`` to list of C sources to compile.
+
+* Ensure ``duk_module_node.h`` is in the include path.
+
+* Include the extra header in calling code and initialize the bindings::
+
+      #include "duktape.h"
+      #include "duk_module_node.h"
+
+      /* After initializing the Duktape heap or when creating a new
+       * thread with a new global environment:
+       */
+      duk_push_object(ctx);
+      duk_push_c_function(ctx, cb_resolve_module, DUK_VARARGS);
+      duk_put_prop_string(ctx, -2, "resolve");
+      duk_push_c_function(ctx, cb_load_module, DUK_VARARGS);
+      duk_put_prop_string(ctx, -2, "load");
+      duk_module_node_init(ctx);
+
+  Do not call ``duk_module_node_init()`` more than once for the same global
+  environment.  Doing so is undefined behavior and may put the module system
+  in an inconsistent state.
+  
+  It is possible to replace the callbacks after initialization by setting the
+  following internal properties on the global stash:
+  
+  - `\xffmodResolve`
+  
+  - `\xffmodLoad`
+
+* The resolve callback is a Duktape/C function which takes the string passed
+  to ``require()`` and resolves it to a canonical module ID (for Node.js this
+  is usually the fully resolved filename of the module)::
+
+      duk_ret_t cb_resolve_module(duk_context *ctx) {
+          /*
+           *  Entry stack: [ requested_id parent_id ]
+           */
+
+          const char *requested_id = duk_get_string(ctx, 0);
+          const char *parent_id = duk_get_string(ctx, 1);  /* calling module */
+          const char *resolved_id;
+
+          /* Arrive at the canonical module ID somehow. */
+
+          duk_push_string(ctx, resolved_id);
+          return 1;  /*nrets*/
+      }
+
+  If the module ID cannot be resolved, the resolve callback should throw an
+  error, which will propagate out of the ``require()`` call.  Note also that
+  when the global ``require`` is called, the parent ID is an empty string.
+
+* The load callback is a Duktape/C function which takes the resolved module ID
+  and either returns the Ecmascript source code for the module, or populates
+  ``module.exports`` itself and returns undefined (useful for C modules)::
+
+      duk_ret_t cb_load_module(duk_context *ctx) {
+          /*
+           *  Entry stack: [ resolved_id exports module ]
+           */
+
+          /* Arrive at the JS source code for the module somehow. */
+
+          duk_push_string(ctx, module_source);
+          return 1;  /*nrets*/
+      }
+
+  As with the resolve callback, the load callback should throw an error if the
+  module cannot be loaded for any reason.
+
+* After these steps, ``require`` will be registered to the global object and
+  the module system is ready to use.

--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -1,0 +1,275 @@
+/*
+ *  Node.js-like module loading framework for Duktape
+ *
+ *  https://nodejs.org/api/modules.html
+ */
+
+#include "duktape.h"
+#include "duk_module_node.h"
+
+#if DUK_VERSION >= 19999
+static duk_int_t duk__eval_module_source (duk_context *ctx, void *udata);
+#else
+static duk_int_t duk__eval_module_source (duk_context *ctx);
+#endif
+static void duk__push_module_object (duk_context *ctx, const char *id);
+
+static duk_bool_t duk__get_cached_module(duk_context *ctx, const char *id) {
+	duk_push_global_stash(ctx);
+	(void) duk_get_prop_string(ctx, -1, "\xff" "requireCache");
+	if (duk_get_prop_string(ctx, -1, id)) {
+		duk_remove(ctx, -2);
+		duk_remove(ctx, -2);
+		return 1;
+	} else {
+		duk_pop_3(ctx);
+		return 0;
+	}
+}
+
+/* Place a `module` object on the top of the value stack into the require cache
+ * based on its `.id` property.  As a convenience to the caller, leave the
+ * object on top of the value stack afterwards.
+ */
+static void duk__put_cached_module(duk_context *ctx) {
+	/* [ ... module ] */
+
+	duk_push_global_stash(ctx);
+	(void) duk_get_prop_string(ctx, -1, "\xff" "requireCache");
+	duk_dup(ctx, -3);
+
+	/* [ ... module stash req_cache module ] */
+
+	(void) duk_get_prop_string(ctx, -1, "id");
+	duk_dup(ctx, -2);
+	duk_put_prop(ctx, -4);
+
+	duk_pop_3(ctx);  /* [ ... module ] */
+}
+
+static void duk__del_cached_module(duk_context *ctx, const char *id) {
+	duk_push_global_stash(ctx);
+	(void) duk_get_prop_string(ctx, -1, "\xff" "requireCache");
+	duk_del_prop_string(ctx, -1, id);
+	duk_pop_2(ctx);
+}
+
+static duk_ret_t duk__handle_require(duk_context *ctx) {
+	/*
+	 *  Value stack handling here is a bit sloppy but should be correct.
+	 *  Call handling will clean up any extra garbage for us.
+	 */
+
+	const char *id;
+	duk_ret_t nrets;
+	const char *parent_id;
+	duk_idx_t module_idx;
+	duk_idx_t stash_idx;
+	duk_int_t ret;
+
+	duk_push_global_stash(ctx);
+	stash_idx = duk_normalize_index(ctx, -1);
+
+	duk_push_current_function(ctx);
+	(void) duk_get_prop_string(ctx, -1, "\xff" "moduleId");
+	parent_id = duk_require_string(ctx, -1);
+
+	/* [ id stash require parent_id ] */
+
+	id = duk_require_string(ctx, 0);
+
+	(void) duk_get_prop_string(ctx, stash_idx, "\xff" "modResolve");
+	duk_dup(ctx, 0);   /* module ID */
+	duk_dup(ctx, -3);  /* parent ID */
+	duk_call(ctx, 2);
+
+	/* [ ... stash ... resolved_id ] */
+
+	id = duk_require_string(ctx, -1);
+
+	if (duk__get_cached_module(ctx, id)) {
+		goto have_module;  /* use the cached module */
+	}
+
+	duk__push_module_object(ctx, id);
+	duk__put_cached_module(ctx);  /* module remains on stack */
+
+	/*
+	 *  From here on out, we have to be careful not to throw.  If it can't be
+	 *  avoided, the error must be caught and the module removed from the
+	 *  require cache before rethrowing.  This allows the application to
+	 *  reattempt loading the module.
+	 */
+
+	module_idx = duk_normalize_index(ctx, -1);
+
+	/* [ ... stash ... resolved_id module ] */
+
+	(void) duk_get_prop_string(ctx, stash_idx, "\xff" "modLoad");
+	duk_dup(ctx, -3);  /* resolved ID */
+	(void) duk_get_prop_string(ctx, module_idx, "exports");
+	duk_dup(ctx, module_idx);
+	ret = duk_pcall(ctx, 3);
+	if (ret != DUK_EXEC_SUCCESS) {
+		duk__del_cached_module(ctx, id);
+		duk_throw(ctx);  /* rethrow */
+	}
+
+	if (duk_is_string(ctx, -1)) {
+		duk_int ret;
+
+		/* [ ... module source ] */
+
+#if DUK_VERSION >= 19999
+		ret = duk_safe_call(ctx, duk__eval_module_source, NULL, 2, 1);
+#else
+		ret = duk_safe_call(ctx, duk__eval_module_source, 2, 1);
+#endif
+		if (ret != DUK_EXEC_SUCCESS) {
+			duk__del_cached_module(ctx, id);
+			duk_throw(ctx);  /* rethrow */
+		}
+	} else if (duk_is_undefined(ctx, -1)) {
+		/* nop */
+	} else {
+		duk__del_cached_module(ctx, id);
+		duk_error(ctx, DUK_ERR_API_ERROR, "error in module load callback");
+	}
+
+	/* fall through */
+
+ have_module:
+	/* [ ... module ] */
+
+	(void) duk_get_prop_string(ctx, -1, "exports");
+	return 1;
+}
+
+static void duk__push_require_function(duk_context *ctx, const char *id) {
+	duk_push_c_function(ctx, duk__handle_require, 1);
+	duk_push_string(ctx, "name");
+	duk_push_string(ctx, "require");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE);
+	duk_push_string(ctx, id);
+	duk_put_prop_string(ctx, -2, "\xff" "moduleId");
+
+	/* require.cache */
+	duk_push_global_stash(ctx);
+	(void) duk_get_prop_string(ctx, -1, "\xff" "requireCache");
+	duk_put_prop_string(ctx, -3, "cache");
+	duk_pop(ctx);
+}
+
+static void duk__push_module_object(duk_context *ctx, const char *id) {
+	duk_push_object(ctx);
+
+	/* Node.js uses the canonicalized filename of a module for both module.id
+	 * and module.filename.  We have no concept of a file system here, so just
+	 * use the module ID for both values.
+	 */
+	duk_push_string(ctx, id);
+	duk_dup(ctx, -1);
+	duk_put_prop_string(ctx, -3, "filename");
+	duk_put_prop_string(ctx, -2, "id");
+
+	/* module.exports = {} */
+	duk_push_object(ctx);
+	duk_put_prop_string(ctx, -2, "exports");
+
+	/* module.loaded = false */
+	duk_push_false(ctx);
+	duk_put_prop_string(ctx, -2, "loaded");
+
+	/* module.require */
+	duk__push_require_function(ctx, id);
+	duk_put_prop_string(ctx, -2, "require");
+}
+
+#if DUK_VERSION >= 19999
+static duk_int_t duk__eval_module_source (duk_context *ctx, void *udata) {
+#else
+static duk_int_t duk__eval_module_source (duk_context *ctx) {
+#endif
+	/*
+	 *  Stack: [ module source ]
+	 */
+
+#if DUK_VERSION >= 19999
+	(void) udata;
+#endif
+
+	/* Wrap the module code in a function expression.  This is the simplest
+	 * way to implement CommonJS closure semantics and matches the behavior of
+	 * e.g. Node.js.
+	 */
+	duk_push_string(ctx, "(function main(exports, require, module, __filename, __dirname) { ");
+	duk_dup(ctx, 1);  /* source */
+	duk_push_string(ctx, " })");
+	duk_concat(ctx, 3);
+
+	/* [ module source func_src ] */
+
+	(void) duk_get_prop_string(ctx, 0, "filename");
+	duk_compile(ctx, DUK_COMPILE_EVAL);
+	duk_call(ctx, 0);
+
+	/* [ module source func ] */
+
+	/* call the function wrapper */
+	(void) duk_get_prop_string(ctx, 0, "exports");   /* exports */
+	(void) duk_get_prop_string(ctx, 0, "require");   /* require */
+	duk_dup(ctx, 0);                                 /* module */
+	(void) duk_get_prop_string(ctx, 0, "filename");  /* __filename */
+	duk_push_undefined(ctx);                         /* __dirname */
+	duk_call(ctx, 5);
+
+	/* module.loaded = true */
+	duk_push_true(ctx);
+	duk_put_prop_string(ctx, 0, "loaded");
+
+	/* [ module source retval ] */
+
+	duk_pop_2(ctx);
+
+	/* [ module ] */
+
+	return 1;
+}
+
+void duk_module_node_init(duk_context *ctx) {
+	/*
+	 *  Stack: [ ... options ] => [ ... ]
+	 */
+
+	duk_idx_t options_idx;
+
+	duk_require_object_coercible(ctx, -1);
+	options_idx = duk_require_normalize_index(ctx, -1);
+
+	/* initialize the require cache to a fresh object */
+	duk_push_global_stash(ctx);
+	duk_push_object(ctx);
+	duk_put_prop_string(ctx, -2, "\xff" "requireCache");
+	duk_pop(ctx);
+
+	/* stash callbacks for later use */
+	duk_push_global_stash(ctx);
+	duk_get_prop_string(ctx, options_idx, "resolve");
+	duk_require_function(ctx, -1);
+	duk_put_prop_string(ctx, -2, "\xff" "modResolve");
+	duk_get_prop_string(ctx, options_idx, "load");
+	duk_require_function(ctx, -1);
+	duk_put_prop_string(ctx, -2, "\xff" "modLoad");
+	duk_pop(ctx);
+
+	/* register `require` as a global function */
+	duk_push_global_object(ctx);
+	duk_push_string(ctx, "require");
+	duk__push_require_function(ctx, "");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE |
+	                      DUK_DEFPROP_SET_WRITABLE |
+	                      DUK_DEFPROP_SET_CONFIGURABLE);
+	duk_pop(ctx);
+
+	duk_pop(ctx);  /* pop argument */
+}

--- a/extras/module-node/duk_module_node.h
+++ b/extras/module-node/duk_module_node.h
@@ -1,0 +1,8 @@
+#if !defined(DUK_MODULE_NODE_H_INCLUDED)
+#define DUK_MODULE_NODE_H_INCLUDED
+
+#include "duktape.h"
+
+extern void duk_module_node_init (duk_context *ctx);
+
+#endif  /* DUK_MODULE_NODE_H_INCLUDED */

--- a/extras/module-node/test.c
+++ b/extras/module-node/test.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <string.h>
+#include "duktape.h"
+#include "duk_module_node.h"
+
+static duk_ret_t cb_resolve_module(duk_context *ctx) {
+	const char *module_id;
+	const char *parent_id;
+
+	module_id = duk_require_string(ctx, 0);
+	parent_id = duk_require_string(ctx, 1);
+
+	duk_push_sprintf(ctx, "%s.js", module_id);
+	printf("resolve_cb: id:'%s', parent-id:'%s', resolve-to:'%s'\n",
+		module_id, parent_id, duk_get_string(ctx, -1));
+
+	return 1;
+}
+
+static duk_ret_t cb_load_module(duk_context *ctx) {
+	const char *filename;
+	const char *module_id;
+
+	module_id = duk_require_string(ctx, 0);
+	duk_get_prop_string(ctx, 2, "filename");
+	filename = duk_require_string(ctx, -1);
+
+	printf("load_cb: id:'%s', filename:'%s'\n", module_id, filename);
+
+	if (strcmp(module_id, "pig.js") == 0) {
+		duk_push_sprintf(ctx, "module.exports = 'you\\'re about to get eaten by %s';",
+			module_id);
+	} else if (strcmp(module_id, "cow.js") == 0) {
+		duk_push_string(ctx, "module.exports = require('pig');");
+	} else if (strcmp(module_id, "ape.js") == 0) {
+		duk_push_string(ctx, "module.exports = { module: module, __filename: __filename, wasLoaded: module.loaded };");
+	} else {
+		duk_push_string(ctx, "module.exports = undefined;");
+	}
+
+	return 1;
+}
+
+static duk_ret_t handle_print(duk_context *ctx) {
+	printf("%s\n", duk_safe_to_string(ctx, 0));
+	return 0;
+}
+
+int main(int argc, char *argv[]) {
+	duk_context *ctx;
+	int i;
+
+	ctx = duk_create_heap_default();
+	if (!ctx) {
+		return 1;
+	}
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, cb_resolve_module, DUK_VARARGS);
+	duk_put_prop_string(ctx, -2, "resolve");
+	duk_push_c_function(ctx, cb_load_module, DUK_VARARGS);
+	duk_put_prop_string(ctx, -2, "load");
+	duk_module_node_init(ctx);
+	printf("top after init: %ld\n", (long) duk_get_top(ctx));
+
+	for (i = 1; i < argc; i++) {
+		printf("Evaling: %s\n", argv[i]);
+		(void) duk_peval_string(ctx, argv[i]);
+		printf("--> %s\n", duk_safe_to_string(ctx, -1));
+		duk_pop(ctx);
+	}
+
+	printf("Done\n\n");
+	duk_destroy_heap(ctx);
+	return 0;
+}

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -159,6 +159,7 @@ def create_dist_directories(dist):
 	mkdir(os.path.join(dist, 'extras', 'console'))
 	mkdir(os.path.join(dist, 'extras', 'logging'))
 	mkdir(os.path.join(dist, 'extras', 'minimal-printf'))
+	mkdir(os.path.join(dist, 'extras', 'module-node'))
 	mkdir(os.path.join(dist, 'polyfills'))
 	#mkdir(os.path.join(dist, 'doc'))  # Empty, so omit
 	mkdir(os.path.join(dist, 'licenses'))
@@ -615,6 +616,14 @@ copy_files([
 	'Makefile',
 	'test.c'
 ], os.path.join('extras', 'minimal-printf'), os.path.join(dist, 'extras', 'minimal-printf'))
+
+copy_files([
+	'README.rst',
+	'duk_module_node.c',
+	'duk_module_node.h',
+	'Makefile',
+	'test.c'
+], os.path.join('extras', 'module-node'), os.path.join(dist, 'extras', 'module-node'))
 
 copy_files([
 	'Makefile.cmdline',


### PR DESCRIPTION
A module loading framework and `require()` implementation based on Node.js.  Semantics match Node.js wherever possible and most features of the Node module system are provided.

https://nodejs.org/api/modules.html

Features:
* Application provides callbacks to perform module resolution and loading
* Module caching based on resolved module ID
* Tolerates circular `require()` chains
* Supports `module.exports`, `module.loaded`, and `module.require`
* Supports `require.cache`
* Supports `__filename` (but not `__dirname`)

Checklist:
- [x] Expose `duk__push_require_function()` to calling code? => `duk_module_node_init()` registers a global `require`, so not needed
- [x] Manual tests to ensure correctness of all features such as `module.loaded`, `require.cache`, etc.
- [x] Full documentation, in particular for callbacks
- [x] More/better sanity checks/guards around callback invocations? => callbacks are now Duktape/C functions
- [x] Rename extra to `module-node`
- [x] Match Node.js module ID semantics (`module.id === module.filename`)