### PR TITLE
Remove duk_put_function_list() and duk_put_number_list()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1710,6 +1710,10 @@ Planned
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),
   DUK_FPUTC(), DUK_STDOUT, DUK_STDERR, DUK_STDIN, duk_file (GH-787, GH-761)
 
+* Add duk_def_prop_list() with a flexible and more easily versionably
+  macro-based initializers syntax; this API call will eventually replace
+  duk_put_function_list() and duk_put_number_list() (GH-130, GH-575)
+
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
   same time provider as seen by Ecmascript code (GH-771)

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1701,6 +1701,9 @@ Planned
   related changes; instead, an artificial property "length" is available via
   GetHeapObjInfo (GH-703, GH-856)
 
+* Incompatible change: remove duk_put_function_list() and duk_put_number_list()
+  functions.
+
 * Allow ES6 unescaped right bracket (']') in regular expressions (non-standard
   before ES6 Annex B), left bracket ('[') not yet supported because it needs
   backtracking (GH-871)

--- a/doc/c-module-convention.rst
+++ b/doc/c-module-convention.rst
@@ -31,7 +31,10 @@ The init function for a module ``my_module`` should have the following form::
 
         duk_push_object(ctx);  /* module result */
 
-        duk_put_function_list(ctx, -1, my_module_funcs);
+        /* Since Duktape 1.5.0 duk_def_prop_list() is the most flexible
+         * static property list initializer.
+         */
+        duk_def_prop_list(ctx, -1, my_module_props);
 
         duk_push_int(ctx, 42);
         duk_put_prop_string(ctx, -2, "meaningOfLife");

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -389,6 +389,13 @@ To upgrade:
       rc = duk_safe_call(ctx, my_safe_call, 1 /*nargs*/, 1 /*nrets*/);
       #endif
 
+duk_put_function_list() and duk_put_number_list() replaced by duk_def_prop_list()
+---------------------------------------------------------------------------------
+
+FIXME.
+
+FIXME: compat extra?
+
 Duktape specific error codes removed from API
 ---------------------------------------------
 

--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -464,36 +464,6 @@ DUK_EXTERNAL duk_bool_t duk_next(duk_context *ctx, duk_idx_t enum_index, duk_boo
  *  Helpers for writing multiple properties
  */
 
-DUK_EXTERNAL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_idx, const duk_function_list_entry *funcs) {
-	const duk_function_list_entry *ent = funcs;
-
-	DUK_ASSERT_CTX_VALID(ctx);
-
-	obj_idx = duk_require_normalize_index(ctx, obj_idx);
-	if (ent != NULL) {
-		while (ent->key != NULL) {
-			duk_push_c_function(ctx, ent->value, ent->nargs);
-			duk_put_prop_string(ctx, obj_idx, ent->key);
-			ent++;
-		}
-	}
-}
-
-DUK_EXTERNAL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const duk_number_list_entry *numbers) {
-	const duk_number_list_entry *ent = numbers;
-
-	DUK_ASSERT_CTX_VALID(ctx);
-
-	obj_idx = duk_require_normalize_index(ctx, obj_idx);
-	if (ent != NULL) {
-		while (ent->key != NULL) {
-			duk_push_number(ctx, ent->value);
-			duk_put_prop_string(ctx, obj_idx, ent->key);
-			ent++;
-		}
-	}
-}
-
 #if defined(DUK_USE_UNION_INITIALIZERS)
 #define DUK__PROP_SELECT(unionval,structval) (unionval)
 #else

--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -494,6 +494,156 @@ DUK_EXTERNAL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const
 	}
 }
 
