### PR TITLE
Make "uncaught error" fatal error more verbose

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1669,6 +1669,8 @@ Planned
 * Add a human readable summary of 'new MyConstructor()' constructor call
   target when the target is non-constructable (GH-757)
 
+* Add a safe summary for "uncaught error" fatal error (GH-832)
+
 * Remove duk_{get,put,has,del}_var() calls from API header; they were not
   fully implemented and not part of the documented public API (GH-762)
 

--- a/src/duk_api_internal.h
+++ b/src/duk_api_internal.h
@@ -96,9 +96,7 @@ DUK_INTERNAL_DECL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL duk_hstring *duk_safe_to_hstring(duk_context *ctx, duk_idx_t idx);
 #endif
 DUK_INTERNAL_DECL void duk_to_object_class_string_top(duk_context *ctx);
-#if !defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL void duk_push_hobject_class_string(duk_context *ctx, duk_hobject *h);
-#endif
 
 DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped_raw(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped);  /* out_clamped=NULL, RangeError if outside range */
 DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped(duk_context *ctx, duk_idx_t idx, duk_int_t minval, duk_int_t maxval);
@@ -142,10 +140,9 @@ DUK_INTERNAL_DECL void duk_push_lightfunc_name(duk_context *ctx, duk_tval *tv);
 DUK_INTERNAL_DECL void duk_push_lightfunc_tostring(duk_context *ctx, duk_tval *tv);
 DUK_INTERNAL_DECL duk_hbufobj *duk_push_bufobj_raw(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
 
-#if !defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL const char *duk_push_string_tval_readable(duk_context *ctx, duk_tval *tv);
-#endif
+DUK_INTERNAL_DECL const char *duk_push_string_tval_readable_error(duk_context *ctx, duk_tval *tv);
 
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [] -> [val] */
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx);     /* [val] -> [] */

--- a/src/duk_error_longjmp.c
+++ b/src/duk_error_longjmp.c
@@ -5,6 +5,37 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_PREFER_SIZE)
+DUK_LOCAL void duk__uncaught_minimal(duk_hthread *thr) {
+	duk_fatal((duk_context *) thr, "uncaught error");
+}
+#endif
+
+#if 0
+DUK_LOCAL void duk__uncaught_readable(duk_hthread *thr) {
+	const char *summary;
+	char buf[64];
+
+	summary = duk_push_string_tval_readable((duk_context *) thr, &thr->heap->lj.value1);
+	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
+	buf[sizeof(buf) - 1] = (char) 0;
+	duk_fatal((duk_context *) thr, (const char *) buf);
+}
+#endif
+
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_LOCAL void duk__uncaught_error_aware(duk_hthread *thr) {
+	const char *summary;
+	char buf[64];
+
+	summary = duk_push_string_tval_readable_error((duk_context *) thr, &thr->heap->lj.value1);
+	DUK_ASSERT(summary != NULL);
+	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
+	buf[sizeof(buf) - 1] = (char) 0;
+	duk_fatal((duk_context *) thr, (const char *) buf);
+}
+#endif
+
 DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 	DUK_ASSERT(thr != NULL);
 
@@ -26,7 +57,11 @@ DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 		                 (int) thr->heap->lj.type, (int) thr->heap->lj.iserror,
 		                 &thr->heap->lj.value1, &thr->heap->lj.value2));
 
-		duk_fatal((duk_context *) thr, "uncaught error");
+#if defined(DUK_USE_PREFER_SIZE)
+		duk__uncaught_minimal(thr);
+#else
+		duk__uncaught_error_aware(thr);
+#endif
 		DUK_UNREACHABLE();
 	}
 #endif  /* DUK_USE_CPP_EXCEPTIONS */


### PR DESCRIPTION
Stringify the uncaught error object safely into the fatal error message. This fatal error occurs quite commonly when protected calls are not used to wrap potentially unsafe operations, so it's useful if the fatal error message provides at least a clue of what went wrong.

- [x] Use verbose fatal error message when not size optimized
- [x] Refactor error-aware summarization to an internal helper
- [x] Test coverage for fatal error => skipped, tested manually
- [x] Releases entry