### PR TITLE
Makefile perf test tweaks, add Jerryscript to perf test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1271,9 +1271,9 @@ massif-arcfour: massif-test-dev-arcfour
 # - Node.js (V8) is JITed
 # - Luajit is JITed
 
-#TIME=$(PYTHON) util/time_multi.py --count 1 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
-#TIME=$(PYTHON) util/time_multi.py --count 3 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
-TIME=$(PYTHON) util/time_multi.py --count 5 --sleep 0 --sleep-factor 0.8 --mode min # Take minimum time of N
+#TIME=$(PYTHON) util/time_multi.py --count 1 --sleep 0 --sleep-factor 2.0 --mode min # Take minimum time of N
+#TIME=$(PYTHON) util/time_multi.py --count 3 --sleep 0 --sleep-factor 2.0 --mode min # Take minimum time of N
+TIME=$(PYTHON) util/time_multi.py --count 5 --sleep 0 --sleep-factor 2.0 --mode min # Take minimum time of N
 
 # Blocks: optimization variants, previous versions, other interpreting engines,
 # other JIT engines.
@@ -1285,12 +1285,15 @@ perftest: duk duk.O2 duk.O3 duk.O4
 		printf ' duk.O3 %5s' "`$(TIME) ./duk.O3 $$i`"; \
 		printf ' duk.O4 %5s' "`$(TIME) ./duk.O4 $$i`"; \
 		printf ' |'; \
+		printf ' duk.O2.150 %5s' "`$(TIME) ./duk.O2.150 $$i`"; \
+		printf ' duk.O2.140 %5s' "`$(TIME) ./duk.O2.140 $$i`"; \
 		printf ' duk.O2.130 %5s' "`$(TIME) ./duk.O2.130 $$i`"; \
 		printf ' duk.O2.124 %5s' "`$(TIME) ./duk.O2.124 $$i`"; \
 		printf ' duk.O2.113 %5s' "`$(TIME) ./duk.O2.113 $$i`"; \
 		printf ' duk.O2.102 %5s' "`$(TIME) ./duk.O2.102 $$i`"; \
 		printf ' |'; \
 		printf ' mujs %5s' "`$(TIME) mujs $$i`"; \
+		printf ' jerry %5s' "`$(TIME) jerry $$i`"; \
 		printf ' lua %5s' "`$(TIME) lua $${i%%.js}.lua`"; \
 		printf ' python %5s' "`$(TIME) $(PYTHON) $${i%%.js}.py`"; \
 		printf ' perl %5s' "`$(TIME) perl $${i%%.js}.pl`"; \
@@ -1301,16 +1304,15 @@ perftest: duk duk.O2 duk.O3 duk.O4
 		printf ' luajit %5s' "`$(TIME) luajit $${i%%.js}.lua`"; \
 		printf '\n'; \
 	done
-perftestduk: duk duk.O2
+perftestduk: duk.O2
 	for i in tests/perf/*.js; do \
 		printf '%-36s:' "`basename $$i`"; \
-		printf ' duk.Os %5s' "`$(TIME) ./duk $$i`"; \
 		printf ' duk.O2 %5s' "`$(TIME) ./duk.O2 $$i`"; \
 		printf ' |'; \
-		printf ' duk.O2.130 %5s' "`$(TIME) ./duk.O2.130 $$i`"; \
-		printf ' duk.O2.124 %5s' "`$(TIME) ./duk.O2.124 $$i`"; \
-		printf ' duk.O2.113 %5s' "`$(TIME) ./duk.O2.113 $$i`"; \
-		printf ' duk.O2.102 %5s' "`$(TIME) ./duk.O2.102 $$i`"; \
+		printf ' mujs %5s' "`$(TIME) mujs $$i`"; \
+		printf ' jerry %5s' "`$(TIME) jerry $$i`"; \
+		printf ' duk.O2.master %5s' "`$(TIME) ./duk.O2.master $$i`"; \
+		printf ' duk.O2.150 %5s' "`$(TIME) ./duk.O2.150 $$i`"; \
 		printf '\n'; \
 	done
 perftestduk3: duk.O2


### PR DESCRIPTION
- Add Jerryscript to manual microbenchmark test set
- Tweak some of the time_multi.py parameters for longer cooldown

I'll also post a comparison here for current `make duk.O2`, MuJS and JerryScript. MuJS and JerryScript  are compiled using defaults, `duk.O2` is pretty much defaults except enabling fastints (which are not enabled by default because they don't port to platforms without 64-bit integer support, i.e. exotics).

This is just a ballpark and not entirely representative for several reasons. For example:

- JerryScript is low memory targeted so a comparable Duktape build for low memory targets should be memory optimized. However, in some environments memory is not the main issue in which case performance oriented configuration is more appropriate; I don't yet know how to do that for JerryScript.
- Duktape configuration includes reference counting and interrupt counter support (script timeouts etc) which could be disabled for a more accurate comparison with a matching feature set for engines being compared to.

I'll try to see if I can come up with a more comprehensive performance test "panel" which would include microbenchmarks but also e.g. Google V8 benchmark and Kraken, for multiple engines *and* multiple configurations. I'd like to run that for every commit which means some dedicated performance testing hardware so that the run completes in reasonable time, so this will take a bit :)

A similar comparison panel would be useful for footprint, again with multiple engines and multiple configurations (where appropriate).