### PR TITLE
Improve assembly generated for interrupt counter in executor dispatch loop

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1839,7 +1839,8 @@ Planned
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for
   Array .length coercion (GH-862); value stack operation optimization
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
-  opcode handler optimizations (GH-903)
+  opcode handler optimizations (GH-903); executor interrupt counter optimization
+  (GH-900)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src/duk_api_debug.c
+++ b/src/duk_api_debug.c
@@ -199,8 +199,7 @@ DUK_EXTERNAL void duk_debugger_pause(duk_context *ctx) {
 		 * inside the debugger message loop: the interrupt counter will be reset
 		 * to its proper value when the message loop exits.
 		 */
-		thr->interrupt_init = 1;
-		thr->interrupt_counter = 0;
+		DUK_HTHREAD_INTCTR_SET(thr, 1);
 	}
 }
 

--- a/src/duk_heap_misc.c
+++ b/src/duk_heap_misc.c
@@ -56,8 +56,7 @@ DUK_INTERNAL void duk_heap_switch_thread(duk_heap *heap, duk_hthread *new_thr) {
 			 * interrupt before executing the first insturction.
 			 */
 			DUK_DD(DUK_DDPRINT("switch thread, initial entry, init default interrupt counter"));
-			new_thr->interrupt_counter = 0;
-			new_thr->interrupt_init = 0;
+			DUK_HTHREAD_INTCTR_SET_IMMEDIATE(new_thr);
 		} else {
 			/* Copy interrupt counter/init value state to new thread (if any).
 			 * It's OK for new_thr to be the same as curr_thr.

--- a/src/duk_hthread.h
+++ b/src/duk_hthread.h
@@ -191,6 +191,23 @@
 	 DUK_ASSERT_EXPR((thr)->valstack_bottom > (thr)->valstack), \
 	 (thr)->valstack_bottom - 1)
 
+/* Initialize interrupt counter to a new countdown value.  If the value is 1,
+ * one opcode would be executed before interrupting.  This is behind a macro
+ * because changes in the counter model are likely and need specific tweaks
+ * (like subtracting 1 or not).
+ */
+#define DUK_HTHREAD_INTCTR_SET(thr,val) do { \
+		duk_int_t duk__val; \
+		duk__val = (val); \
+		(thr)->interrupt_init = duk__val; \
+		(thr)->interrupt_counter = duk__val; \
+	} while (0)
+
+#define DUK_HTHREAD_INTCTR_SET_IMMEDIATE(thr) do { \
+		(thr)->interrupt_init = 0; \
+		(thr)->interrupt_counter = 0; \
+	} while (0)
+
 /*
  *  Struct defines
  */

--- a/src/duk_js_call.c
+++ b/src/duk_js_call.c
@@ -1717,7 +1717,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 		DUK_DD(DUK_DDPRINT("returning with debugger enabled, force interrupt"));
 		DUK_ASSERT(thr->interrupt_counter <= thr->interrupt_init);
 		thr->interrupt_init -= thr->interrupt_counter;
-		thr->interrupt_counter = 0;
+		thr->interrupt_counter = 0;  /* FIXME: for consistency this should be 1? */
 		thr->heap->dbg_force_restart = 1;
 	}
 #endif
@@ -1850,7 +1850,7 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
 		DUK_DD(DUK_DDPRINT("returning with debugger enabled, force interrupt"));
 		DUK_ASSERT(thr->interrupt_counter <= thr->interrupt_init);
 		thr->interrupt_init -= thr->interrupt_counter;
-		thr->interrupt_counter = 0;
+		thr->interrupt_counter = 0;  /* FIXME: for consistency, should be 1? */
 		thr->heap->dbg_force_restart = 1;
 	}
 #endif


### PR DESCRIPTION
Making the interrupt decision based on the updated value (rather than old value) seems to work better on at least x86/x64.

Tasks:
- [ ] Change interrupt counter mechanism in executor
- [ ] Fix counter init locations, hide the init behind a macro for further tweaks
- [ ] Test interrupt fixup handling, i.e. accurate counting
- [ ] Releases entry