### PR TITLE
Fixes for buffer object index property handling

### DIFF
--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -1806,8 +1806,22 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 
 				DUK_ASSERT(!DUK_HOBJECT_HAS_EXOTIC_ARGUMENTS(obj));
 				return 1;  /* cannot be e.g. arguments exotic, since exotic 'traits' are mutually exclusive */
+			} else if (arr_idx != DUK__NO_ARRAY_INDEX) {
+				/* index is exotic but out of bounds -> no property */
+				/* FIXME: technically "not found" but because we don't want to walk the parent,
+				 * pretend the value is undefined for now.  Fix either in [[Get]], or add another
+				 * internal flag to indicate DUK_PROPDESC_FLAG_BLOCK which hasprop can check.
+				 */
+				if (flags & DUK_GETDESC_FLAG_PUSH_VALUE) {
+					duk_push_undefined(ctx);
+				}
+				out_desc->flags = DUK_PROPDESC_FLAG_WRITABLE | DUK_PROPDESC_FLAG_VIRTUAL;
+				return 1;
+#if 0
+				return 0;  /* not found */
+#endif
 			} else {
-				/* index is above internal buffer length -> property is fully normal */
+				/* index is not exotic -> property is fully normal */
 				DUK_DDD(DUK_DDDPRINT("array index outside buffer -> normal property"));
 			}
 		} else if (key == DUK_HTHREAD_STRING_LENGTH(thr)) {
@@ -1847,6 +1861,21 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 			}
 			out_desc->flags = DUK_PROPDESC_FLAG_VIRTUAL;
 			return 1;  /* cannot be arguments exotic */
+		} else if (key == DUK_HTHREAD_STRING_MINUS_ZERO(thr)) {
+			/* Buffer object "-0" is considered an exotic index
+			 * but is always considered to be out of bounds (and
+			 * thus treated differently from the zero index).
+			 */
+			/* FIXME: technically "not found" but because we don't want to walk the parent,
+			 * pretend the value is undefined for now.  Fix either in [[Get]], or add another
+			 * internal flag to indicate DUK_PROPDESC_FLAG_BLOCK which hasprop can check.
+			 */
+			/* FIXME: share code with OOB index check above */
+			if (flags & DUK_GETDESC_FLAG_PUSH_VALUE) {
+				duk_push_undefined(ctx);
+			}
+			out_desc->flags = DUK_PROPDESC_FLAG_WRITABLE | DUK_PROPDESC_FLAG_VIRTUAL;
+			return 1;
 		}
 	} else if (DUK_HOBJECT_HAS_EXOTIC_DUKFUNC(obj)) {
 		DUK_DDD(DUK_DDDPRINT("duktape/c object exotic property get for key: %!O, arr_idx: %ld",
@@ -2176,6 +2205,10 @@ DUK_LOCAL duk_bool_t duk__getprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 		return 0;
 	}
 
+	/* XXX: the string '-0' should be detected as a virtual index and
+	 * always considered out-of-bounds.
+	 */
+
 	/* If index is not valid, idx will be DUK__NO_ARRAY_INDEX which
 	 * is 0xffffffffUL.  We don't need to check for that explicitly
 	 * because 0xffffffffUL will never be inside bufobj length.
@@ -2183,6 +2216,11 @@ DUK_LOCAL duk_bool_t duk__getprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 
 	/* Careful with wrapping (left shifting idx would be unsafe). */
 	if (idx >= (h_bufobj->length >> h_bufobj->shift)) {
+		if (idx != DUK__NO_ARRAY_INDEX) {
+			DUK_D(DUK_DPRINT("bufobj access out-of-bounds (but index property), read undefined"));
+			duk_push_undefined(ctx);
+			return 1;  /* FIXME: technically caller would want to return 0 from getprop; fix */
+		}
 		return 0;
 	}
 	DUK_ASSERT(idx != DUK__NO_ARRAY_INDEX);
@@ -2410,6 +2448,9 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			                     (duk_tval *) duk_get_tval(ctx, -1)));
 			return 1;
 		}
