### PR TITLE
Add improved ES6 Annex B regexp identity escape

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1715,9 +1715,14 @@ Planned
   and constructor call argument count from 511 to 255, and maximum Ecmascript
   function constant count from 262144 to 65536 (GH-903)
 
-* Allow ES6 unescaped right bracket (']') in regular expressions (non-standard
-  before ES6 Annex B), left bracket ('[') not yet supported because it needs
-  backtracking (GH-871)
+* Allow ES6 Annex B unescaped right bracket (']') in regular expressions
+  (non-standard before ES6 Annex B), left bracket ('[') not yet supported
+  because it needs backtracking (GH-871)
+
+* Allow ES6 Annex B identity escapes, i.e. allow identity escapes also for
+  identifier part characters; the support is not yet complete as Duktape
+  won't backtrack on e.g. an invalid hex escape and treat it literally
+  (GH-926)
 
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),

--- a/tests/ecmascript/test-dev-es6-regexp-identity-escape.js
+++ b/tests/ecmascript/test-dev-es6-regexp-identity-escape.js
@@ -1,0 +1,68 @@
+/*
+ *  ES6 Annex B allows regexp identity escape for any source code character
+ *  except 'c'.  With DUK_USE_ES6_REGEXP_SYNTAX Duktape does too; test for
+ *  a few basic cases.
+ */
+
+/*===
+true
+true
+8232 plain SyntaxError
+8232 charclass SyntaxError
+8233 plain SyntaxError
+8233 charclass SyntaxError
+===*/
+
+function test() {
+    var re;
+    var i;
+
+    // Original reported issue: https://github.com/svaarala/duktape/issues/643
+    try {
+        re = eval('/[\\' + String.fromCharCode(198) + ']/');
+        print(re.test('\u00c6'));
+    } catch (e) {
+        print(e.name);
+    }
+
+    // Same case outside of a character class.
+    try {
+        re = eval('/\\' + String.fromCharCode(198) + '/');
+        print(re.test('\u00c6'));
+    } catch (e) {
+        print(e.name);
+    }
+
+    // Test BMP above ASCII range.  Everything is accepted except U+2028
+    // and U+2029 which are treated like newlines and cause a RegExp syntax
+    // error (V8 has the same behavior).
+    for (i = 0x0080; i <= 0xffff; i++) {
+        try {
+            re = eval('/\\' + String.fromCharCode(i) + '/');
+            if (re.test(String.fromCharCode(i)) !== true) {
+                print(i, 'plain', 'no match');
+            }
+        } catch (e) {
+            print(i, 'plain', e.name);
+        }
+
+        try {
+            re = eval('/[\\' + String.fromCharCode(i) + ']/');
+            if (re.test(String.fromCharCode(i)) !== true) {
+                print(i, 'charclass', 'no match');
+            }
+        } catch (e) {
+            print(i, 'charclass', e.name);
+        }
+    }
+
+    // As of Duktape 2.0 there are still some differences for the ASCII range
+    // because Duktape won't backtrack on e.g. an invalid hex escape to treat
+    // the characters literally.
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-regexp-identity-escape.js
+++ b/tests/ecmascript/test-regexp-identity-escape.js
@@ -4,7 +4,7 @@ var txt;
 var i;
 
 /*===
-SyntaxError
+/\z/
 ===*/
 
 /*
@@ -15,7 +15,8 @@ SyntaxError
  *     <ZWJ>
  *     <ZWNJ>
  *
- *  Note: Rhino and V8 will accept this.
+ *  However, with ES6 Annex B support this is accepted by Duktape (matching
+ *  both Rhino and V8).
  */
 
 try {


### PR DESCRIPTION
Allow almost all source characters as identity escapes when `DUK_USE_ES6_REGEXP_SYNTAX` is enabled. However, the pull doesn't add support for backtracking out of e.g. an invalid hex escape and treat it literally.

Fixes #643.