### PR TITLE
Fix duk_harray non-writable length handling for index write

### DIFF
--- a/src/duk_hobject_props.c
+++ b/src/duk_hobject_props.c
@@ -2135,8 +2135,11 @@ DUK_LOCAL duk_bool_t duk__putprop_shallow_fastpath_array_tval(duk_hthread *thr, 
 		                     "(arr_idx=%ld, old_len=%ld)",
 		                     (long) idx, (long) old_len));
 		if (DUK_HARRAY_LENGTH_NONWRITABLE(a)) {
-			DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
-			return 0;  /* not reachable */
+			/* The correct behavior here is either a silent error
+			 * or a TypeError, depending on strictness.  Fall back
+			 * to the slow path to handle the situation.
+			 */
+			return 0;
 		}
 		new_len = idx + 1;
 

--- a/tests/ecmascript/test-dev-duk-harray.js
+++ b/tests/ecmascript/test-dev-duk-harray.js
@@ -231,8 +231,15 @@ true
 
 1,2,3,4,5,6,7,8,9,10
 1,2,3,4,5,foo,7,8,9,10
+foo
+write succeeded
+1,2,3,4,5,foo,7,8,9,10
+undefined
+1,2,3,4,5,6,7,8,9,10
+1,2,3,4,5,foo,7,8,9,10
 TypeError: not writable
 1,2,3,4,5,foo,7,8,9,10
+undefined
 ===*/
 
 function arrayLengthTest() {
@@ -266,18 +273,40 @@ function arrayLengthTest() {
     print(Object.getOwnPropertyNames(obj));
 
     // Writing to an Array when .length is write protected.
+    // In a non-strict function this must be a silent failure.
     arr = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
     Object.defineProperty(arr, 'length', { writable: false });
     print(arr);
     arr[5] = 'foo';  // OK, length not changed
     print(arr);
     try {
-        arr[10] = 'foo';
+        print(arr[10] = 'foo');
+        print('write succeeded');
     } catch (e) {
         //print(e.stack);
         print(e);
     }
     print(arr);
+    print(arr[10]);
+
+    // For a strict function the result must be a TypeError.
+    arr = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+    Object.defineProperty(arr, 'length', { writable: false });
+    print(arr);
+    arr[5] = 'foo';  // OK, length not changed
+    print(arr);
+    try {
+        (function() {
+            'use strict';
+            print(arr[10] = 'foo');
+            print('write succeeded');
+        })();
+    } catch (e) {
+        //print(e.stack);
+        print(e);
+    }
+    print(arr);
+    print(arr[10]);
 }
 
 try {


### PR DESCRIPTION
Fix a small bug in duk_harray index write when .length is non-writable. The TypeError thrown must be suppressed in non-strict functions. This bug was not in 1.x branch so no releases entry.