### PR TITLE
Remove unused duk_hobject property layout(s)

### DIFF
--- a/src/duk_hobject.h
+++ b/src/duk_hobject.h
@@ -750,6 +750,9 @@ struct duk_hobject {
 	 *                                                      0xffffffffUL = unused, 0xfffffffeUL = deleted
 	 *    e_size * sizeof(duk_uint8_t)           bytes of   entry flags (e_next gc reachable)
 	 *
+	 *  FIXME: decide what layouts to keep; currently layout 3 is unused,
+	 *  performance test it to see if it could replace 1 or 2 (or both).
+	 *
 	 *  In layout 1, the 'e_next' count is rounded to 4 or 8 on platforms
 	 *  requiring 4 or 8 byte alignment.  This ensures proper alignment
 	 *  for the entries, at the cost of memory footprint.  However, it's


### PR DESCRIPTION
Currently layouts 1 and 2 are used and layout 3 is not. Layout 3 would provide natural alignment without padding on a majority of common platforms, but is a bit slower than layout 1 and 2.

Another option would be to add direct property allocation pointers by default (to make the layout differences irrelevant) and drops these fields only for low memory builds. Yet another option would be to store direct pointers and use the pointers to dynamically compute values like `e_next` which are currently explicit fields.