### PR TITLE
Avoid side effects during string intern processing

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1793,6 +1793,11 @@ Planned
   .length is larger than the internal array part size (created e.g. when
   calling new Array(10)) without falling back to the slow path (GH-703)
 
+* Fix potential memory unsafe behavior when duk_push_(l)string() data pointer
+  is from a dynamic/external buffer (or any other relocatable data source)
+  and a finalizer side effect resizes/reconfigures the buffer, invalidating
+  the pointer before string table code has time to copy the data (GH-884)
+
 * Internal performance improvement: avoid one extra shift when computing
   reg/const pointers in the bytecode executor (GH-674)
 

--- a/src/duk_heap_markandsweep.c
+++ b/src/duk_heap_markandsweep.c
@@ -1313,6 +1313,9 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 
 	/* XXX: stringtable emergency compaction? */
 
+	/* XXX: remove this feature entirely? it would only matter for
+	 * emergency GC.  Disable for lowest memory builds.
+	 */
 #if defined(DUK_USE_MS_STRINGTABLE_RESIZE)
 	if (!(flags & DUK_MS_FLAG_NO_STRINGTABLE_RESIZE)) {
 		DUK_DD(DUK_DDPRINT("resize stringtable: %p", (void *) heap));

--- a/src/duk_heap_stringtable.c
+++ b/src/duk_heap_stringtable.c
@@ -10,6 +10,15 @@
 #define DUK__DELETED_MARKER(heap)             DUK_STRTAB_DELETED_MARKER((heap))
 #endif
 
+#if defined(DUK_USE_MARK_AND_SWEEP)
+#define DUK__PREVENT_MS_SIDE_EFFECTS(heap) do { \
+		(heap)->mark_and_sweep_base_flags |= \
+		        DUK_MS_FLAG_NO_STRINGTABLE_RESIZE |  /* avoid recursive string table call */ \
+		        DUK_MS_FLAG_NO_FINALIZERS |          /* avoid pressure to add/remove strings, invalidation of call data argument, etc. */ \
+		        DUK_MS_FLAG_NO_OBJECT_COMPACTION;    /* avoid array abandoning which interns strings */ \
+	} while (0)
+#endif
+
 /*
  *  Create a hstring and insert into the heap.  The created object
  *  is directly garbage collectable with reference count zero.
@@ -46,7 +55,7 @@ duk_hstring *duk__alloc_init_hstring(duk_heap *heap,
 			goto alloc_error;
 		}
 		DUK_MEMZERO(res, sizeof(duk_hstring_external));
-#ifdef DUK_USE_EXPLICIT_NULL_INIT
+#if defined(DUK_USE_EXPLICIT_NULL_INIT)
 		DUK_HEAPHDR_STRING_INIT_NULLS(&res->hdr);
 #endif
 		DUK_HEAPHDR_SET_TYPE_AND_FLAGS(&res->hdr, DUK_HTYPE_STRING, DUK_HSTRING_FLAG_EXTDATA);
@@ -60,7 +69,7 @@ duk_hstring *duk__alloc_init_hstring(duk_heap *heap,
 			goto alloc_error;
 		}
 		DUK_MEMZERO(res, sizeof(duk_hstring));
-#ifdef DUK_USE_EXPLICIT_NULL_INIT
+#if defined(DUK_USE_EXPLICIT_NULL_INIT)
 		DUK_HEAPHDR_STRING_INIT_NULLS(&res->hdr);
 #endif
 		DUK_HEAPHDR_SET_TYPE_AND_FLAGS(&res->hdr, DUK_HTYPE_STRING, 0);
@@ -636,10 +645,7 @@ DUK_LOCAL void duk__remove_matching_hstring_probe(duk_heap *heap, duk_hstring **
 }
 
 DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t new_size) {
-#ifdef DUK_USE_MARK_AND_SWEEP
-	duk_small_uint_t prev_mark_and_sweep_base_flags;
-#endif
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 	duk_uint32_t old_used = heap->st_used;
 #endif
 	duk_uint32_t old_size = heap->st_size;
@@ -653,7 +659,7 @@ DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t n
 	duk_uint32_t new_used = 0;
 	duk_uint32_t i;
 
-#ifdef DUK_USE_DEBUG
+#if defined(DUK_USE_DEBUG)
 	DUK_UNREF(old_used);  /* unused with some debug level combinations */
 #endif
 
