### PR TITLE
Make coroutine support optional

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1672,6 +1672,9 @@ Planned
 * Minor changes to error messages for errors thrown by Duktape internals
   (GH-827)
 
+* Make coroutine support optional (DUK_USE_COROUTINE_SUPPORT); disabling
+  coroutines reduces code footprint by about 2kB (GH-829)
+
 * Add an extra module (extras/duk-v1-compat) providing many Duktape 1.x API
   calls removed in Duktape 2.x (multiple Github issues)
 

--- a/config/config-options/DUK_USE_COROUTINE_SUPPORT.yaml
+++ b/config/config-options/DUK_USE_COROUTINE_SUPPORT.yaml
@@ -1,0 +1,8 @@
+define: DUK_USE_COROUTINE_SUPPORT
+feature_enables: DUK_OPT_COROUTINE_SUPPORT
+introduced: 2.0.0
+default: true
+tags:
+  - execution
+description: >
+  Enable support Duktape coroutines, i.e. yield/resume.

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -78,3 +78,6 @@ DUK_USE_REGEXP_CANON_WORKAROUND: false
 #DUK_USE_ROM_OBJECTS: true
 #DUK_USE_ROM_GLOBAL_INHERIT: true  # select inherit or clone; inherit recommended
 #DUK_USE_ROM_GLOBAL_CLONE: false
+
+# Reduce footprint by dropping coroutine support (about 2kB).
+#DUK_USE_COROUTINE_SUPPORT: false

--- a/config/examples/low_memory_strip.yaml
+++ b/config/examples/low_memory_strip.yaml
@@ -1,0 +1,25 @@
+# More stripping for low memory environments, removing e.g. RegExp support,
+# coroutine support, etc.
+
+DUK_USE_BUFFEROBJECT_SUPPORT: false
+
+DUK_USE_REGEXP_SUPPORT: false
+
+DUK_USE_REFERENCE_COUNTING: false
+DUK_USE_DOUBLE_LINKED_HEAP: false
+
+# Consider to reduce code footprint at the expense of less safeguards against
+# bugs in calling C code
+DUK_USE_VALSTACK_UNSAFE: true
+
+# Short term workaround with large footprint, disable.
+DUK_USE_REGEXP_CANON_WORKAROUND: false
+
+# Coroutine support has about 2kB footprint.
+DUK_USE_COROUTINE_SUPPORT: false
+
+# ES6 Proxy has about 2kB footprint.
+DUK_USE_ES6_PROXY: false
+
+# Don't support non-BMP characters in source code (UTF-8 otherwise OK).
+DUK_USE_SOURCE_NONBMP: false

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -73,6 +73,8 @@ There are four basic goals for low memory optimization:
 The following genconfig option file template enables most low memory related
 option: ``config/examples/low_memory.yaml``.  It doesn't enable pointer
 compression because that always requires some application specific code.
+More aggressive feature stripping examples are in
+``config/examples/low_memory_strip.yaml``.
 
 Optimizing code footprint
 =========================
@@ -142,6 +144,19 @@ Add GCC specific options to remove unused symbols::
 
 Here the difference is ~8kB on x64.  For the dist Makefile.hello example,
 which uses very few public API calls, the difference is ~12kB.
+
+Miscellaneous
+-------------
+
+* On some low memory targets only libc features which are actually used get
+  pulled into the binary being built.  In such cases it may be useful to
+  avoid calling platform sprintf/sscanf because they may be surprisingly
+  large (>20 kB).  You can use ``extras/minimal-printf`` instead.
+
+* Math functions can sometimes have a relatively large footprint (15-20 kB),
+  usually from trigonometric and other transcendental functions.  You can
+  stub out unnecessary functions in ``duk_config.h``.  Note, however, that
+  Duktape internals at present depend on a few Math functions like ``DUK_FMOD()``.
 
 Suggested feature options
 =========================

--- a/src/duk_bi_thread.c
+++ b/src/duk_bi_thread.c
@@ -8,6 +8,7 @@
  *  Constructor
  */
 
+#if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
 	duk_hthread *new_thr;
 	duk_hobject *func;
@@ -31,6 +32,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
 
 	return 1;  /* return thread */
 }
+#else
+DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return DUK_RET_ERROR;
+}
+#endif
 
 /*
  *  Resume a thread.
@@ -47,6 +54,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
  *  Note: yield and resume handling is currently asymmetric.
  */
 
