### PR TITLE
Make console-extra safe against Duktape.enc change

### DIFF
--- a/extras/console/duk_console.c
+++ b/extras/console/duk_console.c
@@ -113,13 +113,15 @@ void duk_console_init(duk_context *ctx, duk_uint_t flags) {
 	 * to ToString(v).
 	 */
 	duk_eval_string(ctx,
-		"(function format(v){"
-		    "try{"
-		        "return Duktape.enc('jx',v);"
-		    "}catch(e){"
-		        "return ''+v;"
-		    "}"
-		"})");
+		"(function (E) {"
+		    "return function format(v){"
+		        "try{"
+		            "return E('jx',v);"
+		        "}catch(e){"
+		            "return ''+v;"
+		        "}"
+		    "};"
+		"})(Duktape.enc)");
 	duk_put_prop_string(ctx, -2, "format");
 
 	duk__console_reg_vararg_func(ctx, duk__console_assert, "assert");


### PR DESCRIPTION
Current version in master looks up `Duktape.enc` for every attempt to format a value:

```
((o) Duktape [linenoise] 1.99.99 (v1.5.0-433-g25513d3)
duk> console.log({foo:123})
{foo:123}
= undefined
duk> Duktape.enc = function () {return 'aiee';}
= function () {"ecmascript"}
duk> console.log({foo:123})
aiee
= undefined
duk> 
```

With this fix applied:

```
((o) Duktape [linenoise] 1.99.99 (v1.5.0-433-g25513d3-dirty)
duk> console.log({foo:123})
{foo:123}
= undefined
duk> Duktape.enc = function () {return 'aiee';}
= function () {"ecmascript"}
duk> console.log({foo:123})
{foo:123}
= undefined
```