### PR TITLE
Add ROM built-in lightfunc conversion

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1715,6 +1715,10 @@ Planned
   and constructor call argument count from 511 to 255, and maximum Ecmascript
   function constant count from 262144 to 65536 (GH-903)
 
+* Add support for converting ROM function property values into lightfuncs in
+  genbuiltins.py to reduce code footprint for ROM-based built-ins and custom
+  bindings; footprint reduction is around 14-15kB on 32-bit targets (GH-872)
+
 * Allow ES6 Annex B unescaped right bracket (']') in regular expressions
   (non-standard before ES6 Annex B), left bracket ('[') not yet supported
   because it needs backtracking (GH-871)

--- a/config/genconfig.py
+++ b/config/genconfig.py
@@ -460,7 +460,7 @@ def fill_dependencies_for_snippets(snippets, idx_deps):
 #	print(repr(graph))
 #	print(repr(snlist))
 #	print('Resolved helper defines: %r' % resolved)
-	print('Resolved %d helper defines' % len(resolved))
+#	print('Resolved %d helper defines' % len(resolved))
 
 def serialize_snippet_list(snippets):
 	ret = []

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -33,13 +33,13 @@ realistic memory targets are roughly:
     various internal structures (strings, buffers, objects), pointer
     compression, external strings, etc may need to be used
 
-* 256kB flash memory (code) and 96kB system RAM
+* 192-256kB flash memory (code) and 96kB system RAM
 
   - Requires a bare metal system, possibly a custom C library, etc.
 
   - http://pt.slideshare.net/seoyounghwang77/js-onmicrocontrollers
 
-* 256kB flash memory (code) and 64kB system RAM
+* 160-192kB flash memory (code) and 64kB system RAM
 
   - Requires a bare metal system, possibly a custom C library, etc.
 
@@ -347,7 +347,9 @@ The following may be appropriate when even less memory is available
   - Rerun ``make_dist.py`` with ``--rom-support`` to create a distributable
     with support for ROM builtins.  ROM builtin support is not enabled by
     default because it increases the size of ``duktape.c`` considerably.
-    (See ``util/example_rombuild.sh`` for some very simple examples.)
+    Add the option ``--rom-auto-lightfunc`` to convert built-in function
+    properties into lightfuncs to reduce ROM footprint.  (See
+    ``util/example_rombuild.sh`` for some very simple examples.)
 
   - Moving built-ins into ROM makes them read-only which has some side
     effects.  Some side effects are technical compliance issues while
@@ -377,6 +379,16 @@ The following may be appropriate when even less memory is available
 
     + ``util/example_rombuild.sh``: illustrates how to run ``make_dist.py``
       with user builtins
+
+* Consider using lightfuncs for representing function properties of ROM
+  built-ins.
+
+  - For custom built-ins you can use a "lightfunc" type for a property
+    value directly.
+
+  - You can also request automatic lightfunc conversion for built-in
+    function properties using ``--rom-auto-lightfunc``.  This saves
+    around 15kB for Duktape built-ins.
 
 Notes on pointer compression
 ============================

--- a/src/builtins.yaml
+++ b/src/builtins.yaml
@@ -34,6 +34,10 @@
 #        + e: enumerable
 #        + c: configurable
 #        + a: accessor (determined automatically, not necessary to give explicitly)
+#    - autoLightfunc: if true (which is default), function property may be
+#      automatically converted to a lightfunc if other automatic lightfunc
+#      conversion criteria are met; use "autoLightfunc: false" to prevent
+#      lightfunc conversion
 #    - May also have feature tags like "es6: true" to indicate property
 #      is related to a specific standard
 #    - To disable a property without removing its metadata, you can use
@@ -61,6 +65,13 @@
 #    - Pointer:
 #      - type: pointer
 #      - NOTE: not supported yet, type is reserved
+#    - Lightfunc:
+#      - type: lightfunc
+#      - native: native function name
+#      - magic: -128 to 127
+#      - length: 0 to 15
+#      - nargs: 0 to 14; or varargs: true
+#      - varargs: if true, target has variable arguments
 #    - Reference to a built-in object:
 #      - type: object
 #        id: ID string of target object
@@ -315,6 +326,7 @@ objects:
           type: function
           native: duk_bi_global_object_eval
           length: 1
+        autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
       - key: "parseInt"
         value:
           type: function
@@ -2267,12 +2279,14 @@ objects:
           native: duk_bi_thread_yield
           length: 2
         duktape: true
+        autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
       - key: "resume"
         value:
           type: function
           native: duk_bi_thread_resume
           length: 3
         duktape: true
+        autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
       - key: "current"
         value:
           type: function

