### PR TITLE
Avoid value stack churn for array .length coercion

### DIFF
--- a/src/duk_js_ops.c
+++ b/src/duk_js_ops.c
@@ -213,7 +213,8 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 		/* recursive call for a primitive value (guaranteed not to cause second
 		 * recursion).
 		 */
-		d = duk_js_tonumber(thr, duk_require_tval(ctx, -1));
+		DUK_ASSERT(duk_get_tval(ctx, -1) != NULL);
+		d = duk_js_tonumber(thr, duk_get_tval(ctx, -1));
 
 		duk_pop(ctx);
 		return d;


### PR DESCRIPTION
Coerce a potential new array .length in place without pushing it on the value stack for coercion. Fast path fastints (very common) and doubles (very common, especially with fastints disabled). Other types are very rarely assigned so their handling is as compact as possible.