### PR TITLE
Fix some signed shift warnings for clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ CCOPTS_FEATURES =
 #CCOPTS_FEATURES += -DDUK_OPT_NO_MARK_AND_SWEEP
 #CCOPTS_FEATURES += -DDUK_OPT_NO_VOLUNTARY_GC
 #CCOPTS_FEATURES += -DDUK_OPT_NO_FILE_IO
-CCOPTS_FEATURES += '-DDUK_OPT_FATAL_HANDLER(udata,msg)=do { const char *fatal_msg = (msg); fprintf(stderr, "*** FATAL ERROR: %s\n", fatal_msg ? fatal_msg : "no message"); *((unsigned int *) 0) = (unsigned int) 0xdeadbeefUL; abort(); } while(0)'
+CCOPTS_FEATURES += '-DDUK_OPT_FATAL_HANDLER(udata,msg)=do { const char *fatal_msg = (msg); fprintf(stderr, "*** FATAL ERROR: %s\n", fatal_msg ? fatal_msg : "no message"); *((volatile unsigned int *) 0) = (unsigned int) 0xdeadbeefUL; abort(); } while(0)'
 CCOPTS_FEATURES += -DDUK_OPT_SELF_TESTS
 #CCOPTS_FEATURES += -DDUK_OPT_NO_TRACEBACKS
 #CCOPTS_FEATURES += -DDUK_OPT_NO_PC2LINE

--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,9 @@ duk.raw: dist linenoise
 
 duk-clang: dist linenoise
 	# Use -Wcast-align to trigger issues like: https://github.com/svaarala/duktape/issues/270
-	clang -o $@ -Wcast-align $(CCOPTS_NONDEBUG) $(DUKTAPE_SOURCES) $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
+	# Use -Wshift-sign-overflow to trigger issues like: https://github.com/svaarala/duktape/issues/812
+	# -Weverything
+	clang -o $@ -Wcast-align -Wshift-sign-overflow $(CCOPTS_NONDEBUG) $(DUKTAPE_SOURCES) $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
 	-@size $@
 
 duk.O2: dist linenoise

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1681,6 +1681,9 @@ Planned
 * Fix -Wshadow warnings on some GCC versions for variable/argument name
   'index' by avoiding such identifiers in API and internals (GH-810)
 
+* Fix -Wshift-sign-overflow warnings on some Clang versions for signed left
+  shifts whose result was used as unsigned (GH-812, GH-813)
+
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than
   being declared as actual symbols; this reduces compilation warnings with

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -172,7 +172,7 @@ static void cmdline_fatal_handler(void *udata, const char *msg) {
 	fprintf(stderr, "*** FATAL ERROR: %s\n", msg ? msg : "no message");
 	fprintf(stderr, "Causing intentional segfault...\n");
 	fflush(stderr);
-	*((unsigned int *) 0) = (unsigned int) 0xdeadbeefUL;
+	*((volatile unsigned int *) 0) = (unsigned int) 0xdeadbeefUL;
 	abort();
 }
 

--- a/misc/shift_warning.c
+++ b/misc/shift_warning.c
@@ -1,0 +1,40 @@
+/*
+ *  With 32-bit integers the expression:
+ *
+ *      uint32_t x = 26 << 27;
+ *
+ *  causes a warning on some compilers because the signed integer 26 (0x1a) is
+ *  first shifted 27 positions to the left which remains within unsigned 32-bit
+ *  range but overflows the signed 32-bit range.  This has no practical impact
+ *  (at least on common compilers) because the result is ultimately an unsigned
+ *  32-bit integer, 0xd0000000.
+ *
+ *  In GCC 4.x there doesn't seem to be a warning option to detect this.
+ *  In clang this works (also -Weverything):
+ *
+ *      $ clang -Wshift-sign-overflow -otest misc/shift_warning.c
+ *      misc/shift_warning.c:19:9: warning: signed shift result (0xD0000000)
+ *           sets the sign bit of the shift expression's type ('int') and
+ *           becomes negative [-Wshift-sign-overflow]
+ *             t = 26 << 27;
+ *                 ~~ ^  ~~
+ *      1 warning generated.
+ *
+ *      $ ./test
+ *      d0000000
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[]) {
+	uint32_t t;
+
+	t = 26 << 27;
+	printf("%08lx\n", (unsigned long) t);
+
+	(void) argc;
+	(void) argv;
+
+	return 0;
+}

--- a/src/duk_heaphdr.h
+++ b/src/duk_heaphdr.h
@@ -219,7 +219,7 @@ struct duk_heaphdr_string {
 
 #define DUK_HEAPHDR_SET_FLAG_RANGE(h,m,n,v)  do { \
 		(h)->h_flags = \
-			((h)->h_flags & (~(((1 << (n)) - 1) << (m)))) \
+			((h)->h_flags & (~(((1UL << (n)) - 1UL) << (m)))) \
 			| ((v) << (m)); \
 	} while (0)
 

--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -349,15 +349,15 @@ DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_t
 		 */
 
 		u2 = ((duk_uint32_t) i2) & 0xffffffffUL;
-		i3 = i1 << (u2 & 0x1f);                      /* E5 Section 11.7.1, steps 7 and 8 */
-		i3 = i3 & ((duk_int32_t) 0xffffffffUL);      /* Note: left shift, should mask */
+		i3 = (duk_int32_t) (((duk_uint32_t) i1) << (u2 & 0x1fUL));  /* E5 Section 11.7.1, steps 7 and 8 */
+		i3 = i3 & ((duk_int32_t) 0xffffffffUL);                     /* Note: left shift, should mask */
 		break;
 	}
 	case DUK_OP_BASR: {
 		/* signed shift */
 
 		u2 = ((duk_uint32_t) i2) & 0xffffffffUL;
-		i3 = i1 >> (u2 & 0x1f);                      /* E5 Section 11.7.2, steps 7 and 8 */
+		i3 = i1 >> (u2 & 0x1fUL);                      /* E5 Section 11.7.2, steps 7 and 8 */
 		break;
 	}
 	case DUK_OP_BLSR: {
@@ -367,7 +367,7 @@ DUK_LOCAL void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_t
 		u2 = ((duk_uint32_t) i2) & 0xffffffffUL;
 
 		/* special result value handling */
-		u3 = u1 >> (u2 & 0x1f);     /* E5 Section 11.7.2, steps 7 and 8 */
+		u3 = u1 >> (u2 & 0x1fUL);     /* E5 Section 11.7.2, steps 7 and 8 */
 #if defined(DUK_USE_FASTINT)
 		fi3 = (duk_int64_t) u3;
 		goto fastint_result_set;


### PR DESCRIPTION
- [x] Example of signed shift issues
- [x] Fix internal signed shift issues, verify with clang warnings enabled
- [x] Fix some volatile NULL pointer issues, clang warnings
- [x] Add warning options for Makefile duk-clang target
- [x] Releases entry