### PR TITLE
Dispatch DUK_OP_ADD separately

### DIFF
--- a/src/duk_js_executor.c
+++ b/src/duk_js_executor.c
@@ -3053,7 +3053,17 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			break;
 		}
 
-		case DUK_OP_ADD:
+		case DUK_OP_ADD: {
+			duk_small_uint_fast_t a = DUK_DEC_A(ins);
+			duk_tval *tv_b;
+			duk_tval *tv_c;
+
+			tv_b = DUK__REGCONSTP_B(ins);
+			tv_c = DUK__REGCONSTP_C(ins);
+			duk__vm_arith_add(thr, tv_b, tv_c, a);
+			break;
+		}
+
 		case DUK_OP_SUB:
 		case DUK_OP_MUL:
 		case DUK_OP_DIV:
@@ -3065,15 +3075,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 			tv_b = DUK__REGCONSTP_B(ins);
 			tv_c = DUK__REGCONSTP_C(ins);
-			if (op == DUK_OP_ADD) {
-				/*
-				 *  Handling DUK_OP_ADD this way is more compact (experimentally)
-				 *  than a separate case with separate argument decoding.
-				 */
-				duk__vm_arith_add(thr, tv_b, tv_c, a);
-			} else {
-				duk__vm_arith_binary_op(thr, tv_b, tv_c, a, op);
-			}
+			duk__vm_arith_binary_op(thr, tv_b, tv_c, a, op);
 			break;
 		}
 

--- a/tests/perf/test-arith-add.js
+++ b/tests/perf/test-arith-add.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 0xdeadbeef;
+    y = 0xcafed00d;
+
+    for (i = 0, n = 4e7; i < n; i++) {
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-arith-div.js
+++ b/tests/perf/test-arith-div.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 0xdeadbeef;
+    y = 0xcafed00d;
+
+    for (i = 0, n = 4e7; i < n; i++) {
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+        z = x / y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-arith-mod.js
+++ b/tests/perf/test-arith-mod.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 0xdeadbeef;
+    y = 0xcafed00d;
+
+    for (i = 0, n = 4e7; i < n; i++) {
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+        z = x % y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-arith-mul.js
+++ b/tests/perf/test-arith-mul.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 0xdeadbeef;
+    y = 0xcafed00d;
+
+    for (i = 0, n = 4e7; i < n; i++) {
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+        z = x * y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-arith-sub.js
+++ b/tests/perf/test-arith-sub.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 0xdeadbeef;
+    y = 0xcafed00d;
+
+    for (i = 0, n = 4e7; i < n; i++) {
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+        z = x - y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
Just a small tweak to opcode dispatch: addition is handled using a different helper than other binary arithmetic so dispatch it separately to eliminate an awkward comparison.

- [x] Change dispatch
- [ ] Add perf tests (fastint or not? now mixed)
- [ ] Releases entry