### PR TITLE
Math twoarg coercion order

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1869,6 +1869,10 @@ Planned
   automatically for AmigaOS on M68K, regardless of OS version or compiler
   (GH-932)
 
+* Fix two-argument Math function (like Math.atan2()) argument coercion
+  order; the order was not guaranteed but specification requires left-to-right
+  ordering (GH-943)
+
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch
   by around 20-25% and avoid a two-level dispatch for EXTRA opcodes; the

--- a/src/duk_bi_math.c
+++ b/src/duk_bi_math.c
@@ -284,22 +284,28 @@ DUK_LOCAL const duk__two_arg_func duk__two_arg_funcs[] = {
 DUK_INTERNAL duk_ret_t duk_bi_math_object_onearg_shared(duk_context *ctx) {
 	duk_small_int_t fun_idx = duk_get_current_magic(ctx);
 	duk__one_arg_func fun;
+	duk_double_t arg1;
 
 	DUK_ASSERT(fun_idx >= 0);
 	DUK_ASSERT(fun_idx < (duk_small_int_t) (sizeof(duk__one_arg_funcs) / sizeof(duk__one_arg_func)));
+	arg1 = duk_to_number(ctx, 0);
 	fun = duk__one_arg_funcs[fun_idx];
-	duk_push_number(ctx, (duk_double_t) fun((double) duk_to_number(ctx, 0)));
+	duk_push_number(ctx, (duk_double_t) fun((double) arg1));
 	return 1;
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_math_object_twoarg_shared(duk_context *ctx) {
 	duk_small_int_t fun_idx = duk_get_current_magic(ctx);
 	duk__two_arg_func fun;
+	duk_double_t arg1;
+	duk_double_t arg2;
 
 	DUK_ASSERT(fun_idx >= 0);
 	DUK_ASSERT(fun_idx < (duk_small_int_t) (sizeof(duk__two_arg_funcs) / sizeof(duk__two_arg_func)));
+	arg1 = duk_to_number(ctx, 0);  /* explicit ordered evaluation to match coercion semantics */
+	arg2 = duk_to_number(ctx, 1);
 	fun = duk__two_arg_funcs[fun_idx];
-	duk_push_number(ctx, (duk_double_t) fun((double) duk_to_number(ctx, 0), (double) duk_to_number(ctx, 1)));
+	duk_push_number(ctx, (duk_double_t) fun((double) arg1, (double) arg2));
 	return 1;
 }
 


### PR DESCRIPTION
Fix minor compliance issue in Math.atan2() (and other two-arg function) coercion ordering: the coercion ordering was not guaranteed to be left-to-right and was indeed right-to-left on at least Linux x64.