+#if defined(DUK_USE_UNION_INITIALIZERS)
+#define DUK__PROP_SELECT(unionval,structval) (unionval)
+#else
+#define DUK__PROP_SELECT(unionval,structval) (structval)
+#endif
+
+DUK_EXTERNAL void duk_def_prop_list(duk_context *ctx, duk_idx_t obj_index, const duk_prop_list_entry *props) {
+	const duk_prop_list_entry *ent = props;
+#if defined(DUK_USE_ASSERTIONS)
+	duk_idx_t entry_top;
+#endif
+
+	DUK_ASSERT_CTX_VALID(ctx);
+#if defined(DUK_USE_ASSERTIONS)
+	entry_top = duk_get_top(ctx);
+#endif
+
+	obj_index = duk_require_normalize_index(ctx, obj_index);
+	for (;;) {
+		/* FIXME: optimize by using DUK_TVAL_SET_xxx() */
+		duk_uint_t defprop_flags;
+
+#if defined(DUK_USE_ASSERTIONS)
+		DUK_ASSERT_TOP(ctx, entry_top);
+#endif
+		if (ent->key == NULL) {
+			DUK_ASSERT(ent->etype == DUK_PROPINIT_END);
+			break;
+		}
+		duk_push_string(ctx, ent->key);
+
+		defprop_flags = ent->eattr;  /* these are assumed to be correct, up to the duk_api_public.h macros */
+
+		DUK_ASSERT(ent->etype != DUK_PROPINIT_END);  /* key == NULL <=> DUK_PROPINIT_END */
+		switch (ent->etype) {
+		case DUK_PROPINIT_UNDEFINED: {
+			duk_push_undefined(ctx);
+			break;
+		}
+		case DUK_PROPINIT_NULL: {
+			duk_push_null(ctx);
+			break;
+		}
+		case DUK_PROPINIT_BOOLEAN: {
+			duk_push_boolean(ctx, DUK__PROP_SELECT(ent->u.bval, ent->s.ival));
+			break;
+		}
+		case DUK_PROPINIT_NUMBER: {
+			duk_push_number(ctx, DUK__PROP_SELECT(ent->u.num, ent->s.num));
+			break;
+		}
+		case DUK_PROPINIT_STRING: {
+			duk_push_string(ctx, (const char *) DUK__PROP_SELECT(ent->u.str.str, ent->s.ptr));
+			break;
+		}
+		case DUK_PROPINIT_LSTRING: {
+			duk_push_lstring(ctx,
+			                 (const char *) DUK__PROP_SELECT(ent->u.str.str, ent->s.ptr),
+			                 (duk_size_t) DUK__PROP_SELECT(ent->u.str.len, ent->s.idx));
+			break;
+		}
+		case DUK_PROPINIT_OBJECT: {
+			DUK_ERROR_INTERNAL((duk_hthread *) ctx);  /* FIXME: unimplemented */
+			break;
+		}
+		case DUK_PROPINIT_BUFFER: {
+			/* FIXME: buffer nature: fixed/dynamic */
+			/* FIXME: initialization? */
+			/* FIXME: buffer objects */
+			void *bufdata;
+			const void *initdata;
+			duk_size_t buflen;
+			buflen = (duk_size_t) DUK__PROP_SELECT(ent->u.str.len, ent->s.idx);
+			bufdata = duk_push_fixed_buffer(ctx, buflen);
+			DUK_ASSERT(bufdata != NULL);
+			initdata = (const void *) DUK__PROP_SELECT(ent->u.buf.buf, ent->s.ptr);
+			if (initdata) {
+				DUK_MEMCPY(bufdata, initdata, buflen);
+			}
+			break;
+		}
+		case DUK_PROPINIT_POINTER: {
+			/* FIXME: lose const for struct case */
+			duk_push_pointer(ctx, (void *) DUK__PROP_SELECT(ent->u.ptr, ent->s.ptr));
+			break;
+		}
+		case DUK_PROPINIT_FUNCTION: {
+			duk_push_c_function(ctx,
+			                    DUK__PROP_SELECT(ent->u.func.func, ent->s.func1),
+			                    DUK__PROP_SELECT(ent->u.func.nargs, ent->s.idx));
+			duk_set_magic(ctx, -1, DUK__PROP_SELECT(ent->u.func.magic, ent->s.ival));
+			/* FIXME: 'length' for a non-lightfunc? */
+			break;
+		}
+		case DUK_PROPINIT_LIGHTFUNC: {
+			duk_push_c_lightfunc(ctx,
+			                    DUK__PROP_SELECT(ent->u.func.func, ent->s.func1),
+			                    DUK__PROP_SELECT(ent->u.func.nargs, ent->s.idx),
+			                    DUK__PROP_SELECT(ent->u.func.length, (duk_idx_t) ent->s.num),
+			                    DUK__PROP_SELECT(ent->u.func.magic, (duk_int_t) ent->s.ival));
+			break;
+		}
+		case DUK_PROPINIT_ACCESSOR: {
+			/* FIXME: getter/setter nargs; provided by user or not?
+			 * Should the default be sensitive to custom key argument presence?
+			 */
+			/* FIXME: tolerating NULL? */
+			duk_push_c_function(ctx,
+			                    DUK__PROP_SELECT(ent->u.accessor.getter, ent->s.func1),
+			                    1 /*nargs*/);
+			duk_push_c_function(ctx,
+			                    DUK__PROP_SELECT(ent->u.accessor.setter, ent->s.func2),
+			                    2 /*nargs*/);
+			DUK_ASSERT(defprop_flags & DUK_DEFPROP_HAVE_GETTER);
+			DUK_ASSERT(defprop_flags & DUK_DEFPROP_HAVE_SETTER);
+			break;
+		}
+		case DUK_PROPINIT_PROPLIST: {
+			const duk_prop_list_entry *sub_props;
+			duk_push_object(ctx);
+			sub_props = (const duk_prop_list_entry *) DUK__PROP_SELECT(ent->u.props, ent->s.ptr);
+			DUK_ASSERT(sub_props != NULL);
+			duk_require_stack(ctx, 1);  /* this matters for deep recursion */
+			duk_def_prop_list(ctx, -1, sub_props);
+			break;
+		}
+		case DUK_PROPINIT_STACK: {
+			DUK_ERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);  /* FIXME */
+			break;
+		}
+		default: {
+			DUK_ERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
+		}
+		}  /* switch */
+
+		duk_def_prop(ctx, obj_index, defprop_flags);
+		ent++;
+	}
+
+	/* Because this call is generally used to initialize objects, it's
+	 * useful to automatically compact the object here.
+	 */
+	duk_compact(ctx, obj_index);
+
+#if defined(DUK_USE_ASSERTIONS)
+	DUK_ASSERT_TOP(ctx, entry_top);
+#endif
+}
+#undef DUK__PROP_SELECT
+
 /*
  *  Shortcut for accessing global object properties
  */

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -33,8 +33,6 @@ extern "C" {
  */
 
 struct duk_memory_functions;
-struct duk_function_list_entry;  /* to be removed */
-struct duk_number_list_entry;    /* to be removed */
 struct duk_time_components;
 struct duk_prop_list_entry;
 
@@ -794,10 +792,6 @@ DUK_EXTERNAL_DECL duk_int_t duk_get_current_magic(duk_context *ctx);
 #define DUK_PROPINIT_ACCESSOR    13
 #define DUK_PROPINIT_PROPLIST    14
 #define DUK_PROPINIT_STACK       15
-
-/* These are to be removed, in favor of the more flexible duk_def_prop_list() */
-DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs);
-DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers);
 
 DUK_EXTERNAL_DECL void duk_def_prop_list(duk_context *ctx, duk_idx_t obj_index, const duk_prop_list_entry *props);
 

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -33,9 +33,10 @@ extern "C" {
  */
 
 struct duk_memory_functions;
-struct duk_function_list_entry;
-struct duk_number_list_entry;
+struct duk_function_list_entry;  /* to be removed */
+struct duk_number_list_entry;    /* to be removed */
 struct duk_time_components;
+struct duk_prop_list_entry;
 
 /* duk_context is now defined in duk_config.h because it may also be
  * referenced there by prototypes.
@@ -44,6 +45,7 @@ typedef struct duk_memory_functions duk_memory_functions;
 typedef struct duk_function_list_entry duk_function_list_entry;
 typedef struct duk_number_list_entry duk_number_list_entry;
 typedef struct duk_time_components duk_time_components;
+typedef struct duk_prop_list_entry duk_prop_list_entry;
 
 typedef duk_ret_t (*duk_c_function)(duk_context *ctx);
 typedef void *(*duk_alloc_function) (void *udata, duk_size_t size);
@@ -88,6 +90,68 @@ struct duk_time_components {
 	duk_uint_t second;          /* second: 0-59 (in POSIX time no leap second) */
 	duk_uint_t weekday;         /* weekday: 0-6, 0=Sunday, 1=Monday, ..., 6=Saturday */
 	duk_double_t millisecond;   /* may contain sub-millisecond fractions */
+};
+
+/* This structure is INTERNAL, you should never create instances of the
+ * struct using anything other than the DUK_PROP_xxx() initializer macros
+ * (which are part of the public API).  This is necessary to make it easy
+ * to extend the internal structure with new types and fields without
+ * breaking compatibility, and to support both compilers with and without
+ * union initializers.
+ */
+/* FIXME: key and value struct may need to be separated if arrays are supported */
+struct duk_prop_list_entry {
+	/* FIXME: padding impact */
+	duk_uint16_t etype;  /* entry type and flags (avoid name 'type') */
+	duk_uint16_t eattr;  /* entry attributes (match duk_def_prop() directly) */
+	const char *key;
+#if defined(DUK_USE_UNION_INITIALIZERS)
+	/* Ideal case: compiler supports designated union initializers
+	 * so the union can be clean and space efficient.
+	 */
+	union {
+		duk_bool_t bval;  /* avoid name 'bool' */
+		duk_double_t num;
+		struct {
+			const char *str;
+			duk_size_t len;
+		} str;
+		struct {
+			const void *buf;
+			duk_size_t len;
+		} buf;
+		void *ptr;
+		struct {
+			duk_c_function func;
+			duk_idx_t nargs;
+			duk_idx_t length;
+			duk_int_t magic;
+		} func;
+		struct {
+			duk_c_function getter;
+			duk_c_function setter;
+		} accessor;
+		duk_prop_list_entry *props;
+	} u;
+#else  /* DUK_USE_UNION_INITIALIZERS */
+	/* Portable case: compiler doesn't support designed union
+	 * initializers.  Use a struct and a minimal sequence of reused
+	 * fields for the initializer values.
+	 */
+
+	/* FIXME: lstring needs a duk_size_t field which would be nice to avoid.
+	 * If there's a guarantee that sizeof(duk_size_t) >= sizeof(duk_idx_t),
+	 * 'idx' could be changed to duk_size_t.
+	 */
+	struct {
+		duk_double_t num;      /* double, func length */
+		const void *ptr;       /* string or pointer */
+		duk_c_function func1;  /* func or getter */
+		duk_c_function func2;  /* setter */
+		duk_idx_t idx;         /* func nargs */
+		duk_int_t ival;        /* bool, func magic */
+	} s;
+#endif  /* DUK_USE_UNION_INITIALIZERS */
 };
 
 /*
@@ -139,9 +203,9 @@ struct duk_time_components {
 #define DUK_TYPE_NUMBER                   4    /* Ecmascript number: double */
 #define DUK_TYPE_STRING                   5    /* Ecmascript string: CESU-8 / extended UTF-8 encoded */
 #define DUK_TYPE_OBJECT                   6    /* Ecmascript object: includes objects, arrays, functions, threads */
