### PR TITLE
Escape "D." to avoid list interpretation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,7 +30,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Julien Hamaide (https://github.com/crazyjul)
 * Sebastian Götte (https://github.com/jaseg)
 * Tomasz Magulski (https://github.com/magul)
-* D. Bohdan (https://github.com/dbohdan)
+* \D. Bohdan (https://github.com/dbohdan)
 * Ondřej Jirman (https://github.com/megous)
 
 Other contributions


### PR DESCRIPTION
Github formatting will interpret "D. xxx" as a numbered list, rendering it as "iv. xxx".  Escape the D to avoid this.