### PR TITLE
Add -lstring variants for property access API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.strip
 /_*
 /duk.*
+/duk
 /libduktape.*
 /build/
 /dist/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Ole André Vadla Ravnås (https://github.com/oleavr)
 * Harold Brenes (https://github.com/harold-b)
 * Oliver Crow (https://github.com/ocrow)
+* Jakub Chłapiński (https://github.com/jchlapinski)
 
 Other contributions
 ===================

--- a/src/duk_api_object.c
+++ b/src/duk_api_object.c
@@ -44,6 +44,15 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx,
 	return duk_get_prop(ctx, obj_idx);
 }
 
+DUK_EXTERNAL duk_bool_t duk_get_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(key != NULL);
+
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_lstring(ctx, key, key_len);
+	return duk_get_prop(ctx, obj_idx);
+}
+
 DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -119,6 +128,16 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx,
 	return duk_put_prop(ctx, obj_idx);
 }
 
+DUK_EXTERNAL duk_bool_t duk_put_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(key != NULL);
+
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_lstring(ctx, key, key_len);
+	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
+	return duk_put_prop(ctx, obj_idx);
+}
+
 DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -175,6 +194,15 @@ DUK_EXTERNAL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx,
 	return duk_del_prop(ctx, obj_idx);
 }
 
+DUK_EXTERNAL duk_bool_t duk_del_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(key != NULL);
+
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_lstring(ctx, key, key_len);
+	return duk_del_prop(ctx, obj_idx);
+}
+
 DUK_EXTERNAL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -224,6 +252,15 @@ DUK_EXTERNAL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx,
 
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_string(ctx, key);
+	return duk_has_prop(ctx, obj_idx);
+}
+
+DUK_EXTERNAL duk_bool_t duk_has_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(key != NULL);
+
+	obj_idx = duk_require_normalize_index(ctx, obj_idx);
+	duk_push_lstring(ctx, key, key_len);
 	return duk_has_prop(ctx, obj_idx);
 }
 
@@ -513,6 +550,21 @@ DUK_EXTERNAL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key)
 	return ret;
 }
 
+DUK_EXTERNAL duk_bool_t duk_get_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_bool_t ret;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(ctx, thr->builtins[DUK_BIDX_GLOBAL]);
+	ret = duk_get_prop_lstring(ctx, -1, key, key_len);
+	duk_remove(ctx, -2);
+	return ret;
+}
+
 DUK_EXTERNAL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_bool_t ret;
@@ -525,6 +577,22 @@ DUK_EXTERNAL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key)
 	duk_push_hobject(ctx, thr->builtins[DUK_BIDX_GLOBAL]);
 	duk_insert(ctx, -2);
 	ret = duk_put_prop_string(ctx, -2, key);  /* [ ... global val ] -> [ ... global ] */
+	duk_pop(ctx);
+	return ret;
+}
+
+DUK_EXTERNAL duk_bool_t duk_put_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_bool_t ret;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(ctx, thr->builtins[DUK_BIDX_GLOBAL]);
+	duk_insert(ctx, -2);
+	ret = duk_put_prop_lstring(ctx, -2, key, key_len);  /* [ ... global val ] -> [ ... global ] */
 	duk_pop(ctx);
 	return ret;
 }

--- a/src/duk_api_public.h.in
+++ b/src/duk_api_public.h.in
@@ -672,20 +672,26 @@ DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t flags);
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_get_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key);
+DUK_EXTERNAL_DECL duk_bool_t duk_put_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
 
 /*
  *  Object prototype


### PR DESCRIPTION
I am using Duktape trough FFI in my project written in Rust. In Rust, strings are not null-terminated and have specified length. Many of the duktape API functions already have "lstring" variants that allow me to pass Rust strings directly, without the need to copy and null-terminating them, which is great. However a few rather useful variants for property access are missing. In this PR I would like to add the following functions to the public API:
```
DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
DUK_EXTERNAL_DECL duk_bool_t duk_get_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
DUK_EXTERNAL_DECL duk_bool_t duk_put_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
```

Those additional implementations are not-so trivial to implement outside of Duktape API, and probably adding them to the API will not enlarge library size by much. This change will make much easier to integrate Duktape into languages with non null-terminated strings.

Regards. 