-#define DUK_TYPE_BUFFER                   7    /* fixed or dynamic, garbage collected byte buffer */
-#define DUK_TYPE_POINTER                  8    /* raw void pointer */
-#define DUK_TYPE_LIGHTFUNC                9    /* lightweight function pointer */
+#define DUK_TYPE_BUFFER                   7    /* Duktape plain buffer: fixed or dynamic, garbage collected byte buffer */
+#define DUK_TYPE_POINTER                  8    /* Duktape plain pointer: raw void pointer */
+#define DUK_TYPE_LIGHTFUNC                9    /* Duktape lightweight function pointer */
 #define DUK_TYPE_MAX                      9
 
 /* Value mask types, used by e.g. duk_get_type_mask() */
@@ -710,8 +774,153 @@ DUK_EXTERNAL_DECL duk_int_t duk_get_current_magic(duk_context *ctx);
  *  Module helpers: put multiple function or constant properties
  */
 
-DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_idx, const duk_function_list_entry *funcs);
-DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_idx, const duk_number_list_entry *numbers);
+/* FIXME: macro for declaring the property list?
+ * #define DUK_PROP_LIST_TYPE duk_prop_list_entry
+ */
+
+#define DUK_PROPINIT_END         0
+#define DUK_PROPINIT_UNDEFINED   1
+#define DUK_PROPINIT_NULL        2
+#define DUK_PROPINIT_BOOLEAN     3
+#define DUK_PROPINIT_NUMBER      4
+#define DUK_PROPINIT_STRING      5
+#define DUK_PROPINIT_LSTRING     6
+#define DUK_PROPINIT_OBJECT      7
+#define DUK_PROPINIT_ARRAY       8
+#define DUK_PROPINIT_BUFFER      9
+#define DUK_PROPINIT_POINTER     10
+#define DUK_PROPINIT_FUNCTION    11
+#define DUK_PROPINIT_LIGHTFUNC   12
+#define DUK_PROPINIT_ACCESSOR    13
+#define DUK_PROPINIT_PROPLIST    14
+#define DUK_PROPINIT_STACK       15
+
+/* These are to be removed, in favor of the more flexible duk_def_prop_list() */
+DUK_EXTERNAL_DECL void duk_put_function_list(duk_context *ctx, duk_idx_t obj_index, const duk_function_list_entry *funcs);
+DUK_EXTERNAL_DECL void duk_put_number_list(duk_context *ctx, duk_idx_t obj_index, const duk_number_list_entry *numbers);
+
+DUK_EXTERNAL_DECL void duk_def_prop_list(duk_context *ctx, duk_idx_t obj_index, const duk_prop_list_entry *props);
+
+/* Property list initializers are union initializers when possible; when not,
+ * use struct initializers as a workaround.  The form of initialization must
+ * work correctly for global read-only initializers (so that the initializers
+ * can be placed into ROM).
+ */
+/* These defines and initializers are private, don't use directly. */
+#define DUK_PROPATTR_PLAIN (DUK_DEFPROP_HAVE_VALUE | \
+                            DUK_DEFPROP_SET_WRITABLE | \
+                            DUK_DEFPROP_SET_ENUMERABLE | \
+                            DUK_DEFPROP_SET_CONFIGURABLE)
+#define DUK_PROPATTR_ACCESSOR (DUK_DEFPROP_HAVE_GETTER | \
+                               DUK_DEFPROP_HAVE_SETTER | \
+                               DUK_DEFPROP_SET_ENUMERABLE | \
+                               DUK_DEFPROP_SET_CONFIGURABLE)
+/* FIXME: should HAVE_GETTER and HAVE_SETTER be NULL sensitive? */
+
+#if defined(DUK_USE_UNION_INITIALIZERS)
+#define DUK_PROP_END() \
+	{ DUK_PROPINIT_END, DUK_PROPATTR_PLAIN, NULL, { .bval = 0 } }
+#define DUK_PROP_UNDEFINED(keyval) \
+	{ DUK_PROPINIT_UNDEFINED, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .bval = 0 } }
+#define DUK_PROP_NULL(keyval) \
+	{ DUK_PROPINIT_NULL, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .bval = 0 } }
+#define DUK_PROP_BOOLEAN(keyval,boolval) \
+	{ DUK_PROPINIT_BOOLEAN, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .bval = (boolval) } }
+#define DUK_PROP_NUMBER(keyval,numval) \
+	{ DUK_PROPINIT_NUMBER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .num = (numval) } }
+#define DUK_PROP_STRING(keyval,strval) \
+	{ DUK_PROPINIT_STRING, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .str = { (strval), 0 } } }
+#define DUK_PROP_LSTRING(keyval,strval,lenval) \
+	{ DUK_PROPINIT_LSTRING, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .str = { (strval), (lenval) } } }
+#define DUK_PROP_OBJECT(keyval) \
+	error__unimplemented_FIXME
+#define DUK_PROP_BUFFER(keyval,bufval,lenval) \
+	{ DUK_PROPINIT_BUFFER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .buf = { (bufval), (lenval) } } }
+#define DUK_PROP_POINTER(keyval,ptrval) \
+	{ DUK_PROPINIT_POINTER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .ptr = (ptrval) } }
+#define DUK_PROP_FUNCTION(keyval,funcval,nargsval) \
+	{ DUK_PROPINIT_FUNCTION, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .func = { (funcval), (nargsval), 0, 0 } } }  /* FIXME: magic? or separate initializer? */
+#define DUK_PROP_LIGHTFUNC(keyval,funcval,nargsval) \
+	{ DUK_PROPINIT_LIGHTFUNC, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .func = { (funcval), (nargsval), (nargsval), 0 } } }  /* FIXME: repeated nargs! */
+#define DUK_PROP_LIGHTFUNC_LENGTH_MAGIC(keyval,funcval,nargsval,lengthval,magicval) \
+	{ DUK_PROPINIT_LIGHTFUNC, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .func = { (funcval), (nargsval), (lengthval), (magicval) } } }
+#define DUK_PROP_ACCESSOR(keyval,getterval,setterval) \
+	{ DUK_PROPINIT_ACCESSOR, DUK_PROPATTR_ACCESSOR, (keyval), \
+	  { .accessor = { (getterval), (setterval) } } }
+#define DUK_PROP_PROPLIST(keyval,plistval) \
+	{ DUK_PROPINIT_PROPLIST, DUK_PROPATTR_PLAIN, (keyval), \
+	  { .props = (plistval) } }
+/* FIXME: stack? */
+#else  /* DUK_USE_UNION_INITIALIZERS */
+#define DUK_PROP_END() \
+	{ DUK_PROPINIT_END, DUK_PROPATTR_PLAIN, NULL, \
+	  { 0.0, NULL, NULL, NULL, 0, 0 } }
+#define DUK_PROP_UNDEFINED(keyval) \
+	{ DUK_PROPINIT_UNDEFINED, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, NULL, NULL, NULL, 0, 0 } }
+#define DUK_PROP_NULL(keyval) \
+	{ DUK_PROPINIT_NULL, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, NULL, NULL, NULL, 0, 0 } }
+#define DUK_PROP_BOOLEAN(keyval,boolval) \
+	{ DUK_PROPINIT_BOOLEAN, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, NULL, NULL, NULL, 0, (boolval) } }
+#define DUK_PROP_NUMBER(keyval,numval) \
+	{ DUK_PROPINIT_NUMBER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { (numval), NULL, NULL, NULL, 0, 0 } }
+#define DUK_PROP_STRING(keyval,strval) \
+	{ DUK_PROPINIT_STRING, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, (const void *) (strval), NULL, NULL, 0, 0 } }
+#define DUK_PROP_LSTRING(keyval,strval,lenval) \
+	{ DUK_PROPINIT_LSTRING, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, (const void *) (strval), NULL, NULL, (lenval), 0 } }  /* FIXME: string length */
+#define DUK_PROP_OBJECT(keyval) \
+	error__unimplemented_FIXME
+#define DUK_PROP_BUFFER(keyval,bufval,lenval) \
+	{ DUK_PROPINIT_BUFFER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, (const void *) (bufval), NULL, NULL, (lenval), 0 } }   /* FIXME: length type */
+#define DUK_PROP_POINTER(keyval,ptrval) \
+	{ DUK_PROPINIT_POINTER, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, (const void *) (ptrval), NULL, NULL, 0, 0 } }
+#define DUK_PROP_FUNCTION(keyval,funcval,nargsval) \
+	{ DUK_PROPINIT_FUNCTION, DUK_PROPATTR_PLAIN, (keyval), \
+	  { (duk_double_t) 0, NULL, (funcval), NULL, (nargsval), 0 } }
+#define DUK_PROP_LIGHTFUNC(keyval,funcval,nargsval) \
+	{ DUK_PROPINIT_LIGHTFUNC, DUK_PROPATTR_PLAIN, (keyval), \
+	  { (duk_double_t) (nargsval), NULL, (funcval), NULL, (nargsval), 0 } }  /* FIXME: repated nargs */
+#define DUK_PROP_LIGHTFUNC_LENGTH_MAGIC(keyval,funcval,nargsval,lengthval,magicval) \
+	{ DUK_PROPINIT_LIGHTFUNC, DUK_PROPATTR_PLAIN, (keyval), \
+	  { (duk_double_t) (lengthval), NULL, (funcval), NULL, (nargsval), (magicval) } }
+#define DUK_PROP_ACCESSOR(keyval,getterval,setterval) \
+	{ DUK_PROPINIT_ACCESSOR, DUK_PROPATTR_ACCESSOR, (keyval), \
+	  { 0.0, NULL, (getterval), (setterval), 0, 0 } }
+#define DUK_PROP_PROPLIST(keyval,plistval) \
+	{ DUK_PROPINIT_PROPLIST, DUK_PROPATTR_PLAIN, (keyval), \
+	  { 0.0, (const void *) (plistval), NULL, NULL, 0, 0 } }
+/* FIXME: stack? */
+#endif  /* DUK_USE_UNION_INITIALIZERS */
+
+/*
+ *  Variable access
+ */
+
+/* XXX: These calls are incomplete and not usable now.  They are not (yet)
+ * part of the public API.
+ */
+DUK_EXTERNAL_DECL void duk_get_var(duk_context *ctx);
+DUK_EXTERNAL_DECL void duk_put_var(duk_context *ctx);
+DUK_EXTERNAL_DECL duk_bool_t duk_del_var(duk_context *ctx);
+DUK_EXTERNAL_DECL duk_bool_t duk_has_var(duk_context *ctx);
 
 /*
  *  Object operations

--- a/src/duk_heap_alloc.c
+++ b/src/duk_heap_alloc.c
@@ -640,6 +640,11 @@ DUK_LOCAL void duk__dump_type_sizes(void) {
 	DUK__DUMPSZ(duk_compiler_ctx);
 	DUK__DUMPSZ(duk_re_matcher_ctx);
 	DUK__DUMPSZ(duk_re_compiler_ctx);
+
+	DUK__DUMPSZ(duk_memory_functions);
+	DUK__DUMPSZ(duk_function_list_entry);
+	DUK__DUMPSZ(duk_number_list_entry);
+	DUK__DUMPSZ(duk_prop_list_entry);
 }
 DUK_LOCAL void duk__dump_type_limits(void) {
 	DUK_D(DUK_DPRINT("limits"));
@@ -703,6 +708,11 @@ DUK_LOCAL void duk__dump_misc_options(void) {
 	DUK_D(DUK_DPRINT("DUK_USE_VARIADIC_MACROS: yes"));
 #else
 	DUK_D(DUK_DPRINT("DUK_USE_VARIADIC_MACROS: no"));
+#endif
+#if defined(DUK_USE_UNION_INITIALIZERS)
+	DUK_D(DUK_DPRINT("DUK_USE_UNION_INITIALIZERS: yes"));
+#else
+	DUK_D(DUK_DPRINT("DUK_USE_UNION_INITIALIZERS: no"));
 #endif
 #if defined(DUK_USE_INTEGER_LE)
 	DUK_D(DUK_DPRINT("integer endianness: little"));

--- a/tests/api/test-def-prop-list.c
+++ b/tests/api/test-def-prop-list.c
@@ -1,0 +1,575 @@
+/*
+ *  Test duk_def_prop_list() and initializers.
+ */
+
+/*===
+*** test_types (duk_safe_call)
+My getter called, top=1, key=accessorValue
+{
+    undefinedValue: undefined,
+    nullValue: null,
+    booleanTrueValue: true,
+    booleanFalseValue: false,
+    numberValue: 123.456,
+    stringValue: "NUL terminated string value",
+    lstringValue: "string with\x00internal NULs",
+    bufferWithoutInitValue: |000000000000000000000000000000000000|,
+    bufferWithInitValue: |deadbeef12345678|,
+    pointerValue: (0xdeadbeef),
+    functionValue: {_func:true},
+    lightfuncValue1: {_func:true},
+    lightfuncValue2: {_func:true},
+    accessorValue: "getter-returned-value",
+    proplistValue: {
+        name: "subObject",
+        comment: "a new object is created for DUK_PROP_PROPLIST()"
+    }
+}
+My function called, top-at-entry=3, magic=0, .length=3
+My function called, top-at-entry=4, magic=0, .length=4
+My function called, top-at-entry=4, magic=9, .length=2
+My getter called, top=1, key=accessorValue
+getter-returned-value
+My setter called, top=2, key=accessorValue, value=foobar
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+/* Test basic types. */
+
+static duk_ret_t my_function(duk_context *ctx) {
+	duk_push_current_function(ctx);
+	duk_get_prop_string(ctx, -1, "length");
+	printf("My function called, top-at-entry=%ld, magic=%ld, .length=%s\n",
+	       (long) duk_get_top(ctx) - 2, (long) duk_get_current_magic(ctx), duk_safe_to_string(ctx, -1));
+	return 0;
+}
+
+static duk_ret_t my_getter(duk_context *ctx) {
+	printf("My getter called, top=%ld, key=%s\n",
+	       (long) duk_get_top(ctx), duk_safe_to_string(ctx, 0));
+	duk_push_string(ctx, "getter-returned-value");
+	return 1;
+}
+
+static duk_ret_t my_setter(duk_context *ctx) {
+	printf("My setter called, top=%ld, key=%s, value=%s\n",
+	       (long) duk_get_top(ctx), duk_safe_to_string(ctx, 1), duk_safe_to_string(ctx, 0));
+	return 0;
+}
+
+static duk_ret_t test_types(duk_context *ctx) {
+	unsigned char buf_data[10] = {
+		0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78, 0xaa, 0xbb  /* 0xaa and 0xbb ignored because of length */
+	};
+	duk_prop_list_entry sub_props[] = {
+		DUK_PROP_STRING("name", "subObject"),
+		DUK_PROP_STRING("comment", "a new object is created for DUK_PROP_PROPLIST()"),
+		DUK_PROP_END()
+	};
+	duk_prop_list_entry props[] = {
+		DUK_PROP_UNDEFINED("undefinedValue"),
+		DUK_PROP_NULL("nullValue"),
+		DUK_PROP_BOOLEAN("booleanTrueValue", 123),  /* any nonzero */
+		DUK_PROP_BOOLEAN("booleanFalseValue", 0),
+		DUK_PROP_NUMBER("numberValue", 123.456),
+		DUK_PROP_STRING("stringValue", "NUL terminated string value"),
+		DUK_PROP_LSTRING("lstringValue", "string with\x00internal NULs[IGNORED]", 25),
+		/* FIXME: object */
+		DUK_PROP_BUFFER("bufferWithoutInitValue", NULL, 18),  /* fixed buffer without initialization data */
+		DUK_PROP_BUFFER("bufferWithInitValue", buf_data, 8),  /* fixed buffer with initialization data */
+		DUK_PROP_POINTER("pointerValue", (void *) 0xdeadbeef),
+		DUK_PROP_FUNCTION("functionValue", my_function, 3 /*nargs*/),
+		DUK_PROP_LIGHTFUNC("lightfuncValue1", my_function, 4 /*nargs*/),
+		DUK_PROP_LIGHTFUNC_LENGTH_MAGIC("lightfuncValue2", my_function, 4 /*nargs*/, 2 /*length*/, 9 /*magic*/),
+		DUK_PROP_ACCESSOR("accessorValue", my_getter, my_setter),
+		DUK_PROP_PROPLIST("proplistValue", sub_props),
+		DUK_PROP_END()
+	};
+
+	duk_push_object(ctx);
+	duk_def_prop_list(ctx, -1, props);
+
+	duk_eval_string(ctx, "(function (v) { print(Duktape.enc('jx', v, null, 4)); })");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    v.functionValue('foo', 'bar', 'quux', 'baz', 'quuux');\n"
+		"    v.lightfuncValue1('foo', 'bar', 'quux', 'baz', 'quuux');\n"
+		"    v.lightfuncValue2('foo', 'bar', 'quux', 'baz', 'quuux');\n"
+		"    print(v.accessorValue);\n"
+		"    v.accessorValue = 'foobar';\n"
+		"})");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/*===
+*** test_deep_structure (duk_safe_call)
+{
+ index: 0,
+ child: {
+  index: 1,
+  child: {
+   index: 2,
+   child: {
+    index: 3,
+    child: {
+     index: 4,
+     child: {
+      index: 5,
+      child: {
+       index: 6,
+       child: {
+        index: 7,
+        child: {
+         index: 8,
+         child: {
+          index: 9,
+          child: {
+           index: 10,
+           child: {
+            index: 11,
+            child: {
+             index: 12,
+             child: {
+              index: 13,
+              child: {
+               index: 14,
+               child: {
+                index: 15,
+                child: {
+                 index: 16,
+                 child: {
+                  index: 17,
+                  child: {
+                   index: 18,
+                   child: {
+                    index: 19,
+                    child: {
+                     index: 20,
+                     child: {
+                      index: 21,
+                      child: {
+                       index: 22,
+                       child: {
+                        index: 23,
+                        child: {
+                         index: 24,
+                         child: {
+                          index: 25,
+                          child: {
+                           index: 26,
+                           child: {
+                            index: 27,
+                            child: {
+                             index: 28,
+                             child: {
+                              index: 29,
+                              child: {
+                               index: 30,
+                               child: {
+                                index: 31,
+                                child: {
+                                 index: 32,
+                                 child: {
+                                  index: 33,
+                                  child: {
+                                   index: 34,
+                                   child: {
+                                    index: 35,
+                                    child: {
+                                     index: 36,
+                                     child: {
+                                      index: 37,
+                                      child: {
+                                       index: 38,
+                                       child: {
+                                        index: 39,
+                                        child: {
+                                         index: 40,
+                                         child: {
+                                          index: 41,
+                                          child: {
+                                           index: 42,
+                                           child: {
+                                            index: 43,
+                                            child: {
+                                             index: 44,
+                                             child: {
+                                              index: 45,
+                                              child: {
+                                               index: 46,
+                                               child: {
+                                                index: 47,
+                                                child: {
+                                                 index: 48,
+                                                 child: {
+                                                  index: 49,
+                                                  child: {
+                                                   index: 50,
+                                                   child: {
+                                                    index: 51,
+                                                    child: {
+                                                     index: 52,
+                                                     child: {
+                                                      index: 53,
+                                                      child: {
+                                                       index: 54,
+                                                       child: {
+                                                        index: 55,
+                                                        child: {
+                                                         index: 56,
+                                                         child: {
+                                                          index: 57,
+                                                          child: {
+                                                           index: 58,
+                                                           child: {
+                                                            index: 59,
+                                                            child: {
+                                                             index: 60,
+                                                             child: {
+                                                              index: 61,
+                                                              child: {
+                                                               index: 62,
+                                                               child: {
+                                                                index: 63,
+                                                                child: {
+                                                                 index: 64,
+                                                                 child: {
+                                                                  index: 65,
+                                                                  child: {
+                                                                   index: 66,
+                                                                   child: {
+                                                                    index: 67,
+                                                                    child: {
+                                                                     index: 68,
+                                                                     child: {
+                                                                      index: 69,
+                                                                      child: {
+                                                                       index: 70,
+                                                                       child: {
+                                                                        index: 71,
+                                                                        child: {
+                                                                         index: 72,
+                                                                         child: {
+                                                                          index: 73,
+                                                                          child: {
+                                                                           index: 74,
+                                                                           child: {
+                                                                            index: 75,
+                                                                            child: {
+                                                                             index: 76,
+                                                                             child: {
+                                                                              index: 77,
+                                                                              child: {
+                                                                               index: 78,
+                                                                               child: {
+                                                                                index: 79,
+                                                                                child: {
+                                                                                 index: 80,
+                                                                                 child: {
+                                                                                  index: 81,
+                                                                                  child: {
+                                                                                   index: 82,
+                                                                                   child: {
+                                                                                    index: 83,
+                                                                                    child: {
+                                                                                     index: 84,
+                                                                                     child: {
+                                                                                      index: 85,
+                                                                                      child: {
+                                                                                       index: 86,
+                                                                                       child: {
+                                                                                        index: 87,
+                                                                                        child: {
+                                                                                         index: 88,
+                                                                                         child: {
+                                                                                          index: 89,
+                                                                                          child: {
+                                                                                           index: 90,
+                                                                                           child: {
+                                                                                            index: 91,
+                                                                                            child: {
+                                                                                             index: 92,
+                                                                                             child: {
+                                                                                              index: 93,
+                                                                                              child: {
+                                                                                               index: 94,
+                                                                                               child: {
+                                                                                                index: 95,
+                                                                                                child: {
+                                                                                                 index: 96,
+                                                                                                 child: {
+                                                                                                  index: 97,
+                                                                                                  child: {
+                                                                                                   index: 98,
+                                                                                                   child: {
+                                                                                                    index: 99,
+                                                                                                    child: {
+                                                                                                     index: 100,
+                                                                                                     child: {
+                                                                                                      index: 101,
+                                                                                                      child: {
+                                                                                                       index: 102,
+                                                                                                       child: {
+                                                                                                        index: 103,
+                                                                                                        child: {
+                                                                                                         index: 104,
+                                                                                                         child: {
+                                                                                                          index: 105,
+                                                                                                          child: {
+                                                                                                           index: 106,
+                                                                                                           child: {
+                                                                                                            index: 107,
+                                                                                                            child: {
+                                                                                                             index: 108,
+                                                                                                             child: {
+                                                                                                              index: 109,
+                                                                                                              child: {
+                                                                                                               index: 110,
+                                                                                                               child: {
+                                                                                                                index: 111,
+                                                                                                                child: {
+                                                                                                                 index: 112,
+                                                                                                                 child: {
+                                                                                                                  index: 113,
+                                                                                                                  child: {
+                                                                                                                   index: 114,
+                                                                                                                   child: {
+                                                                                                                    index: 115,
+                                                                                                                    child: {
+                                                                                                                     index: 116,
+                                                                                                                     child: {
+                                                                                                                      index: 117,
+                                                                                                                      child: {
+                                                                                                                       index: 118,
+                                                                                                                       child: {
+                                                                                                                        index: 119,
+                                                                                                                        child: {
+                                                                                                                         index: 120,
+                                                                                                                         child: {
+                                                                                                                          index: 121,
+                                                                                                                          child: {
+                                                                                                                           index: 122,
+                                                                                                                           child: {
+                                                                                                                            index: 123,
+                                                                                                                            child: {
+                                                                                                                             index: 124,
+                                                                                                                             child: {
+                                                                                                                              index: 125,
+                                                                                                                              child: {
+                                                                                                                               index: 126,
+                                                                                                                               child: {
+                                                                                                                                index: 127,
+                                                                                                                                child: {
+                                                                                                                                 index: 128,
+                                                                                                                                 child: {
+                                                                                                                                  index: 129,
+                                                                                                                                  child: {
+                                                                                                                                   name: "deepest"
+                                                                                                                                  }
+                                                                                                                                 }
+                                                                                                                                }
+                                                                                                                               }
+                                                                                                                              }
+                                                                                                                             }
+                                                                                                                            }
+                                                                                                                           }
+                                                                                                                          }
+                                                                                                                         }
+                                                                                                                        }
+                                                                                                                       }
+                                                                                                                      }
+                                                                                                                     }
+                                                                                                                    }
+                                                                                                                   }
+                                                                                                                  }
+                                                                                                                 }
+                                                                                                                }
+                                                                                                               }
+                                                                                                              }
+                                                                                                             }
+                                                                                                            }
+                                                                                                           }
+                                                                                                          }
+                                                                                                         }
+                                                                                                        }
+                                                                                                       }
+                                                                                                      }
+                                                                                                     }
+                                                                                                    }
+                                                                                                   }
+                                                                                                  }
+                                                                                                 }
+                                                                                                }
+                                                                                               }
+                                                                                              }
+                                                                                             }
+                                                                                            }
+                                                                                           }
+                                                                                          }
+                                                                                         }
+                                                                                        }
+                                                                                       }
+                                                                                      }
+                                                                                     }
+                                                                                    }
+                                                                                   }
+                                                                                  }
+                                                                                 }
+                                                                                }
+                                                                               }
+                                                                              }
+                                                                             }
+                                                                            }
+                                                                           }
+                                                                          }
+                                                                         }
+                                                                        }
+                                                                       }
+                                                                      }
+                                                                     }
+                                                                    }
+                                                                   }
+                                                                  }
+                                                                 }
+                                                                }
+                                                               }
+                                                              }
+                                                             }
+                                                            }
+                                                           }
+                                                          }
+                                                         }
+                                                        }
+                                                       }
+                                                      }
+                                                     }
+                                                    }
+                                                   }
+                                                  }
+                                                 }
+                                                }
+                                               }
+                                              }
+                                             }
+                                            }
+                                           }
+                                          }
+                                         }
+                                        }
+                                       }
+                                      }
+                                     }
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+/* Test a deeply nested structure.  This ensures that duk_def_prop_list() does
+ * a stack extend check when it recurses (otherwise we'd run out of stack space
+ * at around depth 64-128).
+ */
+
+#define MKPROPS(idx,idx_child) \
+	static duk_prop_list_entry p##idx[] = { DUK_PROP_NUMBER("index", (idx)), DUK_PROP_PROPLIST("child", p##idx_child), DUK_PROP_END() }
+
+static duk_prop_list_entry p130[] = { DUK_PROP_STRING("name", "deepest"), DUK_PROP_END() };
+MKPROPS(129, 130); MKPROPS(128, 129); MKPROPS(127, 128); MKPROPS(126, 127); MKPROPS(125, 126);
+MKPROPS(124, 125); MKPROPS(123, 124); MKPROPS(122, 123); MKPROPS(121, 122); MKPROPS(120, 121);
+MKPROPS(119, 120); MKPROPS(118, 119); MKPROPS(117, 118); MKPROPS(116, 117); MKPROPS(115, 116);
+MKPROPS(114, 115); MKPROPS(113, 114); MKPROPS(112, 113); MKPROPS(111, 112); MKPROPS(110, 111);
+MKPROPS(109, 110); MKPROPS(108, 109); MKPROPS(107, 108); MKPROPS(106, 107); MKPROPS(105, 106);
+MKPROPS(104, 105); MKPROPS(103, 104); MKPROPS(102, 103); MKPROPS(101, 102); MKPROPS(100, 101);
+MKPROPS(99, 100); MKPROPS(98, 99); MKPROPS(97, 98); MKPROPS(96, 97); MKPROPS(95, 96);
+MKPROPS(94, 95); MKPROPS(93, 94); MKPROPS(92, 93); MKPROPS(91, 92); MKPROPS(90, 91);
+MKPROPS(89, 90); MKPROPS(88, 89); MKPROPS(87, 88); MKPROPS(86, 87); MKPROPS(85, 86);
+MKPROPS(84, 85); MKPROPS(83, 84); MKPROPS(82, 83); MKPROPS(81, 82); MKPROPS(80, 81);
+MKPROPS(79, 80); MKPROPS(78, 79); MKPROPS(77, 78); MKPROPS(76, 77); MKPROPS(75, 76);
+MKPROPS(74, 75); MKPROPS(73, 74); MKPROPS(72, 73); MKPROPS(71, 72); MKPROPS(70, 71);
+MKPROPS(69, 70); MKPROPS(68, 69); MKPROPS(67, 68); MKPROPS(66, 67); MKPROPS(65, 66);
+MKPROPS(64, 65); MKPROPS(63, 64); MKPROPS(62, 63); MKPROPS(61, 62); MKPROPS(60, 61);
+MKPROPS(59, 60); MKPROPS(58, 59); MKPROPS(57, 58); MKPROPS(56, 57); MKPROPS(55, 56);
+MKPROPS(54, 55); MKPROPS(53, 54); MKPROPS(52, 53); MKPROPS(51, 52); MKPROPS(50, 51);
+MKPROPS(49, 50); MKPROPS(48, 49); MKPROPS(47, 48); MKPROPS(46, 47); MKPROPS(45, 46);
+MKPROPS(44, 45); MKPROPS(43, 44); MKPROPS(42, 43); MKPROPS(41, 42); MKPROPS(40, 41);
+MKPROPS(39, 40); MKPROPS(38, 39); MKPROPS(37, 38); MKPROPS(36, 37); MKPROPS(35, 36);
+MKPROPS(34, 35); MKPROPS(33, 34); MKPROPS(32, 33); MKPROPS(31, 32); MKPROPS(30, 31);
+MKPROPS(29, 30); MKPROPS(28, 29); MKPROPS(27, 28); MKPROPS(26, 27); MKPROPS(25, 26);
+MKPROPS(24, 25); MKPROPS(23, 24); MKPROPS(22, 23); MKPROPS(21, 22); MKPROPS(20, 21);
+MKPROPS(19, 20); MKPROPS(18, 19); MKPROPS(17, 18); MKPROPS(16, 17); MKPROPS(15, 16);
+MKPROPS(14, 15); MKPROPS(13, 14); MKPROPS(12, 13); MKPROPS(11, 12); MKPROPS(10, 11);
+MKPROPS(9, 10); MKPROPS(8, 9); MKPROPS(7, 8); MKPROPS(6, 7); MKPROPS(5, 6);
+MKPROPS(4, 5); MKPROPS(3, 4); MKPROPS(2, 3); MKPROPS(1, 2); MKPROPS(0, 1);
+
+static duk_ret_t test_deep_structure(duk_context *ctx) {
+	duk_push_object(ctx);
+	duk_def_prop_list(ctx, -1, p0);
+
+	duk_eval_string(ctx, "(function (v) { print(Duktape.enc('jx', v, null, 1)); })");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/*
+ *  Main
+ */
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_types);
+	TEST_SAFE_CALL(test_deep_structure);
+}
+
+/* FIXME: index check */

