### PR TITLE
Remove unnecessary NaN check for a few API calls

### DIFF
--- a/src/duk_api_stack.c
+++ b/src/duk_api_stack.c
@@ -1142,11 +1142,11 @@ DUK_EXTERNAL duk_double_t duk_get_number(duk_context *ctx, duk_idx_t idx) {
 		ret.d = DUK_TVAL_GET_NUMBER(tv);
 	}
 
-	/* Number should already be in NaN-normalized form, but let's
-	 * normalize anyway.
+	/* When using packed duk_tval, number must be in NaN-normalized form
+	 * for it to be a duk_tval, so no need to normalize.  NOP for unpacked
+	 * duk_tval.
 	 */
 	DUK_ASSERT(DUK_DBLUNION_IS_NORMALIZED(&ret));
-	DUK_DBLUNION_NORMALIZE_NAN_CHECK(&ret);
 	return ret.d;
 }
 
@@ -1165,11 +1165,11 @@ DUK_EXTERNAL duk_double_t duk_require_number(duk_context *ctx, duk_idx_t idx) {
 
 	ret.d = DUK_TVAL_GET_NUMBER(tv);
 
-	/* Number should already be in NaN-normalized form,
-	 * but let's normalize anyway.
+	/* When using packed duk_tval, number must be in NaN-normalized form
+	 * for it to be a duk_tval, so no need to normalize.  NOP for unpacked
+	 * duk_tval.
 	 */
 	DUK_ASSERT(DUK_DBLUNION_IS_NORMALIZED(&ret));
-	DUK_DBLUNION_NORMALIZE_NAN_CHECK(&ret);
 	return ret.d;
 }
 

--- a/src/duk_tval.h
+++ b/src/duk_tval.h
@@ -366,9 +366,12 @@ typedef struct {
 #if defined(DUK_USE_FASTINT)
 #define DUK_TVAL_SET_DOUBLE(tv,val)  do { \
 		duk_tval *duk__tv; \
+		duk_double_t duk__dblval; \
+		duk__dblval = (val); \
+		DUK_ASSERT_DOUBLE_IS_NORMALIZED(duk__dblval); /* nop for unpacked duk_tval */ \
 		duk__tv = (tv); \
 		duk__tv->t = DUK__TAG_NUMBER; \
-		duk__tv->v.d = (val); \
+		duk__tv->v.d = duk__dblval; \
 	} while (0)
 #define DUK_TVAL_SET_I48(tv,val)  do { \
 		duk_tval *duk__tv; \
@@ -412,9 +415,12 @@ typedef struct {
 	DUK_TVAL_SET_NUMBER((tv), (duk_double_t) (val))
 #define DUK_TVAL_SET_NUMBER(tv,val)  do { \
 		duk_tval *duk__tv; \
+		duk_double_t duk__dblval; \
+		duk__dblval = (val); \
+		DUK_ASSERT_DOUBLE_IS_NORMALIZED(duk__dblval); /* nop for unpacked duk_tval */ \
 		duk__tv = (tv); \
 		duk__tv->t = DUK__TAG_NUMBER; \
-		duk__tv->v.d = (val); \
+		duk__tv->v.d = duk__dblval; \
 	} while (0)
 #define DUK_TVAL_SET_NUMBER_CHKFAST(tv,d) \
 	DUK_TVAL_SET_NUMBER((tv), (d))


### PR DESCRIPTION
- [x] Remove NaN checks (asserts only) from a few API calls
- [x] Add NaN asserts to DUK_TVAL_SET_xxx() calls where appropriate to catch offenders early