### PR TITLE
Make finalizer support optional

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1814,6 +1814,9 @@ Planned
 * Make coroutine support optional (DUK_USE_COROUTINE_SUPPORT); disabling
   coroutines reduces code footprint by about 2kB (GH-829)
 
+* Make finalizer support optional (DUK_USE_FINALIZER_SUPPORT); disabling
+  coroutines reduces code footprint by about 0.8kB (GH-936)
+
 * Add an internal type for representing Array instances (duk_harray) to
   simplify array operations and improve performance; this also changes the
   key order of Object.getOwnPropertyNames() for sparse arrays (arrays whose

--- a/config/config-options/DUK_USE_COROUTINE_SUPPORT.yaml
+++ b/config/config-options/DUK_USE_COROUTINE_SUPPORT.yaml
@@ -4,4 +4,4 @@ default: true
 tags:
   - execution
 description: >
-  Enable support Duktape coroutines, i.e. yield/resume.
+  Enable support for Duktape coroutines, i.e. yield/resume.

--- a/config/config-options/DUK_USE_FINALIZER_SUPPORT.yaml
+++ b/config/config-options/DUK_USE_FINALIZER_SUPPORT.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_FINALIZER_SUPPORT
+introduced: 2.0.0
+default: true
+tags:
+  - execution
+description: >
+  Enable support for object finalizers (Duktape specific).

--- a/config/examples/low_memory_strip.yaml
+++ b/config/examples/low_memory_strip.yaml
@@ -18,6 +18,9 @@ DUK_USE_REGEXP_CANON_WORKAROUND: false
 # Coroutine support has about 2kB footprint.
 DUK_USE_COROUTINE_SUPPORT: false
 
+# Finalizer support has about 0.8kB footprint.
+DUK_USE_FINALIZER_SUPPORT: false
+
 # ES6 Proxy has about 2kB footprint.
 DUK_USE_ES6_PROXY: false
 

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -651,6 +651,7 @@ DUK_EXTERNAL void duk_set_prototype(duk_context *ctx, duk_idx_t idx) {
  *  Object finalizer
  */
 
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 /* XXX: these could be implemented as macros calling an internal function
  * directly.
  * XXX: same issue as with Duktape.fin: there's no way to delete the property
@@ -667,3 +668,16 @@ DUK_EXTERNAL void duk_set_finalizer(duk_context *ctx, duk_idx_t idx) {
 
 	duk_put_prop_stridx(ctx, idx, DUK_STRIDX_INT_FINALIZER);
 }
+#else  /* DUK_USE_FINALIZER_SUPPORT */
+DUK_EXTERNAL void duk_get_finalizer(duk_context *ctx, duk_idx_t idx) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_UNREF(idx);
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+
+DUK_EXTERNAL void duk_set_finalizer(duk_context *ctx, duk_idx_t idx) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_UNREF(idx);
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+#endif  /* DUK_USE_FINALIZER_SUPPORT */

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -203,6 +203,7 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_gc(duk_context *ctx) {
 #endif
 }
 
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
 	(void) duk_require_hobject(ctx, 0);
 	if (duk_get_top(ctx) >= 2) {
@@ -222,6 +223,11 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
 		return 1;
 	}
 }
+#else  /* DUK_USE_FINALIZER_SUPPORT */
+DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+#endif  /* DUK_USE_FINALIZER_SUPPORT */
 
 DUK_INTERNAL duk_ret_t duk_bi_duktape_object_enc(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -175,6 +175,7 @@ DUK_LOCAL void duk__free_stringtable(duk_heap *heap) {
 	duk_heap_free_strtab(heap);
 }
 
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 DUK_LOCAL void duk__free_run_finalizers(duk_heap *heap) {
 	duk_hthread *thr;
 	duk_heaphdr *curr;
@@ -268,6 +269,7 @@ DUK_LOCAL void duk__free_run_finalizers(duk_heap *heap) {
 	DUK_ASSERT(DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap));
 	DUK_HEAP_CLEAR_MARKANDSWEEP_RUNNING(heap);
 }
+#endif  /* DUK_USE_FINALIZER_SUPPORT */
 
 DUK_INTERNAL void duk_heap_free(duk_heap *heap) {
 	DUK_D(DUK_DPRINT("free heap: %p", (void *) heap));
@@ -313,8 +315,10 @@ DUK_INTERNAL void duk_heap_free(duk_heap *heap) {
 	duk_heap_mark_and_sweep(heap, DUK_MS_FLAG_SKIP_FINALIZERS);  /* skip finalizers; queue finalizable objects to heap_allocated */
 #endif
 
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 	DUK_HEAP_SET_FINALIZER_NORESCUE(heap);  /* rescue no longer supported */
 	duk__free_run_finalizers(heap);
+#endif  /* DUK_USE_FINALIZER_SUPPORT */
 
 	/* Note: heap->heap_thread, heap->curr_thread, and heap->heap_object
 	 * are on the heap allocated list.

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -939,7 +939,9 @@ DUK_INTERNAL_DECL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_b
 DUK_INTERNAL_DECL void duk_hobject_set_prototype_updref(duk_hthread *thr, duk_hobject *h, duk_hobject *p);
 
 /* finalization */
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 DUK_INTERNAL_DECL void duk_hobject_run_finalizer(duk_hthread *thr, duk_hobject *obj);
+#endif
 
 /* pc2line */
 #if defined(DUK_USE_PC2LINE)

--- a/src-input/duk_hobject_finalizer.c
+++ b/src-input/duk_hobject_finalizer.c
@@ -17,6 +17,7 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_FINALIZER_SUPPORT)
 DUK_LOCAL duk_ret_t duk__finalize_helper(duk_context *ctx, void *udata) {
 	duk_hthread *thr;
 
@@ -109,3 +110,4 @@ DUK_INTERNAL void duk_hobject_run_finalizer(duk_hthread *thr, duk_hobject *obj) 
 
 	DUK_ASSERT_TOP(ctx, entry_top);
 }
+#endif  /* DUK_USE_FINALIZER_SUPPORT */


### PR DESCRIPTION
Useful for lowmem builds. The impact is not very large (slightly less than 1kB) but may matter for stripped builds.