### PR TITLE
Add __attribute__ ((unused)) for internal functions for gcc/clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ CCOPTS_SHARED =
 CCOPTS_SHARED += -D_POSIX_C_SOURCE=200809L  # to avoid linenoise strdup() warnings
 CCOPTS_SHARED += -pedantic -ansi -std=c99 -fstrict-aliasing
 # -Wextra is very picky but catches e.g. signed/unsigned comparisons
-CCOPTS_SHARED += -Wall -Wextra -Wunused-result -Wdeclaration-after-statement
+CCOPTS_SHARED += -Wall -Wextra -Wunused-result -Wdeclaration-after-statement -Wunused-function
 CCOPTS_SHARED += -Wcast-qual
 CCOPTS_SHARED += -Wshadow
 CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an error
@@ -304,7 +304,7 @@ CCOPTS_DEBUG += -DDUK_OPT_DEBUG
 CCOPTS_DEBUG += -DDUK_OPT_DEBUG_LEVEL=0
 CCOPTS_DEBUG += -DDUK_OPT_ASSERTIONS
 
-GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result
+GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -Wunused-function
 GXXOPTS_SHARED += '-DDUK_OPT_DEBUG_WRITE(level,file,line,func,msg)={fprintf(stderr, "D%ld %s:%ld (%s): %s\n", (long) (level), (file), (long) (line), (func), (msg));}'
 GXXOPTS_NONDEBUG = $(GXXOPTS_SHARED) -Os -fomit-frame-pointer
 GXXOPTS_NONDEBUG += -I./dist/src -I./dist/examples/alloc-logging -I./dist/examples/alloc-torture -I./dist/examples/alloc-hybrid -I./dist/extras/print-alert -I./dist/extras/console -I./dist/extras/logging -I./dist/extras/module-duktape

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1873,6 +1873,10 @@ Planned
   order; the order was not guaranteed but specification requires left-to-right
   ordering (GH-943)
 
+* Reduce harmless "unused function" warnings for GCC and Clang by using
+  __attribute__ ((unused)) for internal function declarations (GH-916,
+  GH-942)
+
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch
   by around 20-25% and avoid a two-level dispatch for EXTRA opcodes; the

--- a/config/header-snippets/gcc_clang_visibility.h.in
+++ b/config/header-snippets/gcc_clang_visibility.h.in
@@ -1,11 +1,26 @@
 #define DUK_EXTERNAL_DECL  __attribute__ ((visibility("default"))) extern
 #define DUK_EXTERNAL       __attribute__ ((visibility("default")))
 #if defined(DUK_SINGLE_FILE)
+#if (defined(DUK_F_GCC_VERSION) && DUK_F_GCC_VERSION >= 30101) || defined(DUK_F_CLANG)
+/* Minimize warnings for unused internal functions with GCC >= 3.1.1 and
+ * Clang.  Based on documentation it should suffice to have the attribute
+ * in the declaration only, but in practice some warnings are generated unless
+ * the attribute is also applied to the definition.
+ */
+#define DUK_INTERNAL_DECL  static __attribute__ ((unused))
+#define DUK_INTERNAL       static __attribute__ ((unused))
+#else
 #define DUK_INTERNAL_DECL  static
 #define DUK_INTERNAL       static
+#endif
+#else
+#if (defined(DUK_F_GCC_VERSION) && DUK_F_GCC_VERSION >= 30101) || defined(DUK_F_CLANG)
+#define DUK_INTERNAL_DECL  __attribute__ ((visibility("hidden"))) __attribute__ ((unused)) extern
+#define DUK_INTERNAL       __attribute__ ((visibility("hidden"))) __attribute__ ((unused))
 #else
 #define DUK_INTERNAL_DECL  __attribute__ ((visibility("hidden"))) extern
 #define DUK_INTERNAL       __attribute__ ((visibility("hidden")))
+#endif
 #endif
 #define DUK_LOCAL_DECL     static
 #define DUK_LOCAL          static


### PR DESCRIPTION
Fixes #916.

Tasks:
- [x] Implement fix in default configuration files
- [x] Check fix works in practice
- [x] Check both combined and separate source compilation
- [x] Releases entry