+		/* FIXME: check that "-0" is handled correctly if the fast path
+		 * doesn't catch it.  It's OK if it goes through the slow path.
+		 */
 
 #if defined(DUK_USE_ES6_PROXY)
 		if (DUK_UNLIKELY(DUK_HOBJECT_HAS_EXOTIC_PROXYOBJ(curr))) {
@@ -2520,15 +2561,26 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			pop_count = 1;
 		}
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX &&
-		    arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
-			duk_pop_n(ctx, pop_count);
-			duk_push_uint(ctx, ((duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h))[arr_idx]);
+		if (arr_idx != DUK__NO_ARRAY_INDEX) {
+			if (arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
+				duk_pop_n(ctx, pop_count);
+				duk_push_uint(ctx, ((duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h))[arr_idx]);
 
-			DUK_DDD(DUK_DDDPRINT("-> %!T (base is buffer, key is an index inside buffer length "
-			                     "after coercion -> return byte as number)",
-			                     (duk_tval *) duk_get_tval(ctx, -1)));
-			return 1;
+				DUK_DDD(DUK_DDDPRINT("-> %!T (base is buffer, key is an index inside buffer length "
+				                     "after coercion -> return byte as number)",
+				                     (duk_tval *) duk_get_tval(ctx, -1)));
+				return 1;
+			} else {
+				/* Plain buffer mimics typed array behavior, terminate
+				 * lookup even though index property is not present.
+				 */
+				duk_pop_n(ctx, pop_count);
+				duk_push_undefined(ctx);
+
+				DUK_DDD(DUK_DDDPRINT("-> %!T (base is buffer, key is an index out-of-bounds -> undefined",
+				                     (duk_tval *) duk_get_tval(ctx, -1)));
+				return 0;  /* FIXME: does this matter internally? */
+			}
 		}
 
 		if (pop_count == 0) {
@@ -2807,6 +2859,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 		arr_idx = duk__push_tval_to_hstring_arr_idx(ctx, tv_key, &key);
 		if (duk__key_is_plain_buf_ownprop(thr, DUK_TVAL_GET_BUFFER(tv_obj), key, arr_idx)) {
 			rc = 1;
+			goto pop_and_return;
+		}
+		if (arr_idx != DUK__NO_ARRAY_INDEX) {
+			/* Don't traverse to parent for buffer objects. */
+			rc = 0;
 			goto pop_and_return;
 		}
 		obj = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
@@ -3475,31 +3532,37 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 			pop_count = 1;
 		}
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX &&
-		    arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
-			duk_uint8_t *data;
-			DUK_DDD(DUK_DDDPRINT("writing to buffer data at index %ld", (long) arr_idx));
-			data = (duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h);
+		if (arr_idx != DUK__NO_ARRAY_INDEX) {
+			if (arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
+				duk_uint8_t *data;
+				DUK_DDD(DUK_DDDPRINT("writing to buffer data at index %ld", (long) arr_idx));
+				data = (duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h);
 
-			/* XXX: duk_to_int() ensures we'll get 8 lowest bits as
-			 * as input is within duk_int_t range (capped outside it).
-			 */
+				/* XXX: duk_to_int() ensures we'll get 8 lowest bits as
+				 * as input is within duk_int_t range (capped outside it).
+				 */
 #if defined(DUK_USE_FASTINT)
-			/* Buffer writes are often integers. */
-			if (DUK_TVAL_IS_FASTINT(tv_val)) {
-				data[arr_idx] = (duk_uint8_t) DUK_TVAL_GET_FASTINT_U32(tv_val);
-			}
-			else
+				/* Buffer writes are often integers. */
+				if (DUK_TVAL_IS_FASTINT(tv_val)) {
+					data[arr_idx] = (duk_uint8_t) DUK_TVAL_GET_FASTINT_U32(tv_val);
+				}
+				else
 #endif
-			{
-				duk_push_tval(ctx, tv_val);
-				data[arr_idx] = (duk_uint8_t) duk_to_uint32(ctx, -1);
-				pop_count++;
-			}
+				{
+					duk_push_tval(ctx, tv_val);
+					data[arr_idx] = (duk_uint8_t) duk_to_uint32(ctx, -1);
+					pop_count++;
+				}
 
-			duk_pop_n(ctx, pop_count);
-			DUK_DDD(DUK_DDDPRINT("result: success (buffer data write)"));
-			return 1;
+				duk_pop_n(ctx, pop_count);
+				DUK_DDD(DUK_DDDPRINT("result: success (buffer data write)"));
+				return 1;
+			} else {
+				/* Don't look up inherited properties, write is ignored. */
+				duk_pop_n(ctx, pop_count);
+				DUK_DDD(DUK_DDDPRINT("result: success (buffer write ignored: number index, out of bounds)"));
+				return 1;
+			}
 		}
 
 		if (pop_count == 0) {
@@ -3714,6 +3777,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 						} else {
 							DUK_D(DUK_DPRINT("bufobj access out of underlying buffer, ignoring (write skipped)"));
 						}
