### PR TITLE
Add suspend and resume API

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,6 +34,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Ondřej Jirman (https://github.com/megous)
 * Saúl Ibarra Corretgé <saghul@gmail.com>
 * Jeremy HU <huxingyi@msn.com>
+* Ole André Vadla Ravnås (https://github.com/oleavr)
 
 Other contributions
 ===================
@@ -71,7 +72,6 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * Michael Drake (https://github.com/tlsa)
 * https://github.com/chris-y
 * Laurent Zubiaur (https://github.com/lzubiaur)
-* Ole André Vadla Ravnås (https://github.com/oleavr)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -32,6 +32,7 @@ extern "C" {
  *  in Duktape web documentation.
  */
 
+struct duk_thread_state;
 struct duk_memory_functions;
 struct duk_function_list_entry;
 struct duk_number_list_entry;
@@ -40,6 +41,7 @@ struct duk_time_components;
 /* duk_context is now defined in duk_config.h because it may also be
  * referenced there by prototypes.
  */
+typedef struct duk_thread_state duk_thread_state;
 typedef struct duk_memory_functions duk_memory_functions;
 typedef struct duk_function_list_entry duk_function_list_entry;
 typedef struct duk_number_list_entry duk_number_list_entry;
@@ -60,6 +62,10 @@ typedef void (*duk_debug_read_flush_function) (void *udata);
 typedef void (*duk_debug_write_flush_function) (void *udata);
 typedef duk_idx_t (*duk_debug_request_function) (duk_context *ctx, void *udata, duk_idx_t nvalues);
 typedef void (*duk_debug_detached_function) (duk_context *ctx, void *udata);
+
+struct duk_thread_state {
+	char data[128];
+};
 
 struct duk_memory_functions {
 	duk_alloc_function alloc_func;
@@ -255,6 +261,9 @@ duk_context *duk_create_heap(duk_alloc_function alloc_func,
                              void *heap_udata,
                              duk_fatal_function fatal_handler);
 DUK_EXTERNAL_DECL void duk_destroy_heap(duk_context *ctx);
+
+DUK_EXTERNAL_DECL void duk_suspend(duk_context *ctx, duk_thread_state *state);
+DUK_EXTERNAL_DECL void duk_resume(duk_context *ctx, const duk_thread_state *state);
 
 #define duk_create_heap_default() \
 	duk_create_heap(NULL, NULL, NULL, NULL, NULL)


### PR DESCRIPTION
This allows a native thread to suspend its Duktape thread while for
example calling out to an external blocking API, allowing other native
threads to cooperatively run code on the same heap in the meantime.

It is left up to the application to synchronize its native threads so
only a single native thread executes code at a time, each taking care to
use distinct Duktape threads while doing so.

Related to #834.