### PR TITLE
Fix genconfig bool comparison

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1908,6 +1908,11 @@ Planned
   order; the order was not guaranteed but specification requires left-to-right
   ordering (GH-943)
 
+* Fix genconfig.py forced option boolean comparison; for forced numeric option
+  value 0 genconfig would emit "#undef XXX" (instead of "#define XXX 0") and
+  for forced numeric option value 1 it would emit "#define XXX" (instead of
+  "#define XXX 1") (GH-954)
+
 * Reduce harmless "unused function" warnings for GCC and Clang by using
   __attribute__ ((unused)) for internal function declarations (GH-916,
   GH-942)

--- a/tools/extract_unique_options.py
+++ b/tools/extract_unique_options.py
@@ -10,7 +10,7 @@ import os, sys, re
 # DUK_USE_xxx/DUK_OPT_xxx are used as placeholders and not matched
 # (only uppercase allowed)
 re_use = re.compile(r'DUK_USE_[A-Z0-9_]+')
-re_opt = re.compile(r'DUK_OPT_[A-Z0-9_]+')
+re_opt = re.compile(r'DUK_OPT_[A-Z0-9_]+')  # removed in Duktape 2.x; match anyway just in case
 
 def main():
     uses = {}

--- a/tools/genconfig.py
+++ b/tools/genconfig.py
@@ -825,9 +825,10 @@ def emit_default_from_config_meta(ret, doc, forced_opts, undef_done):
     defname = doc['define']
     defval = forced_opts.get(defname, doc['default'])
 
-    if defval == True:
+    # NOTE: careful with Python equality, e.g. "0 == False" is true.
+    if isinstance(defval, bool) and defval == True:
         ret.line('#define ' + defname)
-    elif defval == False:
+    elif isinstance(defval, bool) and defval == False:
         if not undef_done:
             ret.line('#undef ' + defname)
         else:


### PR DESCRIPTION
Forced options with numeric value 0 or 1 would be handled incorrectly:
- For 0, genconfig would emit `#undef XXX` rather than `#define XXX 0`.
- For 1, genconfig would emit `#define XXX` rather than `#define XXX 1`.

This was caused by Python comparison without boolean type check; in Python `0 == False` and `1 == True` are true (but `2 == True` is not).