### PR TITLE
Add internal duk_get_tval_or_unused()

### DIFF
--- a/src/duk_api_internal.h
+++ b/src/duk_api_internal.h
@@ -34,6 +34,7 @@ DUK_INTERNAL_DECL const char *duk_get_type_name(duk_context *ctx, duk_idx_t idx)
 DUK_INTERNAL_DECL duk_small_uint_t duk_get_class_number(duk_context *ctx, duk_idx_t idx);
 
 DUK_INTERNAL_DECL duk_tval *duk_get_tval(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_tval *duk_get_tval_or_unused(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL duk_tval *duk_require_tval(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL void duk_push_tval(duk_context *ctx, duk_tval *tv);
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -472,7 +472,9 @@ DUK_EXTERNAL_DECL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t idx
 
 DUK_EXTERNAL_DECL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t idx);
-DUK_EXTERNAL_DECL duk_bool_t duk_is_null_or_undefined(duk_context *ctx, duk_idx_t idx);
+#define duk_is_null_or_undefined(ctx, idx) \
+	((duk_get_type_mask((ctx), (idx)) & (DUK_TYPE_MASK_NULL | DUK_TYPE_MASK_UNDEFINED)) ? 1 : 0)
+
 DUK_EXTERNAL_DECL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx);

--- a/src/duk_tval.h
+++ b/src/duk_tval.h
@@ -33,6 +33,12 @@
 
 /* use duk_double_union as duk_tval directly */
 typedef union duk_double_union duk_tval;
+typedef struct {
+	duk_uint16_t a;
+	duk_uint16_t b;
+	duk_uint16_t c;
+	duk_uint16_t d;
+} duk_tval_unused;
 
 /* tags */
 #define DUK_TAG_NORMALIZED_NAN    0x7ff8UL   /* the NaN variant we use */
@@ -54,6 +60,10 @@ typedef union duk_double_union duk_tval;
 /* for convenience */
 #define DUK_XTAG_BOOLEAN_FALSE    0xfff50000UL
 #define DUK_XTAG_BOOLEAN_TRUE     0xfff50001UL
+
+/* DUK_TVAL_UNUSED initializer for duk_tval_unused, works for any endianness. */
+#define DUK_TVAL_UNUSED_INITIALIZER() \
+	{ DUK_TAG_UNUSED, DUK_TAG_UNUSED, DUK_TAG_UNUSED, DUK_TAG_UNUSED }
 
 /* two casts to avoid gcc warning: "warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]" */
 #if defined(DUK_USE_64BIT_OPS)
@@ -292,6 +302,20 @@ struct duk_tval_struct {
 		duk_c_function lightfunc;
 	} v;
 };
+
+typedef struct {
+	duk_small_uint_t t;
+	duk_small_uint_t v_extra;
+	/* The rest of the fields don't matter except for debug dumps and such
+	 * for which a partial initializer may trigger out-ot-bounds memory
+	 * reads.  Include a double field which is usually as large or larger
+	 * than pointers (not always however).
+	 */
+	duk_double_t d;
+} duk_tval_unused;
+
+#define DUK_TVAL_UNUSED_INITIALIZER() \
+	{ DUK_TAG_UNUSED, 0, 0.0 }
 
 #define DUK__TAG_NUMBER               0  /* not exposed */
 #if defined(DUK_USE_FASTINT)

--- a/tests/api/test-get-require-push-heapptr.c
+++ b/tests/api/test-get-require-push-heapptr.c
@@ -27,7 +27,7 @@ idx 6: type 7, duk_get_heapptr() -> non-NULL
 idx 6: type 7, duk_require_heapptr() -> non-NULL
 top: 7
 idx 7: type 0, duk_get_heapptr() -> NULL
-idx 7: type 5, duk_require_heapptr() -> RangeError: invalid stack index 7
+idx 7: type 5, duk_require_heapptr() -> TypeError: heapobject required, found none (stack index 7)
 "test string"
 {foo:"bar"}
 |deadbeef|


### PR DESCRIPTION
The call returns a non-NULL duk_tval pointer to a static DUK_TAG_UNUSED so that a call site can avoid an unnecessary NULL check.  This is useful fore.g. calls like duk_get_boolean(), and reduces size optimized footprint.

Also change `duk_is_null_or_undefined()` to be a type mask based macro: it's quite rarely used.