+#if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hthread *thr_resume;
@@ -185,6 +193,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
+#else
+DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return DUK_RET_ERROR;
+}
+#endif
 
 /*
  *  Yield the current thread.
@@ -201,6 +215,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
  *  Note: yield and resume handling is currently asymmetric.
  */
 
+#if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *caller_func;
@@ -298,8 +313,21 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
+#else
+DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return DUK_RET_ERROR;
+}
+#endif
 
+#if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_current(duk_context *ctx) {
 	duk_push_current_thread(ctx);
 	return 1;
 }
+#else
+DUK_INTERNAL duk_ret_t duk_bi_thread_current(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return DUK_RET_ERROR;
+}
+#endif

--- a/testrunner/client-simple-node/run_commit_test.py
+++ b/testrunner/client-simple-node/run_commit_test.py
@@ -305,17 +305,24 @@ def context_linux_x64_gcc_defsize_fltoetc():
 		])
 	return context_helper_get_binary_size_diff(comp)
 
-def context_helper_minsize_fltoetc(archopt):
+def context_helper_minsize_fltoetc(archopt, strip):
 	cwd = os.getcwd()
 	def comp():
 		execute([ 'make', 'dist' ])
-		execute([
+		cmd = [
 			'python2', os.path.join(cwd, 'config', 'genconfig.py'),
 			'--metadata', os.path.join(cwd, 'config'),
 			'--output', os.path.join(cwd, 'dist', 'src', 'duk_config.h'),
-			'--option-file', os.path.join(cwd, 'config', 'examples', 'low_memory.yaml'),
+			'--option-file', os.path.join(cwd, 'config', 'examples', 'low_memory.yaml')
+		]
+		if strip:
+			cmd += [
+				'--option-file', os.path.join(cwd, 'config', 'examples', 'low_memory_strip.yaml')
+			]
+		cmd += [
 			'duk-config-header'
-		])
+		]
+		execute(cmd)
 		execute([
 			'gcc', '-oduk', archopt,
 			'-Os', '-fomit-frame-pointer',
@@ -330,13 +337,22 @@ def context_helper_minsize_fltoetc(archopt):
 	return context_helper_get_binary_size_diff(comp)
 
 def context_linux_x64_gcc_minsize_fltoetc():
-	return context_helper_minsize_fltoetc('-m64')
+	return context_helper_minsize_fltoetc('-m64', False)
 
 def context_linux_x86_gcc_minsize_fltoetc():
-	return context_helper_minsize_fltoetc('-m32')
+	return context_helper_minsize_fltoetc('-m32', False)
 
 def context_linux_x32_gcc_minsize_fltoetc():
-	return context_helper_minsize_fltoetc('-mx32')
+	return context_helper_minsize_fltoetc('-mx32', False)
+
+def context_linux_x64_gcc_stripsize_fltoetc():
+	return context_helper_minsize_fltoetc('-m64', True)
+
+def context_linux_x86_gcc_stripsize_fltoetc():
+	return context_helper_minsize_fltoetc('-m32', True)
+
+def context_linux_x32_gcc_stripsize_fltoetc():
+	return context_helper_minsize_fltoetc('-mx32', True)
 
 def context_linux_x64_cpp_exceptions():
 	# For now rather simple: compile, run, and grep for my_class
@@ -857,6 +873,9 @@ context_handlers = {
 	'linux-x64-gcc-minsize-fltoetc': context_linux_x64_gcc_minsize_fltoetc,
 	'linux-x86-gcc-minsize-fltoetc': context_linux_x86_gcc_minsize_fltoetc,
 	'linux-x32-gcc-minsize-fltoetc': context_linux_x32_gcc_minsize_fltoetc,
+	'linux-x64-gcc-stripsize-fltoetc': context_linux_x64_gcc_stripsize_fltoetc,
+	'linux-x86-gcc-stripsize-fltoetc': context_linux_x86_gcc_stripsize_fltoetc,
+	'linux-x32-gcc-stripsize-fltoetc': context_linux_x32_gcc_stripsize_fltoetc,
 
 	'linux-x64-cpp-exceptions': context_linux_x64_cpp_exceptions,
 


### PR DESCRIPTION
They're quite often not needed and the footprint can be avoided on low memory targets.