### PR TITLE
Implement an API to safely summarize any value as a string

### DIFF
--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -175,6 +175,9 @@ struct duk_time_components {
 #define DUK_HINT_STRING                   1    /* prefer string */
 #define DUK_HINT_NUMBER                   2    /* prefer number */
 
+/* Summarization flags */
+#define DUK_SUMMARY_ERROR_AWARE           (1 << 0)
+
 /* Enumeration flags for duk_enum() */
 #define DUK_ENUM_INCLUDE_NONENUMERABLE    (1 << 0)    /* enumerate non-numerable properties in addition to enumerable */
 #define DUK_ENUM_INCLUDE_INTERNAL         (1 << 1)    /* enumerate internal properties (regardless of enumerability) */
@@ -628,6 +631,7 @@ DUK_EXTERNAL_DECL void *duk_to_pointer(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL void duk_to_object(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL void duk_to_defaultvalue(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
 DUK_EXTERNAL_DECL void duk_to_primitive(duk_context *ctx, duk_idx_t idx, duk_int_t hint);
+DUK_EXTERNAL_DECL void duk_safe_push_summary(duk_context *ctx, duk_idx_t idx, duk_uint_t flags);
 
 #define DUK_BUF_MODE_FIXED      0   /* internal: request fixed buffer result */
 #define DUK_BUF_MODE_DYNAMIC    1   /* internal: request dynamic buffer result */

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -17,6 +17,7 @@
  */
 
 DUK_LOCAL_DECL duk_idx_t duk__push_c_function_raw(duk_context *ctx, duk_c_function func, duk_idx_t nargs, duk_uint_t flags);
+DUK_LOCAL const char *duk__push_string_tval_readable(duk_context *ctx, duk_tval *tv, duk_bool_t error_aware);
 
 /*
  *  Global state for working around missing variadic macros
@@ -2337,6 +2338,22 @@ DUK_EXTERNAL const char *duk_to_string(duk_context *ctx, duk_idx_t idx) {
  skip_replace:
 	DUK_ASSERT(duk_is_string(ctx, idx));
 	return duk_require_string(ctx, idx);
+}
+
+DUK_EXTERNAL void duk_safe_push_summary(duk_context *ctx, duk_idx_t idx, duk_uint_t flags) {
+	duk_tval *tv;
+	duk_bool_t error_aware = 0;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	tv = duk_get_tval_or_unused(ctx, idx);
+	DUK_ASSERT(tv != NULL);
+
+	if (flags & DUK_SUMMARY_ERROR_AWARE) {
+		error_aware = 1;
+	}
+
+	duk__push_string_tval_readable(ctx, tv, error_aware);
 }
 
 DUK_INTERNAL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t idx) {

--- a/tests/api/test-safe-push-summary.c
+++ b/tests/api/test-safe-push-summary.c
@@ -1,0 +1,64 @@
+/*===
+duk_is_string()=1
+'pig'
+'the big fat pig ate everyone and...'
+duk_is_string()=1
+812
+9000.1
+false
+true
+null
+undefined
+Error: the pig ate it
+===*/
+
+void test(duk_context *ctx) {
+	duk_push_string(ctx, "pig");
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("duk_is_string()=%d\n", duk_is_string(ctx, -1));
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_string(ctx, "the big fat pig ate everyone and now it's too fat");
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_int(ctx, 812);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("duk_is_string()=%d\n", duk_is_string(ctx, -1));
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_number(ctx, 9000.1);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_false(ctx);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_true(ctx);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_null(ctx);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_undefined(ctx);
+	duk_safe_push_summary(ctx, -1, 0x0);
+	printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_2(ctx);
+
+	duk_push_error(ctx, DUK_ERR_ERROR, "the pig ate it");
+	duk_safe_push_summary(ctx, -1, 0x0);
+	duk_safe_push_summary(ctx, -2, DUK_SUMMARY_ERROR_AWARE);
+	printf("%s\n", duk_get_string(ctx, -2));
+	//printf("%s\n", duk_get_string(ctx, -1));
+	duk_pop_3(ctx);
+}


### PR DESCRIPTION
Fixes #776.

This adds a function, `duk_to_summary()` to the public API which exposes the `duk_tval` summarization mechanism used internally for verbose errors for use by applications.
- [x] Initial draft implementation => `duk_to_summary()`
- [ ] API structure - Multiple calls, one call with flags, something else?
- [ ] Semantics - Should we coerce the value to a summary, replacing it; or push the summary to the stack without modifying the original value?
- [ ] API documentation for new call(s)
- [ ] API testcases for new call(s)
