### PR TITLE
Minor fixes to module-node extra

### DIFF
--- a/extras/module-node/README.rst
+++ b/extras/module-node/README.rst
@@ -84,6 +84,6 @@ The application needs only to provide the module resolution and loading logic:
 * After these steps, ``require()`` will be registered to the global object and
   the module system is ready to use.
 
-* The main module (file being evaluated) should be loaded using ``duk_note_peval_file``.
-  This function registers the module in ``require.main`` and thus should only be called
-  once.
+* The main module (file being evaluated) should be loaded using
+  ``duk_module_node_peval_main()``.  This function registers the module in
+  ``require.main`` and thus should only be called once.

--- a/extras/module-node/duk_module_node.h
+++ b/extras/module-node/duk_module_node.h
@@ -3,7 +3,7 @@
 
 #include "duktape.h"
 
-extern duk_ret_t duk_module_node_peval_file(duk_context *ctx, const char* path);
+extern duk_ret_t duk_module_node_peval_main(duk_context *ctx, const char *path);
 extern void duk_module_node_init(duk_context *ctx);
 
 #endif  /* DUK_MODULE_NODE_H_INCLUDED */


### PR DESCRIPTION
- [x] Fix function call name in README
- [x] Fix forward declaration arguments for `duk__push_module_object()` (was missing "int main" argument)
- [x] Change "int main" to "duk_bool_t main"
- [x] Comment and C convention trivia
- [x] Consider renaming `duk_module_node_peval_file()`
- [x] Fix dependency on now removed error codes
- [x] Fix duk_safe_call() argument discrepancy in master