### PR TITLE
Change x86/x64/x32 align-by default from 1 to 4

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2493,6 +2493,10 @@ Planned
 
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
+* Change default data alignment for x86, x64, and x32 from align-by-1 (no
+  alignment) to align-by-4 which may be marginally faster and avoids some
+  -fsanitize warnings (GH-814)
+
 * Compiler warning fix for using DUK_UNREF() on a volatile argument (GH-1282)
 
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal

--- a/config/architectures/architecture_x32.h.in
+++ b/config/architectures/architecture_x32.h.in
@@ -2,10 +2,11 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
+/* While x86/x64/x32 doesn't usually require any alignment, providing at least
+ * align by 4 may be marginally faster (depends on processor architecture).
+ * It's also possible to enable Alignment Check (AC) for userspace software.
  */
 #if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
+#define DUK_USE_ALIGN_BY 4
 #endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_x64.h.in
+++ b/config/architectures/architecture_x64.h.in
@@ -2,10 +2,11 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
+/* While x86/x64/x32 doesn't usually require any alignment, providing at least
+ * align by 4 may be marginally faster (depends on processor architecture).
+ * It's also possible to enable Alignment Check (AC) for userspace software.
  */
 #if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
+#define DUK_USE_ALIGN_BY 4
 #endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_x86.h.in
+++ b/config/architectures/architecture_x86.h.in
@@ -2,10 +2,11 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
+/* While x86/x64/x32 doesn't usually require any alignment, providing at least
+ * align by 4 may be marginally faster (depends on processor architecture).
+ * It's also possible to enable Alignment Check (AC) for userspace software.
  */
 #if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
+#define DUK_USE_ALIGN_BY 4
 #endif
 #define DUK_USE_PACKED_TVAL

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -113,3 +113,7 @@ DUK_USE_ES6_UNICODE_ESCAPE: false
 DUK_USE_REFLECT_BUILTIN: false
 DUK_USE_ES6: false
 DUK_USE_SYMBOL_BUILTIN: false
+
+# Consider switching alignment to align-by-1 for more compact struct layouts
+# if the architecture supports it.
+#DUK_USE_ALIGN_BY: 1


### PR DESCRIPTION
Align-by-4 avoids some -fsanitize warnings (see #812) and may be marginally faster, though the impact depends on the specific processor architecture.
- [x] Config metadata changes
- [x] Update low memory example to suggest align-by-1
- [x] Genconfig bug fix for forced options with value 1
- [ ] Add commit test coverage for alignments
- [x] Open pull for removing unused object layouts (layout 3 at least, maybe keep layout 1) - #815
- [x] Releases entry