@@ -667,23 +673,18 @@ DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t n
 
 	DUK_ASSERT(new_size > (duk_uint32_t) duk__count_used_probe(heap));  /* required for rehash to succeed, equality not that useful */
 	DUK_ASSERT(old_entries);
-#ifdef DUK_USE_MARK_AND_SWEEP
-	DUK_ASSERT((heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_STRINGTABLE_RESIZE) == 0);
-#endif
 
 	/*
 	 *  The attempt to allocate may cause a GC.  Such a GC must not attempt to resize
 	 *  the stringtable (though it can be swept); finalizer execution and object
 	 *  compaction must also be postponed to avoid the pressure to add strings to the
-	 *  string table.
+	 *  string table.  Call site must prevent these.
 	 */
 
-#ifdef DUK_USE_MARK_AND_SWEEP
-	prev_mark_and_sweep_base_flags = heap->mark_and_sweep_base_flags;
-	heap->mark_and_sweep_base_flags |= \
-	        DUK_MS_FLAG_NO_STRINGTABLE_RESIZE |  /* avoid recursive call here */
-	        DUK_MS_FLAG_NO_FINALIZERS |          /* avoid pressure to add/remove strings */
-	        DUK_MS_FLAG_NO_OBJECT_COMPACTION;    /* avoid array abandoning which interns strings */
+#if defined(DUK_USE_MARK_AND_SWEEP)
+	DUK_ASSERT(heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_STRINGTABLE_RESIZE);
+	DUK_ASSERT(heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_FINALIZERS);
+	DUK_ASSERT(heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_OBJECT_COMPACTION);
 #endif
 
 #if defined(DUK_USE_HEAPPTR16)