--- a/util/example_rombuild.sh
+++ b/util/example_rombuild.sh
@@ -12,6 +12,7 @@ PYTHON=`which python2 python | head -1`
 make clean
 $PYTHON util/make_dist.py \
 	--rom-support \
+	--rom-auto-lightfunc \
 	--user-builtin-metadata util/example_user_builtins1.yaml \
 	--user-builtin-metadata util/example_user_builtins2.yaml
 
@@ -37,6 +38,7 @@ make duk dukd  # XXX: currently fails to start, DUK_CMDLINE_LOGGING_SUPPORT, DUK
 $PYTHON config/genconfig.py \
 	--metadata config \
 	--output dist/src/duk_config.h \
+	--option-file config/examples/low_memory.yaml \
 	-DDUK_USE_ROM_STRINGS \
 	-DDUK_USE_ROM_OBJECTS \
 	-DDUK_USE_ROM_GLOBAL_INHERIT \

--- a/util/example_user_builtins1.yaml
+++ b/util/example_user_builtins1.yaml
@@ -139,8 +139,8 @@ objects:
 
   # Example of plain value types supported at the moment:
   #
-  # - Object, function, and accessor types not illustrated here
-  #   (see src/builtins.yaml for examples of those).
+  # - Object, function, lightfunc, and accessor types not illustrated
+  #   here (see src/builtins.yaml for examples of those).
   #
   # - Duktape buffer and pointer types cannot be used by built-in
   #   objects at the moment.
@@ -186,6 +186,16 @@ objects:
       - key: "stringType"
         value: "foobar"               # Encode string as UTF-8, then map bytes to U+0000...U+00FF
         attributes: wec
+
+      #- key: "lightfuncType"
+      #  value:
+      #    type: lightfunc
+      #    native: duk_bi_math_object_random
+      #    nargs: 0
+      #    varargs: false
+      #    length: 13
+      #    magic: 0
+      #  attributes: wec
 
   # Object IDs are only resolved when metadata loading is complete, so it's
   # OK to create reference loops or refer to objects defined later (even in

--- a/util/make_dist.py
+++ b/util/make_dist.py
@@ -202,6 +202,7 @@ parser.add_option('--git-commit', dest='git_commit', default=None, help='Force g
 parser.add_option('--git-describe', dest='git_describe', default=None, help='Force git describe')
 parser.add_option('--git-branch', dest='git_branch', default=None, help='Force git branch name')
 parser.add_option('--rom-support', dest='rom_support', action='store_true', help='Add support for ROM strings/objects (increases duktape.c size considerably)')
+parser.add_option('--rom-auto-lightfunc', dest='rom_auto_lightfunc', action='store_true', default=False, help='Convert ROM built-in function properties into lightfuncs automatically whenever possible')
 parser.add_option('--user-builtin-metadata', dest='user_builtin_metadata', action='append', default=[], help='User strings and objects to add, YAML format (can be repeated for multiple overrides)')
 (opts, args) = parser.parse_args()
 
@@ -814,11 +815,15 @@ with open(os.path.join(dist, 'duk_used_stridx_bidx_defs.json.tmp'), 'wb') as f:
 	f.write(res)
 
 gb_opts = []
+gb_opts.append('--ram-support')  # enable by default
 if opts.rom_support:
 	# ROM string/object support is not enabled by default because
 	# it increases the generated duktape.c considerably.
 	print('Enabling --rom-support for genbuiltins.py')
 	gb_opts.append('--rom-support')
+if opts.rom_auto_lightfunc:
+	print('Enabling --rom-auto-lightfunc for genbuiltins.py')
+	gb_opts.append('--rom-auto-lightfunc')
 for fn in opts.user_builtin_metadata:
 	print('Forwarding --user-builtin-metadata %s' % fn)
 	gb_opts.append('--user-builtin-metadata')


### PR DESCRIPTION
For RAM built-ins there's an option to convert built-in functions into lightfuncs to save RAM. Add also support for ROM built-ins to do the same to reduce code footprint for environments where both RAM and ROM are tight.

Tasks:
- [x] Add metadata format for lightfuncs and check that their ROM conversion works (RAM conversion not needed at this point)
- [x] Add a metadata tag to indicate "no automatic lightfunc" conversion for functions that are otherwise eligible but shouldn't be lightfunc converted
- [x] Add genbuiltins.py option `--rom-auto-lightfunc` for automatic lightfunc conversion (specifying lightfuncs manually without this option should also be possible)
- [x] For testing convert all built-ins into lightfuncs, using the same rules as the RAM path
- [x] Check .length handling; metadata already normalized
- [x] Fix typing for lightfunc initializer
- [x] Testrunner coverage: test that ROM built-ins + lightfuncs build
- [x] Documentation, low-memory.rst for now (maybe migrate more concrete instructions to a Wiki page?)
- [x] Releases entry