### PR TITLE
More cleanups for dist and prepare-and-config split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1067,7 +1067,7 @@ cloc:	dist cloc-1.60.pl
 # XXX: make prints a harmless warning related to the sub-make.
 dist:
 	@make codepolicycheck
-	$(PYTHON) util/make_dist.py --create-spdx
+	$(PYTHON) util/dist.py --create-spdx
 
 .PHONY:	dist-src
 dist-src:	dist

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Automatically generated bleeding edge snapshots from master are available at
 [duktape.org/snapshots](http://duktape.org/snapshots).
 
 You can also clone this repository, make modifications, and build a source
-distributable on Linux, OSX, and Windows using `python util/make_dist.py`.
+distributable on Linux, OSX, and Windows using `python util/dist.py`.
 
 Getting started: modifying and rebuilding the distributable
 -----------------------------------------------------------
@@ -74,17 +74,17 @@ distributable in Linux, OSX, or Windows:
 
     # Linux; can often install from packages or using 'pip'
     $ sudo apt-get install python python-yaml
-    $ python util/make_dist.py
+    $ python util/dist.py
 
     # OSX
     # Install Python 2.7.x
     $ pip install PyYAML
-    $ python util/make_dist.py
+    $ python util/dist.py
 
     # Windows
     ; Install Python 2.7.x from python.org, and add it to PATH
     > pip install PyYAML
-    > python util\make_dist.py
+    > python util\dist.py
 
 The source distributable directory will be in `dist/`.
 

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1761,8 +1761,8 @@ Planned
 * Incompatible change: genconfig.py has been relocated to tools/genconfig.py
   in the end user distributable (GH-929)
 
-* Incompatible change: make_dist.py no longer supports ROM built-ins, use
-  tools/prepare_sources.py instead (GH-929)
+* Incompatible change: util/dist.py no longer supports ROM built-ins, use
+  tools/configure.py instead (GH-929)
 
 * Include raw input sources and a prepare-and-config tool in the distributable,
   which allow user code to regenerate a config file and source code files for

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ build_script:
   # Make dist.
 
   - cmd: cd C:\projects\duktape
-  - cmd: python util\make_dist.py
+  - cmd: python util\dist.py
 
   # --- Visual Studio 2015 ---
 

--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -58,23 +58,26 @@ To build an example command line tool, use the following::
 
 This distributable contains:
 
-* ``src/``: main Duktape library in a "single source file" format (duktape.c,
+* Pre-configured Duktape header and source files using the Duktape default
+  configuration:
+
+  - ``src/``: main Duktape library in a "single source file" format (duktape.c,
   duktape.h, and duk_config.h).
 
-* ``src-noline/``: contains a variant of ``src/duktape.c`` with no ``#line``
-  directives which is preferable for some users.  See discussion in
-  https://github.com/svaarala/duktape/pull/363.
+  * ``src-noline/``: contains a variant of ``src/duktape.c`` with no ``#line``
+    directives which is preferable for some users.  See discussion in
+    https://github.com/svaarala/duktape/pull/363.
 
-* ``src-separate/``: main Duktape library in multiple files format.
+  * ``src-separate/``: main Duktape library in multiple files format.
 
-* ``src-input/``: raw input source files used for a config-and-prepare which
+* ``src-input/``: raw input source files used by ``configure.py`` which
   recreates the combined/separate prepared sources with specific options.
 
-* ``tools/``: various Python tools, such as prepare_sources.py for doing a
-  config-and-prepare and genconfig.py for creating duk_config.h configuration
-  files, see: http://wiki.duktape.org/Configuring.html.
+* ``tools/``: various Python tools, such as ``configure.py`` for preparing
+  a ``duk_config.h`` header and Duktape source files for compilation, see
+  http://wiki.duktape.org/Configuring.html.
 
-* ``config/``: configuration metadata for genconfig.py.
+* ``config/``: configuration metadata for ``configure.py``.
 
 * ``examples/``: further examples for using Duktape.  Although Duktape
   itself is widely portable, some of the examples are Linux only.

--- a/doc/duk-config.rst
+++ b/doc/duk-config.rst
@@ -118,17 +118,6 @@ Generating an autodetect duk_config.h
 To generate an autodetect header suitable for directly supported platforms
 (matches Duktape 1.2 platform support)::
 
-    # The --metadata option can point to a metadata directory or a tar.gz
-    # file with packed metadata (included in end user distributable).
-
-    $ cd duktape-2.0.0
-    $ python tools/genconfig.py \
-        --metadata config/genconfig_metadata.tar.gz \
-        --output /tmp/duk_config.h \
-        duk-config-header
-
-    # The same command using unpacked metadata present in Duktape source repo.
-
     $ cd duktape-2.0.0
     $ python tools/genconfig.py \
         --metadata config/ \

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -238,7 +238,7 @@ Suggested options
     There are example files in the distributable for Unicode data limited
     to 8-bit codepoints.
 
-  - Provide the stripped files to ``prepare_sources.py`` to reduce Unicode
+  - Provide the stripped files to ``configure.py`` to reduce Unicode
     table size.
 
   - Possible footprint savings are about 2-3kB.
@@ -355,7 +355,7 @@ The following may be appropriate when even less memory is available
     is more memory efficient: it creates a writable (empty) global object
     which inherits from the ROM global object.
 
-  - Rerun ``prepare_sources.py`` with ``--rom-support`` to create prepared
+  - Rerun ``configure.py`` with ``--rom-support`` to create prepared
     sources with support for ROM builtins.  ROM builtin support is not
     enabled by default because it increases the size of ``duktape.c``
     considerably.  Add the option ``--rom-auto-lightfunc`` to convert
@@ -388,8 +388,8 @@ The following may be appropriate when even less memory is available
 
     + ``src/builtins.yaml``: documents some more format details
 
-    + ``util/example_rombuild.sh``: illustrates how to run
-      ``prepare_sources.py`` with user builtins
+    + ``util/example_rombuild.sh``: illustrates how to run ``configure.py``
+      with user builtins
 
 * Consider using lightfuncs for representing function properties of ROM
   built-ins.
@@ -448,10 +448,11 @@ Note that:
   is counterproductive because the external pointer takes more room than the
   character data.
 
-The Duktape built-in strings are available from build metadata:
+The Duktape built-in strings are available from prepared source metadata:
 
-* ``dist/duk_build_meta.json``, the ``builtin_strings_base64`` contains
-  the byte exact strings used, encoded with base-64.
+* For example, ``dist/src/duk_source_meta.json``, the
+  ``builtin_strings_base64`` contains the byte exact strings used, encoded
+  with base-64.
 
 Strings used by application C and Ecmascript code can be extracted with
 various methods.  The Duktape main repo contains an example script for

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -279,7 +279,7 @@ Checklist for ordinary releases
   - Trivial compile test for combined source
 
   - Trivial compile test for separate sources (important because
-    it's easy to forget to add files in make_dist.sh)
+    it's easy to forget to add files in util/dist.py)
 
 * Store binaries to duktape-releases repo
 

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -75,15 +75,15 @@ There are some tooling changes in this release:
 * The distributable now includes raw sources (``src/`` in Duktape main repo)
   in ``src-input/`` and some tooling in ``tools/``.
 
-* The tooling includes a new ``tools/prepare_sources.py`` tool which creates
+* The tooling includes a new ``tools/configure.py`` tool which creates
   a ``duk_config.h`` and matching prepared sources simultaneously.  This
   allows use of ROM built-ins from the distributable (previously required a
-  manual ``make_dist.py --rom-support ...`` command.
+  manual ``dist.py --rom-support ...`` command.
 
-* The ``make_dist.py`` utility in Duktape main repo no longer supports
-  ``--rom-support``, ``--rom-auto-lightfunc``, and ``--user-builtin-metadata``
-  options.  Use the  ``tools/prepare_sources.py`` tool instead, which supports
-  these options.
+* The ``make_dist.py`` utility in Duktape main repo has been renamed to
+  ``dist.py`` and no longer supports ``--rom-support``,
+  ``--rom-auto-lightfunc``, and ``--user-builtin-metadata`` options.  Use
+  the  ``tools/configure.py`` tool instead, which supports these options.
 
 * The distributable still includes sources prepared using default configuration
   (``src/``, ``src-noline/``, and ``src-separate``) and some configuration
@@ -102,7 +102,30 @@ To upgrade:
   ``tools/genconfig.py``.
 
 * If you're using ROM built-ins via ``make_dist.py``, change your build to
-  use ``tools/prepare_sources.py`` instead.
+  use ``tools/configure.py`` instead.
+
+Dist package file changes
+-------------------------
+
+* Configuration metadata is now in unpacked form on ``dist/config`` to match
+  the Duktape master repo and make config files more convenient to patch.
+  The ``dist/tools/genconfig.py`` tool no longer accepts a tar.gz metadata
+  argument.
+
+* The pre-built ``duk_config.h`` examples have been removed as somewhat
+  useless.  Use ``dist/tools/configure.py`` (or ``dist/tools/genconfig.py)``
+  to generate ``duk_config.h`` files.
+
+* ``dist/duk_build_meta.json`` has been renamed to ``dist/duk_dist_meta.json``
+  for clarity.  It no longer contains string data scanned from source files.
+  This metadata is now in source directories, e.g.
+  ``dist/src/duk_source_meta.json`` as the string set potentially depends
+  on options used to prepare sources.
+
+* Source metadata, e.g. ``dist/src/metadata.json``, has been renamed to
+  ``dist/src/duk_source_meta.json`` for clarity.  The metadata contains
+  Duktape version information, strings scanned from source files, and for
+  combined (amalgamated) sources the line number metadata.
 
 Buffer behavior changes
 -----------------------

--- a/examples/cmdline/duk_cmdline_ajduk.c
+++ b/examples/cmdline/duk_cmdline_ajduk.c
@@ -507,10 +507,11 @@ void ajsheap_extstr_free_1(const void *ptr) {
  *  is gathered during application compile time and baked into the application
  *  binary.
  *
- *  Duktape built-in strings are available from duk_build_meta.json, see
- *  tools/duk_meta_to_strarray.py.  There may also be a lot of application
- *  specific strings, e.g. those used by application specific APIs.  These
- *  must be gathered through some other means, see e.g. tools/scan_strings.py.
+ *  Duktape built-in strings are available from duk_source_meta.json in a
+ *  prepared source directory, see tools/duk_meta_to_strarray.py.  There
+ *  may also be a lot of application specific strings, e.g. those used by
+ *  application specific APIs.  These must be gathered through some other
+ *  means, see e.g. tools/scan_strings.py.
  */
 
 static const char *strdata_duk_builtin_strings[] = {

--- a/extras/alloc-pool/Makefile
+++ b/extras/alloc-pool/Makefile
@@ -16,11 +16,10 @@ test:
 
 .PHONY: ptrcomptest
 ptrcomptest:
-	tar -x -v -z -f ../../config/genconfig_metadata.tar.gz examples/low_memory.yaml
 	python ../../tools/genconfig.py \
-		--metadata ../../config/genconfig_metadata.tar.gz \
+		--metadata ../../config \
 		--output ./duk_config.h \
-		--option-file examples/low_memory.yaml \
+		--option-file ../../config/examples/low_memory.yaml \
 		--option-file ptrcomp.yaml \
 		--fixup-file ptrcomp_fixup.h \
 		duk-config-header

--- a/testrunner/client-simple-node/run_commit_test.py
+++ b/testrunner/client-simple-node/run_commit_test.py
@@ -315,10 +315,10 @@ def context_helper_minsize_fltoetc(archopt, strip):
         execute([ 'rm', '-rf', os.path.join(cwd, 'dist', 'src-separate') ])
 
         cmd = [
-            'python2', os.path.join(cwd, 'dist', 'tools', 'prepare_sources.py'),
+            'python2', os.path.join(cwd, 'dist', 'tools', 'configure.py'),
             '--source-directory', os.path.join(cwd, 'dist', 'src-input'),
             '--output-directory', os.path.join(cwd, 'dist'),
-            '--config-metadata', os.path.join(cwd, 'dist', 'config', 'genconfig_metadata.tar.gz'),
+            '--config-metadata', os.path.join(cwd, 'dist', 'config'),
             '--option-file', os.path.join(cwd, 'config', 'examples', 'low_memory.yaml')
         ]
         if strip:
@@ -556,7 +556,7 @@ def context_linux_x86_dist_genconfig():
     os.chdir(os.path.join(cwd, 'dist'))
     execute([
         'python2', os.path.join(cwd, 'dist', 'tools', 'genconfig.py'),
-        '--metadata', os.path.join(cwd, 'dist', 'config', 'genconfig_metadata.tar.gz'),
+        '--metadata', os.path.join(cwd, 'dist', 'config'),
         '--output', os.path.join(cwd, 'dist', 'src', 'duk_config.h'),  # overwrite default duk_config.h
         '-DDUK_USE_FASTINT', '-UDUK_USE_JX', '-UDUK_USE_JC',
         'duk-config-header'
@@ -604,7 +604,7 @@ def context_linux_x64_error_variants():
         os.chdir(os.path.join(cwd, 'dist'))
         execute([
             'python2', os.path.join(cwd, 'dist', 'tools', 'genconfig.py'),
-            '--metadata', os.path.join(cwd, 'dist', 'config', 'genconfig_metadata.tar.gz'),
+            '--metadata', os.path.join(cwd, 'dist', 'config'),
             '--output', os.path.join(cwd, 'dist', 'src', 'duk_config.h')  # overwrite default duk_config.h
         ] + params['genconfig_opts'] + [
             'duk-config-header'
@@ -657,10 +657,10 @@ def context_helper_hello_ram(archopt):
         execute([ 'rm', '-rf', os.path.join(cwd, 'dist', 'src-separate') ])
 
         cmd = [
-            'python2', os.path.join(cwd, 'dist', 'tools', 'prepare_sources.py'),
+            'python2', os.path.join(cwd, 'dist', 'tools', 'configure.py'),
             '--source-directory', os.path.join(cwd, 'dist', 'src-input'),
             '--output-directory', os.path.join(cwd, 'dist'),
-            '--config-metadata', os.path.join(cwd, 'dist', 'config', 'genconfig_metadata.tar.gz'),
+            '--config-metadata', os.path.join(cwd, 'dist', 'config'),
             '--rom-support'
         ] + genconfig_opts
         print(repr(cmd))

--- a/tools/README.rst
+++ b/tools/README.rst
@@ -5,8 +5,8 @@ Duktape tools
 This directory contains various Duktape Python tools which are included in
 the end user distributable.
 
-The main use case is config-and-prepare which simultaneously creates
-a ``duk_config.h`` configuration file and prepares source files for
+The main tool is ``configure.py`` which simultaneously creates a
+``duk_config.h`` configuration file and prepares source files for
 compilation.  These two operations are combined because:
 
 1. Configuration options may affect source file preparation.
@@ -27,37 +27,5 @@ be as portable as possible.  For example:
 * Avoid depending on Python executable name, use ``sys.executable`` instead
   to launch Python commands.
 
-The tooling has been written for Python 2.x and there's no support for
+The tooling has been written for Python 2.x.  There's no support for
 Python 3.x at present.
-
-TODO
-====
-
-- Go through all .py files once more and figure out what to move into tools
-
-- Go through all moves, and git grep for "call sites"
-
-- Add dist/config/genconfig.py copy for convenience?
-
-STEPS
-=====
-
-- Move all scripts that should be in the end user distributable into 'tools/'.
-
-- Change all references for the scripts for their new location so that existing
-  dist and build works.  No other changes at this point.
-
-- Split make_dist.py into two parts:
-
-  1. Revised dist part which first copies files into the end user distributable
-     and then runs the prepare step *in the distributable* for the default
-     configuration.
-
-  2. Separate config-and-prepare utility which does most of the current dist
-     processing.  This will take the --rom-auto-lightfunc and other stuff now.
-     It also interfaces with genconfig.
-
-- Update documentation: new locations (e.g. in genconfig docs, READMEs etc),
-  new config process, ROM built-in stuff, etc.
-
-- At this point the initial rework is complete.

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -2875,7 +2875,7 @@ def main():
         rom_emit_object_initializer_types_and_macros(gc_src)
         rom_emit_objects(gc_src, rom_meta, rom_bi_str_map)
     else:
-        gc_src.emitLine('#error ROM support not enabled, rerun prepare_sources.py with --rom-support')
+        gc_src.emitLine('#error ROM support not enabled, rerun configure.py with --rom-support')
     gc_src.emitLine('#else  /* DUK_USE_ROM_STRINGS */')
     emit_ramstr_source_strinit_data(gc_src, ramstr_data)
     gc_src.emitLine('#endif  /* DUK_USE_ROM_STRINGS */')
@@ -2886,7 +2886,7 @@ def main():
         gc_src.emitLine('#error DUK_USE_ROM_OBJECTS requires DUK_USE_ROM_STRINGS')
         gc_src.emitLine('#endif')
     else:
-        gc_src.emitLine('#error ROM support not enabled, rerun prepare_sources.py with --rom-support')
+        gc_src.emitLine('#error ROM support not enabled, rerun configure.py with --rom-support')
     gc_src.emitLine('#else  /* DUK_USE_ROM_OBJECTS */')
     if opts.ram_support:
         emit_ramobj_source_nativefunc_array(gc_src, ram_native_funcs)  # endian independent
@@ -2900,7 +2900,7 @@ def main():
         gc_src.emitLine('#error invalid endianness defines')
         gc_src.emitLine('#endif')
     else:
-        gc_src.emitLine('#error RAM support not enabled, rerun prepare_sources.py with --ram-support')
+        gc_src.emitLine('#error RAM support not enabled, rerun configure.py with --ram-support')
     gc_src.emitLine('#endif  /* DUK_USE_ROM_OBJECTS */')
 
     gc_hdr = dukutil.GenerateC()
@@ -2913,13 +2913,13 @@ def main():
         emit_header_stridx_defines(gc_hdr, rom_meta)
         rom_emit_strings_header(gc_hdr, rom_meta)
     else:
-        gc_hdr.emitLine('#error ROM support not enabled, rerun prepare_sources.py with --rom-support')
+        gc_hdr.emitLine('#error ROM support not enabled, rerun configure.py with --rom-support')
     gc_hdr.emitLine('#else  /* DUK_USE_ROM_STRINGS */')
     if opts.ram_support:
         emit_header_stridx_defines(gc_hdr, ram_meta)
         emit_ramstr_header_strinit_defines(gc_hdr, ram_meta, ramstr_data, ramstr_maxlen)
     else:
-        gc_hdr.emitLine('#error RAM support not enabled, rerun prepare_sources.py with --ram-support')
+        gc_hdr.emitLine('#error RAM support not enabled, rerun configure.py with --ram-support')
     gc_hdr.emitLine('#endif  /* DUK_USE_ROM_STRINGS */')
     gc_hdr.emitLine('')
     gc_hdr.emitLine('#if defined(DUK_USE_ROM_OBJECTS)')
@@ -2936,7 +2936,7 @@ def main():
         emit_header_native_function_declarations(gc_hdr, rom_meta)
         rom_emit_objects_header(gc_hdr, rom_meta)
     else:
-        gc_hdr.emitLine('#error RAM support not enabled, rerun prepare_sources.py with --ram-support')
+        gc_hdr.emitLine('#error RAM support not enabled, rerun configure.py with --ram-support')
     gc_hdr.emitLine('#else  /* DUK_USE_ROM_OBJECTS */')
     if opts.ram_support:
         emit_header_native_function_declarations(gc_hdr, ram_meta)
@@ -2952,7 +2952,7 @@ def main():
         gc_hdr.emitLine('#error invalid endianness defines')
         gc_hdr.emitLine('#endif')
     else:
-        gc_hdr.emitLine('#error RAM support not enabled, rerun prepare_sources.py with --ram-support')
+        gc_hdr.emitLine('#error RAM support not enabled, rerun configure.py with --ram-support')
     gc_hdr.emitLine('#endif  /* DUK_USE_ROM_OBJECTS */')
     gc_hdr.emitLine('#endif  /* DUK_BUILTINS_H_INCLUDED */')
 

--- a/tools/prepare_unicode_data.py
+++ b/tools/prepare_unicode_data.py
@@ -6,10 +6,18 @@
 
 import os
 import sys
+import optparse
 
 def main():
-    f_in = open(sys.argv[1], 'rb')
-    f_out = open(sys.argv[2], 'wb')
+    parser = optparse.OptionParser()
+    parser.add_option('--unicode-data', dest='unicode_data')
+    parser.add_option('--output', dest='output')
+    (opts, args) = parser.parse_args()
+    assert(opts.unicode_data is not None)
+    assert(opts.output is not None)
+
+    f_in = open(opts.unicode_data, 'rb')
+    f_out = open(opts.output, 'wb')
     while True:
         line = f_in.readline()
         if line == '' or line == '\n':
@@ -23,9 +31,13 @@ def main():
             cp1 = long(parts[0], 16)
             cp2 = long(parts2[0], 16)
 
-            suffix = ';'.join(parts[1:])
-            for i in xrange(cp1, cp2 + 1):  # inclusive
+            tmp = parts[1:]
+            tmp[0] = '-""-'
+            suffix = ';'.join(tmp)
+            f_out.write(line)
+            for i in xrange(cp1 + 1, cp2):
                 f_out.write('%04X;%s' % (i, suffix))
+            f_out.write(line2)
         else:
             f_out.write(line)
 

--- a/util/example_rombuild.sh
+++ b/util/example_rombuild.sh
@@ -12,14 +12,14 @@ make clean dist
 # metadata can be provided through one or more YAML files (which are applied
 # in sequence).  Duktape configuration can be given at the same time.
 rm -rf dist/src dist/src-noline dist/src-separate
-$PYTHON dist/tools/prepare_sources.py \
+$PYTHON dist/tools/configure.py \
 	--source-directory dist/src-input \
 	--output-directory dist \
 	--rom-support \
 	--rom-auto-lightfunc \
 	--user-builtin-metadata util/example_user_builtins1.yaml \
 	--user-builtin-metadata util/example_user_builtins2.yaml \
-	--config-metadata dist/config/genconfig_metadata.tar.gz \
+	--config-metadata dist/config \
 	-DDUK_USE_ROM_STRINGS \
 	-DDUK_USE_ROM_OBJECTS \
 	-DDUK_USE_ROM_GLOBAL_INHERIT \
@@ -34,14 +34,14 @@ make duk dukd  # XXX: currently fails to start, DUK_CMDLINE_LOGGING_SUPPORT, DUK
 # --support-feature-options by moving the options into a genconfig
 # YAML config file.
 rm -rf dist/src dist/src-noline dist/src-separate
-$PYTHON dist/tools/prepare_sources.py \
+$PYTHON dist/tools/configure.py \
 	--source-directory dist/src-input \
 	--output-directory dist \
 	--rom-support \
 	--rom-auto-lightfunc \
 	--user-builtin-metadata util/example_user_builtins1.yaml \
 	--user-builtin-metadata util/example_user_builtins2.yaml \
-	--config-metadata dist/config/genconfig_metadata.tar.gz \
+	--config-metadata dist/config \
 	--support-feature-options \
 	-DDUK_USE_ROM_STRINGS \
 	-DDUK_USE_ROM_OBJECTS \

--- a/util/example_user_builtins1.yaml
+++ b/util/example_user_builtins1.yaml
@@ -8,9 +8,9 @@
 #
 #  See examples below for details on how to use these.
 #
-#  Note that genbuiltins.py and prepare_sources.py accept multiple user
-#  built-in YAML files, so that you can manage your custom strings and
-#  objects in individual YAML files for modularity.
+#  Note that genbuiltins.py and configure.py accept multiple user built-in
+#  YAML files, so that you can manage your custom strings and objects in
+#  individual YAML files for modularity.
 #
 #  When using pointer compression, all ROM strings and objects need a number
 #  from the ROM pointer compression range (e.g. [0xf800,0xffff]).  By default


### PR DESCRIPTION
- [x] Rename `prepare_sources.py` tool; naming matters because it'll become an important external tool.
- [x] Refactor prepare_sources.py so that it only generates separate or combined sources (with or without #line directives) as requested per execution, rather than creating all variants. Rework make_dist.py to run the tool multiple times.
- [x] Metadata files for build and prepared sources: `duk_dist_meta.json` at top of distributable, `duk_source_meta.json` in a prepared source directory
- [x] Copy config metadata directly into dist package (rather than tar.gz'ing it)
- [x] Remove pre-built `duk_config.h` examples, they're pretty pointless
- [x] Check dist on Windows
- [x] Unicode speedups? => Small improvements made, separate pull for more
- [x] Short form options? Limit to a small set because they make any call sites less obvious => Nothing apparent, keep current set
- [x] Wiki draft for 2.x source preparation
- [x] Compare dist package to the one in master and 1.5.0, check any extra files are intentional
- [x] Fix testrunner jobs that use prepare_sources.py directly (path changes)
- [x] Update Duktape repo snapshot for testrunners

Implements parts of #927.
