### PR TITLE
Add selftest alloc/realloc/free test

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1764,6 +1764,9 @@ Planned
   doesn't currently handleir buffer object virtual properties correctly
   so to remain compliant fall back to slow path for now (GH-867)
 
+* Add a minimal alloc/realloc/free self test to the (optional) internal
+  self test (GH-877)
+
 * Fix buffer object (duk_hbufobj) JSON serialization (bug present in 1.5.0):
   buffer objects were omitted from serialization when they should be
   serialized as normal objects instead (GH-867)

--- a/src/duk_heap_alloc.c
+++ b/src/duk_heap_alloc.c
@@ -750,7 +750,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	 */
 
 #if defined(DUK_USE_SELF_TESTS)
-	if (duk_selftest_run_tests() > 0) {
+	if (duk_selftest_run_tests(alloc_func, realloc_func, free_func, heap_udata) > 0) {
 		fatal_func(heap_udata, "self test(s) failed");
 	}
 #endif

--- a/src/duk_selftest.h
+++ b/src/duk_selftest.h
@@ -6,7 +6,10 @@
 #define DUK_SELFTEST_H_INCLUDED
 
 #if defined(DUK_USE_SELF_TESTS)
-DUK_INTERNAL_DECL duk_uint_t duk_selftest_run_tests(void);
+DUK_INTERNAL_DECL duk_uint_t duk_selftest_run_tests(duk_alloc_function alloc_func,
+                                                    duk_realloc_function realloc_func,
+                                                    duk_free_function free_func,
+                                                    void *udata);
 #endif
 
 #endif  /* DUK_SELFTEST_H_INCLUDED */


### PR DESCRIPTION
Add a minimal self test for alloc/realloc/free into the self test set to catch some basic alloc function issues early.