### PR TITLE
Use Math replacements by default on AmigaOS 3

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1857,6 +1857,10 @@ Planned
   DUK_FILE_MACRO and DUK_LINE_MACRO, which matters if the standard file/line
   macros have been replaced in duk_config.h (GH-897)
 
+* Fix AmigaOS3 portability issue by enabling math function replacements
+  automatically for AmigaOS on M68K, regardless of OS version or compiler
+  (GH-932)
+
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch
   by around 20-25% and avoid a two-level dispatch for EXTRA opcodes; the

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -161,7 +161,13 @@
 /* Missing some obvious constants. */
 #define DUK_F_USE_REPL_ALL
 #elif defined(DUK_F_AMIGAOS) && defined(DUK_F_VBCC)
-/* VBCC is missing the built-ins even in C99 mode (perhaps a header issue) */
+/* VBCC is missing the built-ins even in C99 mode (perhaps a header issue). */
+#define DUK_F_USE_REPL_ALL
+#elif defined(DUK_F_AMIGAOS) && defined(DUK_F_M68K)
+/* AmigaOS + M68K seems to have math issues even when using GCC cross
+ * compilation.  Use replacements for all AmigaOS versions on M68K
+ * regardless of compiler.
+ */
 #define DUK_F_USE_REPL_ALL
 #elif defined(DUK_F_FREEBSD) && defined(DUK_F_CLANG)
 /* Placeholder fix for (detection is wider than necessary):


### PR DESCRIPTION
Use math replacements even when not compiling using VBCC: even when when cross compiling with GCC some math asserts fail.

- [x] Figure out best check: all AmigaOS regardless of version, or is there some version after which replacements are not necessary?
- [x] Releases entry