@@ -692,15 +693,11 @@ DUK_LOCAL duk_bool_t duk__resize_strtab_raw_probe(duk_heap *heap, duk_uint32_t n
 	new_entries = (duk_hstring **) DUK_ALLOC(heap, sizeof(duk_hstring *) * new_size);
 #endif
 
-#ifdef DUK_USE_MARK_AND_SWEEP
-	heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
-#endif
-
 	if (!new_entries) {
 		goto resize_error;
 	}
 
-#ifdef DUK_USE_EXPLICIT_NULL_INIT
+#if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	for (i = 0; i < new_size; i++) {
 #if defined(DUK_USE_HEAPPTR16)
 		new_entries[i] = heap->heapptr_null16;
@@ -836,10 +833,24 @@ DUK_INTERNAL void duk_heap_dump_strtab(duk_heap *heap) {
 DUK_LOCAL duk_hstring *duk__do_intern(duk_heap *heap, const duk_uint8_t *str, duk_uint32_t blen, duk_uint32_t strhash) {
 	duk_hstring *res;
 	const duk_uint8_t *extdata;
+#if defined(DUK_USE_MARK_AND_SWEEP)
+	duk_small_uint_t prev_mark_and_sweep_base_flags;
+#endif
+
+	/* Prevent any side effects on the string table and the caller provided
+	 * str/blen arguments while interning is in progress.  For example, if
+	 * the caller provided str/blen from a dynamic buffer, a finalizer might
+	 * resize that dynamic buffer, invalidating the call arguments.
+	 */
+#if defined(DUK_USE_MARK_AND_SWEEP)
+	DUK_ASSERT((heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_STRINGTABLE_RESIZE) == 0);
+	prev_mark_and_sweep_base_flags = heap->mark_and_sweep_base_flags;
+	DUK__PREVENT_MS_SIDE_EFFECTS(heap);
+#endif
 
 #if defined(DUK_USE_STRTAB_PROBE)
 	if (duk__recheck_strtab_size_probe(heap, heap->st_used + 1)) {
-		return NULL;
+		goto failed;
 	}
 #endif
 
@@ -850,14 +861,14 @@ DUK_LOCAL duk_hstring *duk__do_intern(duk_heap *heap, const duk_uint8_t *str, du
 #endif
 	res = duk__alloc_init_hstring(heap, str, blen, strhash, extdata);
 	if (!res) {
-		return NULL;
+		goto failed;
 	}
 
 #if defined(DUK_USE_STRTAB_CHAIN)
 	if (duk__insert_hstring_chain(heap, res)) {
 		/* failed */
 		DUK_FREE(heap, res);
-		return NULL;
+		goto failed;
 	}
 #elif defined(DUK_USE_STRTAB_PROBE)
 	/* guaranteed to succeed */
@@ -879,7 +890,15 @@ DUK_LOCAL duk_hstring *duk__do_intern(duk_heap *heap, const duk_uint8_t *str, du
 	 * operations which require allocation (and possible gc).
 	 */
 
+ done:
+#if defined(DUK_USE_MARK_AND_SWEEP)
+	heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
+#endif
 	return res;
+
+ failed:
+	res = NULL;
+	goto done;
 }
 
 DUK_LOCAL duk_hstring *duk__do_lookup(duk_heap *heap, const duk_uint8_t *str, duk_uint32_t blen, duk_uint32_t *out_strhash) {
@@ -1015,16 +1034,24 @@ DUK_INTERNAL void duk_heap_string_remove(duk_heap *heap, duk_hstring *h) {
 
 #if defined(DUK_USE_MARK_AND_SWEEP) && defined(DUK_USE_MS_STRINGTABLE_RESIZE)
 DUK_INTERNAL void duk_heap_force_strtab_resize(duk_heap *heap) {
+	duk_small_uint_t prev_mark_and_sweep_base_flags;
 	/* Force a resize so that DELETED entries are eliminated.
 	 * Another option would be duk__recheck_strtab_size_probe();
 	 * but since that happens on every intern anyway, this whole
 	 * check can now be disabled.
 	 */
+
+	DUK_ASSERT((heap->mark_and_sweep_base_flags & DUK_MS_FLAG_NO_STRINGTABLE_RESIZE) == 0);
+	prev_mark_and_sweep_base_flags = heap->mark_and_sweep_base_flags;
+	DUK__PREVENT_MS_SIDE_EFFECTS(heap);
+
 #if defined(DUK_USE_STRTAB_CHAIN)
 	DUK_UNREF(heap);
 #elif defined(DUK_USE_STRTAB_PROBE)
-	duk__resize_strtab_probe(heap);
+	(void) duk__resize_strtab_probe(heap);
 #endif
+
+	heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
 }
 #endif
 

--- a/tests/api/test-dev-string-intern-side-effect.c
+++ b/tests/api/test-dev-string-intern-side-effect.c
@@ -1,0 +1,131 @@
+/*
+ *  Illustrate corner case string intern side effect behavior: when a finalizer
+ *  is triggered during string interning it can potentially invalidate the
+ *  string data pointer/length provided before the data has been copied.
+ *
+ *  This would be quite difficult to trigger in practice.  This tests case
+ *  relies on voluntary mark-and-sweep to trigger when the new duk_hstring
+ *  is allocated.  To achieve that a lot of tries are needed.
+ *
+ *  https://github.com/svaarala/duktape/pull/884
+ *
+ *  Run with valgrind to catch memory unsafe behavior.
+ */
+
+/* When testing manually, increase to e.g. 100. */
+#define TEST_COUNT 3
+
+/*===
+*** test_side_effect (duk_safe_call)
+...0
+finalizer
+resized
+...1
+finalizer
+resized
+...2
+finalizer
+resized
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static int finalizer_ran = 0;
+
+static duk_ret_t my_finalizer(duk_context *ctx) {
+	finalizer_ran = 1;
+#if 1
+	printf("finalizer\n"); fflush(stdout);
+#endif
+	duk_get_global_string(ctx, "currentBuffer");
+	duk_resize_buffer(ctx, -1, 0);
+#if 1
+	printf("resized\n"); fflush(stdout);
+#endif
+	return 0;
+}
+
+static duk_ret_t test_side_effect(duk_context *ctx, void *udata) {
+	int i, count_intern;
+	void *ptr;
+
+	(void) udata;
+
+	for (i = 0; i < TEST_COUNT; i++) {
+		printf("...%d\n", i); fflush(stdout);
+
+		/* Create a dynamic buffer we tweak in the side effect.
+		 * Buffer is not yet registered to global.currentBuffer
+		 * so any previous finalizers (which might still exist)
+		 * can't reach it.
+		 */
+
+		ptr = duk_push_dynamic_buffer(ctx, 1024 * 1024);
+
+		/* Create cyclical garbage which won't get collected by
+		 * refcounting.  This is essential so that there can be
+		 * something with a finalizer when mark-and-sweep gets
+		 * triggered.
+		 */
+
+		duk_push_object(ctx);
+		duk_push_object(ctx);
+		duk_dup(ctx, -2);
+		duk_put_prop_string(ctx, -2, "ref");
+		duk_dup(ctx, -1);
+		duk_put_prop_string(ctx, -3, "ref");
+		duk_push_c_function(ctx, my_finalizer, 0);
+		duk_set_finalizer(ctx, -2);
+
+		/* Fill the buffer and make it reachable for the finalizer. */
+
+		finalizer_ran = 0;
+		memset(ptr, 0, 1024 * 1024);
+		*((int *) ptr) = i;  /* Create a new string on each round. */
+		duk_dup(ctx, -3);
+		duk_put_global_string(ctx, "currentBuffer");
+		duk_remove(ctx, -3);
+
+		/* We're now ready: cause the two objects to become not yet
+		 * collected garbage.  The buffer may be resized before we
+		 * reach the string test, so don't reference 'ptr' anymore.
+		 */
+
+		duk_pop_2(ctx);
+
+		/* Finally, push a new string and hope we trigger the
+		 * finalizer.  Repeat the operation until the finalizer
+		 * runs (it may already have run), and hope it gets triggered
+		 * in the right spot.
+		 */
+
+		count_intern = 0;
+		while (!finalizer_ran) {
+			count_intern++;
+			duk_push_lstring(ctx, ptr, 1024 * 1024);
+			duk_pop(ctx);
+
+			/* Because the fix in https://github.com/svaarala/duktape/pull/884
+			 * prevent side effects in string interning, we need to trigger
+			 * them explicitly at some pointer to avoid looping forever.
+			 * The limit here allows a failure to be detected in e.g. 1.5.0.
+			 */
+			if (count_intern >= 50000) {
+				duk_gc(ctx, 0);
+			}
+		}
+#if 0
+		printf("Finalizer run took %d tries \n", count_intern); fflush(stdout);
+#endif
+	}
+
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_side_effect);
+}


### PR DESCRIPTION
When e.g. pushing a string from the contents of a buffer object there's an outside chance that the mechanics of string pushing (allocation) causes a mark-and-sweep, which triggers a finalizer that resizes or reconfigures the buffer object we're trying to string coerce. When the string interning code has allocated space for the string and is ready to copy the data over, the original address and length might no longer be valid.

There's an explicit workaround for this in `duk_push_buffer_object()` but the workaround is awkward: the code first pushes a fixed buffer and copies the buffer object data there to stabilize it (fixed buffers can't be reallocated/relocated) and then proceeds to string intern the fixed buffer contents.

A better solution would be to ensure string interning cannot trigger finalizers or other side effects. This would then make all call sites safe against this potential (but a bit contrived) issue, and would allow `duk_buffer_to_string()` to be simplified.