### PR TITLE
Avoid variables named "index" which may cause -Wshadow warnings

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1678,6 +1678,9 @@ Planned
 * Fix a harmless compilation warning related to a shadowed variable (GH-793,
   GH-794)
 
+* Fix -Wshadow warnings on some GCC versions for variable/argument name
+  'index' by avoiding such identifiers in API and internals (GH-810)
+
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than
   being declared as actual symbols; this reduces compilation warnings with

--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -275,6 +275,18 @@ The fix is::
           ...
   }
 
+Local variable naming
+---------------------
+
+Variables are generally lowercase and underscore separated, but no strict
+guidelines otherwise.
+
+Avoid local variable names which might shadow with global symbols defined in
+platform headers (not just one platform but potentially any platform).  For
+example, using ``alloc`` would be a bad idea, and ``index`` also causes
+concrete problems with some GCC versions.  There are a few blacklisted
+identifiers in the code policy check.
+
 Other variable declarations
 ---------------------------
 

--- a/src/duk_api_buffer.c
+++ b/src/duk_api_buffer.c
@@ -4,13 +4,13 @@
 
 #include "duk_internal.h"
 
-DUK_EXTERNAL void *duk_resize_buffer(duk_context *ctx, duk_idx_t index, duk_size_t new_size) {
+DUK_EXTERNAL void *duk_resize_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t new_size) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hbuffer_dynamic *h;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	h = (duk_hbuffer_dynamic *) duk_require_hbuffer(ctx, index);
+	h = (duk_hbuffer_dynamic *) duk_require_hbuffer(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
@@ -23,7 +23,7 @@ DUK_EXTERNAL void *duk_resize_buffer(duk_context *ctx, duk_idx_t index, duk_size
 	return DUK_HBUFFER_DYNAMIC_GET_DATA_PTR(thr->heap, h);
 }
 
-DUK_EXTERNAL void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size) {
+DUK_EXTERNAL void *duk_steal_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hbuffer_dynamic *h;
 	void *ptr;
@@ -31,7 +31,7 @@ DUK_EXTERNAL void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_
 
 	DUK_ASSERT(ctx != NULL);
 
-	h = (duk_hbuffer_dynamic *) duk_require_hbuffer(ctx, index);
+	h = (duk_hbuffer_dynamic *) duk_require_hbuffer(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
@@ -54,13 +54,13 @@ DUK_EXTERNAL void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_
 	return ptr;
 }
 
-DUK_EXTERNAL void duk_config_buffer(duk_context *ctx, duk_idx_t index, void *ptr, duk_size_t len) {
+DUK_EXTERNAL void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *ptr, duk_size_t len) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hbuffer_external *h;
 
 	DUK_ASSERT(ctx != NULL);
 
-	h = (duk_hbuffer_external *) duk_require_hbuffer(ctx, index);
+	h = (duk_hbuffer_external *) duk_require_hbuffer(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	if (!DUK_HBUFFER_HAS_EXTERNAL(h)) {

--- a/src/duk_api_codec.c
+++ b/src/duk_api_codec.c
@@ -12,12 +12,12 @@
  * buffer and string values because they're the most common.  In particular,
  * avoid creating a temporary string or buffer when possible.
  */
-DUK_LOCAL const duk_uint8_t *duk__prep_codec_arg(duk_context *ctx, duk_idx_t index, duk_size_t *out_len) {
-	DUK_ASSERT(duk_is_valid_index(ctx, index));  /* checked by caller */
-	if (duk_is_buffer(ctx, index)) {
-		return (const duk_uint8_t *) duk_get_buffer(ctx, index, out_len);
+DUK_LOCAL const duk_uint8_t *duk__prep_codec_arg(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len) {
+	DUK_ASSERT(duk_is_valid_index(ctx, idx));  /* checked by caller */
+	if (duk_is_buffer(ctx, idx)) {
+		return (const duk_uint8_t *) duk_get_buffer(ctx, idx, out_len);
 	} else {
-		return (const duk_uint8_t *) duk_to_lstring(ctx, index, out_len);
+		return (const duk_uint8_t *) duk_to_lstring(ctx, idx, out_len);
 	}
 }
 
@@ -367,7 +367,7 @@ DUK_LOCAL duk_bool_t duk__base64_decode_helper(const duk_uint8_t *src, duk_size_
 }
 #endif  /* DUK_USE_BASE64_FASTPATH */
 
-DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	const duk_uint8_t *src;
 	duk_size_t srclen;
@@ -381,8 +381,8 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index) {
 	 * which makes a copy of the input.
 	 */
 
-	index = duk_require_normalize_index(ctx, index);
-	src = duk__prep_codec_arg(ctx, index, &srclen);
+	idx = duk_require_normalize_index(ctx, idx);
+	src = duk__prep_codec_arg(ctx, idx, &srclen);
 	/* Note: for srclen=0, src may be NULL */
 
 	/* Computation must not wrap; this limit works for 32-bit size_t:
@@ -399,7 +399,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index) {
 	duk__base64_encode_helper((const duk_uint8_t *) src, srclen, dst);
 
 	ret = duk_to_string(ctx, -1);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 	return ret;
 
  type_error:
@@ -407,7 +407,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index) {
 	return NULL;  /* never here */
 }
 
-DUK_EXTERNAL void duk_base64_decode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_base64_decode(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	const duk_uint8_t *src;
 	duk_size_t srclen;
@@ -422,8 +422,8 @@ DUK_EXTERNAL void duk_base64_decode(duk_context *ctx, duk_idx_t index) {
 	 * which causes an unnecessary interning.
 	 */
 
-	index = duk_require_normalize_index(ctx, index);
-	src = duk__prep_codec_arg(ctx, index, &srclen);
+	idx = duk_require_normalize_index(ctx, idx);
+	src = duk__prep_codec_arg(ctx, idx, &srclen);
 
 	/* Computation must not wrap, only srclen + 3 is at risk of
 	 * wrapping because after that the number gets smaller.
@@ -444,14 +444,14 @@ DUK_EXTERNAL void duk_base64_decode(duk_context *ctx, duk_idx_t index) {
 
 	/* XXX: convert to fixed buffer? */
 	(void) duk_resize_buffer(ctx, -1, (duk_size_t) (dst_final - dst));
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 	return;
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
-DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t idx) {
 	const duk_uint8_t *inp;
 	duk_size_t len;
 	duk_size_t i;
@@ -464,8 +464,8 @@ DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
-	inp = duk__prep_codec_arg(ctx, index, &len);
+	idx = duk_require_normalize_index(ctx, idx);
+	inp = duk__prep_codec_arg(ctx, idx, &len);
 	DUK_ASSERT(inp != NULL || len == 0);
 
 	/* Fixed buffer, no zeroing because we'll fill all the data. */
@@ -503,11 +503,11 @@ DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t index) {
 	 */
 
 	ret = duk_to_string(ctx, -1);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 	return ret;
 }
 
-DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	const duk_uint8_t *inp;
 	duk_size_t len;
@@ -522,8 +522,8 @@ DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
-	inp = duk__prep_codec_arg(ctx, index, &len);
+	idx = duk_require_normalize_index(ctx, idx);
+	inp = duk__prep_codec_arg(ctx, idx, &len);
 	DUK_ASSERT(inp != NULL || len == 0);
 
 	if (len & 0x01) {
@@ -584,14 +584,14 @@ DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t index) {
 	}
 #endif  /* DUK_USE_HEX_FASTPATH */
 
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 	return;
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
-DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t idx) {
 #ifdef DUK_USE_ASSERTIONS
 	duk_idx_t top_at_entry;
 #endif
@@ -602,22 +602,22 @@ DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t index) {
 	top_at_entry = duk_get_top(ctx);
 #endif
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 	duk_bi_json_stringify_helper(ctx,
-	                             index /*idx_value*/,
+	                             idx /*idx_value*/,
 	                             DUK_INVALID_INDEX /*idx_replacer*/,
 	                             DUK_INVALID_INDEX /*idx_space*/,
 	                             0 /*flags*/);
 	DUK_ASSERT(duk_is_string(ctx, -1));
-	duk_replace(ctx, index);
-	ret = duk_get_string(ctx, index);
+	duk_replace(ctx, idx);
+	ret = duk_get_string(ctx, idx);
 
 	DUK_ASSERT(duk_get_top(ctx) == top_at_entry);
 
 	return ret;
 }
 
-DUK_EXTERNAL void duk_json_decode(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_json_decode(duk_context *ctx, duk_idx_t idx) {
 #ifdef DUK_USE_ASSERTIONS
 	duk_idx_t top_at_entry;
 #endif
@@ -627,12 +627,12 @@ DUK_EXTERNAL void duk_json_decode(duk_context *ctx, duk_idx_t index) {
 	top_at_entry = duk_get_top(ctx);
 #endif
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 	duk_bi_json_parse_helper(ctx,
-	                         index /*idx_value*/,
+	                         idx /*idx_value*/,
 	                         DUK_INVALID_INDEX /*idx_reviver*/,
 	                         0 /*flags*/);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 
 	DUK_ASSERT(duk_get_top(ctx) == top_at_entry);
 }

--- a/src/duk_api_internal.h
+++ b/src/duk_api_internal.h
@@ -29,11 +29,11 @@ duk_bool_t duk_valstack_resize_raw(duk_context *ctx,
                                    duk_small_uint_t flags);
 
 #if defined(DUK_USE_VERBOSE_ERRORS) && defined(DUK_USE_PARANOID_ERRORS)
-DUK_INTERNAL_DECL const char *duk_get_type_name(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL const char *duk_get_type_name(duk_context *ctx, duk_idx_t idx);
 #endif
 
-DUK_INTERNAL_DECL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL void duk_push_tval(duk_context *ctx, duk_tval *tv);
 
 /* Push the current 'this' binding; throw TypeError if binding is not object
@@ -73,51 +73,51 @@ DUK_INTERNAL_DECL duk_tval *duk_get_borrowed_this_tval(duk_context *ctx);
 #define duk_push_size_t(ctx,val) \
 	duk_push_uint((ctx), (duk_uint_t) (val))  /* XXX: assumed to fit for now */
 
-DUK_INTERNAL_DECL duk_hstring *duk_get_hstring(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hobject *duk_get_hobject(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hbuffer *duk_get_hbuffer(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hthread *duk_get_hthread(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hcompfunc *duk_get_hcompfunc(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hnatfunc *duk_get_hnatfunc(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hstring *duk_get_hstring(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hobject *duk_get_hobject(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hbuffer *duk_get_hbuffer(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hthread *duk_get_hthread(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_get_hcompfunc(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hnatfunc *duk_get_hnatfunc(duk_context *ctx, duk_idx_t idx);
 
-DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_with_class(duk_context *ctx, duk_idx_t index, duk_small_uint_t classnum);
+DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_with_class(duk_context *ctx, duk_idx_t idx, duk_small_uint_t classnum);
 
 #if 0  /* This would be pointless: unexpected type and lightfunc would both return NULL */
-DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_or_lfunc(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_or_lfunc(duk_context *ctx, duk_idx_t idx);
 #endif
-DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hobject *duk_get_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t idx);
 
 #if 0  /*unused*/
-DUK_INTERNAL_DECL void *duk_get_voidptr(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL void *duk_get_voidptr(duk_context *ctx, duk_idx_t idx);
 #endif
 
-DUK_INTERNAL_DECL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t idx);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)  /* only needed by debugger for now */
-DUK_INTERNAL_DECL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t idx);
 #endif
 DUK_INTERNAL_DECL void duk_to_object_class_string_top(duk_context *ctx);
 #if !defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL void duk_push_hobject_class_string(duk_context *ctx, duk_hobject *h);
 #endif
 
-DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped);  /* out_clamped=NULL, RangeError if outside range */
-DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped(duk_context *ctx, duk_idx_t index, duk_int_t minval, duk_int_t maxval);
-DUK_INTERNAL_DECL duk_int_t duk_to_int_check_range(duk_context *ctx, duk_idx_t index, duk_int_t minval, duk_int_t maxval);
+DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped);  /* out_clamped=NULL, RangeError if outside range */
+DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval);
+DUK_INTERNAL_DECL duk_int_t duk_to_int_check_range(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval);
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
-DUK_INTERNAL_DECL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t idx);
 #endif
 
-DUK_INTERNAL_DECL duk_hstring *duk_require_hstring(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hobject *duk_require_hobject(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hbuffer *duk_require_hbuffer(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hthread *duk_require_hthread(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hcompfunc *duk_require_hcompfunc(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hnatfunc *duk_require_hnatfunc(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hstring *duk_require_hstring(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hobject *duk_require_hobject(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hbuffer *duk_require_hbuffer(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hthread *duk_require_hthread(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_require_hcompfunc(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hnatfunc *duk_require_hnatfunc(duk_context *ctx, duk_idx_t idx);
 
-DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_with_class(duk_context *ctx, duk_idx_t index, duk_small_uint_t classnum);
+DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_with_class(duk_context *ctx, duk_idx_t idx, duk_small_uint_t classnum);
 
-DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx_t index);
-DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t idx);
 
 DUK_INTERNAL_DECL void duk_push_hstring(duk_context *ctx, duk_hstring *h);
 DUK_INTERNAL_DECL void duk_push_hstring_stridx(duk_context *ctx, duk_small_int_t stridx);
@@ -143,35 +143,35 @@ DUK_INTERNAL_DECL void duk_push_lightfunc_tostring(duk_context *ctx, duk_tval *t
 DUK_INTERNAL_DECL duk_hbufobj *duk_push_bufobj_raw(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
 
 #if !defined(DUK_USE_PARANOID_ERRORS)
-DUK_INTERNAL_DECL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t index);
+DUK_INTERNAL_DECL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL const char *duk_push_string_tval_readable(duk_context *ctx, duk_tval *tv);
 #endif
 
-DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx);     /* [] -> [val] */
-DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx);     /* [val] -> [] */
-DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx);     /* [] -> [] */
-DUK_INTERNAL_DECL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx);     /* [] -> [] */
+DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [] -> [val] */
+DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [val] -> [] */
+DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [] -> [] */
+DUK_INTERNAL_DECL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [] -> [] */
 
-DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_bool_t *out_has_prop);  /* [] -> [] */
+DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_bool_t *out_has_prop);  /* [] -> [] */
 
-DUK_INTERNAL_DECL void duk_xdef_prop(duk_context *ctx, duk_idx_t obj_index, duk_small_uint_t desc_flags);  /* [key val] -> [] */
-DUK_INTERNAL_DECL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index, duk_small_uint_t desc_flags);  /* [val] -> [] */
-DUK_INTERNAL_DECL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_uint_t desc_flags);  /* [val] -> [] */
-DUK_INTERNAL_DECL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags);  /* [] -> [] */
-DUK_INTERNAL_DECL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_uint_t desc_flags);  /* [] -> [] */
+DUK_INTERNAL_DECL void duk_xdef_prop(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t desc_flags);  /* [key val] -> [] */
+DUK_INTERNAL_DECL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx, duk_small_uint_t desc_flags);  /* [val] -> [] */
+DUK_INTERNAL_DECL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_uint_t desc_flags);  /* [val] -> [] */
+DUK_INTERNAL_DECL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags);  /* [] -> [] */
+DUK_INTERNAL_DECL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_uint_t desc_flags);  /* [] -> [] */
 
 /* These are macros for now, but could be separate functions to reduce code
  * footprint (check call site count before refactoring).
  */
-#define duk_xdef_prop_wec(ctx,obj_index) \
-	duk_xdef_prop((ctx), (obj_index), DUK_PROPDESC_FLAGS_WEC)
-#define duk_xdef_prop_index_wec(ctx,obj_index,arr_index) \
-	duk_xdef_prop_index((ctx), (obj_index), (arr_index), DUK_PROPDESC_FLAGS_WEC)
-#define duk_xdef_prop_stridx_wec(ctx,obj_index,stridx) \
-	duk_xdef_prop_stridx((ctx), (obj_index), (stridx), DUK_PROPDESC_FLAGS_WEC)
+#define duk_xdef_prop_wec(ctx,obj_idx) \
+	duk_xdef_prop((ctx), (obj_idx), DUK_PROPDESC_FLAGS_WEC)
+#define duk_xdef_prop_index_wec(ctx,obj_idx,arr_idx) \
+	duk_xdef_prop_index((ctx), (obj_idx), (arr_idx), DUK_PROPDESC_FLAGS_WEC)
+#define duk_xdef_prop_stridx_wec(ctx,obj_idx,stridx) \
+	duk_xdef_prop_stridx((ctx), (obj_idx), (stridx), DUK_PROPDESC_FLAGS_WEC)
 
 /* Set object 'length'. */
-DUK_INTERNAL_DECL void duk_set_length(duk_context *ctx, duk_idx_t index, duk_size_t length);
+DUK_INTERNAL_DECL void duk_set_length(duk_context *ctx, duk_idx_t idx, duk_size_t length);
 
 /* Raw internal valstack access macros: access is unsafe so call site
  * must have a guarantee that the index is valid.  When that is the case,

--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -12,7 +12,7 @@
  *  defineProperty, getOwnPropertyDescriptor).
  */
 
-DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_index) {
+DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
@@ -24,7 +24,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_index) {
 	 * resize is not necessary for a property get right now.
 	 */
 
-	tv_obj = duk_require_tval(ctx, obj_index);
+	tv_obj = duk_require_tval(ctx, obj_idx);
 	tv_key = duk_require_tval(ctx, -1);
 
 	rc = duk_hobject_getprop(thr, tv_obj, tv_key);
@@ -35,24 +35,24 @@ DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_index) {
 	return rc;  /* 1 if property found, 0 otherwise */
 }
 
-DUK_EXTERNAL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key) {
+DUK_EXTERNAL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_string(ctx, key);
-	return duk_get_prop(ctx, obj_index);
+	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index) {
+DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
-	duk_push_uarridx(ctx, arr_index);
-	return duk_get_prop(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_uarridx(ctx, arr_idx);
+	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -60,19 +60,19 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_inde
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 	DUK_UNREF(thr);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
-	return duk_get_prop(ctx, obj_index);
+	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_bool_t *out_has_prop) {
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_bool_t *out_has_prop) {
 	duk_bool_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT_DISABLE(stridx >= 0);
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 
-	rc = duk_get_prop_stridx(ctx, obj_index, stridx);
+	rc = duk_get_prop_stridx(ctx, obj_idx, stridx);
 	if (out_has_prop) {
 		*out_has_prop = rc;
 	}
@@ -82,7 +82,7 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t 
 	return rc;
 }
 
-DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_index) {
+DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
@@ -97,7 +97,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_index) {
 	 * against it internally).
 	 */
 
-	tv_obj = duk_require_tval(ctx, obj_index);
+	tv_obj = duk_require_tval(ctx, obj_idx);
 	tv_key = duk_require_tval(ctx, -2);
 	tv_val = duk_require_tval(ctx, -1);
 	throw_flag = duk_is_strict_call(ctx);
@@ -109,26 +109,26 @@ DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_index) {
 	return rc;  /* 1 if property found, 0 otherwise */
 }
 
-DUK_EXTERNAL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key) {
+DUK_EXTERNAL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_string(ctx, key);
 	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_index);
+	return duk_put_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index) {
+DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
-	duk_push_uarridx(ctx, arr_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_uarridx(ctx, arr_idx);
 	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_index);
+	return duk_put_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -136,13 +136,13 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_inde
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 	DUK_UNREF(thr);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
 	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_index);
+	return duk_put_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_index) {
+DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
@@ -155,7 +155,7 @@ DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_index) {
 	 * resize is not necessary for a property delete right now.
 	 */
 
-	tv_obj = duk_require_tval(ctx, obj_index);
+	tv_obj = duk_require_tval(ctx, obj_idx);
 	tv_key = duk_require_tval(ctx, -1);
 	throw_flag = duk_is_strict_call(ctx);
 
@@ -166,24 +166,24 @@ DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_index) {
 	return rc;
 }
 
-DUK_EXTERNAL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key) {
+DUK_EXTERNAL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_string(ctx, key);
-	return duk_del_prop(ctx, obj_index);
+	return duk_del_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index) {
+DUK_EXTERNAL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
-	duk_push_uarridx(ctx, arr_index);
-	return duk_del_prop(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_uarridx(ctx, arr_idx);
+	return duk_del_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -191,12 +191,12 @@ DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_inde
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 	DUK_UNREF(thr);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
-	return duk_del_prop(ctx, obj_index);
+	return duk_del_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_index) {
+DUK_EXTERNAL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
@@ -208,7 +208,7 @@ DUK_EXTERNAL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_index) {
 	 * resize is not necessary for a property existence check right now.
 	 */
 
-	tv_obj = duk_require_tval(ctx, obj_index);
+	tv_obj = duk_require_tval(ctx, obj_idx);
 	tv_key = duk_require_tval(ctx, -1);
 
 	rc = duk_hobject_hasprop(thr, tv_obj, tv_key);
@@ -218,24 +218,24 @@ DUK_EXTERNAL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_index) {
 	return rc;  /* 1 if property found, 0 otherwise */
 }
 
-DUK_EXTERNAL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key) {
+DUK_EXTERNAL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_string(ctx, key);
-	return duk_has_prop(ctx, obj_index);
+	return duk_has_prop(ctx, obj_idx);
 }
 
-DUK_EXTERNAL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index) {
+DUK_EXTERNAL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
-	duk_push_uarridx(ctx, arr_index);
-	return duk_has_prop(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_uarridx(ctx, arr_idx);
+	return duk_has_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -243,9 +243,9 @@ DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_inde
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 	DUK_UNREF(thr);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
-	return duk_has_prop(ctx, obj_index);
+	return duk_has_prop(ctx, obj_idx);
 }
 
 /* Define own property without inheritance looks and such.  This differs from
@@ -253,14 +253,14 @@ DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_inde
  * not invoked by this method.  The caller must be careful to invoke any such
  * behaviors if necessary.
  */
-DUK_INTERNAL void duk_xdef_prop(duk_context *ctx, duk_idx_t obj_index, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hstring *key;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_require_hobject(ctx, obj_index);
+	obj = duk_require_hobject(ctx, obj_idx);
 	DUK_ASSERT(obj != NULL);
 	key = duk_to_hstring(ctx, -2);
 	DUK_ASSERT(key != NULL);
@@ -271,20 +271,20 @@ DUK_INTERNAL void duk_xdef_prop(duk_context *ctx, duk_idx_t obj_index, duk_small
 	duk_pop(ctx);  /* pop key */
 }
 
-DUK_INTERNAL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_require_hobject(ctx, obj_index);
+	obj = duk_require_hobject(ctx, obj_idx);
 	DUK_ASSERT(obj != NULL);
 
-	duk_hobject_define_property_internal_arridx(thr, obj, arr_index, desc_flags);
+	duk_hobject_define_property_internal_arridx(thr, obj, arr_idx, desc_flags);
 	/* value popped by call */
 }
 
-DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hstring *key;
@@ -293,7 +293,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_index, du
 	DUK_ASSERT_DISABLE(stridx >= 0);
 	DUK_ASSERT(stridx < DUK_HEAP_NUM_STRINGS);
 
-	obj = duk_require_hobject(ctx, obj_index);
+	obj = duk_require_hobject(ctx, obj_idx);
 	DUK_ASSERT(obj != NULL);
 	key = DUK_HTHREAD_GET_STRING(thr, stridx);
 	DUK_ASSERT(key != NULL);
@@ -303,7 +303,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_index, du
 	/* value popped by call */
 }
 
-DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hstring *key;
@@ -314,7 +314,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_i
 	DUK_ASSERT_DISABLE(builtin_idx >= 0);
 	DUK_ASSERT(builtin_idx < DUK_NUM_BUILTINS);
 
-	obj = duk_require_hobject(ctx, obj_index);
+	obj = duk_require_hobject(ctx, obj_idx);
 	DUK_ASSERT(obj != NULL);
 	key = DUK_HTHREAD_GET_STRING(thr, stridx);
 	DUK_ASSERT(key != NULL);
@@ -329,15 +329,15 @@ DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_i
  * object creation code, function instance creation code, and Function.prototype.bind().
  */
 
-DUK_INTERNAL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_index, duk_small_int_t stridx, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_hobject *obj = duk_require_hobject(ctx, obj_index);
+	duk_hobject *obj = duk_require_hobject(ctx, obj_idx);
 	duk_hobject *thrower = thr->builtins[DUK_BIDX_TYPE_ERROR_THROWER];
 	duk_hobject_define_accessor_internal(thr, obj, DUK_HTHREAD_GET_STRING(thr, stridx), thrower, thrower, desc_flags);
 }
 
 /* Object.defineProperty() equivalent C binding. */
-DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t flags) {
+DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_idx_t idx_base;
 	duk_hobject *obj;
@@ -350,7 +350,7 @@ DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_require_hobject(ctx, obj_index);
+	obj = duk_require_hobject(ctx, obj_idx);
 
 	is_data_desc = flags & (DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_HAVE_WRITABLE);
 	is_acc_desc = flags & (DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_SETTER);
@@ -429,13 +429,13 @@ DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t
  *  and are not exposed through the API.
  */
 
-DUK_EXTERNAL void duk_compact(duk_context *ctx, duk_idx_t obj_index) {
+DUK_EXTERNAL void duk_compact(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_get_hobject(ctx, obj_index);
+	obj = duk_get_hobject(ctx, obj_idx);
 	if (obj) {
 		/* Note: this may fail, caller should protect the call if necessary */
 		duk_hobject_compact_props(thr, obj);
@@ -444,10 +444,10 @@ DUK_EXTERNAL void duk_compact(duk_context *ctx, duk_idx_t obj_index) {
 
 /* XXX: the duk_hobject_enum.c stack APIs should be reworked */
 
-DUK_EXTERNAL void duk_enum(duk_context *ctx, duk_idx_t obj_index, duk_uint_t enum_flags) {
+DUK_EXTERNAL void duk_enum(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t enum_flags) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	duk_dup(ctx, obj_index);
+	duk_dup(ctx, obj_idx);
 	duk_require_hobject_or_lfunc_coerce(ctx, -1);
 	duk_hobject_enumerator_create(ctx, enum_flags);   /* [target] -> [enum] */
 }
@@ -464,31 +464,31 @@ DUK_EXTERNAL duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_index, duk_boo
  *  Helpers for writing multiple properties
  */
 
-DUK_EXTERNAL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs) {
+DUK_EXTERNAL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_idx, const duk_function_list_entry *funcs) {
 	const duk_function_list_entry *ent = funcs;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	if (ent != NULL) {
 		while (ent->key != NULL) {
 			duk_push_c_function(ctx, ent->value, ent->nargs);
-			duk_put_prop_string(ctx, obj_index, ent->key);
+			duk_put_prop_string(ctx, obj_idx, ent->key);
 			ent++;
 		}
 	}
 }
 
-DUK_EXTERNAL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers) {
+DUK_EXTERNAL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const duk_number_list_entry *numbers) {
 	const duk_number_list_entry *ent = numbers;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj_index = duk_require_normalize_index(ctx, obj_index);
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	if (ent != NULL) {
 		while (ent->key != NULL) {
 			duk_push_number(ctx, ent->value);
-			duk_put_prop_string(ctx, obj_index, ent->key);
+			duk_put_prop_string(ctx, obj_idx, ent->key);
 			ent++;
 		}
 	}
@@ -533,7 +533,7 @@ DUK_EXTERNAL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key)
  *  Object prototype
  */
 
-DUK_EXTERNAL void duk_get_prototype(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_get_prototype(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hobject *proto;
@@ -541,7 +541,7 @@ DUK_EXTERNAL void duk_get_prototype(duk_context *ctx, duk_idx_t index) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	obj = duk_require_hobject(ctx, index);
+	obj = duk_require_hobject(ctx, idx);
 	DUK_ASSERT(obj != NULL);
 
 	/* XXX: shared helper for duk_push_hobject_or_undefined()? */
@@ -553,14 +553,14 @@ DUK_EXTERNAL void duk_get_prototype(duk_context *ctx, duk_idx_t index) {
 	}
 }
 
-DUK_EXTERNAL void duk_set_prototype(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_set_prototype(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hobject *proto;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_require_hobject(ctx, index);
+	obj = duk_require_hobject(ctx, idx);
 	DUK_ASSERT(obj != NULL);
 	duk_require_type_mask(ctx, -1, DUK_TYPE_MASK_UNDEFINED |
 	                               DUK_TYPE_MASK_OBJECT);
@@ -588,14 +588,14 @@ DUK_EXTERNAL void duk_set_prototype(duk_context *ctx, duk_idx_t index) {
  * XXX: same issue as with Duktape.fin: there's no way to delete the property
  * now (just set it to undefined).
  */
-DUK_EXTERNAL void duk_get_finalizer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_get_finalizer(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	duk_get_prop_stridx(ctx, index, DUK_STRIDX_INT_FINALIZER);
+	duk_get_prop_stridx(ctx, idx, DUK_STRIDX_INT_FINALIZER);
 }
 
-DUK_EXTERNAL void duk_set_finalizer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_set_finalizer(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	duk_put_prop_stridx(ctx, index, DUK_STRIDX_INT_FINALIZER);
+	duk_put_prop_stridx(ctx, idx, DUK_STRIDX_INT_FINALIZER);
 }

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -328,13 +328,13 @@ DUK_EXTERNAL_DECL duk_bool_t duk_is_constructor_call(duk_context *ctx);
  *  Stack management
  */
 
-DUK_EXTERNAL_DECL duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_require_valid_index(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_require_valid_index(duk_context *ctx, duk_idx_t idx);
 
 DUK_EXTERNAL_DECL duk_idx_t duk_get_top(duk_context *ctx);
-DUK_EXTERNAL_DECL void duk_set_top(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL void duk_set_top(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_idx_t duk_get_top_index(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_require_top_index(duk_context *ctx);
 
@@ -354,14 +354,14 @@ DUK_EXTERNAL_DECL void duk_require_stack_top(duk_context *ctx, duk_idx_t top);
  *  Stack manipulation (other than push/pop)
  */
 
-DUK_EXTERNAL_DECL void duk_swap(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
-DUK_EXTERNAL_DECL void duk_swap_top(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_dup(duk_context *ctx, duk_idx_t from_index);
+DUK_EXTERNAL_DECL void duk_swap(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
+DUK_EXTERNAL_DECL void duk_swap_top(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_dup(duk_context *ctx, duk_idx_t from_idx);
 DUK_EXTERNAL_DECL void duk_dup_top(duk_context *ctx);
-DUK_EXTERNAL_DECL void duk_insert(duk_context *ctx, duk_idx_t to_index);
-DUK_EXTERNAL_DECL void duk_replace(duk_context *ctx, duk_idx_t to_index);
-DUK_EXTERNAL_DECL void duk_copy(duk_context *ctx, duk_idx_t from_index, duk_idx_t to_index);
-DUK_EXTERNAL_DECL void duk_remove(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL void duk_insert(duk_context *ctx, duk_idx_t to_idx);
+DUK_EXTERNAL_DECL void duk_replace(duk_context *ctx, duk_idx_t to_idx);
+DUK_EXTERNAL_DECL void duk_copy(duk_context *ctx, duk_idx_t from_idx, duk_idx_t to_idx);
+DUK_EXTERNAL_DECL void duk_remove(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL void duk_xcopymove_raw(duk_context *to_ctx, duk_context *from_ctx, duk_idx_t count, duk_bool_t is_copy);
 
 #define duk_xmove_top(to_ctx,from_ctx,count) \
@@ -481,70 +481,70 @@ DUK_EXTERNAL_DECL void duk_pop_3(duk_context *ctx);
  *  is not needed; duk_is_valid_index() gives the same information.
  */
 
-DUK_EXTERNAL_DECL duk_int_t duk_get_type(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t index, duk_int_t type);
-DUK_EXTERNAL_DECL duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t index, duk_uint_t mask);
+DUK_EXTERNAL_DECL duk_int_t duk_get_type(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t idx, duk_int_t type);
+DUK_EXTERNAL_DECL duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t idx, duk_uint_t mask);
 
-DUK_EXTERNAL_DECL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t idx);
 
-DUK_EXTERNAL_DECL duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t idx);
 
-#define duk_is_callable(ctx,index) \
-	duk_is_function((ctx), (index))
-DUK_EXTERNAL_DECL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t index);
+#define duk_is_callable(ctx,idx) \
+	duk_is_function((ctx), (idx))
+DUK_EXTERNAL_DECL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t idx);
 
-#define duk_is_primitive(ctx,index) \
-	duk_check_type_mask((ctx), (index), DUK_TYPE_MASK_UNDEFINED | \
-	                                    DUK_TYPE_MASK_NULL | \
-	                                    DUK_TYPE_MASK_BOOLEAN | \
-	                                    DUK_TYPE_MASK_NUMBER | \
-	                                    DUK_TYPE_MASK_STRING | \
-	                                    DUK_TYPE_MASK_BUFFER | \
-	                                    DUK_TYPE_MASK_POINTER | \
-	                                    DUK_TYPE_MASK_LIGHTFUNC)
+#define duk_is_primitive(ctx,idx) \
+	duk_check_type_mask((ctx), (idx), DUK_TYPE_MASK_UNDEFINED | \
+	                                  DUK_TYPE_MASK_NULL | \
+	                                  DUK_TYPE_MASK_BOOLEAN | \
+	                                  DUK_TYPE_MASK_NUMBER | \
+	                                  DUK_TYPE_MASK_STRING | \
+	                                  DUK_TYPE_MASK_BUFFER | \
+	                                  DUK_TYPE_MASK_POINTER | \
+	                                  DUK_TYPE_MASK_LIGHTFUNC)
 
-#define duk_is_object_coercible(ctx,index) \
-	duk_check_type_mask((ctx), (index), DUK_TYPE_MASK_BOOLEAN | \
-	                                    DUK_TYPE_MASK_NUMBER | \
-	                                    DUK_TYPE_MASK_STRING | \
-	                                    DUK_TYPE_MASK_OBJECT | \
-	                                    DUK_TYPE_MASK_BUFFER | \
-	                                    DUK_TYPE_MASK_POINTER | \
-	                                    DUK_TYPE_MASK_LIGHTFUNC)
+#define duk_is_object_coercible(ctx,idx) \
+	duk_check_type_mask((ctx), (idx), DUK_TYPE_MASK_BOOLEAN | \
+	                                  DUK_TYPE_MASK_NUMBER | \
+	                                  DUK_TYPE_MASK_STRING | \
+	                                  DUK_TYPE_MASK_OBJECT | \
+	                                  DUK_TYPE_MASK_BUFFER | \
+	                                  DUK_TYPE_MASK_POINTER | \
+	                                  DUK_TYPE_MASK_LIGHTFUNC)
 
-DUK_EXTERNAL_DECL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t index);
-#define duk_is_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) != 0)
-#define duk_is_eval_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_EVAL_ERROR)
-#define duk_is_range_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_RANGE_ERROR)
-#define duk_is_reference_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_REFERENCE_ERROR)
-#define duk_is_syntax_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_SYNTAX_ERROR)
-#define duk_is_type_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_TYPE_ERROR)
-#define duk_is_uri_error(ctx,index) \
-	(duk_get_error_code((ctx), (index)) == DUK_ERR_URI_ERROR)
+DUK_EXTERNAL_DECL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t idx);
+#define duk_is_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) != 0)
+#define duk_is_eval_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_EVAL_ERROR)
+#define duk_is_range_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_RANGE_ERROR)
+#define duk_is_reference_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_REFERENCE_ERROR)
+#define duk_is_syntax_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_SYNTAX_ERROR)
+#define duk_is_type_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_TYPE_ERROR)
+#define duk_is_uri_error(ctx,idx) \
+	(duk_get_error_code((ctx), (idx)) == DUK_ERR_URI_ERROR)
 
 /*
  *  Get operations: no coercion, returns default value for invalid
@@ -554,48 +554,48 @@ DUK_EXTERNAL_DECL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t i
  *  are not included.
  */
 
-DUK_EXTERNAL_DECL duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_int_t duk_get_int(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_get_string(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_get_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
-DUK_EXTERNAL_DECL void *duk_get_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
-DUK_EXTERNAL_DECL void *duk_get_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
-DUK_EXTERNAL_DECL void *duk_get_pointer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_context *duk_get_context(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void *duk_get_heapptr(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_int_t duk_get_int(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_get_string(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_get_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
+DUK_EXTERNAL_DECL void *duk_get_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
+DUK_EXTERNAL_DECL void *duk_get_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
+DUK_EXTERNAL_DECL void *duk_get_pointer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_context *duk_get_context(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void *duk_get_heapptr(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t idx);
 
 /*
  *  Require operations: no coercion, throw error if index or type
  *  is incorrect.  No defaulting.
  */
 
-#define duk_require_type_mask(ctx,index,mask) \
-	((void) duk_check_type_mask((ctx), (index), (mask) | DUK_TYPE_MASK_THROW))
+#define duk_require_type_mask(ctx,idx,mask) \
+	((void) duk_check_type_mask((ctx), (idx), (mask) | DUK_TYPE_MASK_THROW))
 
-DUK_EXTERNAL_DECL void duk_require_undefined(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_require_null(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_int_t duk_require_int(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_require_string(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_require_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
-DUK_EXTERNAL_DECL void *duk_require_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
-DUK_EXTERNAL_DECL void *duk_require_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
-DUK_EXTERNAL_DECL void *duk_require_pointer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_context *duk_require_context(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_require_function(duk_context *ctx, duk_idx_t index);
-#define duk_require_callable(ctx,index) \
-	duk_require_function((ctx), (index))
-DUK_EXTERNAL_DECL void *duk_require_heapptr(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL void duk_require_undefined(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_require_null(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_int_t duk_require_int(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_require_string(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_require_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
+DUK_EXTERNAL_DECL void *duk_require_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
+DUK_EXTERNAL_DECL void *duk_require_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
+DUK_EXTERNAL_DECL void *duk_require_pointer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_context *duk_require_context(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_require_function(duk_context *ctx, duk_idx_t idx);
+#define duk_require_callable(ctx,idx) \
+	duk_require_function((ctx), (idx))
+DUK_EXTERNAL_DECL void *duk_require_heapptr(duk_context *ctx, duk_idx_t idx);
 
-#define duk_require_object_coercible(ctx,index) \
-	((void) duk_check_type_mask((ctx), (index), DUK_TYPE_MASK_BOOLEAN | \
+#define duk_require_object_coercible(ctx,idx) \
+	((void) duk_check_type_mask((ctx), (idx), DUK_TYPE_MASK_BOOLEAN | \
 	                                            DUK_TYPE_MASK_NUMBER | \
 	                                            DUK_TYPE_MASK_STRING | \
 	                                            DUK_TYPE_MASK_OBJECT | \
@@ -611,57 +611,57 @@ DUK_EXTERNAL_DECL void *duk_require_heapptr(duk_context *ctx, duk_idx_t index);
  *  or an internal error (e.g. from out of memory).
  */
 
-DUK_EXTERNAL_DECL void duk_to_undefined(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_to_null(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_double_t duk_to_number(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_to_string(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
-DUK_EXTERNAL_DECL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size_t *out_size, duk_uint_t flags);
-DUK_EXTERNAL_DECL void *duk_to_pointer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_to_object(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int_t hint);
-DUK_EXTERNAL_DECL void duk_to_primitive(duk_context *ctx, duk_idx_t index, duk_int_t hint);
+DUK_EXTERNAL_DECL void duk_to_undefined(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_to_null(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_double_t duk_to_number(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_to_string(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
+DUK_EXTERNAL_DECL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size, duk_uint_t flags);
+DUK_EXTERNAL_DECL void *duk_to_pointer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_to_object(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
+DUK_EXTERNAL_DECL void duk_to_primitive(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
 
 #define DUK_BUF_MODE_FIXED      0   /* internal: request fixed buffer result */
 #define DUK_BUF_MODE_DYNAMIC    1   /* internal: request dynamic buffer result */
 #define DUK_BUF_MODE_DONTCARE   2   /* internal: don't care about fixed/dynamic nature */
 
-#define duk_to_buffer(ctx,index,out_size) \
-	duk_to_buffer_raw((ctx), (index), (out_size), DUK_BUF_MODE_DONTCARE)
-#define duk_to_fixed_buffer(ctx,index,out_size) \
-	duk_to_buffer_raw((ctx), (index), (out_size), DUK_BUF_MODE_FIXED)
-#define duk_to_dynamic_buffer(ctx,index,out_size) \
-	duk_to_buffer_raw((ctx), (index), (out_size), DUK_BUF_MODE_DYNAMIC)
+#define duk_to_buffer(ctx,idx,out_size) \
+	duk_to_buffer_raw((ctx), (idx), (out_size), DUK_BUF_MODE_DONTCARE)
+#define duk_to_fixed_buffer(ctx,idx,out_size) \
+	duk_to_buffer_raw((ctx), (idx), (out_size), DUK_BUF_MODE_FIXED)
+#define duk_to_dynamic_buffer(ctx,idx,out_size) \
+	duk_to_buffer_raw((ctx), (idx), (out_size), DUK_BUF_MODE_DYNAMIC)
 
 /* safe variants of a few coercion operations */
-DUK_EXTERNAL_DECL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
-#define duk_safe_to_string(ctx,index) \
-	duk_safe_to_lstring((ctx), (index), NULL)
+DUK_EXTERNAL_DECL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
+#define duk_safe_to_string(ctx,idx) \
+	duk_safe_to_lstring((ctx), (idx), NULL)
 
 /*
  *  Misc conversion
  */
 
-DUK_EXTERNAL_DECL const char *duk_base64_encode(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_base64_decode(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_hex_encode(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_hex_decode(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL const char *duk_json_encode(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_json_decode(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL const char *duk_base64_encode(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_base64_decode(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_hex_encode(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_hex_decode(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL const char *duk_json_encode(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_json_decode(duk_context *ctx, duk_idx_t idx);
 
 /*
  *  Buffer
  */
 
-DUK_EXTERNAL_DECL void *duk_resize_buffer(duk_context *ctx, duk_idx_t index, duk_size_t new_size);
-DUK_EXTERNAL_DECL void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
-DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t index, void *ptr, duk_size_t len);
+DUK_EXTERNAL_DECL void *duk_resize_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t new_size);
+DUK_EXTERNAL_DECL void *duk_steal_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
+DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *ptr, duk_size_t len);
 
 /*
  *  Property access
@@ -671,19 +671,19 @@ DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t index, void
  *  index as a property name (e.g. 123 is equivalent to the key "123").
  */
 
-DUK_EXTERNAL_DECL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
-DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
-DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
-DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_index);
-DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
-DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
-DUK_EXTERNAL_DECL void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t flags);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
+DUK_EXTERNAL_DECL void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t flags);
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key);
@@ -692,15 +692,15 @@ DUK_EXTERNAL_DECL duk_bool_t duk_put_global_string(duk_context *ctx, const char 
  *  Object prototype
  */
 
-DUK_EXTERNAL_DECL void duk_get_prototype(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_set_prototype(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL void duk_get_prototype(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_set_prototype(duk_context *ctx, duk_idx_t idx);
 
 /*
  *  Object finalizer
  */
 
-DUK_EXTERNAL_DECL void duk_get_finalizer(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_set_finalizer(duk_context *ctx, duk_idx_t index);
+DUK_EXTERNAL_DECL void duk_get_finalizer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_set_finalizer(duk_context *ctx, duk_idx_t idx);
 
 /*
  *  Global object
@@ -712,24 +712,24 @@ DUK_EXTERNAL_DECL void duk_set_global_object(duk_context *ctx);
  *  Duktape/C function magic value
  */
 
-DUK_EXTERNAL_DECL duk_int_t duk_get_magic(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL void duk_set_magic(duk_context *ctx, duk_idx_t index, duk_int_t magic);
+DUK_EXTERNAL_DECL duk_int_t duk_get_magic(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL void duk_set_magic(duk_context *ctx, duk_idx_t idx, duk_int_t magic);
 DUK_EXTERNAL_DECL duk_int_t duk_get_current_magic(duk_context *ctx);
 
 /*
  *  Module helpers: put multiple function or constant properties
  */
 
-DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs);
-DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers);
+DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_idx, const duk_function_list_entry *funcs);
+DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const duk_number_list_entry *numbers);
 
 /*
  *  Object operations
  */
 
-DUK_EXTERNAL_DECL void duk_compact(duk_context *ctx, duk_idx_t obj_index);
-DUK_EXTERNAL_DECL void duk_enum(duk_context *ctx, duk_idx_t obj_index, duk_uint_t enum_flags);
-DUK_EXTERNAL_DECL duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_index, duk_bool_t get_value);
+DUK_EXTERNAL_DECL void duk_compact(duk_context *ctx, duk_idx_t obj_idx);
+DUK_EXTERNAL_DECL void duk_enum(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t enum_flags);
+DUK_EXTERNAL_DECL duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_idx, duk_bool_t get_value);
 
 /*
  *  String manipulation
@@ -737,19 +737,19 @@ DUK_EXTERNAL_DECL duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_index, du
 
 DUK_EXTERNAL_DECL void duk_concat(duk_context *ctx, duk_idx_t count);
 DUK_EXTERNAL_DECL void duk_join(duk_context *ctx, duk_idx_t count);
-DUK_EXTERNAL_DECL void duk_decode_string(duk_context *ctx, duk_idx_t index, duk_decode_char_function callback, void *udata);
-DUK_EXTERNAL_DECL void duk_map_string(duk_context *ctx, duk_idx_t index, duk_map_char_function callback, void *udata);
-DUK_EXTERNAL_DECL void duk_substring(duk_context *ctx, duk_idx_t index, duk_size_t start_char_offset, duk_size_t end_char_offset);
-DUK_EXTERNAL_DECL void duk_trim(duk_context *ctx, duk_idx_t index);
-DUK_EXTERNAL_DECL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t index, duk_size_t char_offset);
+DUK_EXTERNAL_DECL void duk_decode_string(duk_context *ctx, duk_idx_t idx, duk_decode_char_function callback, void *udata);
+DUK_EXTERNAL_DECL void duk_map_string(duk_context *ctx, duk_idx_t idx, duk_map_char_function callback, void *udata);
+DUK_EXTERNAL_DECL void duk_substring(duk_context *ctx, duk_idx_t idx, duk_size_t start_char_offset, duk_size_t end_char_offset);
+DUK_EXTERNAL_DECL void duk_trim(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t idx, duk_size_t char_offset);
 
 /*
  *  Ecmascript operators
  */
 
-DUK_EXTERNAL_DECL duk_bool_t duk_equals(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
-DUK_EXTERNAL_DECL duk_bool_t duk_strict_equals(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
-DUK_EXTERNAL_DECL duk_bool_t duk_instanceof(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
+DUK_EXTERNAL_DECL duk_bool_t duk_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
+DUK_EXTERNAL_DECL duk_bool_t duk_strict_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
+DUK_EXTERNAL_DECL duk_bool_t duk_instanceof(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
 
 /*
  *  Function (method) calls
@@ -757,10 +757,10 @@ DUK_EXTERNAL_DECL duk_bool_t duk_instanceof(duk_context *ctx, duk_idx_t index1, 
 
 DUK_EXTERNAL_DECL void duk_call(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL void duk_call_method(duk_context *ctx, duk_idx_t nargs);
-DUK_EXTERNAL_DECL void duk_call_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs);
+DUK_EXTERNAL_DECL void duk_call_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_pcall(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs);
-DUK_EXTERNAL_DECL duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs);
+DUK_EXTERNAL_DECL duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL void duk_new(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_pnew(duk_context *ctx, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function func, void *udata, duk_idx_t nargs, duk_idx_t nrets);
@@ -885,7 +885,7 @@ DUK_EXTERNAL_DECL void duk_debugger_pause(duk_context *ctx);
  */
 
 DUK_EXTERNAL_DECL duk_double_t duk_get_now(duk_context *ctx);
-DUK_EXTERNAL_DECL void duk_time_to_components(duk_context *ctx, duk_double_t time, duk_time_components *comp);
+DUK_EXTERNAL_DECL void duk_time_to_components(duk_context *ctx, duk_double_t timeval, duk_time_components *comp);
 DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time_components *comp);
 
 /*

--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -45,9 +45,9 @@ DUK_EXTERNAL duk_int_t duk_api_global_line = 0;
 	} while (0)
 #endif
 
-DUK_LOCAL_DECL duk_heaphdr *duk__get_tagged_heaphdr_raw(duk_context *ctx, duk_idx_t index, duk_uint_t tag);
+DUK_LOCAL_DECL duk_heaphdr *duk__get_tagged_heaphdr_raw(duk_context *ctx, duk_idx_t idx, duk_uint_t tag);
 
-DUK_LOCAL duk_int_t duk__api_coerce_d2i(duk_context *ctx, duk_idx_t index, duk_bool_t require) {
+DUK_LOCAL duk_int_t duk__api_coerce_d2i(duk_context *ctx, duk_idx_t idx, duk_bool_t require) {
 	duk_hthread *thr;
 	duk_tval *tv;
 	duk_small_int_t c;
@@ -55,7 +55,7 @@ DUK_LOCAL duk_int_t duk__api_coerce_d2i(duk_context *ctx, duk_idx_t index, duk_b
 
 	thr = (duk_hthread *) ctx;
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv == NULL) {
 		goto error_notnumber;
 	}
@@ -108,13 +108,13 @@ DUK_LOCAL duk_int_t duk__api_coerce_d2i(duk_context *ctx, duk_idx_t index, duk_b
  error_notnumber:
 
 	if (require) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "number", DUK_STR_NOT_NUMBER);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
 		/* not reachable */
 	}
 	return 0;
 }
 
-DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_context *ctx, duk_idx_t index, duk_bool_t require) {
+DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_context *ctx, duk_idx_t idx, duk_bool_t require) {
 	duk_hthread *thr;
 	duk_tval *tv;
 	duk_small_int_t c;
@@ -124,7 +124,7 @@ DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_context *ctx, duk_idx_t index, duk
 
 	thr = (duk_hthread *) ctx;
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv == NULL) {
 		goto error_notnumber;
 	}
@@ -165,7 +165,7 @@ DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_context *ctx, duk_idx_t index, duk
  error_notnumber:
 
 	if (require) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "number", DUK_STR_NOT_NUMBER);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
 		/* not reachable */
 	}
 	return 0;
@@ -180,10 +180,10 @@ DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_context *ctx, duk_idx_t index, duk
  *  There's some repetition because of this; keep the functions in sync.
  */
 
-DUK_EXTERNAL duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_uidx_t vs_size;
-	duk_uidx_t uindex;
+	duk_uidx_t uidx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
@@ -199,27 +199,27 @@ DUK_EXTERNAL duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t index) {
 	vs_size = (duk_uidx_t) (thr->valstack_top - thr->valstack_bottom);
 	DUK_ASSERT_DISABLE(vs_size >= 0);  /* unsigned */
 
-	if (index < 0) {
-		uindex = vs_size + (duk_uidx_t) index;
+	if (idx < 0) {
+		uidx = vs_size + (duk_uidx_t) idx;
 	} else {
 		/* since index non-negative */
-		DUK_ASSERT(index != DUK_INVALID_INDEX);
-		uindex = (duk_uidx_t) index;
+		DUK_ASSERT(idx != DUK_INVALID_INDEX);
+		uidx = (duk_uidx_t) idx;
 	}
 
 	/* DUK_INVALID_INDEX won't be accepted as a valid index. */
 	DUK_ASSERT(vs_size + (duk_uidx_t) DUK_INVALID_INDEX >= vs_size);
 
-	if (DUK_LIKELY(uindex < vs_size)) {
-		return (duk_idx_t) uindex;
+	if (DUK_LIKELY(uidx < vs_size)) {
+		return (duk_idx_t) uidx;
 	}
 	return DUK_INVALID_INDEX;
 }
 
-DUK_EXTERNAL duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_uidx_t vs_size;
-	duk_uidx_t uindex;
+	duk_uidx_t uidx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
@@ -228,27 +228,27 @@ DUK_EXTERNAL duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t i
 	vs_size = (duk_uidx_t) (thr->valstack_top - thr->valstack_bottom);
 	DUK_ASSERT_DISABLE(vs_size >= 0);  /* unsigned */
 
-	if (index < 0) {
-		uindex = vs_size + (duk_uidx_t) index;
+	if (idx < 0) {
+		uidx = vs_size + (duk_uidx_t) idx;
 	} else {
-		DUK_ASSERT(index != DUK_INVALID_INDEX);
-		uindex = (duk_uidx_t) index;
+		DUK_ASSERT(idx != DUK_INVALID_INDEX);
+		uidx = (duk_uidx_t) idx;
 	}
 
 	/* DUK_INVALID_INDEX won't be accepted as a valid index. */
 	DUK_ASSERT(vs_size + (duk_uidx_t) DUK_INVALID_INDEX >= vs_size);
 
-	if (DUK_LIKELY(uindex < vs_size)) {
-		return (duk_idx_t) uindex;
+	if (DUK_LIKELY(uidx < vs_size)) {
+		return (duk_idx_t) uidx;
 	}
-	DUK_ERROR_API_INDEX(thr, index);
+	DUK_ERROR_API_INDEX(thr, idx);
 	return 0;  /* unreachable */
 }
 
-DUK_INTERNAL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_uidx_t vs_size;
-	duk_uidx_t uindex;
+	duk_uidx_t uidx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
@@ -257,26 +257,26 @@ DUK_INTERNAL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t index) {
 	vs_size = (duk_uidx_t) (thr->valstack_top - thr->valstack_bottom);
 	DUK_ASSERT_DISABLE(vs_size >= 0);  /* unsigned */
 
-	if (index < 0) {
-		uindex = vs_size + (duk_uidx_t) index;
+	if (idx < 0) {
+		uidx = vs_size + (duk_uidx_t) idx;
 	} else {
-		DUK_ASSERT(index != DUK_INVALID_INDEX);
-		uindex = (duk_uidx_t) index;
+		DUK_ASSERT(idx != DUK_INVALID_INDEX);
+		uidx = (duk_uidx_t) idx;
 	}
 
 	/* DUK_INVALID_INDEX won't be accepted as a valid index. */
 	DUK_ASSERT(vs_size + (duk_uidx_t) DUK_INVALID_INDEX >= vs_size);
 
-	if (DUK_LIKELY(uindex < vs_size)) {
-		return thr->valstack_bottom + uindex;
+	if (DUK_LIKELY(uidx < vs_size)) {
+		return thr->valstack_bottom + uidx;
 	}
 	return NULL;
 }
 
-DUK_INTERNAL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_uidx_t vs_size;
-	duk_uidx_t uindex;
+	duk_uidx_t uidx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
@@ -286,40 +286,40 @@ DUK_INTERNAL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t index) {
 	DUK_ASSERT_DISABLE(vs_size >= 0);  /* unsigned */
 
 	/* Use unsigned arithmetic to optimize comparison. */
-	if (index < 0) {
-		uindex = vs_size + (duk_uidx_t) index;
+	if (idx < 0) {
+		uidx = vs_size + (duk_uidx_t) idx;
 	} else {
-		DUK_ASSERT(index != DUK_INVALID_INDEX);
-		uindex = (duk_uidx_t) index;
+		DUK_ASSERT(idx != DUK_INVALID_INDEX);
+		uidx = (duk_uidx_t) idx;
 	}
 
 	/* DUK_INVALID_INDEX won't be accepted as a valid index. */
 	DUK_ASSERT(vs_size + (duk_uidx_t) DUK_INVALID_INDEX >= vs_size);
 
-	if (DUK_LIKELY(uindex < vs_size)) {
-		return thr->valstack_bottom + uindex;
+	if (DUK_LIKELY(uidx < vs_size)) {
+		return thr->valstack_bottom + uidx;
 	}
-	DUK_ERROR_API_INDEX(thr, index);
+	DUK_ERROR_API_INDEX(thr, idx);
 	return NULL;
 }
 
 /* Non-critical. */
-DUK_EXTERNAL duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
 
-	return (duk_normalize_index(ctx, index) >= 0);
+	return (duk_normalize_index(ctx, idx) >= 0);
 }
 
 /* Non-critical. */
-DUK_EXTERNAL void duk_require_valid_index(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_require_valid_index(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(DUK_INVALID_INDEX < 0);
 
-	if (duk_normalize_index(ctx, index) < 0) {
-		DUK_ERROR_API_INDEX(thr, index);
+	if (duk_normalize_index(ctx, idx) < 0) {
+		DUK_ERROR_API_INDEX(thr, idx);
 		return;  /* unreachable */
 	}
 }
@@ -340,11 +340,11 @@ DUK_EXTERNAL duk_idx_t duk_get_top(duk_context *ctx) {
  * This is performance critical especially for call handling, so whenever
  * changing, profile and look at generated code.
  */
-DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_uidx_t vs_size;
 	duk_uidx_t vs_limit;
-	duk_uidx_t uindex;
+	duk_uidx_t uidx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -355,16 +355,16 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t index) {
 	vs_size = (duk_uidx_t) (thr->valstack_top - thr->valstack_bottom);
 	vs_limit = (duk_uidx_t) (thr->valstack_end - thr->valstack_bottom);
 
-	if (index < 0) {
+	if (idx < 0) {
 		/* Negative indices are always within allocated stack but
 		 * must not go below zero index.
 		 */
-		uindex = vs_size + (duk_uidx_t) index;
+		uidx = vs_size + (duk_uidx_t) idx;
 	} else {
 		/* Positive index can be higher than valstack top but must
 		 * not go above allocated stack (equality is OK).
 		 */
-		uindex = (duk_uidx_t) index;
+		uidx = (duk_uidx_t) idx;
 	}
 
 	/* DUK_INVALID_INDEX won't be accepted as a valid index. */
@@ -372,15 +372,15 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t index) {
 	DUK_ASSERT(vs_size + (duk_uidx_t) DUK_INVALID_INDEX >= vs_limit);
 
 #if defined(DUK_USE_VALSTACK_UNSAFE)
-	DUK_ASSERT(uindex <= vs_limit);
+	DUK_ASSERT(uidx <= vs_limit);
 	DUK_UNREF(vs_limit);
 #else
-	if (DUK_UNLIKELY(uindex > vs_limit)) {
-		DUK_ERROR_API_INDEX(thr, index);
+	if (DUK_UNLIKELY(uidx > vs_limit)) {
+		DUK_ERROR_API_INDEX(thr, idx);
 		return;  /* unreachable */
 	}
 #endif
-	DUK_ASSERT(uindex <= vs_limit);
+	DUK_ASSERT(uidx <= vs_limit);
 
 	/* Handle change in value stack top.  Respect value stack
 	 * initialization policy: 'undefined' above top.  Note that
@@ -388,25 +388,25 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t index) {
 	 * so must relookup after DECREF.
 	 */
 
-	if (uindex >= vs_size) {
+	if (uidx >= vs_size) {
 		/* Stack size increases or stays the same. */
 #if defined(DUK_USE_ASSERTIONS)
 		duk_uidx_t count;
 
-		count = uindex - vs_size;
+		count = uidx - vs_size;
 		while (count != 0) {
 			count--;
 			tv = thr->valstack_top + count;
 			DUK_ASSERT(DUK_TVAL_IS_UNDEFINED(tv));
 		}
 #endif
-		thr->valstack_top = thr->valstack_bottom + uindex;
+		thr->valstack_top = thr->valstack_bottom + uidx;
 	} else {
 		/* Stack size decreases. */
 #if defined(DUK_USE_REFERENCE_COUNTING)
 		duk_uidx_t count;
 
-		count = vs_size - uindex;
+		count = vs_size - uidx;
 		DUK_ASSERT(count > 0);
 		while (count > 0) {
 			count--;
@@ -418,7 +418,7 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t index) {
 		duk_uidx_t count;
 		duk_tval *tv_end;
 
-		count = vs_size - uindex;
+		count = vs_size - uidx;
 		tv = thr->valstack_top;
 		tv_end = tv - count;
 		DUK_ASSERT(tv > tv_end);
@@ -820,13 +820,13 @@ DUK_EXTERNAL void duk_swap(duk_context *ctx, duk_idx_t index1, duk_idx_t index2)
 	DUK_TVAL_SET_TVAL(tv2, &tv_tmp);
 }
 
-DUK_EXTERNAL void duk_swap_top(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_swap_top(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	duk_swap(ctx, index, -1);
+	duk_swap(ctx, idx, -1);
 }
 
-DUK_EXTERNAL void duk_dup(duk_context *ctx, duk_idx_t from_index) {
+DUK_EXTERNAL void duk_dup(duk_context *ctx, duk_idx_t from_idx) {
 	duk_hthread *thr;
 	duk_tval *tv_from;
 	duk_tval *tv_to;
@@ -835,7 +835,7 @@ DUK_EXTERNAL void duk_dup(duk_context *ctx, duk_idx_t from_index) {
 	thr = (duk_hthread *) ctx;
 	DUK__CHECK_SPACE();
 
-	tv_from = duk_require_tval(ctx, from_index);
+	tv_from = duk_require_tval(ctx, from_idx);
 	tv_to = thr->valstack_top++;
 	DUK_ASSERT(tv_from != NULL);
 	DUK_ASSERT(tv_to != NULL);
@@ -864,7 +864,7 @@ DUK_EXTERNAL void duk_dup_top(duk_context *ctx) {
 	DUK_TVAL_INCREF(thr, tv_to);  /* no side effects */
 }
 
-DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_index) {
+DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_idx) {
 	duk_tval *p;
 	duk_tval *q;
 	duk_tval tv_tmp;
@@ -872,7 +872,7 @@ DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	p = duk_require_tval(ctx, to_index);
+	p = duk_require_tval(ctx, to_idx);
 	DUK_ASSERT(p != NULL);
 	q = duk_require_tval(ctx, -1);
 	DUK_ASSERT(q != NULL);
@@ -887,8 +887,8 @@ DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_index) {
 
 	nbytes = (duk_size_t) (((duk_uint8_t *) q) - ((duk_uint8_t *) p));  /* Note: 'q' is top-1 */
 
-	DUK_DDD(DUK_DDDPRINT("duk_insert: to_index=%ld, p=%p, q=%p, nbytes=%lu",
-	                     (long) to_index, (void *) p, (void *) q, (unsigned long) nbytes));
+	DUK_DDD(DUK_DDDPRINT("duk_insert: to_idx=%ld, p=%p, q=%p, nbytes=%lu",
+	                     (long) to_idx, (void *) p, (void *) q, (unsigned long) nbytes));
 
 	/* No net refcount changes. */
 
@@ -904,7 +904,7 @@ DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_index) {
 	}
 }
 
-DUK_EXTERNAL void duk_replace(duk_context *ctx, duk_idx_t to_index) {
+DUK_EXTERNAL void duk_replace(duk_context *ctx, duk_idx_t to_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv1;
 	duk_tval *tv2;
@@ -914,7 +914,7 @@ DUK_EXTERNAL void duk_replace(duk_context *ctx, duk_idx_t to_index) {
 
 	tv1 = duk_require_tval(ctx, -1);
 	DUK_ASSERT(tv1 != NULL);
-	tv2 = duk_require_tval(ctx, to_index);
+	tv2 = duk_require_tval(ctx, to_idx);
 	DUK_ASSERT(tv2 != NULL);
 
 	/* For tv1 == tv2, both pointing to stack top, the end result
@@ -927,7 +927,7 @@ DUK_EXTERNAL void duk_replace(duk_context *ctx, duk_idx_t to_index) {
 	DUK_TVAL_DECREF(thr, &tv_tmp);  /* side effects */
 }
 
-DUK_EXTERNAL void duk_copy(duk_context *ctx, duk_idx_t from_index, duk_idx_t to_index) {
+DUK_EXTERNAL void duk_copy(duk_context *ctx, duk_idx_t from_idx, duk_idx_t to_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv1;
 	duk_tval *tv2;
@@ -935,16 +935,16 @@ DUK_EXTERNAL void duk_copy(duk_context *ctx, duk_idx_t from_index, duk_idx_t to_
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);  /* w/o refcounting */
 
-	tv1 = duk_require_tval(ctx, from_index);
+	tv1 = duk_require_tval(ctx, from_idx);
 	DUK_ASSERT(tv1 != NULL);
-	tv2 = duk_require_tval(ctx, to_index);
+	tv2 = duk_require_tval(ctx, to_idx);
 	DUK_ASSERT(tv2 != NULL);
 
 	/* For tv1 == tv2, this is a no-op (no explicit check needed). */
 	DUK_TVAL_SET_TVAL_UPDREF(thr, tv2, tv1);  /* side effects */
 }
 
-DUK_EXTERNAL void duk_remove(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_remove(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *p;
 	duk_tval *q;
@@ -955,7 +955,7 @@ DUK_EXTERNAL void duk_remove(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	p = duk_require_tval(ctx, index);
+	p = duk_require_tval(ctx, idx);
 	DUK_ASSERT(p != NULL);
 	q = duk_require_tval(ctx, -1);
 	DUK_ASSERT(q != NULL);
@@ -1061,41 +1061,41 @@ DUK_EXTERNAL void duk_xcopymove_raw(duk_context *to_ctx, duk_context *from_ctx, 
  *  Get/require
  */
 
-DUK_EXTERNAL void duk_require_undefined(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_require_undefined(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_UNDEFINED(tv)) {
 		return;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "undefined", DUK_STR_NOT_UNDEFINED);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "undefined", DUK_STR_NOT_UNDEFINED);
 	return;  /* not reachable */
 }
 
-DUK_EXTERNAL void duk_require_null(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_require_null(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_NULL(tv)) {
 		return;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "null", DUK_STR_NOT_NULL);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "null", DUK_STR_NOT_NULL);
 	return;  /* not reachable */
 }
 
-DUK_EXTERNAL duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t idx) {
 	duk_bool_t ret = 0;  /* default: false */
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BOOLEAN(tv)) {
 		ret = DUK_TVAL_GET_BOOLEAN(tv);
 	}
@@ -1104,30 +1104,30 @@ DUK_EXTERNAL duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t index) {
 	return ret;
 }
 
-DUK_EXTERNAL duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BOOLEAN(tv)) {
 		duk_bool_t ret = DUK_TVAL_GET_BOOLEAN(tv);
 		DUK_ASSERT(ret == 0 || ret == 1);
 		return ret;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "boolean", DUK_STR_NOT_BOOLEAN);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "boolean", DUK_STR_NOT_BOOLEAN);
 	return 0;  /* not reachable */
 }
 
-DUK_EXTERNAL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t idx) {
 	duk_double_union ret;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
 	ret.d = DUK_DOUBLE_NAN;  /* default: NaN */
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_NUMBER(tv)) {
 		ret.d = DUK_TVAL_GET_NUMBER(tv);
 	}
@@ -1141,13 +1141,13 @@ DUK_EXTERNAL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t index) {
 	return ret.d;
 }
 
-DUK_EXTERNAL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_NUMBER(tv)) {
 		duk_double_union ret;
 		ret.d = DUK_TVAL_GET_NUMBER(tv);
@@ -1160,35 +1160,35 @@ DUK_EXTERNAL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t index) 
 		DUK_DBLUNION_NORMALIZE_NAN_CHECK(&ret);
 		return ret.d;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "number", DUK_STR_NOT_NUMBER);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
 	return DUK_DOUBLE_NAN;  /* not reachable */
 }
 
-DUK_EXTERNAL duk_int_t duk_get_int(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_int_t duk_get_int(duk_context *ctx, duk_idx_t idx) {
 	/* Custom coercion for API */
 	DUK_ASSERT_CTX_VALID(ctx);
-	return (duk_int_t) duk__api_coerce_d2i(ctx, index, 0 /*require*/);
+	return (duk_int_t) duk__api_coerce_d2i(ctx, idx, 0 /*require*/);
 }
 
-DUK_EXTERNAL duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t idx) {
 	/* Custom coercion for API */
 	DUK_ASSERT_CTX_VALID(ctx);
-	return (duk_uint_t) duk__api_coerce_d2ui(ctx, index, 0 /*require*/);
+	return (duk_uint_t) duk__api_coerce_d2ui(ctx, idx, 0 /*require*/);
 }
 
-DUK_EXTERNAL duk_int_t duk_require_int(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_int_t duk_require_int(duk_context *ctx, duk_idx_t idx) {
 	/* Custom coercion for API */
 	DUK_ASSERT_CTX_VALID(ctx);
-	return (duk_int_t) duk__api_coerce_d2i(ctx, index, 1 /*require*/);
+	return (duk_int_t) duk__api_coerce_d2i(ctx, idx, 1 /*require*/);
 }
 
-DUK_EXTERNAL duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t idx) {
 	/* Custom coercion for API */
 	DUK_ASSERT_CTX_VALID(ctx);
-	return (duk_uint_t) duk__api_coerce_d2ui(ctx, index, 1 /*require*/);
+	return (duk_uint_t) duk__api_coerce_d2ui(ctx, idx, 1 /*require*/);
 }
 
-DUK_EXTERNAL const char *duk_get_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len) {
+DUK_EXTERNAL const char *duk_get_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len) {
 	const char *ret;
 	duk_tval *tv;
 
@@ -1200,7 +1200,7 @@ DUK_EXTERNAL const char *duk_get_lstring(duk_context *ctx, duk_idx_t index, duk_
 		*out_len = 0;
 	}
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_STRING(tv)) {
 		/* Here we rely on duk_hstring instances always being zero
 		 * terminated even if the actual string is not.
@@ -1216,7 +1216,7 @@ DUK_EXTERNAL const char *duk_get_lstring(duk_context *ctx, duk_idx_t index, duk_
 	return ret;
 }
 
-DUK_EXTERNAL const char *duk_require_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len) {
+DUK_EXTERNAL const char *duk_require_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	const char *ret;
 
@@ -1225,32 +1225,32 @@ DUK_EXTERNAL const char *duk_require_lstring(duk_context *ctx, duk_idx_t index, 
 	/* Note: this check relies on the fact that even a zero-size string
 	 * has a non-NULL pointer.
 	 */
-	ret = duk_get_lstring(ctx, index, out_len);
+	ret = duk_get_lstring(ctx, idx, out_len);
 	if (ret) {
 		return ret;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "string", DUK_STR_NOT_STRING);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "string", DUK_STR_NOT_STRING);
 	return NULL;  /* not reachable */
 }
 
-DUK_EXTERNAL const char *duk_get_string(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_get_string(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	return duk_get_lstring(ctx, index, NULL);
+	return duk_get_lstring(ctx, idx, NULL);
 }
 
-DUK_EXTERNAL const char *duk_require_string(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_require_string(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	return duk_require_lstring(ctx, index, NULL);
+	return duk_require_lstring(ctx, idx, NULL);
 }
 
-DUK_EXTERNAL void *duk_get_pointer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void *duk_get_pointer(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_POINTER(tv)) {
 		void *p = DUK_TVAL_GET_POINTER(tv);  /* may be NULL */
 		return (void *) p;
@@ -1259,7 +1259,7 @@ DUK_EXTERNAL void *duk_get_pointer(duk_context *ctx, duk_idx_t index) {
 	return NULL;
 }
 
-DUK_EXTERNAL void *duk_require_pointer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void *duk_require_pointer(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
@@ -1268,22 +1268,22 @@ DUK_EXTERNAL void *duk_require_pointer(duk_context *ctx, duk_idx_t index) {
 	/* Note: here we must be wary of the fact that a pointer may be
 	 * valid and be a NULL.
 	 */
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_POINTER(tv)) {
 		void *p = DUK_TVAL_GET_POINTER(tv);  /* may be NULL */
 		return (void *) p;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "pointer", DUK_STR_NOT_POINTER);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "pointer", DUK_STR_NOT_POINTER);
 	return NULL;  /* not reachable */
 }
 
 #if 0  /*unused*/
-DUK_INTERNAL void *duk_get_voidptr(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL void *duk_get_voidptr(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_HEAP_ALLOCATED(tv)) {
 		duk_heaphdr *h = DUK_TVAL_GET_HEAPHDR(tv);
 		DUK_ASSERT(h != NULL);
@@ -1294,7 +1294,7 @@ DUK_INTERNAL void *duk_get_voidptr(duk_context *ctx, duk_idx_t index) {
 }
 #endif
 
-DUK_LOCAL void *duk__get_buffer_helper(duk_context *ctx, duk_idx_t index, duk_size_t *out_size, duk_bool_t throw_flag) {
+DUK_LOCAL void *duk__get_buffer_helper(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size, duk_bool_t throw_flag) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
@@ -1305,7 +1305,7 @@ DUK_LOCAL void *duk__get_buffer_helper(duk_context *ctx, duk_idx_t index, duk_si
 		*out_size = 0;
 	}
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BUFFER(tv)) {
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv);
 		DUK_ASSERT(h != NULL);
@@ -1316,20 +1316,20 @@ DUK_LOCAL void *duk__get_buffer_helper(duk_context *ctx, duk_idx_t index, duk_si
 	}
 
 	if (throw_flag) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "buffer", DUK_STR_NOT_BUFFER);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "buffer", DUK_STR_NOT_BUFFER);
 	}
 	return NULL;
 }
 
-DUK_EXTERNAL void *duk_get_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size) {
-	return duk__get_buffer_helper(ctx, index, out_size, 0 /*throw_flag*/);
+DUK_EXTERNAL void *duk_get_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size) {
+	return duk__get_buffer_helper(ctx, idx, out_size, 0 /*throw_flag*/);
 }
 
-DUK_EXTERNAL void *duk_require_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size) {
-	return duk__get_buffer_helper(ctx, index, out_size, 1 /*throw_flag*/);
+DUK_EXTERNAL void *duk_require_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size) {
+	return duk__get_buffer_helper(ctx, idx, out_size, 1 /*throw_flag*/);
 }
 
-DUK_LOCAL void *duk__get_buffer_data_helper(duk_context *ctx, duk_idx_t index, duk_size_t *out_size, duk_bool_t throw_flag) {
+DUK_LOCAL void *duk__get_buffer_data_helper(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size, duk_bool_t throw_flag) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
@@ -1340,7 +1340,7 @@ DUK_LOCAL void *duk__get_buffer_data_helper(duk_context *ctx, duk_idx_t index, d
 		*out_size = 0;
 	}
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv == NULL) {
 		goto fail;
 	}
@@ -1378,17 +1378,17 @@ DUK_LOCAL void *duk__get_buffer_data_helper(duk_context *ctx, duk_idx_t index, d
 
  fail:
 	if (throw_flag) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "buffer", DUK_STR_NOT_BUFFER);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "buffer", DUK_STR_NOT_BUFFER);
 	}
 	return NULL;
 }
 
-DUK_EXTERNAL void *duk_get_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size) {
-	return duk__get_buffer_data_helper(ctx, index, out_size, 0 /*throw_flag*/);
+DUK_EXTERNAL void *duk_get_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size) {
+	return duk__get_buffer_data_helper(ctx, idx, out_size, 0 /*throw_flag*/);
 }
 
-DUK_EXTERNAL void *duk_require_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size) {
-	return duk__get_buffer_data_helper(ctx, index, out_size, 1 /*throw_flag*/);
+DUK_EXTERNAL void *duk_require_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size) {
+	return duk__get_buffer_data_helper(ctx, idx, out_size, 1 /*throw_flag*/);
 }
 
 /* Raw helper for getting a value from the stack, checking its tag.
@@ -1396,12 +1396,12 @@ DUK_EXTERNAL void *duk_require_buffer_data(duk_context *ctx, duk_idx_t index, du
  * tag in the packed representation.
  */
 
-DUK_LOCAL duk_heaphdr *duk__get_tagged_heaphdr_raw(duk_context *ctx, duk_idx_t index, duk_uint_t tag) {
+DUK_LOCAL duk_heaphdr *duk__get_tagged_heaphdr_raw(duk_context *ctx, duk_idx_t idx, duk_uint_t tag) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && (DUK_TVAL_GET_TAG(tv) == tag)) {
 		duk_heaphdr *ret;
 		ret = DUK_TVAL_GET_HEAPHDR(tv);
@@ -1412,104 +1412,104 @@ DUK_LOCAL duk_heaphdr *duk__get_tagged_heaphdr_raw(duk_context *ctx, duk_idx_t i
 	return (duk_heaphdr *) NULL;
 }
 
-DUK_INTERNAL duk_hstring *duk_get_hstring(duk_context *ctx, duk_idx_t index) {
-	return (duk_hstring *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_STRING);
+DUK_INTERNAL duk_hstring *duk_get_hstring(duk_context *ctx, duk_idx_t idx) {
+	return (duk_hstring *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_STRING);
 }
 
-DUK_INTERNAL duk_hstring *duk_require_hstring(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hstring *duk_require_hstring(duk_context *ctx, duk_idx_t idx) {
 	duk_heaphdr *h;
-	h = duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_STRING);
+	h = duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_STRING);
 	if (h == NULL) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, index, "string", DUK_STR_NOT_STRING);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, idx, "string", DUK_STR_NOT_STRING);
 	}
 	return (duk_hstring *) h;
 }
 
-DUK_INTERNAL duk_hobject *duk_get_hobject(duk_context *ctx, duk_idx_t index) {
-	return (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+DUK_INTERNAL duk_hobject *duk_get_hobject(duk_context *ctx, duk_idx_t idx) {
+	return (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 }
 
-DUK_INTERNAL duk_hobject *duk_require_hobject(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hobject *duk_require_hobject(duk_context *ctx, duk_idx_t idx) {
 	duk_heaphdr *h;
-	h = duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	h = duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (h == NULL) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, index, "object", DUK_STR_NOT_OBJECT);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, idx, "object", DUK_STR_NOT_OBJECT);
 	}
 	return (duk_hobject *) h;
 }
 
-DUK_INTERNAL duk_hbuffer *duk_get_hbuffer(duk_context *ctx, duk_idx_t index) {
-	return (duk_hbuffer *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_BUFFER);
+DUK_INTERNAL duk_hbuffer *duk_get_hbuffer(duk_context *ctx, duk_idx_t idx) {
+	return (duk_hbuffer *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_BUFFER);
 }
 
-DUK_INTERNAL duk_hbuffer *duk_require_hbuffer(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hbuffer *duk_require_hbuffer(duk_context *ctx, duk_idx_t idx) {
 	duk_heaphdr *h;
-	h = duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_BUFFER);
+	h = duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_BUFFER);
 	if (h == NULL) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, index, "buffer", DUK_STR_NOT_BUFFER);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(ctx, idx, "buffer", DUK_STR_NOT_BUFFER);
 	}
 	return (duk_hbuffer *) h;
 }
 
-DUK_INTERNAL duk_hthread *duk_get_hthread(duk_context *ctx, duk_idx_t index) {
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+DUK_INTERNAL duk_hthread *duk_get_hthread(duk_context *ctx, duk_idx_t idx) {
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (h != NULL && !DUK_HOBJECT_IS_THREAD(h)) {
 		h = NULL;
 	}
 	return (duk_hthread *) h;
 }
 
-DUK_INTERNAL duk_hthread *duk_require_hthread(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hthread *duk_require_hthread(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (!(h != NULL && DUK_HOBJECT_IS_THREAD(h))) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "thread", DUK_STR_NOT_THREAD);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "thread", DUK_STR_NOT_THREAD);
 	}
 	return (duk_hthread *) h;
 }
 
-DUK_INTERNAL duk_hcompfunc *duk_get_hcompfunc(duk_context *ctx, duk_idx_t index) {
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+DUK_INTERNAL duk_hcompfunc *duk_get_hcompfunc(duk_context *ctx, duk_idx_t idx) {
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (h != NULL && !DUK_HOBJECT_IS_COMPFUNC(h)) {
 		h = NULL;
 	}
 	return (duk_hcompfunc *) h;
 }
 
-DUK_INTERNAL duk_hcompfunc *duk_require_hcompfunc(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hcompfunc *duk_require_hcompfunc(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (!(h != NULL && DUK_HOBJECT_IS_COMPFUNC(h))) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "compiledfunction", DUK_STR_NOT_COMPFUNC);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "compiledfunction", DUK_STR_NOT_COMPFUNC);
 	}
 	return (duk_hcompfunc *) h;
 }
 
-DUK_INTERNAL duk_hnatfunc *duk_get_hnatfunc(duk_context *ctx, duk_idx_t index) {
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+DUK_INTERNAL duk_hnatfunc *duk_get_hnatfunc(duk_context *ctx, duk_idx_t idx) {
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (h != NULL && !DUK_HOBJECT_IS_NATFUNC(h)) {
 		h = NULL;
 	}
 	return (duk_hnatfunc *) h;
 }
 
-DUK_INTERNAL duk_hnatfunc *duk_require_hnatfunc(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hnatfunc *duk_require_hnatfunc(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	duk_hobject *h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (!(h != NULL && DUK_HOBJECT_IS_NATFUNC(h))) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "nativefunction", DUK_STR_NOT_NATFUNC);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "nativefunction", DUK_STR_NOT_NATFUNC);
 	}
 	return (duk_hnatfunc *) h;
 }
 
-DUK_EXTERNAL duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 	duk_hobject *h;
 	duk_hnatfunc *f;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return NULL;
 	}
@@ -1528,44 +1528,44 @@ DUK_EXTERNAL duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t index
 	return f->func;
 }
 
-DUK_EXTERNAL duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_c_function ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	ret = duk_get_c_function(ctx, index);
+	ret = duk_get_c_function(ctx, idx);
 	if (!ret) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "nativefunction", DUK_STR_NOT_NATFUNC);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "nativefunction", DUK_STR_NOT_NATFUNC);
 	}
 	return ret;
 }
 
-DUK_EXTERNAL void duk_require_function(duk_context *ctx, duk_idx_t index) {
-	if (!duk_is_function(ctx, index)) {
-		DUK_ERROR_REQUIRE_TYPE_INDEX((duk_hthread *) ctx, index, "function", DUK_STR_NOT_FUNCTION);
+DUK_EXTERNAL void duk_require_function(duk_context *ctx, duk_idx_t idx) {
+	if (!duk_is_function(ctx, idx)) {
+		DUK_ERROR_REQUIRE_TYPE_INDEX((duk_hthread *) ctx, idx, "function", DUK_STR_NOT_FUNCTION);
 	}
 }
 
-DUK_EXTERNAL duk_context *duk_get_context(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_context *duk_get_context(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	return (duk_context *) duk_get_hthread(ctx, index);
+	return (duk_context *) duk_get_hthread(ctx, idx);
 }
 
-DUK_EXTERNAL duk_context *duk_require_context(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_context *duk_require_context(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	return (duk_context *) duk_require_hthread(ctx, index);
+	return (duk_context *) duk_require_hthread(ctx, idx);
 }
 
-DUK_EXTERNAL void *duk_get_heapptr(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void *duk_get_heapptr(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 	void *ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_HEAP_ALLOCATED(tv)) {
 		ret = (void *) DUK_TVAL_GET_HEAPHDR(tv);
 		DUK_ASSERT(ret != NULL);
@@ -1575,14 +1575,14 @@ DUK_EXTERNAL void *duk_get_heapptr(duk_context *ctx, duk_idx_t index) {
 	return (void *) NULL;
 }
 
-DUK_EXTERNAL void *duk_require_heapptr(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void *duk_require_heapptr(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	void *ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	if (DUK_TVAL_IS_HEAP_ALLOCATED(tv)) {
 		ret = (void *) DUK_TVAL_GET_HEAPHDR(tv);
@@ -1590,7 +1590,7 @@ DUK_EXTERNAL void *duk_require_heapptr(duk_context *ctx, duk_idx_t index) {
 		return ret;
 	}
 
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "heapobject", DUK_STR_UNEXPECTED_TYPE);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "heapobject", DUK_STR_UNEXPECTED_TYPE);
 	return (void *) NULL;  /* not reachable */
 }
 
@@ -1598,7 +1598,7 @@ DUK_EXTERNAL void *duk_require_heapptr(duk_context *ctx, duk_idx_t index) {
 /* This would be pointless: we'd return NULL for both lightfuncs and
  * unexpected types.
  */
-DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc(duk_context *ctx, duk_idx_t idx) {
 }
 #endif
 
@@ -1607,18 +1607,18 @@ DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc(duk_context *ctx, duk_idx_t i
  * to an object).  Return value is NULL if value is neither an object nor a
  * lightfunc.
  */
-DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	if (DUK_TVAL_IS_OBJECT(tv)) {
 		return DUK_TVAL_GET_OBJECT(tv);
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
-		duk_to_object(ctx, index);
-		return duk_require_hobject(ctx, index);
+		duk_to_object(ctx, idx);
+		return duk_require_hobject(ctx, idx);
 	}
 
 	return NULL;
@@ -1627,20 +1627,20 @@ DUK_INTERNAL duk_hobject *duk_get_hobject_or_lfunc_coerce(duk_context *ctx, duk_
 /* Useful for internal call sites where we either expect an object (function)
  * or a lightfunc.  Returns NULL for a lightfunc.
  */
-DUK_INTERNAL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	if (DUK_TVAL_IS_OBJECT(tv)) {
 		return DUK_TVAL_GET_OBJECT(tv);
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
 		return NULL;
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "object", DUK_STR_NOT_OBJECT);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "object", DUK_STR_NOT_OBJECT);
 	return NULL;  /* not reachable */
 }
 
@@ -1648,38 +1648,38 @@ DUK_INTERNAL duk_hobject *duk_require_hobject_or_lfunc(duk_context *ctx, duk_idx
  * or a lightfunc.  Accepts an object (returned as is) or a lightfunc (coerced
  * to an object).  Return value is never NULL.
  */
-DUK_INTERNAL duk_hobject *duk_require_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hobject *duk_require_hobject_or_lfunc_coerce(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	if (DUK_TVAL_IS_OBJECT(tv)) {
 		return DUK_TVAL_GET_OBJECT(tv);
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
-		duk_to_object(ctx, index);
-		return duk_require_hobject(ctx, index);
+		duk_to_object(ctx, idx);
+		return duk_require_hobject(ctx, idx);
 	}
-	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, "object", DUK_STR_NOT_OBJECT);
+	DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "object", DUK_STR_NOT_OBJECT);
 	return NULL;  /* not reachable */
 }
 
-DUK_INTERNAL duk_hobject *duk_get_hobject_with_class(duk_context *ctx, duk_idx_t index, duk_small_uint_t classnum) {
+DUK_INTERNAL duk_hobject *duk_get_hobject_with_class(duk_context *ctx, duk_idx_t idx, duk_small_uint_t classnum) {
 	duk_hobject *h;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT_DISABLE(classnum >= 0);  /* unsigned */
 	DUK_ASSERT(classnum <= DUK_HOBJECT_CLASS_MAX);
 
-	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (h != NULL && DUK_HOBJECT_GET_CLASS_NUMBER(h) != classnum) {
 		h = NULL;
 	}
 	return h;
 }
 
-DUK_INTERNAL duk_hobject *duk_require_hobject_with_class(duk_context *ctx, duk_idx_t index, duk_small_uint_t classnum) {
+DUK_INTERNAL duk_hobject *duk_require_hobject_with_class(duk_context *ctx, duk_idx_t idx, duk_small_uint_t classnum) {
 	duk_hthread *thr;
 	duk_hobject *h;
 
@@ -1688,23 +1688,23 @@ DUK_INTERNAL duk_hobject *duk_require_hobject_with_class(duk_context *ctx, duk_i
 	DUK_ASSERT(classnum <= DUK_HOBJECT_CLASS_MAX);
 	thr = (duk_hthread *) ctx;
 
-	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, index, DUK_TAG_OBJECT);
+	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_OBJECT);
 	if (!(h != NULL && DUK_HOBJECT_GET_CLASS_NUMBER(h) == classnum)) {
 		duk_hstring *h_class;
 		h_class = DUK_HTHREAD_GET_STRING(thr, DUK_HOBJECT_CLASS_NUMBER_TO_STRIDX(classnum));
 		DUK_UNREF(h_class);
 
-		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, index, (const char *) DUK_HSTRING_GET_DATA(h_class), DUK_STR_UNEXPECTED_TYPE);
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, (const char *) DUK_HSTRING_GET_DATA(h_class), DUK_STR_UNEXPECTED_TYPE);
 	}
 	return h;
 }
 
-DUK_EXTERNAL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return 0;
 	}
@@ -1748,13 +1748,13 @@ DUK_EXTERNAL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t index) {
 	DUK_UNREACHABLE();
 }
 
-DUK_INTERNAL void duk_set_length(duk_context *ctx, duk_idx_t index, duk_size_t length) {
+DUK_INTERNAL void duk_set_length(duk_context *ctx, duk_idx_t idx, duk_size_t length) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *h;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	h = duk_get_hobject(ctx, index);
+	h = duk_get_hobject(ctx, idx);
 	if (!h) {
 		return;
 	}
@@ -1772,14 +1772,14 @@ DUK_INTERNAL void duk_set_length(duk_context *ctx, duk_idx_t index, duk_size_t l
 
 /* E5 Section 8.12.8 */
 
-DUK_LOCAL duk_bool_t duk__defaultvalue_coerce_attempt(duk_context *ctx, duk_idx_t index, duk_small_int_t func_stridx) {
-	if (duk_get_prop_stridx(ctx, index, func_stridx)) {
+DUK_LOCAL duk_bool_t duk__defaultvalue_coerce_attempt(duk_context *ctx, duk_idx_t idx, duk_small_int_t func_stridx) {
+	if (duk_get_prop_stridx(ctx, idx, func_stridx)) {
 		/* [ ... func ] */
 		if (duk_is_callable(ctx, -1)) {
-			duk_dup(ctx, index);         /* -> [ ... func this ] */
+			duk_dup(ctx, idx);         /* -> [ ... func this ] */
 			duk_call_method(ctx, 0);     /* -> [ ... retval ] */
 			if (duk_is_primitive(ctx, -1)) {
-				duk_replace(ctx, index);
+				duk_replace(ctx, idx);
 				return 1;
 			}
 			/* [ ... retval ]; popped below */
@@ -1789,7 +1789,7 @@ DUK_LOCAL duk_bool_t duk__defaultvalue_coerce_attempt(duk_context *ctx, duk_idx_
 	return 0;
 }
 
-DUK_EXTERNAL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int_t hint) {
+DUK_EXTERNAL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t idx, duk_int_t hint) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	/* inline initializer for coercers[] is not allowed by old compilers like BCC */
@@ -1801,8 +1801,8 @@ DUK_EXTERNAL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int
 	coercers[0] = DUK_STRIDX_VALUE_OF;
 	coercers[1] = DUK_STRIDX_TO_STRING;
 
-	index = duk_require_normalize_index(ctx, index);
-	obj = duk_require_hobject_or_lfunc(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
+	obj = duk_require_hobject_or_lfunc(ctx, idx);
 
 	if (hint == DUK_HINT_NONE) {
 		if (obj != NULL && DUK_HOBJECT_GET_CLASS_NUMBER(obj) == DUK_HOBJECT_CLASS_DATE) {
@@ -1817,58 +1817,58 @@ DUK_EXTERNAL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int
 		coercers[1] = DUK_STRIDX_VALUE_OF;
 	}
 
-	if (duk__defaultvalue_coerce_attempt(ctx, index, coercers[0])) {
+	if (duk__defaultvalue_coerce_attempt(ctx, idx, coercers[0])) {
 		return;
 	}
 
-	if (duk__defaultvalue_coerce_attempt(ctx, index, coercers[1])) {
+	if (duk__defaultvalue_coerce_attempt(ctx, idx, coercers[1])) {
 		return;
 	}
 
 	DUK_ERROR_TYPE(thr, DUK_STR_DEFAULTVALUE_COERCE_FAILED);
 }
 
-DUK_EXTERNAL void duk_to_undefined(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_to_undefined(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, tv);  /* side effects */
 }
 
-DUK_EXTERNAL void duk_to_null(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_to_null(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	DUK_TVAL_SET_NULL_UPDREF(thr, tv);  /* side effects */
 }
 
 /* E5 Section 9.1 */
-DUK_EXTERNAL void duk_to_primitive(duk_context *ctx, duk_idx_t index, duk_int_t hint) {
+DUK_EXTERNAL void duk_to_primitive(duk_context *ctx, duk_idx_t idx, duk_int_t hint) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(hint == DUK_HINT_NONE || hint == DUK_HINT_NUMBER || hint == DUK_HINT_STRING);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	if (!duk_check_type_mask(ctx, index, DUK_TYPE_MASK_OBJECT |
+	if (!duk_check_type_mask(ctx, idx, DUK_TYPE_MASK_OBJECT |
 	                                     DUK_TYPE_MASK_LIGHTFUNC)) {
 		/* everything except object stay as is */
 		return;
 	}
-	duk_to_defaultvalue(ctx, index, hint);
+	duk_to_defaultvalue(ctx, idx, hint);
 }
 
 /* E5 Section 9.2 */
-DUK_EXTERNAL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_bool_t val;
@@ -1876,9 +1876,9 @@ DUK_EXTERNAL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t index) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 
 	val = duk_js_toboolean(tv);
@@ -1890,20 +1890,20 @@ DUK_EXTERNAL duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t index) {
 	return val;
 }
 
-DUK_EXTERNAL duk_double_t duk_to_number(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_double_t duk_to_number(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_double_t d;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	/* XXX: fastint? */
 	d = duk_js_tonumber(thr, tv);
 
 	/* Note: need to re-lookup because ToNumber() may have side effects */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, d);  /* side effects */
 	return d;
 }
@@ -1914,97 +1914,97 @@ DUK_EXTERNAL duk_double_t duk_to_number(duk_context *ctx, duk_idx_t index) {
 
 typedef duk_double_t (*duk__toint_coercer)(duk_hthread *thr, duk_tval *tv);
 
-DUK_LOCAL duk_double_t duk__to_int_uint_helper(duk_context *ctx, duk_idx_t index, duk__toint_coercer coerce_func) {
+DUK_LOCAL duk_double_t duk__to_int_uint_helper(duk_context *ctx, duk_idx_t idx, duk__toint_coercer coerce_func) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_double_t d;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	d = coerce_func(thr, tv);
 
 	/* XXX: fastint? */
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, d);  /* side effects */
 	return d;
 }
 
-DUK_EXTERNAL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t idx) {
 	/* Value coercion (in stack): ToInteger(), E5 Section 9.4
 	 * API return value coercion: custom
 	 */
 	DUK_ASSERT_CTX_VALID(ctx);
-	(void) duk__to_int_uint_helper(ctx, index, duk_js_tointeger);
-	return (duk_int_t) duk__api_coerce_d2i(ctx, index, 0 /*require*/);
+	(void) duk__to_int_uint_helper(ctx, idx, duk_js_tointeger);
+	return (duk_int_t) duk__api_coerce_d2i(ctx, idx, 0 /*require*/);
 }
 
-DUK_EXTERNAL duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t idx) {
 	/* Value coercion (in stack): ToInteger(), E5 Section 9.4
 	 * API return value coercion: custom
 	 */
 	DUK_ASSERT_CTX_VALID(ctx);
-	(void) duk__to_int_uint_helper(ctx, index, duk_js_tointeger);
-	return (duk_uint_t) duk__api_coerce_d2ui(ctx, index, 0 /*require*/);
+	(void) duk__to_int_uint_helper(ctx, idx, duk_js_tointeger);
+	return (duk_uint_t) duk__api_coerce_d2ui(ctx, idx, 0 /*require*/);
 }
 
-DUK_EXTERNAL duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_int32_t ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	ret = duk_js_toint32(thr, tv);
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_TVAL_SET_FASTINT_I32_UPDREF(thr, tv, ret);  /* side effects */
 	return ret;
 }
 
-DUK_EXTERNAL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_uint32_t ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	ret = duk_js_touint32(thr, tv);
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv, ret);  /* side effects */
 	return ret;
 }
 
-DUK_EXTERNAL duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_uint16_t ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	ret = duk_js_touint16(thr, tv);
 
 	/* Relookup in case coerce_func() has side effects, e.g. ends up coercing an object */
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_TVAL_SET_FASTINT_U32_UPDREF(thr, tv, ret);  /* side effects */
 	return ret;
 }
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 /* Special coercion for Uint8ClampedArray. */
-DUK_INTERNAL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t idx) {
 	duk_double_t d;
 	duk_double_t t;
 	duk_uint8_t ret;
@@ -2014,7 +2014,7 @@ DUK_INTERNAL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t index) 
 	 * directly.
 	 */
 
-	d = duk_to_number(ctx, index);
+	d = duk_to_number(ctx, idx);
 	if (d <= 0.0) {
 		return 0;
 	} else if (d >= 255) {
@@ -2039,11 +2039,11 @@ DUK_INTERNAL duk_uint8_t duk_to_uint8clamped(duk_context *ctx, duk_idx_t index) 
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
-DUK_EXTERNAL const char *duk_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len) {
+DUK_EXTERNAL const char *duk_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	(void) duk_to_string(ctx, index);
-	return duk_require_lstring(ctx, index, out_len);
+	(void) duk_to_string(ctx, idx);
+	return duk_require_lstring(ctx, idx, out_len);
 }
 
 DUK_LOCAL duk_ret_t duk__safe_to_string_raw(duk_context *ctx, void *udata) {
@@ -2054,17 +2054,17 @@ DUK_LOCAL duk_ret_t duk__safe_to_string_raw(duk_context *ctx, void *udata) {
 	return 1;
 }
 
-DUK_EXTERNAL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len) {
+DUK_EXTERNAL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
 	/* We intentionally ignore the duk_safe_call() return value and only
 	 * check the output type.  This way we don't also need to check that
 	 * the returned value is indeed a string in the success case.
 	 */
 
-	duk_dup(ctx, index);
+	duk_dup(ctx, idx);
 	(void) duk_safe_call(ctx, duk__safe_to_string_raw, NULL /*udata*/, 1 /*nargs*/, 1 /*nrets*/);
 	if (!duk_is_string(ctx, -1)) {
 		/* Error: try coercing error to string once. */
@@ -2082,16 +2082,16 @@ DUK_EXTERNAL const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, 
 	DUK_ASSERT(duk_is_string(ctx, -1));
 	DUK_ASSERT(duk_get_string(ctx, -1) != NULL);
 
-	duk_replace(ctx, index);
-	return duk_get_lstring(ctx, index, out_len);
+	duk_replace(ctx, idx);
+	return duk_get_lstring(ctx, idx, out_len);
 }
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)  /* only needed by debugger for now */
-DUK_INTERNAL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t index) {
-	(void) duk_safe_to_string(ctx, index);
-	DUK_ASSERT(duk_is_string(ctx, index));
-	DUK_ASSERT(duk_get_hstring(ctx, index) != NULL);
-	return duk_get_hstring(ctx, index);
+DUK_INTERNAL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t idx) {
+	(void) duk_safe_to_string(ctx, idx);
+	DUK_ASSERT(duk_is_string(ctx, idx));
+	DUK_ASSERT(duk_get_hstring(ctx, idx) != NULL);
+	return duk_get_hstring(ctx, idx);
 }
 #endif
 
@@ -2142,7 +2142,7 @@ DUK_INTERNAL void duk_push_hobject_class_string(duk_context *ctx, duk_hobject *h
 #endif  /* !DUK_USE_PARANOID_ERRORS */
 
 /* XXX: other variants like uint, u32 etc */
-DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped) {
+DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_tval tv_tmp;
@@ -2152,7 +2152,7 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index,
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	d = duk_js_tointeger(thr, tv);  /* E5 Section 9.4, ToInteger() */
 
@@ -2174,7 +2174,7 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index,
 	/* 'd' and 'res' agree here */
 
 	/* Relookup in case duk_js_tointeger() ends up e.g. coercing an object. */
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);  /* not popped by side effect */
 	DUK_TVAL_SET_TVAL(&tv_tmp, tv);
 #if defined(DUK_USE_FASTINT)
@@ -2205,25 +2205,25 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t index,
 	return res;
 }
 
-DUK_INTERNAL duk_int_t duk_to_int_clamped(duk_context *ctx, duk_idx_t index, duk_idx_t minval, duk_idx_t maxval) {
+DUK_INTERNAL duk_int_t duk_to_int_clamped(duk_context *ctx, duk_idx_t idx, duk_idx_t minval, duk_idx_t maxval) {
 	duk_bool_t dummy;
-	return duk_to_int_clamped_raw(ctx, index, minval, maxval, &dummy);
+	return duk_to_int_clamped_raw(ctx, idx, minval, maxval, &dummy);
 }
 
-DUK_INTERNAL duk_int_t duk_to_int_check_range(duk_context *ctx, duk_idx_t index, duk_int_t minval, duk_int_t maxval) {
-	return duk_to_int_clamped_raw(ctx, index, minval, maxval, NULL);  /* out_clamped==NULL -> RangeError if outside range */
+DUK_INTERNAL duk_int_t duk_to_int_check_range(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval) {
+	return duk_to_int_clamped_raw(ctx, idx, minval, maxval, NULL);  /* out_clamped==NULL -> RangeError if outside range */
 }
 
-DUK_EXTERNAL const char *duk_to_string(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL const char *duk_to_string(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
@@ -2248,8 +2248,8 @@ DUK_EXTERNAL const char *duk_to_string(duk_context *ctx, duk_idx_t index) {
 		goto skip_replace;
 	}
 	case DUK_TAG_OBJECT: {
-		duk_to_primitive(ctx, index, DUK_HINT_STRING);
-		return duk_to_string(ctx, index);  /* Note: recursive call */
+		duk_to_primitive(ctx, idx, DUK_HINT_STRING);
+		return duk_to_string(ctx, idx);  /* Note: recursive call */
 	}
 	case DUK_TAG_BUFFER: {
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv);
@@ -2296,22 +2296,22 @@ DUK_EXTERNAL const char *duk_to_string(duk_context *ctx, duk_idx_t index) {
 	}
 	}
 
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 
  skip_replace:
-	return duk_require_string(ctx, index);
+	return duk_require_string(ctx, idx);
 }
 
-DUK_INTERNAL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t idx) {
 	duk_hstring *ret;
 	DUK_ASSERT_CTX_VALID(ctx);
-	duk_to_string(ctx, index);
-	ret = duk_get_hstring(ctx, index);
+	duk_to_string(ctx, idx);
+	ret = duk_get_hstring(ctx, idx);
 	DUK_ASSERT(ret != NULL);
 	return ret;
 }
 
-DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size_t *out_size, duk_uint_t mode) {
+DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size, duk_uint_t mode) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hbuffer *h_buf;
 	const duk_uint8_t *src_data;
@@ -2321,9 +2321,9 @@ DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(thr);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	h_buf = duk_get_hbuffer(ctx, index);
+	h_buf = duk_get_hbuffer(ctx, idx);
 	if (h_buf != NULL) {
 		/* Buffer is kept as is, with the fixed/dynamic nature of the
 		 * buffer only changed if requested.  An external buffer
@@ -2352,7 +2352,7 @@ DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size
 		 * explicitly requested).
 		 */
 
-		src_data = (const duk_uint8_t *) duk_to_lstring(ctx, index, &src_size);
+		src_data = (const duk_uint8_t *) duk_to_lstring(ctx, idx, &src_size);
 	}
 
 	dst_data = (duk_uint8_t *) duk_push_buffer(ctx, src_size, (mode == DUK_BUF_MODE_DYNAMIC) /*dynamic*/);
@@ -2364,7 +2364,7 @@ DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size
 		 */
 		DUK_MEMCPY((void *) dst_data, (const void *) src_data, (size_t) src_size);
 	}
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
  skip_copy:
 
 	if (out_size) {
@@ -2373,15 +2373,15 @@ DUK_EXTERNAL void *duk_to_buffer_raw(duk_context *ctx, duk_idx_t index, duk_size
 	return dst_data;
 }
 
-DUK_EXTERNAL void *duk_to_pointer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void *duk_to_pointer(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 	void *res;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
@@ -2420,11 +2420,11 @@ DUK_EXTERNAL void *duk_to_pointer(duk_context *ctx, duk_idx_t index) {
 	}
 
 	duk_push_pointer(ctx, res);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 	return res;
 }
 
-DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
 	duk_uint_t flags = 0;   /* shared flags for a subset of types */
@@ -2432,9 +2432,9 @@ DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
@@ -2570,45 +2570,45 @@ DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t index) {
 	 * String and buffer special behaviors are already enabled which is not
 	 * ideal, but a write to the internal value is not affected by them.
 	 */
-	duk_dup(ctx, index);
+	duk_dup(ctx, idx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 
  replace_value:
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 }
 
 /*
  *  Type checking
  */
 
-DUK_LOCAL duk_bool_t duk__tag_check(duk_context *ctx, duk_idx_t index, duk_small_uint_t tag) {
+DUK_LOCAL duk_bool_t duk__tag_check(duk_context *ctx, duk_idx_t idx, duk_small_uint_t tag) {
 	duk_tval *tv;
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return 0;
 	}
 	return (DUK_TVAL_GET_TAG(tv) == tag);
 }
 
-DUK_LOCAL duk_bool_t duk__obj_flag_any_default_false(duk_context *ctx, duk_idx_t index, duk_uint_t flag_mask) {
+DUK_LOCAL duk_bool_t duk__obj_flag_any_default_false(duk_context *ctx, duk_idx_t idx, duk_uint_t flag_mask) {
 	duk_hobject *obj;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_get_hobject(ctx, index);
+	obj = duk_get_hobject(ctx, idx);
 	if (obj) {
 		return (DUK_HEAPHDR_CHECK_FLAG_BITS((duk_heaphdr *) obj, flag_mask) ? 1 : 0);
 	}
 	return 0;
 }
 
-DUK_EXTERNAL duk_int_t duk_get_type(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_int_t duk_get_type(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return DUK_TYPE_NONE;
 	}
@@ -2655,10 +2655,10 @@ DUK_LOCAL const char *duk__type_names[] = {
 	"lightfunc"
 };
 
-DUK_INTERNAL const char *duk_get_type_name(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL const char *duk_get_type_name(duk_context *ctx, duk_idx_t idx) {
 	duk_int_t type_tag;
 
-	type_tag = duk_get_type(ctx, index);
+	type_tag = duk_get_type(ctx, idx);
 	DUK_ASSERT(type_tag >= DUK_TYPE_MIN && type_tag <= DUK_TYPE_MAX);
 	DUK_ASSERT(DUK_TYPE_MIN == 0 && sizeof(duk__type_names) / sizeof(const char *) == DUK_TYPE_MAX + 1);
 
@@ -2666,18 +2666,18 @@ DUK_INTERNAL const char *duk_get_type_name(duk_context *ctx, duk_idx_t index) {
 }
 #endif
 
-DUK_EXTERNAL duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t index, duk_int_t type) {
+DUK_EXTERNAL duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t idx, duk_int_t type) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	return (duk_get_type(ctx, index) == type) ? 1 : 0;
+	return (duk_get_type(ctx, idx) == type) ? 1 : 0;
 }
 
-DUK_EXTERNAL duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return DUK_TYPE_MASK_NONE;
 	}
@@ -2710,12 +2710,12 @@ DUK_EXTERNAL duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t index) {
 	DUK_UNREACHABLE();
 }
 
-DUK_EXTERNAL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t index, duk_uint_t mask) {
+DUK_EXTERNAL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t idx, duk_uint_t mask) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	if (duk_get_type_mask(ctx, index) & mask) {
+	if (duk_get_type_mask(ctx, idx) & mask) {
 		return 1;
 	}
 	if (mask & DUK_TYPE_MASK_THROW) {
@@ -2725,23 +2725,23 @@ DUK_EXTERNAL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t index, d
 	return 0;
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_UNDEFINED);
+	return duk__tag_check(ctx, idx, DUK_TAG_UNDEFINED);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_NULL);
+	return duk__tag_check(ctx, idx, DUK_TAG_NULL);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 	duk_small_uint_t tag;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return 0;
 	}
@@ -2749,12 +2749,12 @@ DUK_EXTERNAL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t ind
 	return (tag == DUK_TAG_UNDEFINED) || (tag == DUK_TAG_NULL);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_BOOLEAN);
+	return duk__tag_check(ctx, idx, DUK_TAG_BOOLEAN);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -2766,14 +2766,14 @@ DUK_EXTERNAL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t index) {
 
 	/* XXX: shorter version for 12-byte representation? */
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv) {
 		return 0;
 	}
 	return DUK_TVAL_IS_NUMBER(tv);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx) {
 	/* XXX: This will now return false for non-numbers, even though they would
 	 * coerce to NaN (as a general rule).  In particular, duk_get_number()
 	 * returns a NaN for non-numbers, so should this function also return
@@ -2784,100 +2784,100 @@ DUK_EXTERNAL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (!tv || !DUK_TVAL_IS_NUMBER(tv)) {
 		return 0;
 	}
 	return DUK_ISNAN(DUK_TVAL_GET_NUMBER(tv));
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_STRING);
+	return duk__tag_check(ctx, idx, DUK_TAG_STRING);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_OBJECT);
+	return duk__tag_check(ctx, idx, DUK_TAG_OBJECT);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_BUFFER);
+	return duk__tag_check(ctx, idx, DUK_TAG_BUFFER);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_POINTER);
+	return duk__tag_check(ctx, idx, DUK_TAG_POINTER);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk__tag_check(ctx, index, DUK_TAG_LIGHTFUNC);
+	return duk__tag_check(ctx, idx, DUK_TAG_LIGHTFUNC);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t idx) {
 	duk_hobject *obj;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	obj = duk_get_hobject(ctx, index);
+	obj = duk_get_hobject(ctx, idx);
 	if (obj) {
 		return (DUK_HOBJECT_GET_CLASS_NUMBER(obj) == DUK_HOBJECT_CLASS_ARRAY ? 1 : 0);
 	}
 	return 0;
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_LIGHTFUNC(tv)) {
 		return 1;
 	}
 	return duk__obj_flag_any_default_false(ctx,
-	                                       index,
+	                                       idx,
 	                                       DUK_HOBJECT_FLAG_COMPFUNC |
 	                                       DUK_HOBJECT_FLAG_NATFUNC |
 	                                       DUK_HOBJECT_FLAG_BOUND);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	return duk__obj_flag_any_default_false(ctx,
-	                                       index,
+	                                       idx,
 	                                       DUK_HOBJECT_FLAG_NATFUNC);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	return duk__obj_flag_any_default_false(ctx,
-	                                       index,
+	                                       idx,
 	                                       DUK_HOBJECT_FLAG_COMPFUNC);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	return duk__obj_flag_any_default_false(ctx,
-	                                       index,
+	                                       idx,
 	                                       DUK_HOBJECT_FLAG_BOUND);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	return duk__obj_flag_any_default_false(ctx,
-	                                       index,
+	                                       idx,
 	                                       DUK_HOBJECT_FLAG_THREAD);
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BUFFER(tv)) {
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv);
 		DUK_ASSERT(h != NULL);
@@ -2886,12 +2886,12 @@ DUK_EXTERNAL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t index) {
 	return 0;
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BUFFER(tv)) {
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv);
 		DUK_ASSERT(h != NULL);
@@ -2900,12 +2900,12 @@ DUK_EXTERNAL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t index)
 	return 0;
 }
 
-DUK_EXTERNAL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t idx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	tv = duk_get_tval(ctx, index);
+	tv = duk_get_tval(ctx, idx);
 	if (tv && DUK_TVAL_IS_BUFFER(tv)) {
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv);
 		DUK_ASSERT(h != NULL);
@@ -2914,14 +2914,14 @@ DUK_EXTERNAL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t index
 	return 0;
 }
 
-DUK_EXTERNAL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *h;
 	duk_uint_t sanity;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	h = duk_get_hobject(ctx, index);
+	h = duk_get_hobject(ctx, idx);
 
 	sanity = DUK_HOBJECT_PROTOTYPE_CHAIN_SANITY;
 	do {
@@ -4583,8 +4583,8 @@ DUK_INTERNAL const char *duk_push_string_tval_readable(duk_context *ctx, duk_tva
 	return duk_to_string(ctx, -1);
 }
 
-DUK_INTERNAL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t index) {
+DUK_INTERNAL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	return duk_push_string_tval_readable(ctx, duk_get_tval(ctx, index));
+	return duk_push_string_tval_readable(ctx, duk_get_tval(ctx, idx));
 }
 #endif  /* !DUK_USE_PARANOID_ERRORS */

--- a/src/duk_api_string.c
+++ b/src/duk_api_string.c
@@ -122,7 +122,7 @@ DUK_EXTERNAL void duk_join(duk_context *ctx, duk_idx_t count) {
  * Case conversion needs also the character surroundings though.
  */
 
-DUK_EXTERNAL void duk_decode_string(duk_context *ctx, duk_idx_t index, duk_decode_char_function callback, void *udata) {
+DUK_EXTERNAL void duk_decode_string(duk_context *ctx, duk_idx_t idx, duk_decode_char_function callback, void *udata) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h_input;
 	const duk_uint8_t *p, *p_start, *p_end;
@@ -130,7 +130,7 @@ DUK_EXTERNAL void duk_decode_string(duk_context *ctx, duk_idx_t index, duk_decod
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	h_input = duk_require_hstring(ctx, index);
+	h_input = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h_input != NULL);
 
 	p_start = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
@@ -146,7 +146,7 @@ DUK_EXTERNAL void duk_decode_string(duk_context *ctx, duk_idx_t index, duk_decod
 	}
 }
 
-DUK_EXTERNAL void duk_map_string(duk_context *ctx, duk_idx_t index, duk_map_char_function callback, void *udata) {
+DUK_EXTERNAL void duk_map_string(duk_context *ctx, duk_idx_t idx, duk_map_char_function callback, void *udata) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h_input;
 	duk_bufwriter_ctx bw_alloc;
@@ -156,9 +156,9 @@ DUK_EXTERNAL void duk_map_string(duk_context *ctx, duk_idx_t index, duk_map_char
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_normalize_index(ctx, index);
+	idx = duk_normalize_index(ctx, idx);
 
-	h_input = duk_require_hstring(ctx, index);
+	h_input = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h_input != NULL);
 
 	bw = &bw_alloc;
@@ -184,10 +184,10 @@ DUK_EXTERNAL void duk_map_string(duk_context *ctx, duk_idx_t index, duk_map_char
 
 	DUK_BW_COMPACT(thr, bw);
 	duk_to_string(ctx, -1);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 }
 
-DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t index, duk_size_t start_offset, duk_size_t end_offset) {
+DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t idx, duk_size_t start_offset, duk_size_t end_offset) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h;
 	duk_hstring *res;
@@ -196,8 +196,8 @@ DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t index, duk_size_t st
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
-	h = duk_require_hstring(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
+	h = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	if (end_offset >= DUK_HSTRING_GET_CHARLEN(h)) {
@@ -228,13 +228,13 @@ DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t index, duk_size_t st
 	                                     (duk_uint32_t) (end_byte_offset - start_byte_offset));
 
 	duk_push_hstring(ctx, res);
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 }
 
 /* XXX: this is quite clunky.  Add Unicode helpers to scan backwards and
  * forwards with a callback to process codepoints?
  */
-DUK_EXTERNAL void duk_trim(duk_context *ctx, duk_idx_t index) {
+DUK_EXTERNAL void duk_trim(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h;
 	const duk_uint8_t *p, *p_start, *p_end, *p_tmp1, *p_tmp2;  /* pointers for scanning */
@@ -243,8 +243,8 @@ DUK_EXTERNAL void duk_trim(duk_context *ctx, duk_idx_t index) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	index = duk_require_normalize_index(ctx, index);
-	h = duk_require_hstring(ctx, index);
+	idx = duk_require_normalize_index(ctx, idx);
+	h = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	p_start = DUK_HSTRING_GET_DATA(h);
@@ -307,17 +307,17 @@ DUK_EXTERNAL void duk_trim(duk_context *ctx, duk_idx_t index) {
 	}
 
 	duk_push_lstring(ctx, (const char *) q_start, (duk_size_t) (q_end - q_start));
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 }
 
-DUK_EXTERNAL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t index, duk_size_t char_offset) {
+DUK_EXTERNAL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t idx, duk_size_t char_offset) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h;
 	duk_ucodepoint_t cp;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	h = duk_require_hstring(ctx, index);
+	h = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
 	DUK_ASSERT_DISABLE(char_offset >= 0);  /* always true, arg is unsigned */

--- a/src/duk_api_time.c
+++ b/src/duk_api_time.c
@@ -8,7 +8,7 @@ DUK_EXTERNAL duk_double_t duk_get_now(duk_context *ctx) {
 	return ((duk_double_t) DUK_USE_DATE_GET_NOW((ctx)));
 }
 
-DUK_EXTERNAL void duk_time_to_components(duk_context *ctx, duk_double_t time, duk_time_components *comp) {
+DUK_EXTERNAL void duk_time_to_components(duk_context *ctx, duk_double_t timeval, duk_time_components *comp) {
 	duk_int_t parts[DUK_DATE_IDX_NUM_PARTS];
 	duk_double_t dparts[DUK_DATE_IDX_NUM_PARTS];
 	duk_uint_t flags;
@@ -20,7 +20,7 @@ DUK_EXTERNAL void duk_time_to_components(duk_context *ctx, duk_double_t time, du
 	/* XXX: one-based or zero-based? or expose flag(s)? */
 	flags = DUK_DATE_FLAG_ONEBASED | DUK_DATE_FLAG_NAN_TO_ZERO;
 
-	duk_bi_date_timeval_to_parts(time, parts, dparts, flags);
+	duk_bi_date_timeval_to_parts(timeval, parts, dparts, flags);
 
 	/* XXX: expensive conversion */
 	comp->year = (duk_uint_t) parts[DUK_DATE_IDX_YEAR];

--- a/src/duk_bi_array.c
+++ b/src/duk_bi_array.c
@@ -1117,7 +1117,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_unshift(duk_context *ctx) {
 DUK_INTERNAL duk_ret_t duk_bi_array_prototype_indexof_shared(duk_context *ctx) {
 	duk_idx_t nargs;
 	duk_int_t i, len;
-	duk_int_t from_index;
+	duk_int_t from_idx;
 	duk_small_int_t idx_step = duk_get_current_magic(ctx);  /* idx_step is +1 for indexOf, -1 for lastIndexOf */
 
 	/* lastIndexOf() needs to be a vararg function because we must distinguish
@@ -1156,22 +1156,22 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_indexof_shared(duk_context *ctx) {
 		 * lastIndexOf: clamp fromIndex to [-len - 1, len - 1]
 		 * (if clamped to -len-1 -> fromIndex becomes -1, terminates for-loop directly)
 		 */
-		from_index = duk_to_int_clamped(ctx,
-		                                1,
-		                                (idx_step > 0 ? -len : -len - 1),
-		                                (idx_step > 0 ? len : len - 1));
-		if (from_index < 0) {
+		from_idx = duk_to_int_clamped(ctx,
+		                              1,
+		                              (idx_step > 0 ? -len : -len - 1),
+		                              (idx_step > 0 ? len : len - 1));
+		if (from_idx < 0) {
 			/* for lastIndexOf, result may be -1 (mark immediate termination) */
-			from_index = len + from_index;
+			from_idx = len + from_idx;
 		}
 	} else {
 		/* for indexOf, ToInteger(undefined) would be 0, i.e. correct, but
 		 * handle both indexOf and lastIndexOf specially here.
 		 */
 		if (idx_step > 0) {
-			from_index = 0;
+			from_idx = 0;
 		} else {
-			from_index = len - 1;
+			from_idx = len - 1;
 		}
 	}
 
@@ -1181,7 +1181,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_indexof_shared(duk_context *ctx) {
 	 * stack[3] = length (not needed, but not popped above)
 	 */
 
-	for (i = from_index; i >= 0 && i < len; i += idx_step) {
+	for (i = from_idx; i >= 0 && i < len; i += idx_step) {
 		DUK_ASSERT_TOP(ctx, 4);
 
 		if (duk_get_prop_index(ctx, 2, (duk_uarridx_t) i)) {

--- a/src/duk_bi_buffer.c
+++ b/src/duk_bi_buffer.c
@@ -149,7 +149,7 @@ DUK_LOCAL duk_hbufobj *duk__require_bufobj_this(duk_context *ctx) {
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 /* Check that value is a duk_hbufobj and return a pointer to it. */
-DUK_LOCAL duk_hbufobj *duk__require_bufobj_value(duk_context *ctx, duk_idx_t index) {
+DUK_LOCAL duk_hbufobj *duk__require_bufobj_value(duk_context *ctx, duk_idx_t idx) {
 	duk_hthread *thr;
 	duk_tval *tv;
 	duk_hbufobj *h_obj;
@@ -157,9 +157,9 @@ DUK_LOCAL duk_hbufobj *duk__require_bufobj_value(duk_context *ctx, duk_idx_t ind
 	thr = (duk_hthread *) ctx;
 
 	/* Don't accept relative indices now. */
-	DUK_ASSERT(index >= 0);
+	DUK_ASSERT(idx >= 0);
 
-	tv = duk_require_tval(ctx, index);
+	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
 	if (DUK_TVAL_IS_OBJECT(tv)) {
 		h_obj = (duk_hbufobj *) DUK_TVAL_GET_OBJECT(tv);

--- a/src/duk_bi_string.c
+++ b/src/duk_bi_string.c
@@ -1089,18 +1089,18 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
  */
 
 #ifdef DUK_USE_REGEXP_SUPPORT
-DUK_LOCAL void duk__to_regexp_helper(duk_context *ctx, duk_idx_t index, duk_bool_t force_new) {
+DUK_LOCAL void duk__to_regexp_helper(duk_context *ctx, duk_idx_t idx, duk_bool_t force_new) {
 	duk_hobject *h;
 
 	/* Shared helper for match() steps 3-4, search() steps 3-4. */
 
-	DUK_ASSERT(index >= 0);
+	DUK_ASSERT(idx >= 0);
 
 	if (force_new) {
 		goto do_new;
 	}
 
-	h = duk_get_hobject_with_class(ctx, index, DUK_HOBJECT_CLASS_REGEXP);
+	h = duk_get_hobject_with_class(ctx, idx, DUK_HOBJECT_CLASS_REGEXP);
 	if (!h) {
 		goto do_new;
 	}
@@ -1108,9 +1108,9 @@ DUK_LOCAL void duk__to_regexp_helper(duk_context *ctx, duk_idx_t index, duk_bool
 
  do_new:
 	duk_push_hobject_bidx(ctx, DUK_BIDX_REGEXP_CONSTRUCTOR);
-	duk_dup(ctx, index);
+	duk_dup(ctx, idx);
 	duk_new(ctx, 1);  /* [ ... RegExp val ] -> [ ... res ] */
-	duk_replace(ctx, index);
+	duk_replace(ctx, idx);
 }
 #endif  /* DUK_USE_REGEXP_SUPPORT */
 

--- a/src/duk_debug_heap.c
+++ b/src/duk_debug_heap.c
@@ -44,14 +44,14 @@ DUK_LOCAL const char *duk__get_heap_type_string(duk_heaphdr *hdr) {
 #endif
 
 #if 0
-DUK_LOCAL void duk__dump_indented(duk_heaphdr *obj, int index) {
+DUK_LOCAL void duk__dump_indented(duk_heaphdr *obj, int idx) {
 	DUK_UNREF(obj);
-	DUK_UNREF(index);
+	DUK_UNREF(idx);
 	DUK_UNREF(duk__get_heap_type_string);
 
 #ifdef DUK_USE_REFERENCE_COUNTING
 	DUK_D(DUK_DPRINT("  [%ld]: %p %s (flags: 0x%08lx, ref: %ld) -> %!O",
-	                 (long) index,
+	                 (long) idx,
 	                 (void *) obj,
 	                 (const char *) duk__get_heap_type_string(obj),
 	                 (unsigned long) DUK_HEAPHDR_GET_FLAGS(obj),
@@ -59,7 +59,7 @@ DUK_LOCAL void duk__dump_indented(duk_heaphdr *obj, int index) {
 	                 (duk_heaphdr *) obj));
 #else
 	DUK_D(DUK_DPRINT("  [%ld]: %p %s (flags: 0x%08lx) -> %!O",
-	                 (long) index,
+	                 (long) idx,
 	                 (void *) obj,
 	                 (const char *) duk__get_heap_type_string(obj),
 	                 (unsigned long) DUK_HEAPHDR_GET_FLAGS(obj),

--- a/src/duk_error.h
+++ b/src/duk_error.h
@@ -243,12 +243,12 @@
  * vs. non-paranoid distinction affects only a few specific errors.
  */
 #if defined(DUK_USE_PARANOID_ERRORS)
-#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,index,expectname,lowmemstr) do { \
-		duk_err_require_type_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (index), (expectname)); \
+#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,idx,expectname,lowmemstr) do { \
+		duk_err_require_type_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (idx), (expectname)); \
 	} while (0)
 #else  /* DUK_USE_PARANOID_ERRORS */
-#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,index,expectname,lowmemstr) do { \
-		duk_err_require_type_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (index), (expectname)); \
+#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,idx,expectname,lowmemstr) do { \
+		duk_err_require_type_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (idx), (expectname)); \
 	} while (0)
 #endif  /* DUK_USE_PARANOID_ERRORS */
 
@@ -277,8 +277,8 @@
 		DUK_ERROR_ALLOC((thr), DUK_STR_ALLOC_FAILED); \
 	} while (0)
 /* DUK_ERR_ASSERTION_ERROR: no macros needed */
-#define DUK_ERROR_API_INDEX(thr,index) do { \
-		duk_err_api_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (index)); \
+#define DUK_ERROR_API_INDEX(thr,idx) do { \
+		duk_err_api_index((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (idx)); \
 	} while (0)
 #define DUK_ERROR_API(thr,msg) do { \
 		duk_err_api((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO, (msg)); \
@@ -300,7 +300,7 @@
 #else  /* DUK_USE_VERBOSE_ERRORS */
 /* Non-verbose errors for low memory targets: no file, line, or message. */
 
-#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,index,expectname,lowmemstr) do { \
+#define DUK_ERROR_REQUIRE_TYPE_INDEX(thr,idx,expectname,lowmemstr) do { \
 		duk_err_type((thr)); \
 	} while (0)
 
@@ -328,7 +328,7 @@
 #define DUK_ERROR_ALLOC_DEFMSG(thr) do { \
 		duk_err_alloc((thr)); \
 	} while (0)
-#define DUK_ERROR_API_INDEX(thr,index) do { \
+#define DUK_ERROR_API_INDEX(thr,idx) do { \
 		duk_err_api((thr)); \
 	} while (0)
 #define DUK_ERROR_API(thr,msg) do { \
@@ -373,11 +373,11 @@ DUK_INTERNAL_DECL void duk_err_augment_error_throw(duk_hthread *thr);
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 #if defined(DUK_USE_PARANOID_ERRORS)
-DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name));
+DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name));
 #else
-DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name));
+DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name));
 #endif
-DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_api_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index));
+DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_api_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_api(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_unimplemented_defmsg(duk_hthread *thr, const char *filename, duk_int_t linenumber));

--- a/src/duk_error_macros.c
+++ b/src/duk_error_macros.c
@@ -36,21 +36,21 @@ DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, duk_errcode_t code) {
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 #if defined(DUK_USE_PARANOID_ERRORS)
-DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name) {
+DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
 	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
-	                   expect_name, duk_get_type_name((duk_context *) thr, index), (long) index);
+	                   expect_name, duk_get_type_name((duk_context *) thr, idx), (long) idx);
 }
 #else
-DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index, const char *expect_name) {
+DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
 	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
-	                   expect_name, duk_push_string_readable((duk_context *) thr, index), (long) index);
+	                   expect_name, duk_push_string_readable((duk_context *) thr, idx), (long) idx);
 }
 #endif
 DUK_INTERNAL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_RANGE_ERROR, message);
 }
-DUK_INTERNAL void duk_err_api_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t index) {
-	DUK_ERROR_RAW_FMT1(thr, filename, linenumber, DUK_ERR_API_ERROR, "invalid stack index %ld", (long) (index));
+DUK_INTERNAL void duk_err_api_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx) {
+	DUK_ERROR_RAW_FMT1(thr, filename, linenumber, DUK_ERR_API_ERROR, "invalid stack index %ld", (long) (idx));
 }
 DUK_INTERNAL void duk_err_api(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_API_ERROR, message);

--- a/src/duk_lexer.c
+++ b/src/duk_lexer.c
@@ -87,7 +87,7 @@
 #define DUK__ISDIGIT47(x)        ((x) >= DUK_ASC_4 && (x) <= DUK_ASC_7)
 
 /* lexer character window helpers */
-#define DUK__LOOKUP(lex_ctx,index)        ((lex_ctx)->window[(index)].codepoint)
+#define DUK__LOOKUP(lex_ctx,idx)          ((lex_ctx)->window[(idx)].codepoint)
 #define DUK__ADVANCECHARS(lex_ctx,count)  duk__advance_bytes((lex_ctx), (count) * sizeof(duk_lexer_codepoint))
 #define DUK__ADVANCEBYTES(lex_ctx,count)  duk__advance_bytes((lex_ctx), (count))
 #define DUK__INITBUFFER(lex_ctx)          duk__initbuffer((lex_ctx))

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -112,7 +112,19 @@ rejected_plain_identifiers_list = [
 	'abort',
 	'exit',
 	'setjmp',
-	'longjmp'
+	'longjmp',
+
+	# variable/argument names which have shadowing issues with platform headers
+	# see e.g. https://github.com/svaarala/duktape/pull/810
+	'index',
+	'rindex',
+
+	# for consistency avoid these too, use obj_idx rather than obj_index, etc
+	'obj_index',
+	'from_index',
+	'to_index',
+	'arr_index',
+	'uindex',
 ]
 rejected_plain_identifiers = {}
 for id in rejected_plain_identifiers_list:

--- a/website/api/duk_base64_decode.yaml
+++ b/website/api/duk_base64_decode.yaml
@@ -1,7 +1,7 @@
 name: duk_base64_decode
 
 proto: |
-  void duk_base64_decode(duk_context *ctx, duk_idx_t index);
+  void duk_base64_decode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... base64_val! ... ] -> [ ... val! ... ]

--- a/website/api/duk_base64_encode.yaml
+++ b/website/api/duk_base64_encode.yaml
@@ -1,7 +1,7 @@
 name: duk_base64_encode
 
 proto: |
-  const char *duk_base64_encode(duk_context *ctx, duk_idx_t index);
+  const char *duk_base64_encode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... base64_val! ... ]

--- a/website/api/duk_call_prop.yaml
+++ b/website/api/duk_call_prop.yaml
@@ -1,7 +1,7 @@
 name: duk_call_prop
 
 proto: |
-  void duk_call_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs);
+  void duk_call_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs);
 
 stack: |
   [ ... obj! ... key! arg1! ...! argN! ] -> [ ... obj! ... retval! ]

--- a/website/api/duk_char_code_at.yaml
+++ b/website/api/duk_char_code_at.yaml
@@ -1,14 +1,14 @@
 name: duk_char_code_at
 
 proto: |
-  duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t index, duk_size_t char_offset);
+  duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t idx, duk_size_t char_offset);
 
 stack: |
   [ ... str! ... ]
 
 summary: |
   <p>Get the codepoint of a character at character offset <code>char_offset</code>
-  of a string at <code>index</code>.  If the value at <code>index</code> is not
+  of a string at <code>idx</code>.  If the value at <code>idx</code> is not
   a string, an error is thrown.  If <code>char_offset</code> is invalid (outside
   the string) a zero is returned.</p>
 

--- a/website/api/duk_check_type.yaml
+++ b/website/api/duk_check_type.yaml
@@ -1,13 +1,13 @@
 name: duk_check_type
 
 proto: |
-  duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t index, duk_int_t type);
+  duk_bool_t duk_check_type(duk_context *ctx, duk_idx_t idx, duk_int_t type);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Matches the type of the value at <code>index</code> against <code>type</code>.
+  <p>Matches the type of the value at <code>idx</code> against <code>type</code>.
   Returns 1 if the type matches, zero otherwise.</p>
 
 example: |

--- a/website/api/duk_check_type_mask.yaml
+++ b/website/api/duk_check_type_mask.yaml
@@ -1,13 +1,13 @@
 name: duk_check_type_mask
 
 proto: |
-  duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t index, duk_uint_t mask);
+  duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t idx, duk_uint_t mask);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Matches the type of the value at <code>index</code> against the type
+  <p>Matches the type of the value at <code>idx</code> against the type
   mask bits given in <code>mask</code>.  Returns 1 if the value type matches
   one of the type mask bits and zero otherwise.</p>
 

--- a/website/api/duk_compact.yaml
+++ b/website/api/duk_compact.yaml
@@ -1,12 +1,12 @@
 name: duk_compact
 
 proto: |
-  void duk_compact(duk_context *ctx, duk_idx_t obj_index);
+  void duk_compact(duk_context *ctx, duk_idx_t obj_idx);
 
 summary: |
   <p>
   Resizes an object's internal memory allocation to minimize memory usage.
-  If the value at <code>obj_index</code> is not an object, does nothing.
+  If the value at <code>obj_idx</code> is not an object, does nothing.
   Although compaction is normally safe, it can fail due to an internal error
   (such as out-of-memory error).  Compaction only affects to an object's
   "own properties", not its inherited properties.

--- a/website/api/duk_config_buffer.yaml
+++ b/website/api/duk_config_buffer.yaml
@@ -1,7 +1,7 @@
 name: duk_config_buffer
 
 proto: |
-  void duk_config_buffer(duk_context *ctx, duk_idx_t index, void *ptr, duk_size_t len);
+  void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *ptr, duk_size_t len);
 
 stack: |
   [ ... buf! ... ] -> [ ... buf! ... ]

--- a/website/api/duk_copy.yaml
+++ b/website/api/duk_copy.yaml
@@ -1,13 +1,13 @@
 name: duk_copy
 
 proto: |
-  void duk_copy(duk_context *ctx, duk_idx_t from_index, duk_idx_t to_index);
+  void duk_copy(duk_context *ctx, duk_idx_t from_idx, duk_idx_t to_idx);
 
 stack: |
-  [ ... old(to_index)! ... val(from_index)! ... ] -> [ ... val(to_index)! ... val(from_index)! ... ]
+  [ ... old(to_idx)! ... val(from_idx)! ... ] -> [ ... val(to_idx)! ... val(from_idx)! ... ]
 
 summary: |
-  <p>Copy a value from <code>from_index</code> to <code>to_index</code>,
+  <p>Copy a value from <code>from_idx</code> to <code>to_idx</code>,
   overwriting the previous value.  If either index is invalid, throws an
   error.</p>
 
@@ -16,9 +16,9 @@ summary: |
   /* to_index must be normalize in case it is negative and would change its
    * meaning after duk_dup().
    */
-  to_index = duk_normalize_index(ctx, to_index);
-  duk_dup(ctx, from_index);
-  duk_replace(ctx, to_index);
+  to_idx = duk_normalize_idx(ctx, to_idx);
+  duk_dup(ctx, from_idx);
+  duk_replace(ctx, to_idx);
   </pre>
 
 example: |

--- a/website/api/duk_decode_string.yaml
+++ b/website/api/duk_decode_string.yaml
@@ -1,13 +1,13 @@
 name: duk_decode_string
 
 proto: |
-  void duk_decode_string(duk_context *ctx, duk_idx_t index, duk_decode_char_function callback, void *udata);
+  void duk_decode_string(duk_context *ctx, duk_idx_t idx, duk_decode_char_function callback, void *udata);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Process string at <code>index</code>, calling <code>callback</code> for each codepoint
+  <p>Process string at <code>idx</code>, calling <code>callback</code> for each codepoint
   of the string.  The callback is given the <code>udata</code> argument and a codepoint.
   The input string is not modified.  If the value is not a string or the index is
   invalid, throws an error.</p>

--- a/website/api/duk_def_prop.yaml
+++ b/website/api/duk_def_prop.yaml
@@ -1,7 +1,7 @@
 name: duk_def_prop
 
 proto: |
-  void duk_def_prop(duk_context *ctx, duk_idx_t obj_index, duk_uint_t flags);
+  void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t flags);
 
 stack: |
   [ ... obj! ... key! ] -> [ ... obj! ... ]  (if have no value, setter, getter)
@@ -12,7 +12,7 @@ stack: |
 
 summary: |
   <p>Create or alter the attributes of property <code>key</code> of object at
-  <code>obj_index</code>, with semantics like
+  <code>obj_idx</code>, with semantics like
   <code><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.6">Object.defineProperty()</a></code>.
   When the requested change is not allowed (e.g. property is not configurable), a
   <code>TypeError</code> is thrown.  If the target is not an object (or the

--- a/website/api/duk_del_prop.yaml
+++ b/website/api/duk_del_prop.yaml
@@ -1,13 +1,13 @@
 name: duk_del_prop
 
 proto: |
-  duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_index);
+  duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx);
 
 stack: |
   [ ... obj! ... key! ] -> [ ... obj! ... ]
 
 summary: |
-  <p>Delete the property <code>key</code> of a value at <code>obj_index</code>.
+  <p>Delete the property <code>key</code> of a value at <code>obj_idx</code>.
   <code>key</code> is removed from the stack.  Return code and error throwing
   behavior:</p>
   <ul>
@@ -16,10 +16,10 @@ summary: |
   <li>If property exists but is not configurable, throws an error
       (strict mode semantics).</li>
   <li>If property does not exist, returns <code>1</code> (<i>not</i> 0).</li>
-  <li>If the value at <code>obj_index</code> is not
+  <li>If the value at <code>obj_idx</code> is not
       <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">object coercible</a>,
       throws an error.</li>
-  <li>If <code>obj_index</code> is invalid, throws an error.</li>
+  <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
   <p>The property deletion is equivalent to the Ecmascript expression:</p>

--- a/website/api/duk_del_prop_index.yaml
+++ b/website/api/duk_del_prop_index.yaml
@@ -1,7 +1,7 @@
 name: duk_del_prop_index
 
 proto: |
-  duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
+  duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Like <code><a href="#duk_del_prop">duk_del_prop()</a></code>,
   but the property name is given as an unsigned integer
-  <code>arr_index</code>.  This is especially useful for deleting
+  <code>arr_idx</code>.  This is especially useful for deleting
   array elements (but is not limited to that).</p>
 
   <p>Conceptually the number is coerced to a string for the

--- a/website/api/duk_del_prop_string.yaml
+++ b/website/api/duk_del_prop_string.yaml
@@ -1,7 +1,7 @@
 name: duk_del_prop_string
 
 proto: |
-  duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
+  duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]

--- a/website/api/duk_dup.yaml
+++ b/website/api/duk_dup.yaml
@@ -1,14 +1,14 @@
 name: duk_dup
 
 proto: |
-  void duk_dup(duk_context *ctx, duk_idx_t from_index);
+  void duk_dup(duk_context *ctx, duk_idx_t from_idx);
 
 stack: |
   [ ... val! ... ] -> [ ... val! ... val! ]
 
 summary: |
-  <p>Push a duplicate of value at <code>from_index</code> to the stack.
-  If <code>from_index</code> is invalid, throws an error.</p>
+  <p>Push a duplicate of value at <code>from_idx</code> to the stack.
+  If <code>from_idx</code> is invalid, throws an error.</p>
 
 example: |
   duk_push_int(ctx, 123);  /* -> [ ... 123 ] */

--- a/website/api/duk_enum.yaml
+++ b/website/api/duk_enum.yaml
@@ -1,13 +1,13 @@
 name: duk_enum
 
 proto: |
-  void duk_enum(duk_context *ctx, duk_idx_t obj_index, duk_uint_t enum_flags);
+  void duk_enum(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t enum_flags);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... enum! ]
 
 summary: |
-  <p>Create an enumerator for object at <code>obj_index</code>.  Enumeration
+  <p>Create an enumerator for object at <code>obj_idx</code>.  Enumeration
   details can be controlled with <code>enum_flags</code>.  If the target value
   is not an object, throws an error.</p>
 
@@ -53,7 +53,7 @@ summary: |
 example: |
   duk_enum(ctx, -3, DUK_ENUM_INCLUDE_NONENUMERABLE);
 
-  while (duk_next(ctx, -1 /*enum_index*/, 0 /*get_value*/)) {
+  while (duk_next(ctx, -1 /*enum_idx*/, 0 /*get_value*/)) {
       /* [ ... enum key ] */
       printf("-> key %s\n", duk_get_string(ctx, -1));
       duk_pop(ctx);  /* pop_key */

--- a/website/api/duk_equals.yaml
+++ b/website/api/duk_equals.yaml
@@ -1,13 +1,13 @@
 name: duk_equals
 
 proto: |
-  duk_bool_t duk_equals(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
+  duk_bool_t duk_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
 
 stack: |
   [ ... val1! ... val2! ... ]
 
 summary: |
-  <p>Compare values at <code>index1</code> and <code>index2</code> for equality.
+  <p>Compare values at <code>idx1</code> and <code>idx2</code> for equality.
   Returns 1 if values are considered equal using Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.1">Equals</a>
   operator (<code>==</code>) semantics, otherwise returns 0.  Also returns 0 if either

--- a/website/api/duk_get_boolean.yaml
+++ b/website/api/duk_get_boolean.yaml
@@ -1,13 +1,13 @@
 name: duk_get_boolean
 
 proto: |
-  duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_get_boolean(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the boolean value at <code>index</code> without modifying or coercing
+  <p>Get the boolean value at <code>idx</code> without modifying or coercing
   the value.  Returns 1 if the value is <code>true</code>, 0 if the value is
   <code>false</code>, not a boolean, or the index is invalid.</p>
 

--- a/website/api/duk_get_buffer.yaml
+++ b/website/api/duk_get_buffer.yaml
@@ -1,13 +1,13 @@
 name: duk_get_buffer
 
 proto: |
-  void *duk_get_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_get_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the data pointer for a (plain) buffer value at <code>index</code> without
+  <p>Get the data pointer for a (plain) buffer value at <code>idx</code> without
   modifying or coercing the value.  Returns a non-<code>NULL</code> pointer if the value
   is a valid buffer with a non-zero size.  For a zero-size buffer, may return a
   <code>NULL</code> or a non-<code>NULL</code> pointer.  Returns <code>NULL</code>

--- a/website/api/duk_get_buffer_data.yaml
+++ b/website/api/duk_get_buffer_data.yaml
@@ -1,7 +1,7 @@
 name: duk_get_buffer_data
 
 proto: |
-  void *duk_get_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_get_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Get the data pointer for a plain buffer or a Buffer object (Duktape.Buffer,
   Node.js Buffer, ArrayBuffer, DataView, or TypedArray view) value at
-  <code>index</code> without modifying or coercing the value.  Return a
+  <code>idx</code> without modifying or coercing the value.  Return a
   non-<code>NULL</code> pointer if the value is a valid buffer with a non-zero
   size.  For a zero-size buffer, may return a <code>NULL</code> or a
   non-<code>NULL</code> pointer.  Returns <code>NULL</code> if the value is

--- a/website/api/duk_get_c_function.yaml
+++ b/website/api/duk_get_c_function.yaml
@@ -1,7 +1,7 @@
 name: duk_get_c_function
 
 proto: |
-  duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t index);
+  duk_c_function duk_get_c_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Get the Duktape/C function pointer (a <code>duk_c_function</code>) from an
   Ecmascript function object associated with a Duktape/C function.  If the
-  value is not such a function or <code>index</code> is invalid, returns <code>NULL</code>.</p>
+  value is not such a function or <code>idx</code> is invalid, returns <code>NULL</code>.</p>
 
   <p>If you prefer an error to be thrown for an invalid value or index, use
   <code><a href="#duk_require_c_function">duk_require_c_function()</a></code>.</p>

--- a/website/api/duk_get_context.yaml
+++ b/website/api/duk_get_context.yaml
@@ -1,14 +1,14 @@
 name: duk_get_context
 
 proto: |
-  duk_context *duk_get_context(duk_context *ctx, duk_idx_t index);
+  duk_context *duk_get_context(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get a context pointer for a Duktape thread at <code>index</code>.  If the
-  value at <code>index</code> is not a Duktape thread or the index is invalid,
+  <p>Get a context pointer for a Duktape thread at <code>idx</code>.  If the
+  value at <code>idx</code> is not a Duktape thread or the index is invalid,
   returns <code>NULL</code>.</p>
 
   <p>The returned context pointer is only valid while the Duktape thread

--- a/website/api/duk_get_error_code.yaml
+++ b/website/api/duk_get_error_code.yaml
@@ -1,17 +1,17 @@
 name: duk_get_error_code
 
 proto: |
-  duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t index);
+  duk_errcode_t duk_get_error_code(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Map the value at <code>index</code> to the error codes <code>DUK_ERR_xxx</code>
+  <p>Map the value at <code>idx</code> to the error codes <code>DUK_ERR_xxx</code>
   based on which <code>Error</code> subclass the value inherits from.  For example,
   if the value at the stack top is an user-defined error which inherits from
   <code>ReferenceError</code>, the return value will be <code>DUK_ERR_REFERENCE_ERROR</code>.
-  If the value is not an object, does not inherit from <code>Error</code>, or <code>index</code>
+  If the value is not an object, does not inherit from <code>Error</code>, or <code>idx</code>
   is invalid, returns 0 (= <code>DUK_ERR_NONE</code>).</p>
 
 example: |

--- a/website/api/duk_get_finalizer.yaml
+++ b/website/api/duk_get_finalizer.yaml
@@ -1,13 +1,13 @@
 name: duk_get_finalizer
 
 proto: |
-  void duk_get_finalizer(duk_context *ctx, duk_idx_t index);
+  void duk_get_finalizer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... val! ... finalizer! ]
 
 summary: |
-  <p>Get the finalizer associated with a value at <code>index</code>.  If the
+  <p>Get the finalizer associated with a value at <code>idx</code>.  If the
   value is not an object or it is an object without a finalizer,
   <code>undefined</code> is pushed to the stack instead.</p>
 

--- a/website/api/duk_get_heapptr.yaml
+++ b/website/api/duk_get_heapptr.yaml
@@ -1,14 +1,14 @@
 name: duk_get_heapptr
 
 proto: |
-  void *duk_get_heapptr(duk_context *ctx, duk_idx_t index);
+  void *duk_get_heapptr(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Get a borrowed <code>void *</code> reference to a Duktape heap allocated
-  value (object, buffer, string) at <code>index</code>.  Return <code>NULL</code>
+  value (object, buffer, string) at <code>idx</code>.  Return <code>NULL</code>
   if the index is invalid or the target value is not heap allocated.
   The returned pointer must not be interpreted or dereferenced, but
   <code><a href="#duk_push_heapptr">duk_push_heapptr()</a></code> can be used

--- a/website/api/duk_get_int.yaml
+++ b/website/api/duk_get_int.yaml
@@ -1,13 +1,13 @@
 name: duk_get_int
 
 proto: |
-  duk_int_t duk_get_int(duk_context *ctx, duk_idx_t index);
+  duk_int_t duk_get_int(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the number at <code>index</code> and convert it to a C <code>duk_int_t</code>
+  <p>Get the number at <code>idx</code> and convert it to a C <code>duk_int_t</code>
   by first clamping the value between [DUK_INT_MIN, DUK_INT_MAX] and then
   truncating towards zero.  The value on the stack is not modified.
   If the value is a NaN, is not a number, or the index is invalid,

--- a/website/api/duk_get_length.yaml
+++ b/website/api/duk_get_length.yaml
@@ -1,13 +1,13 @@
 name: duk_get_length
 
 proto: |
-  duk_size_t duk_get_length(duk_context *ctx, duk_idx_t index);
+  duk_size_t duk_get_length(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get a type-specific "length" for value at <code>index</code>:</p>
+  <p>Get a type-specific "length" for value at <code>idx</code>:</p>
   <ul>
   <li>String: character length of string (<i>not</i> byte length)</li>
   <li>Object: <code>Math.floor(ToNumber(obj.length))</code> if result within

--- a/website/api/duk_get_lstring.yaml
+++ b/website/api/duk_get_lstring.yaml
@@ -1,13 +1,13 @@
 name: duk_get_lstring
 
 proto: |
-  const char *duk_get_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
+  const char *duk_get_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get character data pointer and length for a string at <code>index</code>
+  <p>Get character data pointer and length for a string at <code>idx</code>
   without modifying or coercing the value.  Returns a non-<code>NULL</code>
   pointer to the read-only, NUL-terminated string data, and writes the
   string byte length to <code>*out_len</code> (if <code>out_len</code> is

--- a/website/api/duk_get_magic.yaml
+++ b/website/api/duk_get_magic.yaml
@@ -1,14 +1,14 @@
 name: duk_get_magic
 
 proto: |
-  duk_int_t duk_get_magic(duk_context *ctx, duk_idx_t index);
+  duk_int_t duk_get_magic(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Get the 16-bit signed "magic" value associated with the Duktape/C function
-  at <code>index</code>.  If the value is not a Duktape/C function, an error is
+  at <code>idx</code>.  If the value is not a Duktape/C function, an error is
   thrown.</p>
 
   <div class="note">

--- a/website/api/duk_get_number.yaml
+++ b/website/api/duk_get_number.yaml
@@ -1,13 +1,13 @@
 name: duk_get_number
 
 proto: |
-  duk_double_t duk_get_number(duk_context *ctx, duk_idx_t index);
+  duk_double_t duk_get_number(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the number value at <code>index</code> without modifying or coercing
+  <p>Get the number value at <code>idx</code> without modifying or coercing
   the value.  Returns <code>NaN</code> if the value is not a number or the
   index is invalid.</p>
 

--- a/website/api/duk_get_pointer.yaml
+++ b/website/api/duk_get_pointer.yaml
@@ -1,13 +1,13 @@
 name: duk_get_pointer
 
 proto: |
-  void *duk_get_pointer(duk_context *ctx, duk_idx_t index);
+  void *duk_get_pointer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the pointer value at <code>index</code> as <code>void *</code> without
+  <p>Get the pointer value at <code>idx</code> as <code>void *</code> without
   modifying or coercing the value.  Returns <code>NULL</code> if the value is
   not a pointer or the index is invalid.</p>
 

--- a/website/api/duk_get_prop.yaml
+++ b/website/api/duk_get_prop.yaml
@@ -1,14 +1,14 @@
 name: duk_get_prop
 
 proto: |
-  duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_index);
+  duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx);
 
 stack: |
   [ ... obj! ... key! ] -> [ ... obj! ... val! ]  (if key exists)
   [ ... obj! ... key! ] -> [ ... obj! ... undefined! ]  (if key doesn't exist)
 
 summary: |
-  <p>Get the property <code>key</code> of a value at <code>obj_index</code>.
+  <p>Get the property <code>key</code> of a value at <code>obj_idx</code>.
   Return code and error throwing behavior:</p>
   <ul>
   <li>If the property exists, <code>1</code> is returned and <code>key</code>
@@ -17,10 +17,10 @@ summary: |
       an error.</li>
   <li>If the property does not exist, 0 is returned and <code>key</code>
       is replaced by <code>undefined</code> on the value stack.</li>
-  <li>If the value at <code>obj_index</code> is not
+  <li>If the value at <code>obj_idx</code> is not
       <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">object coercible</a>,
       throws an error.</li>
-  <li>If <code>obj_index</code> is invalid, throws an error.</li>
+  <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
   <p>The property read is equivalent to the Ecmascript expression:</p>

--- a/website/api/duk_get_prop_index.yaml
+++ b/website/api/duk_get_prop_index.yaml
@@ -1,7 +1,7 @@
 name: duk_get_prop_index
 
 proto: |
-  duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
+  duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... val! ]  (if key exists)
@@ -10,7 +10,7 @@ stack: |
 summary: |
   <p>Like <code><a href="#duk_get_prop">duk_get_prop()</a></code>,
   but the property name is given as an unsigned integer
-  <code>arr_index</code>.  This is especially useful for accessing
+  <code>arr_idx</code>.  This is especially useful for accessing
   array elements (but is not limited to that).</p>
 
   <p>Conceptually the number is coerced to a string for the property

--- a/website/api/duk_get_prop_string.yaml
+++ b/website/api/duk_get_prop_string.yaml
@@ -1,7 +1,7 @@
 name: duk_get_prop_string
 
 proto: |
-  duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
+  duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... val! ]  (if key exists)

--- a/website/api/duk_get_prototype.yaml
+++ b/website/api/duk_get_prototype.yaml
@@ -1,13 +1,13 @@
 name: duk_get_prototype
 
 proto: |
-  void duk_get_prototype(duk_context *ctx, duk_idx_t index);
+  void duk_get_prototype(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... val! ... proto! ]
 
 summary: |
-  <p>Get the internal prototype of the value at <code>index</code>.  If the
+  <p>Get the internal prototype of the value at <code>idx</code>.  If the
   value is not an object, an error is thrown.  If the object has no prototype
   (which is possible for "naked objects") <code>undefined</code> is pushed to
   the stack instead.</p>

--- a/website/api/duk_get_string.yaml
+++ b/website/api/duk_get_string.yaml
@@ -1,13 +1,13 @@
 name: duk_get_string
 
 proto: |
-  const char *duk_get_string(duk_context *ctx, duk_idx_t index);
+  const char *duk_get_string(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get character data pointer for a string at <code>index</code> without
+  <p>Get character data pointer for a string at <code>idx</code> without
   modifying or coercing the value.  Returns a non-<code>NULL</code> pointer to
   the read-only, NUL-terminated string data.  Returns <code>NULL</code> if the
   value is not a string or the index is invalid.</p>

--- a/website/api/duk_get_type.yaml
+++ b/website/api/duk_get_type.yaml
@@ -1,15 +1,15 @@
 name: duk_get_type
 
 proto: |
-  duk_int_t duk_get_type(duk_context *ctx, duk_idx_t index);
+  duk_int_t duk_get_type(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns type of value at <code>index</code>.  The return value is one of
-  <code>DUK_TYPE_xxx</code> or <code>DUK_TYPE_NONE</code> if <code>index</code> is
-  invalid.</p>
+  <p>Returns type of value at <code>idx</code>.  The return value is one of
+  <code>DUK_TYPE_xxx</code> or <code>DUK_TYPE_NONE</code> if <code>idx</code>
+  is invalid.</p>
 
 example: |
   if (duk_get_type(ctx, -3) == DUK_TYPE_NUMBER) {

--- a/website/api/duk_get_type_mask.yaml
+++ b/website/api/duk_get_type_mask.yaml
@@ -1,14 +1,14 @@
 name: duk_get_type_mask
 
 proto: |
-  duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t index);
+  duk_uint_t duk_get_type_mask(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns type mask of value at <code>index</code>.  The return value is one of
-  <code>DUK_TYPE_MASK_xxx</code> or <code>DUK_TYPE_MASK_NONE</code> if <code>index</code>
+  <p>Returns type mask of value at <code>idx</code>.  The return value is one of
+  <code>DUK_TYPE_MASK_xxx</code> or <code>DUK_TYPE_MASK_NONE</code> if <code>idx</code>
   is invalid.</p>
 
   <p>Type masks allow e.g. for a convenient comparison for multiple types at once

--- a/website/api/duk_get_uint.yaml
+++ b/website/api/duk_get_uint.yaml
@@ -1,13 +1,13 @@
 name: duk_get_uint
 
 proto: |
-  duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t index);
+  duk_uint_t duk_get_uint(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Get the number at <code>index</code> and convert it to a C <code>duk_uint_t</code>
+  <p>Get the number at <code>idx</code> and convert it to a C <code>duk_uint_t</code>
   by first clamping the value between [0, DUK_UINT_MAX] and then
   truncating towards zero.  The value on the stack is not modified.
   If the value is a NaN, is not a number, or the index is invalid,

--- a/website/api/duk_has_prop.yaml
+++ b/website/api/duk_has_prop.yaml
@@ -1,20 +1,20 @@
 name: duk_has_prop
 
 proto: |
-  duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_index);
+  duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx);
 
 stack: |
   [ ... obj! ... key! ] -> [ ... obj! ... ]
 
 summary: |
-  <p>Check whether value at <code>obj_index</code> has a property <code>key</code>.
+  <p>Check whether value at <code>obj_idx</code> has a property <code>key</code>.
   <code>key</code> is removed from the stack.  Return code and error throwing
   behavior:</p>
   <ul>
   <li>If the property exists, <code>1</code> is returned.</li>
   <li>If the property doesn't exist, 0 is returned.</li>
-  <li>If the value at <code>obj_index</code> is not an object, throws an error.</li>
-  <li>If <code>obj_index</code> is invalid, throws an error.</li>
+  <li>If the value at <code>obj_idx</code> is not an object, throws an error.</li>
+  <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
   <p>The property existence check is equivalent to the Ecmascript expression:</p>

--- a/website/api/duk_has_prop_index.yaml
+++ b/website/api/duk_has_prop_index.yaml
@@ -1,7 +1,7 @@
 name: duk_has_prop_index
 
 proto: |
-  duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
+  duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Like <code><a href="#duk_has_prop">duk_has_prop()</a></code>,
   but the property name is given as an unsigned integer
-  <code>arr_index</code>.  This is especially useful for checking
+  <code>arr_idx</code>.  This is especially useful for checking
   existence of array elements (but is not limited to that).</p>
 
   <p>Conceptually the number is coerced to a string for property

--- a/website/api/duk_has_prop_string.yaml
+++ b/website/api/duk_has_prop_string.yaml
@@ -1,7 +1,7 @@
 name: duk_has_prop_string
 
 proto: |
-  duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
+  duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]

--- a/website/api/duk_hex_decode.yaml
+++ b/website/api/duk_hex_decode.yaml
@@ -1,7 +1,7 @@
 name: duk_hex_decode
 
 proto: |
-  void duk_hex_decode(duk_context *ctx, duk_idx_t index);
+  void duk_hex_decode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... hex_val! ... ] -> [ ... val! ... ]

--- a/website/api/duk_hex_encode.yaml
+++ b/website/api/duk_hex_encode.yaml
@@ -1,7 +1,7 @@
 name: duk_hex_encode
 
 proto: |
-  const char *duk_hex_encode(duk_context *ctx, duk_idx_t index);
+  const char *duk_hex_encode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... hex_val! ... ]

--- a/website/api/duk_insert.yaml
+++ b/website/api/duk_insert.yaml
@@ -1,15 +1,15 @@
 name: duk_insert
 
 proto: |
-  void duk_insert(duk_context *ctx, duk_idx_t to_index);
+  void duk_insert(duk_context *ctx, duk_idx_t to_idx);
 
 stack: |
-  [ ... old(to_index)! ... val! ] -> [ ... val(to_index)! old! ... ]
+  [ ... old(to_idx)! ... val! ] -> [ ... val(to_idx)! old! ... ]
 
 summary: |
-  <p>Insert a value at <code>to_index</code> with a value popped from the
-  stack top.  The previous value at <code>to_index</code> and any values
-  above it are moved up the stack by a step.  If <code>to_index</code> is
+  <p>Insert a value at <code>to_idx</code> with a value popped from the
+  stack top.  The previous value at <code>to_idx</code> and any values
+  above it are moved up the stack by a step.  If <code>to_idx</code> is
   an invalid index, throws an error.</p>
 
   <div class="note">

--- a/website/api/duk_instanceof.yaml
+++ b/website/api/duk_instanceof.yaml
@@ -1,13 +1,13 @@
 name: duk_instanceof
 
 proto: |
-  duk_bool_t duk_instanceof(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
+  duk_bool_t duk_instanceof(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
 
 stack: |
   [ ... val1! ... val2! ... ]
 
 summary: |
-  <p>Compare values at <code>index1</code> and <code>index2</code> using the
+  <p>Compare values at <code>idx1</code> and <code>idx2</code> using the
   Ecmascript <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.8.6">instanceof</a>
   operator.  Returns 1 if <code>val1 instanceof val2</code>, 0 if not.  Throws an error
   if either index is invalid; <code>instanceof</code> itself also throws errors for
@@ -16,7 +16,7 @@ summary: |
   <div class="note">
   The error throwing behavior for invalid indices differs from the behavior of
   e.g. <code>duk_equals()</code>, and matches the strictness of <code>instanceof</code>.
-  For example, if rval (index2) is not a callable object <code>instanceof</code>
+  For example, if rval (idx2) is not a callable object <code>instanceof</code>
   throws a TypeError.  Throwing an error for an invalid index is consistent with
   instanceof strictness.
   </div>

--- a/website/api/duk_is_array.yaml
+++ b/website/api/duk_is_array.yaml
@@ -1,14 +1,14 @@
 name: duk_is_array
 
 proto: |
-  duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_array(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is an object and is an Ecmascript array
-  (has the internal class <code>Array</code>), otherwise returns 0.  If <code>index</code>
+  <p>Returns 1 if value at <code>idx</code> is an object and is an Ecmascript array
+  (has the internal class <code>Array</code>), otherwise returns 0.  If <code>idx</code>
   is invalid, also returns 0.</p>
 
   <p>This function returns 1 when the following Ecmascript expression is true:</p>

--- a/website/api/duk_is_boolean.yaml
+++ b/website/api/duk_is_boolean.yaml
@@ -1,14 +1,14 @@
 name: duk_is_boolean
 
 proto: |
-  duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a boolean, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a boolean, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_boolean(ctx, -3)) {

--- a/website/api/duk_is_bound_function.yaml
+++ b/website/api/duk_is_bound_function.yaml
@@ -1,15 +1,15 @@
 name: duk_is_bound_function
 
 proto: |
-  duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_bound_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a Function object which has
+  <p>Returns 1 if value at <code>idx</code> is a Function object which has
   been created with Ecmascript <code>Function.prototype.bind()</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>Bound functions are an Ecmascript concept: they point to a target
   function and supply a <code>this</code> binding and zero or more argument

--- a/website/api/duk_is_buffer.yaml
+++ b/website/api/duk_is_buffer.yaml
@@ -1,14 +1,14 @@
 name: duk_is_buffer
 
 proto: |
-  duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a buffer, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a buffer, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_buffer(ctx, -3)) {

--- a/website/api/duk_is_c_function.yaml
+++ b/website/api/duk_is_c_function.yaml
@@ -1,15 +1,15 @@
 name: duk_is_c_function
 
 proto: |
-  duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_c_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a Function object and is
+  <p>Returns 1 if value at <code>idx</code> is a Function object and is
   assocated with a C function, otherwise returns 0.
-  If <code>index</code> is invalid, also returns 0.</p>
+  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>An example of an underlying C function observing the Duktape/C API
   calling convention:</p>

--- a/website/api/duk_is_callable.yaml
+++ b/website/api/duk_is_callable.yaml
@@ -1,14 +1,14 @@
 name: duk_is_callable
 
 proto: |
-  duk_bool_t duk_is_callable(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_callable(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Return 1 if value at <code>index</code> is callable, otherwise returns 0.
-  Also returns 0 if <code>index</code> is invalid.</p>
+  <p>Return 1 if value at <code>idx</code> is callable, otherwise returns 0.
+  Also returns 0 if <code>idx</code> is invalid.</p>
 
   <p>Currently this is the same as
   <code><a href="#duk_is_function">duk_is_function()</a></code>.</p>

--- a/website/api/duk_is_dynamic_buffer.yaml
+++ b/website/api/duk_is_dynamic_buffer.yaml
@@ -1,14 +1,14 @@
 name: duk_is_dynamic_buffer
 
 proto: |
-  duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a dynamic buffer,
-  otherwise returns 0.  If <code>index</code> is invalid, also
+  <p>Returns 1 if value at <code>idx</code> is a dynamic buffer,
+  otherwise returns 0.  If <code>idx</code> is invalid, also
   returns 0.</p>
 
 example: |

--- a/website/api/duk_is_ecmascript_function.yaml
+++ b/website/api/duk_is_ecmascript_function.yaml
@@ -1,15 +1,15 @@
 name: duk_is_ecmascript_function
 
 proto: |
-  duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_ecmascript_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a Function object which has
+  <p>Returns 1 if value at <code>idx</code> is a Function object which has
   been compiled from Ecmascript source code, otherwise returns 0.
-  If <code>index</code> is invalid, also returns 0.</p>
+  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>Internally Ecmascript functions are compiled into bytecode and executed
   with the Ecmascript bytecode interpreter.</p>

--- a/website/api/duk_is_error.yaml
+++ b/website/api/duk_is_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_error
 
 proto: |
-  duk_bool_t duk_is_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>Error</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>Error</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_error(ctx, -3)) {

--- a/website/api/duk_is_eval_error.yaml
+++ b/website/api/duk_is_eval_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_eval_error
 
 proto: |
-  duk_bool_t duk_is_eval_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_eval_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>EvalError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>EvalError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_EVAL_ERROR</code>.</p>
 

--- a/website/api/duk_is_fixed_buffer.yaml
+++ b/website/api/duk_is_fixed_buffer.yaml
@@ -1,14 +1,14 @@
 name: duk_is_fixed_buffer
 
 proto: |
-  duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a fixed buffer,
-  otherwise returns 0.  If <code>index</code> is invalid, also
+  <p>Returns 1 if value at <code>idx</code> is a fixed buffer,
+  otherwise returns 0.  If <code>idx</code> is invalid, also
   returns 0.</p>
 
 example: |

--- a/website/api/duk_is_function.yaml
+++ b/website/api/duk_is_function.yaml
@@ -1,14 +1,14 @@
 name: duk_is_function
 
 proto: |
-  duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is an object and is a function (has the
-  internal class <code>Function</code>), otherwise returns 0.  If <code>index</code> is
+  <p>Returns 1 if value at <code>idx</code> is an object and is a function (has the
+  internal class <code>Function</code>), otherwise returns 0.  If <code>idx</code> is
   invalid, also returns 0.</p>
 
   <p>This function returns 1 when the following Ecmascript expression is true:</p>

--- a/website/api/duk_is_lightfunc.yaml
+++ b/website/api/duk_is_lightfunc.yaml
@@ -1,14 +1,14 @@
 name: duk_is_lightfunc
 
 proto: |
-  duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a lightfunc, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a lightfunc, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_lightfunc(ctx, -3)) {

--- a/website/api/duk_is_nan.yaml
+++ b/website/api/duk_is_nan.yaml
@@ -1,14 +1,14 @@
 name: duk_is_nan
 
 proto: |
-  duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a <code>NaN</code> (a special
-  number value), otherwise returns 0.  If <code>index</code> is invalid,
+  <p>Returns 1 if value at <code>idx</code> is a <code>NaN</code> (a special
+  number value), otherwise returns 0.  If <code>idx</code> is invalid,
   also returns 0.</p>
 
   <p>IEEE has a large number of different <code>NaN</code> values.  Duktape

--- a/website/api/duk_is_null.yaml
+++ b/website/api/duk_is_null.yaml
@@ -1,14 +1,14 @@
 name: duk_is_null
 
 proto: |
-  duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is either <code>null</code>, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is either <code>null</code>, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_null(ctx, -3)) {

--- a/website/api/duk_is_null_or_undefined.yaml
+++ b/website/api/duk_is_null_or_undefined.yaml
@@ -1,14 +1,14 @@
 name: duk_is_null_or_undefined
 
 proto: |
-  duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is either <code>null</code> or <code>undefined</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is either <code>null</code> or <code>undefined</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>This API call is similar to a <code>(x == null)</code> comparison in Ecmascript, which
   is true for both <code>null</code> and <code>undefined</code>.</p>

--- a/website/api/duk_is_number.yaml
+++ b/website/api/duk_is_number.yaml
@@ -1,14 +1,14 @@
 name: duk_is_number
 
 proto: |
-  duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a number, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a number, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_number(ctx, -3)) {

--- a/website/api/duk_is_object.yaml
+++ b/website/api/duk_is_object.yaml
@@ -1,14 +1,14 @@
 name: duk_is_object
 
 proto: |
-  duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is an object, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is an object, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>Note that many values are considered to be an object, e.g.:</p>
 

--- a/website/api/duk_is_object_coercible.yaml
+++ b/website/api/duk_is_object_coercible.yaml
@@ -1,15 +1,15 @@
 name: duk_is_object_coercible
 
 proto: |
-  duk_bool_t duk_is_object_coercible(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_object_coercible(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is object coercible, as defined in
+  <p>Returns 1 if value at <code>idx</code> is object coercible, as defined in
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">CheckObjectCoercible</a>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>All Ecmascript types are object coercible except <code>undefined</code> and
   <code>null</code>.  The custom buffer and pointer types are object coercible.</p>

--- a/website/api/duk_is_pointer.yaml
+++ b/website/api/duk_is_pointer.yaml
@@ -1,14 +1,14 @@
 name: duk_is_pointer
 
 proto: |
-  duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a pointer, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a pointer, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_pointer(ctx, -3)) {

--- a/website/api/duk_is_primitive.yaml
+++ b/website/api/duk_is_primitive.yaml
@@ -1,15 +1,15 @@
 name: duk_is_primitive
 
 proto: |
-  duk_bool_t duk_is_primitive(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_primitive(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a primitive type, as defined in
+  <p>Returns 1 if value at <code>idx</code> is a primitive type, as defined in
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.1">ToPrimitive</a>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
   <p>Anything other than an object is a primitive type at the moment, including
   custom buffer and pointer types.</p>

--- a/website/api/duk_is_range_error.yaml
+++ b/website/api/duk_is_range_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_range_error
 
 proto: |
-  duk_bool_t duk_is_range_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_range_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>RangeError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>RangeError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_RANGE_ERROR</code>.</p>
 

--- a/website/api/duk_is_reference_error.yaml
+++ b/website/api/duk_is_reference_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_reference_error
 
 proto: |
-  duk_bool_t duk_is_reference_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_reference_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>ReferenceError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>ReferenceError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_REFERENCE_ERROR</code>.</p>
 

--- a/website/api/duk_is_string.yaml
+++ b/website/api/duk_is_string.yaml
@@ -1,14 +1,14 @@
 name: duk_is_string
 
 proto: |
-  duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is a string, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is a string, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_string(ctx, -3)) {

--- a/website/api/duk_is_syntax_error.yaml
+++ b/website/api/duk_is_syntax_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_syntax_error
 
 proto: |
-  duk_bool_t duk_is_syntax_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_syntax_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>SyntaxError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>SyntaxError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_SYNTAX_ERROR</code>.</p>
 

--- a/website/api/duk_is_thread.yaml
+++ b/website/api/duk_is_thread.yaml
@@ -1,14 +1,14 @@
 name: duk_is_thread
 
 proto: |
-  duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is an object and is a Duktape
-  thread (coroutine), otherwise returns 0.  If <code>index</code> is invalid,
+  <p>Returns 1 if value at <code>idx</code> is an object and is a Duktape
+  thread (coroutine), otherwise returns 0.  If <code>idx</code> is invalid,
   also returns 0.</p>
 
 example: |

--- a/website/api/duk_is_type_error.yaml
+++ b/website/api/duk_is_type_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_type_error
 
 proto: |
-  duk_bool_t duk_is_type_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_type_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>TypeError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>TypeError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_TYPE_ERROR</code>.</p>
 

--- a/website/api/duk_is_undefined.yaml
+++ b/website/api/duk_is_undefined.yaml
@@ -1,14 +1,14 @@
 name: duk_is_undefined
 
 proto: |
-  duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> is either <code>undefined</code>, otherwise
-  returns 0.  If <code>index</code> is invalid, also returns 0.</p>
+  <p>Returns 1 if value at <code>idx</code> is either <code>undefined</code>, otherwise
+  returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
   if (duk_is_undefined(ctx, -3)) {

--- a/website/api/duk_is_uri_error.yaml
+++ b/website/api/duk_is_uri_error.yaml
@@ -1,14 +1,14 @@
 name: duk_is_uri_error
 
 proto: |
-  duk_bool_t duk_is_uri_error(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_uri_error(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>index</code> inherits from <code>URIError</code>,
-  otherwise returns 0.  If <code>index</code> is invalid, also returns 0.  This is
+  <p>Returns 1 if value at <code>idx</code> inherits from <code>URIError</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.  This is
   a convenience call for using
   <code><a href="#duk_get_error_code">duk_get_error_code()</a> == DUK_ERR_URI_ERROR</code>.</p>
 

--- a/website/api/duk_is_valid_index.yaml
+++ b/website/api/duk_is_valid_index.yaml
@@ -1,7 +1,7 @@
 name: duk_is_valid_index
 
 proto: |
-  duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_is_valid_index(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_json_decode.yaml
+++ b/website/api/duk_json_decode.yaml
@@ -1,7 +1,7 @@
 name: duk_json_decode
 
 proto: |
-  void duk_json_decode(duk_context *ctx, duk_idx_t index);
+  void duk_json_decode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... json_val! ... ] -> [ ... val! ... ]

--- a/website/api/duk_json_encode.yaml
+++ b/website/api/duk_json_encode.yaml
@@ -1,7 +1,7 @@
 name: duk_json_encode
 
 proto: |
-  const char *duk_json_encode(duk_context *ctx, duk_idx_t index);
+  const char *duk_json_encode(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... json_val! ... ]

--- a/website/api/duk_map_string.yaml
+++ b/website/api/duk_map_string.yaml
@@ -1,13 +1,13 @@
 name: duk_map_string
 
 proto: |
-  void duk_map_string(duk_context *ctx, duk_idx_t index, duk_map_char_function callback, void *udata);
+  void duk_map_string(duk_context *ctx, duk_idx_t idx, duk_map_char_function callback, void *udata);
 
 stack: |
   [ ... val! ... ] -> [ ... val! ... ]
 
 summary: |
-  <p>Process string at <code>index</code>, calling <code>callback</code> for each codepoint
+  <p>Process string at <code>idx</code>, calling <code>callback</code> for each codepoint
   of the string.  The callback is given the <code>udata</code> argument and a codepoint
   and returns a replacement codepoint.  If successful, a new string consisting of
   the replacement codepoints replaces the original.  If the value is not a string or

--- a/website/api/duk_next.yaml
+++ b/website/api/duk_next.yaml
@@ -1,7 +1,7 @@
 name: duk_next
 
 proto: |
-  duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_index, duk_bool_t get_value);
+  duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_idx, duk_bool_t get_value);
 
 stack: |
   [ ... enum! ... ] -> [ ... enum! ... ]             (if enum empty; function returns zero)

--- a/website/api/duk_normalize_index.yaml
+++ b/website/api/duk_normalize_index.yaml
@@ -1,7 +1,7 @@
 name: duk_normalize_index
 
 proto: |
-  duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t index);
+  duk_idx_t duk_normalize_index(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_pcall_prop.yaml
+++ b/website/api/duk_pcall_prop.yaml
@@ -1,7 +1,7 @@
 name: duk_pcall_prop
 
 proto: |
-  duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_index, duk_idx_t nargs);
+  duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs);
 
 stack: |
   [ ... obj! ... key! arg1! ...! argN! ] -> [ ... obj! ... retval! ]  (if success, return value == 0)

--- a/website/api/duk_put_function_list.yaml
+++ b/website/api/duk_put_function_list.yaml
@@ -1,13 +1,13 @@
 name: duk_put_function_list
 
 proto: |
-  void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs);
+  void duk_put_function_list(duk_context *ctx, duk_idx_t obj_idx, const duk_function_list_entry *funcs);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]
 
 summary: |
-  <p>Set multiple function properties into a target object at <code>obj_index</code>.
+  <p>Set multiple function properties into a target object at <code>obj_idx</code>.
   The functions are specified as a list of triples (name, function, nargs), ending
   with a triple where name is <code>NULL</code> (preferably also function is
   <code>NULL</code> for sanity).</p>

--- a/website/api/duk_put_number_list.yaml
+++ b/website/api/duk_put_number_list.yaml
@@ -1,14 +1,14 @@
 name: duk_put_number_list
 
 proto: |
-  void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers);
+  void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const duk_number_list_entry *numbers);
 
 stack: |
   [ ... obj! ... ] -> [ ... obj! ... ]
 
 summary: |
   <p>Set multiple number (<code>double</code>) properties into a target object
-  at <code>obj_index</code>.  The number list is given as a list of pairs
+  at <code>obj_idx</code>.  The number list is given as a list of pairs
   (name, number), ending with a pair where the name is <code>NULL</code>.</p>
 
   <p>This is useful e.g. when defining numeric constants for modules or

--- a/website/api/duk_put_prop.yaml
+++ b/website/api/duk_put_prop.yaml
@@ -1,23 +1,23 @@
 name: duk_put_prop
 
 proto: |
-  duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_index);
+  duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx);
 
 stack: |
   [ ... obj! ... key! val! ] -> [ ... obj! ... ]
 
 summary: |
   <p>Write <code>val</code> to the property <code>key</code> of a value at
-  <code>obj_index</code>.  <code>key</code> and <code>val</code> are removed
+  <code>obj_idx</code>.  <code>key</code> and <code>val</code> are removed
   from the stack.  Return code and error throwing behavior:</p>
   <ul>
   <li>If the property write succeeds, returns <code>1</code>.</li>
   <li>If the property write fails, throws an error (strict mode semantics).
       An error may also be thrown by the "setter" function of an accessor property.</li>
-  <li>If the value at <code>obj_index</code> is not
+  <li>If the value at <code>obj_idx</code> is not
       <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">object coercible</a>,
       throws an error.</li>
-  <li>If <code>obj_index</code> is invalid, throws an error.</li>
+  <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
   <p>The property write is equivalent to the Ecmascript expression:</p>

--- a/website/api/duk_put_prop_index.yaml
+++ b/website/api/duk_put_prop_index.yaml
@@ -1,7 +1,7 @@
 name: duk_put_prop_index
 
 proto: |
-  duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index);
+  duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 
 stack: |
   [ ... obj! ... val! ] -> [ ... obj! ... ]
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Like <code><a href="#duk_put_prop">duk_put_prop()</a></code>,
   but the property name is given as an unsigned integer
-  <code>arr_index</code>.  This is especially useful for writing to
+  <code>arr_idx</code>.  This is especially useful for writing to
   array elements (but is not limited to that).</p>
 
   <p>Conceptually the number is coerced to a string for the property

--- a/website/api/duk_put_prop_string.yaml
+++ b/website/api/duk_put_prop_string.yaml
@@ -1,7 +1,7 @@
 name: duk_put_prop_string
 
 proto: |
-  duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_index, const char *key);
+  duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 
 stack: |
   [ ... obj! ... val! ] -> [ ... obj! ... ]

--- a/website/api/duk_remove.yaml
+++ b/website/api/duk_remove.yaml
@@ -1,15 +1,15 @@
 name: duk_remove
 
 proto: |
-  void duk_remove(duk_context *ctx, duk_idx_t index);
+  void duk_remove(duk_context *ctx, duk_idx_t idx);
 
 stack: |
-  [ ... val(index)! ... ] -> [ ... ... ]
+  [ ... val(idx)! ... ] -> [ ... ... ]
 
 summary: |
-  <p>Remove value at <code>index</code>.  Elements above <code>index</code>
-  are shifted down the stack by a step.  If <code>to_index</code> is
-  an invalid index, throws an error.</p>
+  <p>Remove value at <code>idx</code>.  Elements above <code>idx</code>
+  are shifted down the stack by a step.  If <code>idx</code> is an invalid
+  index, throws an error.</p>
 
 example: |
   duk_push_int(ctx, 123);

--- a/website/api/duk_replace.yaml
+++ b/website/api/duk_replace.yaml
@@ -1,14 +1,14 @@
 name: duk_replace
 
 proto: |
-  void duk_replace(duk_context *ctx, duk_idx_t to_index);
+  void duk_replace(duk_context *ctx, duk_idx_t to_idx);
 
 stack: |
-  [ ... old(to_index)! ... val! ] -> [ ... val(to_index)! ... ]
+  [ ... old(to_idx)! ... val! ] -> [ ... val(to_idx)! ... ]
 
 summary: |
-  <p>Replace value at <code>to_index</code> with a value popped from the
-  stack top.  If <code>to_index</code> is an invalid index, throws an error.</p>
+  <p>Replace value at <code>to_idx</code> with a value popped from the
+  stack top.  If <code>to_idx</code> is an invalid index, throws an error.</p>
 
   <div class="note">
   Negative indices are evaluated prior to popping the value at the stack

--- a/website/api/duk_require_boolean.yaml
+++ b/website/api/duk_require_boolean.yaml
@@ -1,14 +1,14 @@
 name: duk_require_boolean
 
 proto: |
-  duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_require_boolean(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_boolean">duk_get_boolean()</a></code>,
-  but throws an error if the value at <code>index</code> is not a boolean
+  but throws an error if the value at <code>idx</code> is not a boolean
   or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_buffer.yaml
+++ b/website/api/duk_require_buffer.yaml
@@ -1,14 +1,14 @@
 name: duk_require_buffer
 
 proto: |
-  void *duk_require_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_require_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_buffer">duk_get_buffer()</a></code>,
-  but throws an error if the value at <code>index</code> is not a (plain)
+  but throws an error if the value at <code>idx</code> is not a (plain)
   buffer or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_buffer_data.yaml
+++ b/website/api/duk_require_buffer_data.yaml
@@ -1,14 +1,14 @@
 name: duk_require_buffer_data
 
 proto: |
-  void *duk_require_buffer_data(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_require_buffer_data(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_buffer_data">duk_get_buffer_data()</a></code>,
-  but throws an error if the value at <code>index</code> is not a plain buffer
+  but throws an error if the value at <code>idx</code> is not a plain buffer
   or a buffer object or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_c_function.yaml
+++ b/website/api/duk_require_c_function.yaml
@@ -1,14 +1,14 @@
 name: duk_require_c_function
 
 proto: |
-  duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t index);
+  duk_c_function duk_require_c_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_c_function">duk_get_c_function()</a></code>, but
-  throws an error if the value at <code>index</code> is not an Ecmascript function
+  throws an error if the value at <code>idx</code> is not an Ecmascript function
   associated with a Duktape/C function or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_callable.yaml
+++ b/website/api/duk_require_callable.yaml
@@ -1,13 +1,13 @@
 name: duk_require_callable
 
 proto: |
-  void duk_require_callable(duk_context *ctx, duk_idx_t index);
+  void duk_require_callable(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Throw an error if the value at <code>index</code> is not callable
+  <p>Throw an error if the value at <code>idx</code> is not callable
   or if the index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_require_context.yaml
+++ b/website/api/duk_require_context.yaml
@@ -1,14 +1,14 @@
 name: duk_require_context
 
 proto: |
-  duk_context *duk_require_context(duk_context *ctx, duk_idx_t index);
+  duk_context *duk_require_context(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_context">duk_get_context()</a></code>,
-  but throws an error if the value at <code>index</code> is not a Duktape
+  but throws an error if the value at <code>idx</code> is not a Duktape
   thread or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_function.yaml
+++ b/website/api/duk_require_function.yaml
@@ -1,13 +1,13 @@
 name: duk_require_function
 
 proto: |
-  void duk_require_function(duk_context *ctx, duk_idx_t index);
+  void duk_require_function(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Throw an error if the value at <code>index</code> is not a function
+  <p>Throw an error if the value at <code>idx</code> is not a function
   or if the index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_require_heapptr.yaml
+++ b/website/api/duk_require_heapptr.yaml
@@ -1,14 +1,14 @@
 name: duk_require_heapptr
 
 proto: |
-  void *duk_require_heapptr(duk_context *ctx, duk_idx_t index);
+  void *duk_require_heapptr(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_heapptr">duk_get_heapptr()</a></code>,
-  but throws an error if the value at <code>index</code> is not a Duktape
+  but throws an error if the value at <code>idx</code> is not a Duktape
   heap allocated value (object, buffer, string) or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_int.yaml
+++ b/website/api/duk_require_int.yaml
@@ -1,14 +1,14 @@
 name: duk_require_int
 
 proto: |
-  duk_int_t duk_require_int(duk_context *ctx, duk_idx_t index);
+  duk_int_t duk_require_int(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_int">duk_get_int()</a></code>,
-  but throws an error if the value at <code>index</code> is not a number
+  but throws an error if the value at <code>idx</code> is not a number
   or if the index is invalid.</p>
 
   <!--

--- a/website/api/duk_require_lstring.yaml
+++ b/website/api/duk_require_lstring.yaml
@@ -1,14 +1,14 @@
 name: duk_require_lstring
 
 proto: |
-  const char *duk_require_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
+  const char *duk_require_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_lstring">duk_get_lstring()</a></code>,
-  but throws an error if the value at <code>index</code> is not a string
+  but throws an error if the value at <code>idx</code> is not a string
   or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_normalize_index.yaml
+++ b/website/api/duk_require_normalize_index.yaml
@@ -1,7 +1,7 @@
 name: duk_require_normalize_index
 
 proto: |
-  duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t index);
+  duk_idx_t duk_require_normalize_index(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_require_null.yaml
+++ b/website/api/duk_require_null.yaml
@@ -1,13 +1,13 @@
 name: duk_require_null
 
 proto: |
-  void duk_require_null(duk_context *ctx, duk_idx_t index);
+  void duk_require_null(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Throw an error if the value at <code>index</code> is not <code>null</code>
+  <p>Throw an error if the value at <code>idx</code> is not <code>null</code>
   or if the index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_require_number.yaml
+++ b/website/api/duk_require_number.yaml
@@ -1,14 +1,14 @@
 name: duk_require_number
 
 proto: |
-  duk_double_t duk_require_number(duk_context *ctx, duk_idx_t index);
+  duk_double_t duk_require_number(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_number">duk_get_number()</a></code>,
-  but throws an error if the value at <code>index</code> is not a number
+  but throws an error if the value at <code>idx</code> is not a number
   or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_object_coercible.yaml
+++ b/website/api/duk_require_object_coercible.yaml
@@ -1,7 +1,7 @@
 name: duk_require_object_coercible
 
 proto: |
-  void duk_require_object_coercible(duk_context *ctx, duk_idx_t index);
+  void duk_require_object_coercible(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_require_pointer.yaml
+++ b/website/api/duk_require_pointer.yaml
@@ -1,14 +1,14 @@
 name: duk_require_pointer
 
 proto: |
-  void *duk_require_pointer(duk_context *ctx, duk_idx_t index);
+  void *duk_require_pointer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_pointer">duk_get_pointer()</a></code>,
-  but throws an error if the value at <code>index</code> is not a pointer
+  but throws an error if the value at <code>idx</code> is not a pointer
   or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_string.yaml
+++ b/website/api/duk_require_string.yaml
@@ -1,14 +1,14 @@
 name: duk_require_string
 
 proto: |
-  const char *duk_require_string(duk_context *ctx, duk_idx_t index);
+  const char *duk_require_string(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_string">duk_get_string()</a></code>,
-  but throws an error if the value at <code>index</code> is not a string
+  but throws an error if the value at <code>idx</code> is not a string
   or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_require_type_mask.yaml
+++ b/website/api/duk_require_type_mask.yaml
@@ -1,7 +1,7 @@
 name: duk_require_type_mask
 
 proto: |
-  void duk_require_type_mask(duk_context *ctx, duk_idx_t index, duk_uint_t mask);
+  void duk_require_type_mask(duk_context *ctx, duk_idx_t idx, duk_uint_t mask);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_require_uint.yaml
+++ b/website/api/duk_require_uint.yaml
@@ -1,14 +1,14 @@
 name: duk_require_uint
 
 proto: |
-  duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t index);
+  duk_uint_t duk_require_uint(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Like <code><a href="#duk_get_uint">duk_get_uint()</a></code>,
-  but throws an error if the value at <code>index</code> is not a number
+  but throws an error if the value at <code>idx</code> is not a number
   or if the index is invalid.</p>
 
   <!--

--- a/website/api/duk_require_undefined.yaml
+++ b/website/api/duk_require_undefined.yaml
@@ -1,13 +1,13 @@
 name: duk_require_undefined
 
 proto: |
-  void duk_require_undefined(duk_context *ctx, duk_idx_t index);
+  void duk_require_undefined(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Throw an error if the value at <code>index</code> is not <code>undefined</code>
+  <p>Throw an error if the value at <code>idx</code> is not <code>undefined</code>
   or if the index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_require_valid_index.yaml
+++ b/website/api/duk_require_valid_index.yaml
@@ -1,7 +1,7 @@
 name: duk_require_valid_index
 
 proto: |
-  void duk_require_valid_index(duk_context *ctx, duk_idx_t index);
+  void duk_require_valid_index(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_resize_buffer.yaml
+++ b/website/api/duk_resize_buffer.yaml
@@ -1,18 +1,18 @@
 name: duk_resize_buffer
 
 proto: |
-  void *duk_resize_buffer(duk_context *ctx, duk_idx_t index, duk_size_t new_size);
+  void *duk_resize_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t new_size);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Resize a dynamic buffer at <code>index</code> to <code>new_size</code> bytes.
+  <p>Resize a dynamic buffer at <code>idx</code> to <code>new_size</code> bytes.
   If <code>new_size</code> is larger than the current size, newly allocated bytes
   (above old size) are automatically zeroed.  Returns a pointer to the new buffer
   data area.  If <code>new_size</code> is zero, may return either <code>NULL</code> or some
-  non-<code>NULL</code> value.  If resizing fails, the value at <code>index</code> is not
-  a dynamic buffer, or <code>index</code> is invalid, throws an error.</p>
+  non-<code>NULL</code> value.  If resizing fails, the value at <code>idx</code> is not
+  a dynamic buffer, or <code>idx</code> is invalid, throws an error.</p>
 
 example: |
   void *ptr;

--- a/website/api/duk_safe_to_lstring.yaml
+++ b/website/api/duk_safe_to_lstring.yaml
@@ -1,7 +1,7 @@
 name: duk_safe_to_lstring
 
 proto: |
-  const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
+  const char *duk_safe_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
 
 stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]

--- a/website/api/duk_safe_to_string.yaml
+++ b/website/api/duk_safe_to_string.yaml
@@ -1,7 +1,7 @@
 name: duk_safe_to_string
 
 proto: |
-  const char *duk_safe_to_string(duk_context *ctx, duk_idx_t index);
+  const char *duk_safe_to_string(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]

--- a/website/api/duk_set_finalizer.yaml
+++ b/website/api/duk_set_finalizer.yaml
@@ -1,13 +1,13 @@
 name: duk_set_finalizer
 
 proto: |
-  void duk_set_finalizer(duk_context *ctx, duk_idx_t index);
+  void duk_set_finalizer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... finalizer! ] -> [ ... val! ... ]
 
 summary: |
-  <p>Set the finalizer of the value at <code>index</code> to the value at
+  <p>Set the finalizer of the value at <code>idx</code> to the value at
   stack top.  If the target value is not an object an error is thrown.  The
   finalizer value can be an arbitrary one; non-function values are treated
   as if no finalizer was set.  To delete a finalizer from an object, set it

--- a/website/api/duk_set_magic.yaml
+++ b/website/api/duk_set_magic.yaml
@@ -1,14 +1,14 @@
 name: duk_set_magic
 
 proto: |
-  void duk_set_magic(duk_context *ctx, duk_idx_t index, duk_int_t magic);
+  void duk_set_magic(duk_context *ctx, duk_idx_t idx, duk_int_t magic);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
   <p>Set the 16-bit signed "magic" value associated with the Duktape/C function
-  at <code>index</code>.  If the value is not a Duktape/C function, an error is
+  at <code>idx</code>.  If the value is not a Duktape/C function, an error is
   thrown.</p>
 
 example: |

--- a/website/api/duk_set_prototype.yaml
+++ b/website/api/duk_set_prototype.yaml
@@ -1,13 +1,13 @@
 name: duk_set_prototype
 
 proto: |
-  void duk_set_prototype(duk_context *ctx, duk_idx_t index);
+  void duk_set_prototype(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... proto! ] -> [ ... val! ... ]
 
 summary: |
-  <p>Set the internal prototype of the value at <code>index</code> to the value
+  <p>Set the internal prototype of the value at <code>idx</code> to the value
   at stack top (which must be an object or <code>undefined</code>).  If the
   target value is not an object or the prototype value is not an object or
   <code>undefined</code>, an error is thrown.</p>

--- a/website/api/duk_set_top.yaml
+++ b/website/api/duk_set_top.yaml
@@ -1,13 +1,13 @@
 name: duk_set_top
 
 proto: |
-  void duk_set_top(duk_context *ctx, duk_idx_t index);
+  void duk_set_top(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ...! ] -> [ ...! ]
 
 summary: |
-  <p>Set stack top (stack size) to match the argument <code>index</code>,
+  <p>Set stack top (stack size) to match the argument <code>idx</code>,
   normalizing negative index values.  If the value stack shrinks,
   values above the new stack top are dropped; if the value stack grows,
   <code>undefined</code> values are pushed to the new stack slots.</p>

--- a/website/api/duk_steal_buffer.yaml
+++ b/website/api/duk_steal_buffer.yaml
@@ -1,13 +1,13 @@
 name: duk_steal_buffer
 
 proto: |
-  void *duk_steal_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_steal_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Steal the current allocation of the dynamic buffer at <code>index</code>.
+  <p>Steal the current allocation of the dynamic buffer at <code>idx</code>.
   In concrete terms, Duktape forgets the previous allocation and resets the
   buffer to zero size (and NULL data pointer).  Pointer to the previous
   allocation is returned and previous allocation length is written to

--- a/website/api/duk_strict_equals.yaml
+++ b/website/api/duk_strict_equals.yaml
@@ -1,13 +1,13 @@
 name: duk_strict_equals
 
 proto: |
-  duk_bool_t duk_strict_equals(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
+  duk_bool_t duk_strict_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
 
 stack: |
   [ ... val1! ... val2! ... ]
 
 summary: |
-  <p>Compare values at <code>index1</code> and <code>index2</code> for equality.
+  <p>Compare values at <code>idx1</code> and <code>idx2</code> for equality.
   Returns 1 if values are considered equal using Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.4">Strict Equals</a>
   operator (<code>===</code>) semantics, otherwise returns 0.  Also returns 0 if either index

--- a/website/api/duk_substring.yaml
+++ b/website/api/duk_substring.yaml
@@ -1,14 +1,14 @@
 name: duk_substring
 
 proto: |
-  void duk_substring(duk_context *ctx, duk_idx_t index, duk_size_t start_char_offset, duk_size_t end_char_offset);
+  void duk_substring(duk_context *ctx, duk_idx_t idx, duk_size_t start_char_offset, duk_size_t end_char_offset);
 
 stack: |
   [ ... str! ... ] -> [ ... substr! ... ]
 
 summary: |
-  <p>Replace a string at <code>index</code> with a substring [<code>start_char_offset</code>,
-  <code>end_char_offset</code>[ of the string itself.  If the value at <code>index</code> is
+  <p>Replace a string at <code>idx</code> with a substring [<code>start_char_offset</code>,
+  <code>end_char_offset</code>[ of the string itself.  If the value at <code>idx</code> is
   not a string or the index is invalid, throws an error.</p>
 
   <p>The substring operation works with characters, not bytes, and the offsets

--- a/website/api/duk_swap.yaml
+++ b/website/api/duk_swap.yaml
@@ -1,13 +1,13 @@
 name: duk_swap
 
 proto: |
-  void duk_swap(duk_context *ctx, duk_idx_t index1, duk_idx_t index2);
+  void duk_swap(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
 
 stack: |
   [ ... val1! ... val2! ... ] -> [ ... val2! ... val1! ... ]
 
 summary: |
-  <p>Swap values at indices <code>index1</code> and <code>index2</code>.  If the
+  <p>Swap values at indices <code>idx1</code> and <code>idx2</code>.  If the
   indices are the same, the call is a no-op.  If either index is invalid,
   throws an error.</p>
 

--- a/website/api/duk_swap_top.yaml
+++ b/website/api/duk_swap_top.yaml
@@ -1,15 +1,15 @@
 name: duk_swap_top
 
 proto: |
-  void duk_swap_top(duk_context *ctx, duk_idx_t index);
+  void duk_swap_top(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val1! ... val2! ] -> [ ... val2! ... val1! ]
 
 summary: |
-  <p>Swap stack top with value at <code>index</code>.  If <code>index</code> refers
+  <p>Swap stack top with value at <code>idx</code>.  If <code>idx</code> refers
   to the stack top, the call is a no-op.  If the value stack is empty or
-  <code>index</code> is invalid, throws an error.</p>
+  <code>idx</code> is invalid, throws an error.</p>
 
 example: |
   duk_swap_top(ctx, -3);

--- a/website/api/duk_to_boolean.yaml
+++ b/website/api/duk_to_boolean.yaml
@@ -1,16 +1,16 @@
 name: duk_to_boolean
 
 proto: |
-  duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t index);
+  duk_bool_t duk_to_boolean(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToBoolean(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.2">ToBoolean()</a>
   coerced value.  Returns 1 if the result of the coercion <code>true</code>, 0 otherwise.
-  If <code>index</code> is invalid, throws an error.</p>
+  If <code>idx</code> is invalid, throws an error.</p>
 
   <div include="ref-custom-type-coercion.html" />
 

--- a/website/api/duk_to_buffer.yaml
+++ b/website/api/duk_to_buffer.yaml
@@ -1,16 +1,16 @@
 name: duk_to_buffer
 
 proto: |
-  void *duk_to_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_to_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ] -> [ ... buffer(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with a buffer-coerced value.  Returns
+  <p>Replace the value at <code>idx</code> with a buffer-coerced value.  Returns
   a pointer to the buffer data (may be <code>NULL</code> for a zero-size buffer),
   and writes the size of the buffer into <code>*out_size</code> (if <code>out_size</code>
-  is non-<code>NULL</code>).  If <code>index</code> is invalid, throws an error.</p>
+  is non-<code>NULL</code>).  If <code>idx</code> is invalid, throws an error.</p>
 
   <p>Coercion rules:</p>
   <ul>

--- a/website/api/duk_to_defaultvalue.yaml
+++ b/website/api/duk_to_defaultvalue.yaml
@@ -1,20 +1,20 @@
 name: duk_to_defaultvalue
 
 proto: |
-  void duk_to_defaultvalue(duk_context *ctx, duk_idx_t index, duk_int_t hint);
+  void duk_to_defaultvalue(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
 
 stack: |
   [ ... val! ... ] -> [ ... DefaultValue(val)! ... ]
 
 summary: |
-  <p>Replace the object at <code>index</code> with an Ecmascript
+  <p>Replace the object at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.8">[[DefaultValue]]</a>
   coerced value.  The <code>hint</code> argument indicates preference for a string
   (<code>DUK_HINT_STRING</code>), a number (<code>DUK_HINT_NUMBER</code>), or neither
   (<code>DUK_HINT_NONE</code>).  <code>DUK_HINT_NONE</code> causes a preference to a number, unless
   the input value is a <code>Date</code> instance, in which case a string is preferred
   (the exact coercion behavior is described in the Ecmascript specification).
-  If the value is not an object or <code>index</code> is invalid, throws an error.</p>
+  If the value is not an object or <code>idx</code> is invalid, throws an error.</p>
 
   <div include="ref-custom-type-coercion.html" />
 

--- a/website/api/duk_to_dynamic_buffer.yaml
+++ b/website/api/duk_to_dynamic_buffer.yaml
@@ -1,7 +1,7 @@
 name: duk_to_dynamic_buffer
 
 proto: |
-  void *duk_to_dynamic_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_to_dynamic_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_to_fixed_buffer.yaml
+++ b/website/api/duk_to_fixed_buffer.yaml
@@ -1,7 +1,7 @@
 name: duk_to_fixed_buffer
 
 proto: |
-  void *duk_to_fixed_buffer(duk_context *ctx, duk_idx_t index, duk_size_t *out_size);
+  void *duk_to_fixed_buffer(duk_context *ctx, duk_idx_t idx, duk_size_t *out_size);
 
 stack: |
   [ ... val! ... ]

--- a/website/api/duk_to_int32.yaml
+++ b/website/api/duk_to_int32.yaml
@@ -1,15 +1,15 @@
 name: duk_to_int32
 
 proto: |
-  duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t index);
+  duk_int32_t duk_to_int32(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToInt32(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.5">ToInt32()</a>
-  coerced value.  Returns the coerced value.  If <code>index</code> is invalid, throws
+  coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>
 
   <div include="ref-custom-type-coercion.html" />

--- a/website/api/duk_to_lstring.yaml
+++ b/website/api/duk_to_lstring.yaml
@@ -1,17 +1,17 @@
 name: duk_to_lstring
 
 proto: |
-  const char *duk_to_lstring(duk_context *ctx, duk_idx_t index, duk_size_t *out_len);
+  const char *duk_to_lstring(duk_context *ctx, duk_idx_t idx, duk_size_t *out_len);
 
 stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.8">ToString()</a>
   coerced value.  Returns a non-<code>NULL</code> pointer to the read-only,
   NUL-terminated string data, and writes the string byte length to <code>*out_len</code>
-  (if <code>out_len</code> is non-<code>NULL</code>).  If <code>index</code> is invalid, throws
+  (if <code>out_len</code> is non-<code>NULL</code>).  If <code>idx</code> is invalid, throws
   an error.</p>
 
   <div include="ref-custom-type-coercion.html" />

--- a/website/api/duk_to_null.yaml
+++ b/website/api/duk_to_null.yaml
@@ -1,13 +1,13 @@
 name: duk_to_null
 
 proto: |
-  void duk_to_null(duk_context *ctx, duk_idx_t index);
+  void duk_to_null(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... null! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with <code>null</code>, regardless
+  <p>Replace the value at <code>idx</code> with <code>null</code>, regardless
   of the previous value.  Throws an error if index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_to_number.yaml
+++ b/website/api/duk_to_number.yaml
@@ -1,15 +1,15 @@
 name: duk_to_number
 
 proto: |
-  duk_double_t duk_to_number(duk_context *ctx, duk_idx_t index);
+  duk_double_t duk_to_number(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToNumber(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.3">ToNumber()</a>
-  coerced value.  Returns the coerced value.  If <code>index</code> is invalid, throws
+  coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>
 
   <div include="ref-custom-type-coercion.html" />

--- a/website/api/duk_to_object.yaml
+++ b/website/api/duk_to_object.yaml
@@ -1,18 +1,18 @@
 name: duk_to_object
 
 proto: |
-  void duk_to_object(duk_context *ctx, duk_idx_t index);
+  void duk_to_object(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToObject(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.9">ToObject()</a>
   coerced value.  There is no return value.  Throws an error if value at
-  <code>index</code> is not
+  <code>idx</code> is not
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">object coercible</a>,
-  or if <code>index</code> is invalid.</p>
+  or if <code>idx</code> is invalid.</p>
 
   <p>The following types are not object coercible:</p>
   <ul>

--- a/website/api/duk_to_pointer.yaml
+++ b/website/api/duk_to_pointer.yaml
@@ -1,14 +1,14 @@
 name: duk_to_pointer
 
 proto: |
-  void *duk_to_pointer(duk_context *ctx, duk_idx_t index);
+  void *duk_to_pointer(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... pointer(val)! ... ]
 
 summary: |
-  <p>Replaces the value at <code>index</code> with a pointer-coerced value.  Returns
-  the resulting <code>void *</code> value.  If <code>index</code> is invalid, throws an
+  <p>Replaces the value at <code>idx</code> with a pointer-coerced value.  Returns
+  the resulting <code>void *</code> value.  If <code>idx</code> is invalid, throws an
   error.</p>
 
   <p>Coercion rules:</p>

--- a/website/api/duk_to_primitive.yaml
+++ b/website/api/duk_to_primitive.yaml
@@ -1,20 +1,20 @@
 name: duk_to_primitive
 
 proto: |
-  void duk_to_primitive(duk_context *ctx, duk_idx_t index, duk_int_t hint);
+  void duk_to_primitive(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
 
 stack: |
   [ ... val! ... ] -> [ ... ToPrimitive(val)! ]
 
 summary: |
-  <p>Replace the object at <code>index</code> with an Ecmascript
+  <p>Replace the object at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.1">ToPrimitive()</a>
   coerced value.  The <code>hint</code> argument affects coercion of an object into a
   primitive type, and indicates preference for a string (<code>DUK_HINT_STRING</code>),
   a number (<code>DUK_HINT_NUMBER</code>), or neither (<code>DUK_HINT_NONE</code>).
   <code>DUK_HINT_NONE</code> causes a preference to a number, unless the input value
   is a <code>Date</code> instance, in which case a string is preferred (the exact
-  coercion behavior is described in the Ecmascript specification).  If <code>index</code>
+  coercion behavior is described in the Ecmascript specification).  If <code>idx</code>
   is invalid, throws an error.</p>
 
   <p>Custom type coercion:</p>

--- a/website/api/duk_to_string.yaml
+++ b/website/api/duk_to_string.yaml
@@ -1,16 +1,16 @@
 name: duk_to_string
 
 proto: |
-  const char *duk_to_string(duk_context *ctx, duk_idx_t index);
+  const char *duk_to_string(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.8">ToString()</a>
   coerced value.  Returns a non-<code>NULL</code> pointer to the read-only,
-  NUL-terminated string data.  If <code>index</code> is invalid, throws an error.</p>
+  NUL-terminated string data.  If <code>idx</code> is invalid, throws an error.</p>
 
   <div include="ref-custom-type-coercion.html" />
 

--- a/website/api/duk_to_uint.yaml
+++ b/website/api/duk_to_uint.yaml
@@ -1,7 +1,7 @@
 name: duk_to_uint
 
 proto: |
-  duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t index);
+  duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToNumber(val)! ... ]

--- a/website/api/duk_to_uint16.yaml
+++ b/website/api/duk_to_uint16.yaml
@@ -1,15 +1,15 @@
 name: duk_to_uint16
 
 proto: |
-  duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t index);
+  duk_uint16_t duk_to_uint16(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToUint16(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.7">ToUint16()</a>
-  coerced value.  Returns the coerced value.  If <code>index</code> is invalid, throws
+  coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>
 
   <div include="ref-custom-type-coercion.html" />

--- a/website/api/duk_to_uint32.yaml
+++ b/website/api/duk_to_uint32.yaml
@@ -1,15 +1,15 @@
 name: duk_to_uint32
 
 proto: |
-  duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t index);
+  duk_uint32_t duk_to_uint32(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... ToUint32(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an Ecmascript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.6">ToUint32()</a>
-  coerced value.  Returns the coerced value.  If <code>index</code> is invalid, throws
+  coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>
 
   <div include="ref-custom-type-coercion.html" />

--- a/website/api/duk_to_undefined.yaml
+++ b/website/api/duk_to_undefined.yaml
@@ -1,13 +1,13 @@
 name: duk_to_undefined
 
 proto: |
-  void duk_to_undefined(duk_context *ctx, duk_idx_t index);
+  void duk_to_undefined(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... val! ... ] -> [ ... undefined! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with <code>undefined</code>, regardless
+  <p>Replace the value at <code>idx</code> with <code>undefined</code>, regardless
   of the previous value.  Throws an error if index is invalid.</p>
 
   <div class="note">

--- a/website/api/duk_trim.yaml
+++ b/website/api/duk_trim.yaml
@@ -1,13 +1,13 @@
 name: duk_trim
 
 proto: |
-  void duk_trim(duk_context *ctx, duk_idx_t index);
+  void duk_trim(duk_context *ctx, duk_idx_t idx);
 
 stack: |
   [ ... str! ... ] -> [ ... trimmed_str! ... ]
 
 summary: |
-  <p>Trim string at <code>index</code>.  If the value at <code>index</code> is not a
+  <p>Trim string at <code>idx</code>.  If the value at <code>idx</code> is not a
   string or the index is invalid, throws an error.</p>
 
   <p>Trimming removes white space characters from the beginning and


### PR DESCRIPTION
- [x] Rename `index` -> `idx` in sources
- [x] Rename in website and API documentation
- [x] Code issues note
- [x] Regression testing; could codepolicycheck detect a blacklist of bad names?
- [x] Releases entry