+						duk_pop(ctx);
+						goto success_no_arguments_exotic;
+					} else if (arr_idx != DUK__NO_ARRAY_INDEX) {
+						DUK_D(DUK_DPRINT("bufobj access out of bounds, ignoring (write skipped)"));
 						duk_pop(ctx);
 						goto success_no_arguments_exotic;
 					}
@@ -4438,9 +4505,12 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 		arr_idx = DUK_HSTRING_GET_ARRIDX_FAST(key);
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX &&
-		    arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
-			goto fail_not_configurable;
+		if (arr_idx != DUK__NO_ARRAY_INDEX) {
+			if (arr_idx < DUK_HBUFFER_GET_SIZE(h)) {
+				goto fail_not_configurable;
+			} else {
+				/* FIXME */
+			}
 		}
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv_obj)) {
 		/* Lightfunc virtual properties are non-configurable, so

--- a/tests/ecmascript/test-dev-bufferobject-index-oob.js
+++ b/tests/ecmascript/test-dev-bufferobject-index-oob.js
@@ -1,0 +1,365 @@
+/*
+ *  Typed array out-of-bounds index reads should return undefined and writes
+ *  should be ignored, regardless of any inherited index properties.
+ *
+ *  This is ES6 behavior for typed arrays; Duktape extends the same behavior
+ *  to the non-standard ArrayBuffer and plain buffer indices.  Also Node.js
+ *  Buffer indices behave the same; in newer Node.js versions Buffer inherits
+ *  from Uint8Array.
+ *
+ *  https://github.com/svaarala/duktape/issues/257
+ *  http://www.ecma-international.org/ecma-262/6.0/#sec-integer-indexed-exotic-objects
+ *  https://bugzilla.mozilla.org/show_bug.cgi?id=829896
+ */
+
+print = function () {
+    console.log(Array.prototype.join.call(Array.prototype.map.call(arguments, String), ' '));
+};
+
+function cleanup() {
+    delete Uint16Array.prototype['-0'];
+    delete Uint16Array.prototype['10'];
+    delete Uint16Array.prototype['11'];
+    delete Uint16Array.prototype['12.0'];
+}
+
+function setupU16Array(negZero) {
+    cleanup();
+
+    var u16 = new Uint16Array(10);
+
+    if (negZero) {
+        Object.defineProperty(u16, '-0', {
+            value: 'dummy-neg-zero',
+            writable: true,
+            enumerable: true,
+            configurable: true
+        });
+        Object.defineProperty(u16, '-0.0', {
+            value: 'dummy-neg-zero-dot-zero',
+            writable: true,
+            enumerable: true,
+            configurable: true
+        });
+    }
+    Object.defineProperty(Uint16Array.prototype, '10', {
+        value: 'dummy-10',
+        writable: true,
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(Uint16Array.prototype, '11', {
+        get: function () { print('GETTER CALLED for 11'); return 'dummy-11'; },
+        set: function () { print('SETTER CALLED for 11'); },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(Uint16Array.prototype, '12.0', {
+        value: 'dummy-12.0',
+        writable: true,
+        enumerable: true,
+        configurable: true
+    });
+
+    return u16;
+}
+
+/*===
+read test
+- normal read
+0
+0
+0
+- out-of-bounds read
+dummy-neg-zero
+dummy-neg-zero-dot-zero
+undefined
+undefined
+undefined
+undefined
+undefined
+undefined
+undefined
+undefined
+dummy-12.0
+- zero length Uint16Array
+undefined
+undefined
+undefined
+===*/
+
+function readTest() {
+    var b = setupU16Array(true);
+
+    // Read and write indexed elements within range normally.
+    print('- normal read');
+    print(b[-0]);    // String(-0) === '0', so valid index
+    print(b[0]);
+    print(b[9]);
+
+    // Out-of-bounds read returns undefined, despire inherited
+    // property.  This happens *only* when index is a canonical
+    // one or '-0' (!).
+    //
+    // Negative zero is interesting: ES6 CanonicalNumberIndexString("-0")
+    // returns the number -0 so it triggers exotic index behavior.
+    // However, it's not allowed to actually read/write the view item
+    // at index 0!
+    //
+    // Chrome example (same behavior on Firefox, but not on Node v0.12.1,
+    // probably with newer Node):
+    //
+    //     > x = new Uint8Array(10);
+    //     [0, 0, 0, 0, 0, 0, 0, 0]
+    //     > Uint8Array.prototype['-0'] = 'WOT';
+    //     "WOT"
+    //     > x['-0']
+    //     undefined
+    //     > x['0']
+    //     0
+
+    print('- out-of-bounds read');
+    print(b['-0']);    // considered a numeric index, but does not access [0] *nor* inherits...
+    print(b['-0.0']);  // not considered a numeric index so does inherit
+    print(b[10]);
+    print(b[11]);
+    print(b[12]);
+    print(b['10']);
+    print(b['11']);
+    print(b['12']);
+    print(b['10.0']);
+    print(b['11.0']);
+    print(b['12.0']);
+
+    // For a zero length typed array all index properties are out-of-bounds.
+    b = new Uint16Array(0);
+    print('- zero length Uint16Array');
+    print(b['-0']);
+    print(b[0]);
+    print(b['0']);
+}
+
+try {
+    print('read test');
+    readTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+write test
+- normal write
+0
+123
+123
+234
+0
+123
+- out-of-bounds Write
+undefined
+undefined
+dummy-neg-zero-dot-zero
+123
+undefined
+undefined
+undefined
+undefined
+- zero length Uint16Array
+undefined
+undefined
+undefined
+undefined
+undefined
+undefined
+===*/
+
+function writeTest() {
+    var b = setupU16Array(true);
+
+    // Write indexed elements within range normally.
+    print('- normal write');
+    print(b[-0]); b[-0] = 123; print(b[-0]);  // String(-0) === '0', so valid index
+    print(b[0]); b[0] = 234; print(b[0]);
+    print(b[9]); b[9] = 123; print(b[9]);
+
+    // Out-of-bounds write is ignored, despite inherited property.
+    print('- out-of-bounds Write');
+    print(b['-0']); b['-0'] = 123; print(b['-0']);
+    print(b['-0.0']); b['-0.0'] = 123; print(b['-0.0']);
+    print(b[10]); b[10] = 123; print(b[10]);
+    print(b[11]); b[11] = 123; print(b[11]);
+
+    // For a zero length typed array all index properties are out-of-bounds.
+    b = new Uint16Array(0);
+    print('- zero length Uint16Array');
+    print(b['-0']); b['-0'] = 123; print(b['-0']);
+    print(b[0]); b[0] = 123; print(b[0]);
+    print(b['0']); b['0'] = 234; print(b['0']);
+}
+
+try {
+    print('write test');
+    writeTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+[[HasProperty]] test
+number 0 true
+string -0 false
+string -0.0 true
+number 0 true
+string 0 true
+string 0.0 false
+number 9 true
+string 9 true
+string 9.0 false
+number 10 true
+string 10 true
+string 10.0 false
+number 11 true
+string 11 true
+string 11.0 false
+number 12 false
+string 12 false
+string 12.0 true
+===*/
+
+function hasTest() {
+    var b = setupU16Array(true);
+
+    // Also [[HasProperty]] must ignore inherited values for index
+    // properties.
+    //
+    // The string '-0' is considered an index by ES6 CanonicalNumberIndexString
+    // but the property is never considered to be present regardless of
+    // inherited properties.
+
+    [
+        // -0: String(-0) === '0' so present
+        // '-0': special treatment, never present despire inherited '0'
+        // '-0.0': normal property, here inherited
+        -0, '-0', '-0.0',
+        0, '0', '0.0',
+        9, '9', '9.0',
+        10, '10', '10.0',
+        11, '11', '11.0',
+        12, '12', '12.0'   // '12.0' is present, inherited
+    ].forEach(function (v) {
+        print(typeof v, v, v in b);
+    });
+}
+
+try {
+    print('[[HasProperty]] test');
+    hasTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+===*/
+
+function fullTest() {
+//    var plain = Duktape.Buffer(10);
+    var u8 = new Uint8Array(10);
+    var u32 = new Uint32Array(10);
+    var f64 = new Float64Array(10);
+    var node = new Buffer(10);
+    var i;
+
+    // Add some inherited properties.
+    [
+        ArrayBuffer.prototype,
+        Uint8Array.prototype,
+        Uint32Array.prototype,
+        Float64Array.prototype,
+        Buffer.prototype
+    ].forEach(function (proto) {
+        var i;
+
+        function f1(idx) {
+            Object.defineProperty(proto, idx, {
+                value: 'dummy-' + idx,
+                writable: true,
+                enumerable: true,  // interfere with enumeration too
+                configurable: true
+            });
+        }
+        function f2(idx) {
+            Object.defineProperty(proto, idx, {
+                get: function () { print('GETTER CALLED:', idx); return 'dummy-getter'; },
+                set: function (k) { print('SETTER CALLED:', idx); },
+                enumerable: true,  // interfere with enumeration too
+                configurable: true
+            });
+        }
+
+        for (i = 0; i < 15; i++) {
+            f1(i);
+        }
+        for (i = 15; i < 20; i++) {
+            f2(i);
+        }
+        f2(0xfffffffe);   // valid index
+        f2(0xffffffff);   // not a valid index
+        f2(0x100000000);  // not a valid index, getter matches
+        f2(0x10000000000000000);  // not a valid index, getter matches
+        f2('1.0');  // not a valid index
+    });
+
+    [ /*plain,*/ u8, u32, f64, node ].forEach(function (b, bufidx) {
+        print('*** Buffer value ' + bufidx);
+
+        function test(idx) {
+            print('=== index', idx, '(' + typeof idx + ')');
+            print(idx, 'bufidx', idx in b);
+            print(idx, 'bufstr', String(idx) in b);
+            print(idx, 'bufidx', b[idx]);
+            print(idx, 'bufstr', b[String(idx)]);
+            print(idx, 'parent', Object.getPrototypeOf(Object(b))[idx]);
+            b[idx] = 123;
+            print(idx, b[idx]);
+            print(idx, b[String(idx)]);
+            print(idx, Object.getPrototypeOf(Object(b))[idx]);
+        }
+        for (var i = -1; i < 20; i++) {
+            test(i);
+        }
+
+        // Test non-canonical number index; must be inherited.
+        test('1.0');  // not valid, has ancestor
+        test('2.0');  // not valid, but no ancestor
+
+        // 4G corner cases, also test that index isn't incorrectly
+        // ToUint32() (or otherwise integer) coerced in which case
+        // it would wrap (incorrect).
+        [ 0xfffffffe, 0xffffffff,
+          0x100000000, 0x100000001,
+          '4294967294', '4294967294.0',
+          '4294967295', '4294967295.0',
+          '4294967296', '4294967296.0',
+          '4294967297', '4294967297.0',
+          0x10000000000000000, 0x10000000000001111,  // step must be large enough to make a difference for an IEEE double
+          '18446744073709552000', '18446744073709552000.0',
+          '18446744073709556000', '18446744073709556000.0'
+        ].forEach(function (idx) {
+            test(idx);
+        });
+
+        // Enumeration: FIXME; inherit too?
+        print('== for-in enumeration');
+        for (var k in b) {
+            print(k);
+        }
+
+        // FIXME: own props
+    });
+}
+
+try {
+    //fullTest();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
ES6 specifies new behavior for typed arrays when a numeric index is detected but it is out of bounds with respect to the typed array: in this case the property is not considered to be present; reads report `undefined`, writes are ignored, HasProperty reports not present. Negative zero string (`"-0"`) is considered a numeric index but never present (not equated with `"0"`).

Work in progress, doesn't yet work.