### PR TITLE
Implement Ecmascript 6 Math functions

### DIFF
--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2266,6 +2266,12 @@ objects:
           magic:
             type: math_onearg
             funcname: "floor"  # BI_MATH_FLOOR_IDX
+      - key: "hypot"
+        value:
+          type: function
+          native: duk_bi_math_object_hypot
+          length: 2
+          varargs: true
       - key: "log"
         value:
           type: function

--- a/tests/ecmascript/test-bi-math.js
+++ b/tests/ecmascript/test-bi-math.js
@@ -354,6 +354,34 @@ prE(Math.floor(0.5)); print(zeroSign(Math.floor(0.5)));
 prE(Math.floor(1));
 
 /*===
+hypot
+0
+Infinity
+Infinity
+NaN
+NaN
+0
+5
+7.0710678118654755
+7.0710678118654755
+812
+===*/
+
+print('hypot');
+
+prE(Math.hypot());
+prE(Math.hypot(Infinity, NaN));
+prE(Math.hypot(NaN, -Infinity));
+prE(Math.hypot(1, 2, NaN));
+prE(Math.hypot(1, 2, 'pig'));
+prE(Math.hypot(-0));
+
+prE(Math.hypot(3, 4));
+prE(Math.hypot(3, 4, 5));
+prE(Math.hypot(3, '4', 5));
+prE(Math.hypot(-812));
+
+/*===
 log
 4812184
 NaN


### PR DESCRIPTION
Fixes #838.  Work in progress.
- [ ] Implement new `Math` functions added in ES6
- [ ] Investigate the best way to implement `Math.hypot`, perhaps look at how other engines do it?
- [ ] Add new ES6 `Number` functions: `Number.isNaN()`, etc. => Seperate pull
- [ ] Testcases for ES6 Math functions
