### PR TITLE
Fix duk_put_prop_string() bug when target and value are the same slot

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1877,6 +1877,11 @@ Planned
   for footprint optimized builds (ensure DUK_USE_ARRAY_PROP_FASTPATH is
   disabled for low memory builds) (GH-934)
 
+* Fix incorrect value stack handling in duk_put_prop_(l)string() and
+  duk_put_prop_index() when the target object and the property value
+  are in the same value stack slot (which is unusual but conceptually
+  clear) (GH-959)
+
 * Fix buffer object (duk_hbufobj) JSON serialization (bug present in 1.5.0):
   buffer objects were omitted from serialization when they should be
   serialized as normal objects instead (GH-867)

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -91,7 +91,7 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t 
 	return rc;
 }
 
-DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx) {
+DUK_LOCAL duk_bool_t duk__put_prop_shared(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t idx_key) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
@@ -99,16 +99,19 @@ DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_small_int_t throw_flag;
 	duk_bool_t rc;
 
-	DUK_ASSERT_CTX_VALID(ctx);
-
 	/* Note: copying tv_obj and tv_key to locals to shield against a valstack
 	 * resize is not necessary for a property put right now (putprop protects
 	 * against it internally).
 	 */
 
+	/* Key and value indices are either (-2, -1) or (-1, -2).  Given idx_key,
+	 * idx_val is always (idx_key ^ 0x01).
+	 */
+	DUK_ASSERT((idx_key == -2 && (idx_key ^ 1) == -1) ||
+	           (idx_key == -1 && (idx_key ^ 1) == -2));
 	tv_obj = duk_require_tval(ctx, obj_idx);
-	tv_key = duk_require_tval(ctx, -2);
-	tv_val = duk_require_tval(ctx, -1);
+	tv_key = duk_require_tval(ctx, idx_key);
+	tv_val = duk_require_tval(ctx, idx_key ^ 1);
 	throw_flag = duk_is_strict_call(ctx);
 
 	rc = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, throw_flag);
@@ -118,24 +121,31 @@ DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	return rc;  /* 1 if property found, 0 otherwise */
 }
 
+DUK_EXTERNAL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx) {
+	DUK_ASSERT_CTX_VALID(ctx);
+	return duk__put_prop_shared(ctx, obj_idx, -2);
+}
+
 DUK_EXTERNAL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_idx = duk_require_normalize_index(ctx, obj_idx);
-	duk_push_string(ctx, key);
-	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_idx);
+	/* Careful here and with other duk_put_prop_xxx() helpers: the
+	 * target object and the property value may be in the same value
+	 * stack slot (unusual, but still conceptually clear).
+	 */
+	obj_idx = duk_normalize_index(ctx, obj_idx);
+	(void) duk_push_string(ctx, key);
+	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
 DUK_EXTERNAL duk_bool_t duk_put_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(key != NULL);
 
-	obj_idx = duk_require_normalize_index(ctx, obj_idx);
-	duk_push_lstring(ctx, key, key_len);
-	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_idx);
+	obj_idx = duk_normalize_index(ctx, obj_idx);
+	(void) duk_push_lstring(ctx, key, key_len);
+	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
 DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
@@ -143,8 +153,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_uarridx(ctx, arr_idx);
-	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_idx);
+	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
 DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
@@ -157,8 +166,7 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
-	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
-	return duk_put_prop(ctx, obj_idx);
+	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
 DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx) {

--- a/tests/api/test-put-prop-target-value-same.c
+++ b/tests/api/test-put-prop-target-value-same.c
@@ -1,0 +1,135 @@
+/*
+ *  Test for a bug in value stack handling (Duktape 1.5.1 and prior) where
+ *  the target object and the property value are the same value stack item
+ *  in duk_put_prop_string(), duk_put_prop_lstring(), or duk_put_prop_index().
+ *  Handling for duk_put_prop() doesn't have the issue.
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+[object Object]
+true false
+true false
+final top: 2
+==> rc=0, result='undefined'
+*** test_2 (duk_safe_call)
+[object Object]
+true false
+true false
+final top: 2
+==> rc=0, result='undefined'
+*** test_3 (duk_safe_call)
+[object Object]
+true false
+true false
+final top: 2
+==> rc=0, result='undefined'
+*** test_4 (duk_safe_call)
+[object Object]
+false true
+false true
+final top: 2
+==> rc=0, result='undefined'
+*** test_5 (duk_safe_call)
+[object Object]
+true false
+true false
+final top: 2
+==> rc=0, result='undefined'
+===*/
+
+static void dump_result(duk_context *ctx) {
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    print(v);\n"
+		"    print('example' in v, '123' in v);\n"
+		"    print(v.example === v, v['123'] === v);\n"
+		"})\n");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+}
+
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) duk_push_object(ctx);
+
+	/* This is the ordinary case where the target object and property value
+	 * are distinct value stack entries.
+	 */
+	duk_dup_top(ctx);
+	duk_put_prop_string(ctx, -2, "example");
+
+	dump_result(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) duk_push_object(ctx);
+
+	/* Here the target object and the property value are the same object.
+	 * Technically this should still work but in Duktape 1.5.1 and prior
+	 * this doesn't work.  The result is:
+	 *
+	 *     TypeError: cannot write property 'example' of 'example'
+	 *
+	 * The root cause is that duk_put_prop_string() pushes the key, swaps
+	 * the key and the value, and then calls duk_put_prop() with the
+	 * normalized index of the object intact.  This is incorrect:
+	 * if the value was also the target, it's now out of position.
+	 */
+	duk_dup_top(ctx);
+	duk_put_prop_string(ctx, -1, "example");
+
+	dump_result(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) duk_push_object(ctx);
+
+	duk_dup_top(ctx);
+	duk_put_prop_lstring(ctx, -1, "example", 7);
+
+	dump_result(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) duk_push_object(ctx);
+
+	duk_dup_top(ctx);
+	duk_put_prop_index(ctx, -1, 123);
+
+	dump_result(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
+	(void) duk_push_object(ctx);
+
+	/* The issue doesn't manifest in duk_put_prop(). */
+
+	duk_push_string(ctx, "example");
+	duk_dup(ctx, 0);
+	duk_put_prop(ctx, -1);
+
+	dump_result(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+	TEST_SAFE_CALL(test_2);
+	TEST_SAFE_CALL(test_3);
+	TEST_SAFE_CALL(test_4);
+	TEST_SAFE_CALL(test_5);
+}


### PR DESCRIPTION
When both the target object and property value are the same value stack slot for duk_put_prop_string() the result is not as expected.  No memory unsafe behavior happens though.

There's no similar issue in duk_put_prop(). The issue is caused by how duk_put_prop_string() adds the key to the value stack before calling duk_put_prop(); the normalized object index remains the same but is actually incorrect if the target was also the value:

```c
	obj_idx = duk_require_normalize_index(ctx, obj_idx);
	duk_push_string(ctx, key);
	duk_swap_top(ctx, -2);  /* [val key] -> [key val] */
	return duk_put_prop(ctx, obj_idx);
```

The same issue does affect duk_put_prop_lstring(), duk_put_prop_index(), and duk_put_prop_stridx().

Two possible fixes:
- Reject the situation as an API error as confusing.
- Support the situation. => This is implemented by the pull.

Tasks:
- [x] Figure out preferred fix
- [x] Add bug testcases for current issues
- [x] Releases entry
- [x] Backport to v1.5-maintenance and v1-maintenance => tracked via 1.5.2 fix list