### PR TITLE
Minor cleanups to module-node extra

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1670,7 +1670,7 @@ Planned
   (GH-767)
 
 * Add an extra module (extras/module-node) providing a Node.js-like module
-  loading framework supporting require.cache, module.loaded, etc.
+  loading framework supporting require.cache, module.loaded, etc. (GH-796)
 
 * Add an extra module (extras/minimal-printf) providing minimal,
   Duktape-optimized sprintf(), snprintf(), vsnprintf(), and sscanf()

--- a/extras/console/test.c
+++ b/extras/console/test.c
@@ -5,6 +5,7 @@
 int main(int argc, char *argv[]) {
 	duk_context *ctx;
 	int i;
+	int exitcode = 0;
 
 	ctx = duk_create_heap_default();
 	if (!ctx) {
@@ -16,12 +17,14 @@ int main(int argc, char *argv[]) {
 
 	for (i = 1; i < argc; i++) {
 		printf("Evaling: %s\n", argv[i]);
-		(void) duk_peval_string(ctx, argv[i]);
+		if (duk_peval_string(ctx, argv[i]) != 0) {
+			exitcode = 1;
+		}
 		printf("--> %s\n", duk_safe_to_string(ctx, -1));
 		duk_pop(ctx);
 	}
 
 	printf("Done\n");
 	duk_destroy_heap(ctx);
-	return 0;
+	return exitcode;
 }

--- a/extras/logging/test.c
+++ b/extras/logging/test.c
@@ -24,6 +24,7 @@ static duk_ret_t init_logging(duk_context *ctx, void *udata) {
 int main(int argc, char *argv[]) {
 	duk_context *ctx;
 	int i;
+	int exitcode = 0;
 
 	ctx = duk_create_heap_default();
 	if (!ctx) {
@@ -38,13 +39,18 @@ int main(int argc, char *argv[]) {
 		printf("Evaling: %s\n", argv[i]);
 		duk_push_string(ctx, argv[i]);
 		duk_push_string(ctx, "evalCodeFileName");  /* for automatic logger name testing */
-		duk_compile(ctx, DUK_COMPILE_EVAL);
-		(void) duk_pcall(ctx, 0);
+		if (duk_pcompile(ctx, DUK_COMPILE_EVAL) != 0) {
+			exitcode = 1;
+		} else {
+			if (duk_pcall(ctx, 0) != 0) {
+				exitcode = 1;
+			}
+		}
 		printf("--> %s\n", duk_safe_to_string(ctx, -1));
 		duk_pop(ctx);
 	}
 
 	printf("Done\n");
 	duk_destroy_heap(ctx);
-	return 0;
+	return exitcode;
 }

--- a/extras/module-node/Makefile
+++ b/extras/module-node/Makefile
@@ -2,15 +2,16 @@
 
 .PHONY: test
 test:
-	gcc -o $@ -I../../src/ -I. ../../src/duktape.c duk_module_node.c test.c -lm
+	gcc -Wall -Wextra -std=c99 -o $@ -I../../src/ -I. ../../src/duktape.c duk_module_node.c test.c -lm
 	@printf '\n'
-	./test 'typeof require("pig") === "string" ? "require() OK" : "require() FAILED";'
-	./test 'require("cow").indexOf("pig") !== -1 ? "nested require() OK" : "nested require() FAILED";'
-	./test 'var ape1 = require("ape"); var ape2 = require("ape"); ape1 === ape2 ? "caching OK" : "caching FAILED";'
-	./test 'var ape1 = require("ape"); var inCache = "ape.js" in require.cache; delete require.cache["ape.js"]; var ape2 = require("ape"); inCache && ape2 !== ape1 ? "require.cache OK" : "require.cache FAILED";'
-	./test 'var ape = require("ape"); typeof ape.module.require === "function" ? "module.require OK" : "module.require FAILED";'
-	./test 'var ape = require("ape"); ape.module.exports === ape ? "module.exports OK" : "module.exports FAILED";'
-	./test 'var ape = require("ape"); ape.module.id === "ape.js" && ape.module.id === ape.module.filename ? "module.id OK" : "module.id FAILED";'
-	./test 'var ape = require("ape"); ape.module.filename === "ape.js" ? "module.filename OK" : "module.filename FAILED";'
-	./test 'var ape = require("ape"); ape.module.loaded === true && ape.wasLoaded === false ? "module.loaded OK" : "module.loaded FAILED";'
-	./test 'var ape = require("ape"); ape.__filename === "ape.js" ? "__filename OK" : "__filename FAILED";'
+	./test 'assert(typeof require("pig") === "string", "basic require()");'
+	./test 'assert(require("cow").indexOf("pig") !== -1, "nested require()");'
+	./test 'var ape1 = require("ape"); var ape2 = require("ape"); assert(ape1 === ape2, "caching");'
+	./test 'var ape1 = require("ape"); var inCache = "ape.js" in require.cache; delete require.cache["ape.js"]; var ape2 = require("ape"); assert(inCache && ape2 !== ape1, "require.cache");'
+	./test 'var ape = require("ape"); assert(typeof ape.module.require === "function", "module.require()");'
+	./test 'var ape = require("ape"); assert(ape.module.exports === ape, "module.exports");'
+	./test 'var ape = require("ape"); assert(ape.module.id === "ape.js" && ape.module.id === ape.module.filename, "module.id");'
+	./test 'var ape = require("ape"); assert(ape.module.filename === "ape.js", "module.filename");'
+	./test 'var ape = require("ape"); assert(ape.module.loaded === true && ape.wasLoaded === false, "module.loaded");'
+	./test 'var ape = require("ape"); assert(ape.__filename === "ape.js", "__filename");'
+	./test 'var badger = require("badger"); assert(badger.foo === 123 && badger.bar === 234, "exports.foo assignment");'

--- a/extras/module-node/README.rst
+++ b/extras/module-node/README.rst
@@ -3,7 +3,7 @@ Node.js-like module loading framework
 =====================================
 
 This directory contains an example module resolution and loading framework and
-``require`` implementation based on the Node.js module system:
+``require()`` implementation based on the Node.js module system:
 
 * https://nodejs.org/api/modules.html
 
@@ -35,9 +35,9 @@ The application needs only to provide the module resolution and loading logic:
   It is possible to replace the callbacks after initialization by setting the
   following internal properties on the global stash:
   
-  - `\xffmodResolve`
+  - ``\xffmodResolve``
   
-  - `\xffmodLoad`
+  - ``\xffmodLoad``
 
 * The resolve callback is a Duktape/C function which takes the string passed
   to ``require()`` and resolves it to a canonical module ID (for Node.js this
@@ -60,11 +60,12 @@ The application needs only to provide the module resolution and loading logic:
 
   If the module ID cannot be resolved, the resolve callback should throw an
   error, which will propagate out of the ``require()`` call.  Note also that
-  when the global ``require`` is called, the parent ID is an empty string.
+  when the global ``require()`` is called, the parent ID is an empty string.
 
 * The load callback is a Duktape/C function which takes the resolved module ID
-  and either returns the Ecmascript source code for the module, or populates
-  ``module.exports`` itself and returns undefined (useful for C modules)::
+  and: (1) returns the Ecmascript source code for the module or ``undefined``
+  if there's no source code, e.g. for pure C modules, (2) can populate
+  ``module.exports`` itself, and (3) can replace ``module.exports``::
 
       duk_ret_t cb_load_module(duk_context *ctx) {
           /*
@@ -80,5 +81,5 @@ The application needs only to provide the module resolution and loading logic:
   As with the resolve callback, the load callback should throw an error if the
   module cannot be loaded for any reason.
 
-* After these steps, ``require`` will be registered to the global object and
+* After these steps, ``require()`` will be registered to the global object and
   the module system is ready to use.

--- a/extras/module-node/duk_module_node.h
+++ b/extras/module-node/duk_module_node.h
@@ -3,6 +3,6 @@
 
 #include "duktape.h"
 
-extern void duk_module_node_init (duk_context *ctx);
+extern void duk_module_node_init(duk_context *ctx);
 
 #endif  /* DUK_MODULE_NODE_H_INCLUDED */

--- a/extras/print-alert/test.c
+++ b/extras/print-alert/test.c
@@ -5,6 +5,7 @@
 int main(int argc, char *argv[]) {
 	duk_context *ctx;
 	int i;
+	int exitcode = 0;
 
 	ctx = duk_create_heap_default();
 	if (!ctx) {
@@ -16,12 +17,14 @@ int main(int argc, char *argv[]) {
 
 	for (i = 1; i < argc; i++) {
 		printf("Evaling: %s\n", argv[i]);
-		(void) duk_peval_string(ctx, argv[i]);
+		if (duk_peval_string(ctx, argv[i]) != 0) {
+			exitcode = 1;
+		}
 		printf("--> %s\n", duk_safe_to_string(ctx, -1));
 		duk_pop(ctx);
 	}
 
 	printf("Done\n");
 	duk_destroy_heap(ctx);
-	return 0;
+	return exitcode;
 }


### PR DESCRIPTION
- [x] Fix value stack index use in eval module helper
- [x] Ensure test.c exitcode is != 0 when errors occur (also add this behavior to other extras)
- [x] Add assert() driven `make test`
- [x] __dirname note: not available due to being platform dependent
- [x] Other trivia