--- a/website/api/duk_def_prop_list.yaml
+++ b/website/api/duk_def_prop_list.yaml
@@ -1,0 +1,155 @@
+name: duk_def_prop_list
+
+proto: |
+  void duk_def_prop_list(duk_context *ctx, duk_idx_t obj_index, const duk_prop_list_entry *props);
+
+stack: |
+  [ ... obj! ... ] -> [ ... obj! ... ]
+
+summary: |
+  <p>Set multiple properties into a target object from a property list.
+  The property list contains <code>DUK_PROP_xxx()</code> initializer macros
+  which support multiple types, and ends with <code>DUK_PROP_END()</code>.
+  The property list is processed in order, and if a property appears multiple
+  times the last occurrence wins (unless a previous occurrence is non-configurable
+  in which case a TypeError may be thrown.</p>
+
+  <p>This call is useful e.g. when defining modules statically in C code.
+  See test case <b>FIXME</b> for concrete examples.</p>
+
+  <p>Supported property initializers:</p>
+
+  <table>
+  <tr>
+  <td>DUK_PROP_END()</td>
+  <td>Terminates the property list.  Mandatory; if missing, memory unsafe
+  behavior will result.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_UNDEFINED(key)</td>
+  <td>Ecmascript <code>undefined</code>.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_NULL(key)</td>
+  <td>Ecmascript <code>null</code>.</td>
+  </tr>
+  <tr>
+  <tr>
+  <td>DUK_PROP_BOOLEAN(key,val)</td>
+  <td>Ecmascript boolean, false if val is 0, true otherwise.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_NUMBER(key,val)</td>
+  <td>Ecmascript number (IEEE double).</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_STRING(key,str)</td>
+  <td>Ecmascript string, argument is a NUL-terminated C string.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_LSTRING(key,str,len)</td>
+  <td>Ecmascript string, explicit length.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_BUFFER(key,buf,len)</td>
+  <td>Duktape plain fixed buffer.</td> <!-- FIXME: fixed? flags? -->
+  </tr>
+  <tr>
+  <td>DUK_PROP_POINTER(key,ptr)</td>
+  <td>Duktape plain pointer.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_FUNCTION(key,func,nargs)</td>
+  <td>Duktape/C function, <code>func</code> is a function pointer.
+      Matches <code>duk_push_c_function()</code>.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_LIGHTFUNC(key,func,nargs)</td>
+  <td>Duktape/C lightfunc, <code>func</code> is a function pointer.
+      Matches <code>duk_push_c_lightfunc()</code> with
+      <code>length</code> defaulting to <code>nargs</code> and
+      <code>magic</code> to 0.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_LIGHTFUNC_LENGTH_MAGIC(key,func,nargs,length,magic)</td>
+  <td>Duktape/C lightfunc, <code>func</code> is a function pointer.
+      Matches <code>duk_push_c_lightfunc()</code>.</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_ACCESSOR(key,getfunc,setfunc)</td>
+  <td>Accessor property, <code>getfunc</code> and <code>setfunc</code>
+      are Duktape/C function pointers (may be NULL).</td>
+  </tr>
+  <tr>
+  <td>DUK_PROP_PROPLIST(key,proplist)</td>
+  <td>Sub-object whose properties are specific using a property list.</td>
+  </tr>
+  <tr>
+  <td>FIXME</td>
+  <td>Rest.</td>
+  </tr>
+  </table>
+
+  <div class="note">
+  Property initializers are API macros which hide the internal structures
+  needed for initialization.  This allows new macros and initialization features
+  to be introduced without breaking API compatibility.  The macros also hide
+  compiler specific differences for static initializers; some compilers don't
+  support <i>designated union initializers</i> for example in which case
+  Duktape will fall back to using a bit larger struct-based initializers.
+  </div>
+
+  <div class="note">
+  The initializer macros may evaluate their argument(s) multiple times.
+  For example <code>DUK_PROP_LIGHTFUNC</code> evaluates "nargs" twice
+  because it's used to initialize both lightfunc "nargs" and "length"
+  fields.  Don't rely on any specific evaluation count.
+
+  This is usually not an issue because initializers tend to be static
+  and not computed on-the-fly.  For on-the-fly initializers, be careful
+  to avoid e.g. function call expressions in the macro arguments.
+  </div>
+
+  <div class="note">
+  This API call deprecates the more restrictive (and difficult to version)
+  <code><a href="#duk_put_function_list">duk_put_function_list()</a></code> and
+  <code><a href="#duk_put_number_list">duk_put_number_list()</a></code>.
+  </div>
+
+example: |
+  duk_prop_list_entry sub_props[] = {
+      DUK_PROP_STRING("name", "subObject"),
+      DUK_PROP_STRING("comment", "a new object is created for DUK_PROP_PROPLIST()"),
+      DUK_PROP_END()
+  };
+  duk_prop_list_entry props[] = {
+      DUK_PROP_UNDEFINED("undefinedValue"),
+      DUK_PROP_NULL("nullValue"),
+      DUK_PROP_BOOLEAN("booleanTrueValue", 123),  /* any nonzero */
+      DUK_PROP_BOOLEAN("booleanFalseValue", 0),
+      DUK_PROP_NUMBER("numberValue", 123.456),
+      DUK_PROP_STRING("stringValue", "NUL terminated string value"),
+      DUK_PROP_LSTRING("lstringValue", "string with\x00internal NULs[IGNORED]", 25),
+      /* FIXME: object */
+      DUK_PROP_BUFFER("bufferWithoutInitValue", NULL, 18),  /* fixed buffer without initialization data */
+      DUK_PROP_BUFFER("bufferWithInitValue", buf_data, 8),  /* fixed buffer with initialization data */
+      DUK_PROP_POINTER("pointerValue", (void *) 0xdeadbeef),
+      DUK_PROP_FUNCTION("functionValue", my_function, 3 /*nargs*/),
+      DUK_PROP_LIGHTFUNC("lightfuncValue1", my_function, 4 /*nargs*/),
+      DUK_PROP_LIGHTFUNC_LENGTH_MAGIC("lightfuncValue2", my_function, 4 /*nargs*/, 2 /*length*/, 9 /*magic*/),
+      DUK_PROP_ACCESSOR("accessorValue", my_getter, my_setter),
+      DUK_PROP_PROPLIST("proplistValue", sub_props),
+      DUK_PROP_END()
+  };
+
+  duk_def_prop_list(ctx, -3, props);
+
+tags:
+  - property
+  - module
+
+seealso:
+  - duk_put_function_list
+  - duk_put_number_list
+
+introduced: 1.5.0

--- a/website/api/duk_put_function_list.yaml
+++ b/website/api/duk_put_function_list.yaml
@@ -15,6 +15,11 @@ summary: |
   <p>This is useful e.g. when defining modules or classes implemented
   as a set of Duktape/C functions.</p>
 
+  <div class="note">
+  This API call was deprecated in Duktape 1.5.0: use
+  <code><a href="#duk_def_prop_list">duk_def_prop_list()</a></code> instead.
+  </div>
+
 example: |
   const duk_function_list_entry my_module_funcs[] = {
       { "tweak", do_tweak, 0 /* no args */ },
@@ -39,5 +44,7 @@ tags:
 
 seealso:
   - duk_put_number_list
+  - duk_def_prop_list
 
 introduced: 1.0.0
+deprecated: 1.5.0

--- a/website/api/duk_put_function_list.yaml
+++ b/website/api/duk_put_function_list.yaml
@@ -48,3 +48,4 @@ seealso:
 
 introduced: 1.0.0
 deprecated: 1.5.0
+removed: 2.0.0

--- a/website/api/duk_put_number_list.yaml
+++ b/website/api/duk_put_number_list.yaml
@@ -14,6 +14,11 @@ summary: |
   <p>This is useful e.g. when defining numeric constants for modules or
   classes implemented in C.</p>
 
+  <div class="note">
+  This API call was deprecated in Duktape 1.5.0: use
+  <code><a href="#duk_def_prop_list">duk_def_prop_list()</a></code> instead.
+  </div>
+
 example: |
   const duk_number_list_entry my_module_consts[] = {
       { "FLAG_FOO", (double) (1 << 0) },
@@ -31,5 +36,7 @@ tags:
 
 seealso:
   - duk_put_function_list
+  - duk_def_prop_list
 
 introduced: 1.0.0
+deprecated: 1.5.0

--- a/website/api/duk_put_number_list.yaml
+++ b/website/api/duk_put_number_list.yaml
@@ -40,3 +40,4 @@ seealso:
 
 introduced: 1.0.0
 deprecated: 1.5.0
+removed: 2.0.0

--- a/website/buildsite.py
+++ b/website/buildsite.py
@@ -270,19 +270,9 @@ def processApiDoc(doc, testrefs, used_tags):
 			return cmp( (a[0].isdigit(), a), (b[0].isdigit(), b) )
 		p = sorted(doc['tags'], reverse=True, cmp=mycmp)
 
-		# 'introduced' is automatically added as a tag now
-		#if doc.has_key('introduced'):
-		#	p = [ doc['introduced'] ] + p
-		if doc.has_key('deprecated'):
-			# XXX: must mark deprecation
-			pass
-		if doc.has_key('removed'):
-			# XXX: must mark removal
-			pass
-
 		for idx, val in enumerate(p):
 			classes = [ 'apitag' ]
-			if val == 'experimental' or val == 'nonportable':
+			if val in [ 'experimental', 'nonportable', 'deprecated', 'removed' ]:
 				classes.append('apitagwarn')
 			if val == 'protected':
 				classes.append('apitagprotected')
@@ -752,9 +742,13 @@ def generateApiDoc(apidocdir, apitestdir):
 				apidoc['tags'] = []  # ensures tags is present
 			apidoc['name'] = funcname  # add funcname automatically
 
-			# add 'introduced' version to tag list automatically
+			# Add a few tags automatically.
 			if apidoc.has_key('introduced'):
 				apidoc['tags'].insert(0, apidoc['introduced'])
+			if apidoc.has_key('deprecated'):
+				apidoc['tags'].insert(0, 'deprecated')
+			if apidoc.has_key('removed'):
+				apidoc['tags'].insert(0, 'removed')
 
 			if 'omit' in apidoc['tags']:
 				print 'Omit API doc: ' + str(funcname)


### PR DESCRIPTION
These calls are replaced by the more versatile and more easily versioned `duk_def_prop_list()`.

Tasks:
- [ ] Remove the calls
- [ ] Fix testcases
- [ ] Internal documentation update
- [ ] Website update
- [ ] API document removed tags
- [ ] 2.0 migration note
- [ ] Releases entry
