### PR TITLE
Fix lightfunc constructable handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1798,6 +1798,10 @@ Planned
   and a finalizer side effect resizes/reconfigures the buffer, invalidating
   the pointer before string table code has time to copy the data (GH-884)
 
+* Fix lightfunc constructor call handling: lightfuncs were incorrectly
+  rejected as constructors, now allowed as both direct constructors and
+  via a bound function chain (GH-895)
+
 * Miscellaneous performance improvements: avoid one extra shift when computing
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for
   Array .length coercion (GH-862); value stack operation optimization

--- a/src/duk_api_call.c
+++ b/src/duk_api_call.c
@@ -293,21 +293,41 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 
 	duk_dup(ctx, idx_cons);
 	for (;;) {
-		cons = duk_get_hobject(ctx, -1);
-		if (cons == NULL || !DUK_HOBJECT_HAS_CONSTRUCTABLE(cons)) {
-			/* Checking constructability from anything else than the
-			 * initial constructor is not strictly necessary, but a
-			 * nice sanity check.
-			 */
-			goto not_constructable;
-		}
-		if (!DUK_HOBJECT_HAS_BOUNDFUNC(cons)) {
+		duk_tval *tv;
+		tv = DUK_GET_TVAL_NEGIDX(ctx, -1);
+		DUK_ASSERT(tv != NULL);
+
+		if (DUK_TVAL_IS_OBJECT(tv)) {
+			cons = DUK_TVAL_GET_OBJECT(tv);
+			DUK_ASSERT(cons != NULL);
+			if (!DUK_HOBJECT_IS_CALLABLE(cons) || !DUK_HOBJECT_HAS_CONSTRUCTABLE(cons)) {
+				/* Checking callability of the immediate target
+				 * is important, same for constructability.
+				 * Checking it for functions down the bound
+				 * function chain is not strictly necessary
+				 * because .bind() should normally reject them.
+				 * But it's good to check anyway because it's
+				 * technically possible to edit the bound function
+				 * chain via internal keys.
+				 */
+				goto not_constructable;
+			}
+			if (!DUK_HOBJECT_HAS_BOUNDFUNC(cons)) {
+				break;
+			}
+		} else if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
+			/* Lightfuncs cannot be bound. */
 			break;
+		} else {
+			/* Anything else is not constructable. */
+			goto not_constructable;
 		}
 		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TARGET);  /* -> [... cons target] */
 		duk_remove(ctx, -2);                                  /* -> [... target] */
 	}
-	DUK_ASSERT(cons != NULL && !DUK_HOBJECT_HAS_BOUNDFUNC(cons));
+	DUK_ASSERT(duk_is_callable(ctx, -1));
+	DUK_ASSERT(duk_is_lightfunc(ctx, -1) ||
+	           (duk_get_hobject(ctx, -1) != NULL && !DUK_HOBJECT_HAS_BOUNDFUNC(duk_get_hobject(ctx, -1))));
 
 	/* [... constructor arg1 ... argN final_cons] */
 

--- a/tests/api/test-dev-lightfunc-bound.c
+++ b/tests/api/test-dev-lightfunc-bound.c
@@ -1,0 +1,99 @@
+/*
+ *  Lightfunc cannot be bound, but can appear in a bound function chain as
+ *  the final non-bound function.  This may happen for both constuctor and
+ *  non-constructor call.
+ */
+
+/*===
+*** test_normal_call (duk_safe_call)
+lightfunc called, constructor call: 0
+argument 1: 123
+argument 2: 234
+return value: dummy
+lightfunc called, constructor call: 0
+argument 1: 1001
+argument 2: 2002
+return value: dummy
+final top: 1
+==> rc=0, result='undefined'
+*** test_constructor_call (duk_safe_call)
+lightfunc called, constructor call: 1
+argument 1: 123
+argument 2: 234
+return value: [object Object]
+lightfunc called, constructor call: 1
+argument 1: 1001
+argument 2: 2002
+return value: [object Object]
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t my_lightfunc(duk_context *ctx) {
+	printf("lightfunc called, constructor call: %d\n", (int) duk_is_constructor_call(ctx));
+	printf("argument 1: %s\n", duk_to_string(ctx, 0));
+	printf("argument 2: %s\n", duk_to_string(ctx, 1));
+	duk_push_string(ctx, "dummy");
+	return 1;
+}
+
+static duk_ret_t test_normal_call(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_c_lightfunc(ctx, my_lightfunc, 2, 0, 0);
+
+	/* Call directly. */
+	duk_dup(ctx, -1);
+	duk_push_uint(ctx, 123);
+	duk_push_uint(ctx, 234);
+	duk_call(ctx, 2);
+	printf("return value: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	/* Call via bound function. */
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    return v.bind(null, 1001, 2002);\n"
+		"})");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);  /* -> [ lfunc bound ] */
+	duk_call(ctx, 0);
+	printf("return value: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_constructor_call(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_c_lightfunc(ctx, my_lightfunc, 2, 0, 0);
+
+	/* Call directly. */
+	duk_dup(ctx, -1);
+	duk_push_uint(ctx, 123);
+	duk_push_uint(ctx, 234);
+	duk_new(ctx, 2);
+	printf("return value: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	/* Call via bound function. */
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    return v.bind(null, 1001, 2002);\n"
+		"})");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);  /* -> [ lfunc bound ] */
+	duk_new(ctx, 0);
+	printf("return value: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_normal_call);
+	TEST_SAFE_CALL(test_constructor_call);
+}


### PR DESCRIPTION
Lightfuncs were rejected as constructor call targets. Fix so that lightfuncs are allowed both as direct and indirect (via bound function chain) constructor call targets. Also added to 1.5.1 release.