### PR TITLE
Switch to xoroshiro128+ for built-in PRNG

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1886,6 +1886,10 @@ Planned
   to override the built-in random number generator (which is very simple
   and low footprint optimized) with something faster or better (GH-824)
 
+* Change default built-in PRNG algorithm to xoroshiro128+ with SplitMix64
+  seed mixing; previous algorithm (Shamir's three-op algorithm) is still
+  used for low memory targets and targets without 64-bit types (GH-970)
+
 * Fix incorrect value stack handling in duk_put_prop_(l)string() and
   duk_put_prop_index() when the target object and the property value
   are in the same value stack slot (which is unusual but conceptually

--- a/config/config-options/DUK_USE_GET_RANDOM_DOUBLE.yaml
+++ b/config/config-options/DUK_USE_GET_RANDOM_DOUBLE.yaml
@@ -8,9 +8,9 @@ description: >
   Override the default internal random number generator which is used for
   Math.random() and some other internal call sites (currently, for example,
   Array.prototype.sort()).  The default random number generator has a very
-  low footprint, but has low performance and is not statistically very good.
-  It is also not suitable at all for cryptographic applications.  Overriding
-  the random number generator may thus be useful in some environments.
+  low footprint but is not suitable for serious statistics algorithms or
+  cryptography.  Overriding the random number generator may thus be useful
+  in some environments.
 
   The macro gets a heap userdata argument and must provide an IEEE double
   in the range [0,1[.

--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -120,9 +120,11 @@ commit @GIT_COMMIT@ (@GIT_DESCRIBE@).
 Duktape is copyrighted by its authors (see ``AUTHORS.rst``) and licensed
 under the MIT license (see ``LICENSE.txt``).  String hashing algorithms are
 based on the algorithm from Lua (MIT license), djb2 hash, and Murmurhash2
-(MIT license).  Duktape module loader is based on the CommonJS module
-loading specification (without sharing any code), CommonJS is under the
-MIT license.
+(MIT license).  Pseudorandom number generator algorithms are based on
+Adi Shamir's three-op algorithm, xoroshiro128+ (public domain), and SplitMix64
+(public domain).  Duktape module loader is based on the CommonJS module
+loading specification (without sharing any code), CommonJS is under the MIT
+license.
 
 Have fun!
 

--- a/licenses/splitmix64.txt
+++ b/licenses/splitmix64.txt
@@ -1,0 +1,7 @@
+/*  Written in 2015 by Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */

--- a/licenses/xoroshiro128plus.txt
+++ b/licenses/xoroshiro128plus.txt
@@ -1,0 +1,7 @@
+/*  Written in 2016 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */

--- a/misc/splitmix64.c
+++ b/misc/splitmix64.c
@@ -1,0 +1,28 @@
+/*  Written in 2015 by Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+
+#include <stdint.h>
+
+/* This is a fixed-increment version of Java 8's SplittableRandom generator
+   See http://dx.doi.org/10.1145/2714064.2660195 and
+   http://docs.oracle.com/javase/8/docs/api/java/util/SplittableRandom.html
+
+   It is a very fast generator passing BigCrush, and it can be useful if
+   for some reason you absolutely want 64 bits of state; otherwise, we
+   rather suggest to use a xoroshiro128+ (for moderately parallel
+   computations) or xorshift1024* (for massively parallel computations)
+   generator. */
+
+uint64_t x; /* The state can be seeded with any value. */
+
+uint64_t next() {
+	uint64_t z = (x += UINT64_C(0x9E3779B97F4A7C15));
+	z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+	z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
+	return z ^ (z >> 31);
+}

--- a/misc/splitmix64_test.c
+++ b/misc/splitmix64_test.c
@@ -1,0 +1,27 @@
+/*
+ *  Generate a few random doubles to compare Duktape internal implementation
+ *  against the original splitmix64 source.
+ *
+ *  $ gcc -o /tmp/test -std=c99 splitmix64.c splitmix64_test.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+extern uint64_t x;
+extern uint64_t next(void);
+
+int main(int argc, char *argv[]) {
+	union {
+		uint64_t x;
+		double d;
+	} u;
+	int i;
+
+	x = 0xdeadbeef12345678ULL;
+
+	for (i = 0; i < 10; i++) {
+		printf("%08llx\n", (unsigned long long) next());
+	}
+}

--- a/misc/xoroshiro128plus.c
+++ b/misc/xoroshiro128plus.c
@@ -1,0 +1,69 @@
+/*  Written in 2016 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+
+#include <stdint.h>
+
+/* This is the successor to xorshift128+. It is the fastest full-period
+   generator passing BigCrush without systematic failures, but due to the
+   relatively short period it is acceptable only for applications with a
+   mild amount of parallelism; otherwise, use a xorshift1024* generator.
+
+   Beside passing BigCrush, this generator passes the PractRand test suite
+   up to (and included) 16TB, with the exception of binary rank tests,
+   which fail due to the lowest bit being an LFSR; all other bits pass all
+   tests. We suggest to use a sign test to extract a random Boolean value.
+
+   Note that the generator uses a simulated rotate operation, which most C
+   compilers will turn into a single instruction. In Java, you can use
+   Long.rotateLeft(). In languages that do not make low-level rotation
+   instructions accessible xorshift128+ could be faster.
+
+   The state must be seeded so that it is not everywhere zero. If you have
+   a 64-bit seed, we suggest to seed a splitmix64 generator and use its
+   output to fill s. */
+
+uint64_t s[2];
+
+static inline uint64_t rotl(const uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+uint64_t next(void) {
+	const uint64_t s0 = s[0];
+	uint64_t s1 = s[1];
+	const uint64_t result = s0 + s1;
+
+	s1 ^= s0;
+	s[0] = rotl(s0, 55) ^ s1 ^ (s1 << 14); // a, b
+	s[1] = rotl(s1, 36); // c
+
+	return result;
+}
+
+
+/* This is the jump function for the generator. It is equivalent
+   to 2^64 calls to next(); it can be used to generate 2^64
+   non-overlapping subsequences for parallel computations. */
+
+void jump(void) {
+	static const uint64_t JUMP[] = { 0xbeac0467eba5facb, 0xd86b048b86aa9922 };
+
+	uint64_t s0 = 0;
+	uint64_t s1 = 0;
+	for(int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
+		for(int b = 0; b < 64; b++) {
+			if (JUMP[i] & 1ULL << b) {
+				s0 ^= s[0];
+				s1 ^= s[1];
+			}
+			next();
+		}
+
+	s[0] = s0;
+	s[1] = s1;
+}

--- a/misc/xoroshiro128plus_test.c
+++ b/misc/xoroshiro128plus_test.c
@@ -1,0 +1,34 @@
+/*
+ *  Generate a few random doubles to compare Duktape internal implementation
+ *  against the original xoroshiro128+ source.
+ *
+ *  Doesn't work on middle endian hosts.
+ *
+ *  $ gcc -o /tmp/test -std=c99 xoroshiro128plus.c xoroshiro128plus_test.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+extern uint64_t s[2];
+extern uint64_t next(void);
+
+int main(int argc, char *argv[]) {
+	union {
+		uint64_t x;
+		double d;
+	} u;
+	int i;
+
+	s[0] = 0xdeadbeef12345678ULL;
+	s[1] = 0xcafed00d12345678ULL;
+
+	for (i = 0; i < 100; i++) {
+		if (i == 10) {
+			printf("--- duk_heap_alloc init mixing ends here\n");
+		}
+		u.x = (0x3ffULL << 52) + (next() >> 12);
+		printf("%08llx -> %f\n", (unsigned long long) u.x, u.d - 1.0);
+	}
+}

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -418,7 +418,11 @@ struct duk_heap {
 
 	/* rnd_state for duk_util_tinyrandom.c */
 #if !defined(DUK_USE_GET_RANDOM_DOUBLE)
-	duk_uint32_t rnd_state;
+#if defined(DUK_USE_PREFER_SIZE) || !defined(DUK_USE_64BIT_OPS)
+	duk_uint32_t rnd_state;  /* State for Shamir's three-op algorithm */
+#else
+	duk_uint64_t rnd_state[2];  /* State for xoroshiro128+ */
+#endif
 #endif
 
 	/* For manual debugging: instruction count based on executor and

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -506,6 +506,7 @@ DUK_INTERNAL_DECL void duk_be_finish(duk_bitencoder_ctx *ctx);
 
 #if !defined(DUK_USE_GET_RANDOM_DOUBLE)
 DUK_INTERNAL_DECL duk_double_t duk_util_tinyrandom_get_double(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_util_tinyrandom_prepare_seed(duk_hthread *thr);
 #endif
 
 DUK_INTERNAL_DECL void duk_bw_init(duk_hthread *thr, duk_bufwriter_ctx *bw_ctx, duk_hbuffer_dynamic *h_buf);

--- a/src-input/duk_util_tinyrandom.c
+++ b/src-input/duk_util_tinyrandom.c
@@ -1,15 +1,26 @@
 /*
- *  A tiny random number generator.
+ *  A tiny random number generator used for Math.random() and other internals.
  *
- *  Currently used for Math.random().
+ *  Default algorithm is xoroshiro128+: http://xoroshiro.di.unimi.it/xoroshiro128plus.c
+ *  with SplitMix64 seed preparation: http://xorshift.di.unimi.it/splitmix64.c.
  *
- *  http://www.woodmann.com/forum/archive/index.php/t-3100.html
+ *  Low memory targets and targets without 64-bit types use a slightly smaller
+ *  (but slower) algorithm by Adi Shamir:
+ *  http://www.woodmann.com/forum/archive/index.php/t-3100.html.
+ *
  */
 
 #include "duk_internal.h"
 
 #if !defined(DUK_USE_GET_RANDOM_DOUBLE)
 
+#if defined(DUK_USE_PREFER_SIZE) || !defined(DUK_USE_64BIT_OPS)
+#define DUK__RANDOM_SHAMIR3OP
+#else
+#define DUK__RANDOM_XOROSHIRO128PLUS
+#endif
+
+#if defined(DUK__RANDOM_SHAMIR3OP)
 #define DUK__UPDATE_RND(rnd) do { \
 		(rnd) += ((rnd) * (rnd)) | 0x05UL; \
 		(rnd) = ((rnd) & 0xffffffffUL);       /* if duk_uint32_t is exactly 32 bits, this is a NOP */ \
@@ -17,7 +28,10 @@
 
 #define DUK__RND_BIT(rnd)  ((rnd) >> 31)  /* only use the highest bit */
 
-#if 1
+DUK_INTERNAL void duk_util_tinyrandom_prepare_seed(duk_hthread *thr) {
+	DUK_UNREF(thr);  /* Nothing now. */
+}
+
 DUK_INTERNAL duk_double_t duk_util_tinyrandom_get_double(duk_hthread *thr) {
 	duk_double_t t;
 	duk_small_int_t n;
@@ -41,41 +55,71 @@ DUK_INTERNAL duk_double_t duk_util_tinyrandom_get_double(duk_hthread *thr) {
 
 	return t;
 }
-#else
-/* Not much faster, larger footprint. */
+#endif  /* DUK__RANDOM_SHAMIR3OP */
+
+#if defined(DUK__RANDOM_XOROSHIRO128PLUS)
+DUK_LOCAL DUK_ALWAYS_INLINE duk_uint64_t duk__rnd_splitmix64(duk_uint64_t *x) {
+	duk_uint64_t z;
+	z = (*x += 0x9E3779B97F4A7C15ULL);
+	z = (z ^ (z >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+	z = (z ^ (z >> 27U)) * 0x94D049BB133111EBULL;
+	return z ^ (z >> 31U);
+}
+
+DUK_LOCAL DUK_ALWAYS_INLINE duk_uint64_t duk__rnd_rotl(const duk_uint64_t x, duk_small_uint_t k) {
+	return (x << k) | (x >> (64U - k));
+}
+
+DUK_LOCAL DUK_ALWAYS_INLINE duk_uint64_t duk__xoroshiro128plus(duk_uint64_t *s) {
+	duk_uint64_t s0;
+	duk_uint64_t s1;
+	duk_uint64_t res;
+
+	s0 = s[0];
+	s1 = s[1];
+	res = s0 + s1;
+	s1 ^= s0;
+	s[0] = duk__rnd_rotl(s0, 55) ^ s1 ^ (s1 << 14U);
+	s[1] = duk__rnd_rotl(s1, 36);
+
+	return res;
+}
+
+DUK_INTERNAL void duk_util_tinyrandom_prepare_seed(duk_hthread *thr) {
+	duk_small_uint_t i;
+	duk_uint64_t x;
+
+	/* Mix both halves of the initial seed with SplitMix64.  The intent
+	 * is to ensure that very similar raw seeds (which is usually the case
+	 * because current seed is Date.now()) result in different xoroshiro128+
+	 * seeds.
+	 */
+	x = thr->heap->rnd_state[0];  /* Only [0] is used as input here. */
+	for (i = 0; i < 64; i++) {
+		thr->heap->rnd_state[i & 0x01] = duk__rnd_splitmix64(&x);  /* Keep last 2 values. */
+	}
+}
+
 DUK_INTERNAL duk_double_t duk_util_tinyrandom_get_double(duk_hthread *thr) {
-	duk_double_t t;
-	duk_small_int_t i;
-	duk_uint32_t rnd;
-	duk_uint32_t rndbit;
+	duk_uint64_t v;
 	duk_double_union du;
 
-	rnd = thr->heap->rnd_state;
-
-	du.ui[DUK_DBL_IDX_UI0] = 0x3ff00000UL;
-	du.ui[DUK_DBL_IDX_UI1] = 0x00000000UL;
-
-	DUK_ASSERT(DUK_DBL_IDX_UI0 ^ 1 == DUK_DBL_IDX_UI1);  /* Indices are 0,1 or 1,0. */
-	DUK_ASSERT(DUK_DBL_IDX_UI1 ^ 1 == DUK_DBL_IDX_UI0);
-
-	/* Fill double representation mantissa bits with random number.
-	 * With the implicit leading 1-bit we get a value in [1,2[.
+	/* For big and little endian the integer and IEEE double byte order
+	 * is the same so a direct assignment works.  For mixed endian the
+	 * 32-bit parts must be swapped.
 	 */
-	for (i = 0; i < 52; i++) {
-		DUK__UPDATE_RND(rnd);
-		rndbit = DUK__RND_BIT(rnd);
-		DUK_ASSERT((i >> 5) == 0 || (i >> 5) == 1);
-		du.ui[DUK_DBL_IDX_UI1 ^ (i >> 5)] |= rndbit << (i & 0x1fUL);
-	}
-
-	thr->heap->rnd_state = rnd;
-
-	t = du.d - 1.0;  /* Subtract implicit 1-bit to get [0,1[. */
-	DUK_ASSERT(t >= (duk_double_t) 0.0);
-	DUK_ASSERT(t < (duk_double_t) 1.0);
-
-	return t;
-}
+	v = (0x3ffULL << 52U) | (duk__xoroshiro128plus((duk_uint64_t *) thr->heap->rnd_state) >> 12U);
+	du.ull[0] = v;
+#if defined(DUK_USE_DOUBLE_ME)
+	do {
+		duk_uint32_t tmp;
+		tmp = du.ui[0];
+		du.ui[0] = du.ui[1];
+		du.ui[1] = tmp;
+	} while (0);
 #endif
+	return du.d - 1.0;
+}
+#endif  /* DUK__RANDOM_XOROSHIRO128PLUS */
 
 #endif  /* !DUK_USE_GET_RANDOM_DOUBLE */

--- a/util/dist.py
+++ b/util/dist.py
@@ -727,7 +727,9 @@ def main():
     copy_files([
         'murmurhash2.txt',
         'lua.txt',
-        'commonjs.txt'
+        'commonjs.txt',
+        'xoroshiro128plus.txt',
+        'splitmix64.txt'
     ], 'licenses', os.path.join(dist, 'licenses'))
 
     # Merge debugger metadata.

--- a/website/guide/random.html
+++ b/website/guide/random.html
@@ -4,10 +4,14 @@
 They are also used currently for random pivot selection in the
 <code>Array.prototype.sort()</code> implementation.</p>
 
-<p>The default internal random number generator is optimized for a
-low footprint.  It has a reasonable quality but won't pass stringent
-statistical tests and is not at all suitable for cryptographic
-applications.</p>
+<p>The default internal random number generator is
+<a href="http://xoroshiro.di.unimi.it/xoroshiro128plus.c">xoroshiro128+</a> with
+<a href="http://xorshift.di.unimi.it/splitmix64.c">SplitMix64</a> seed mixing.
+<a href="http://www.woodmann.com/forum/archive/index.php/t-3100.html.">Shamir's three-op PRNG</a>
+is used on low memory targets and when the compiler doesn't have 64-bit
+types.  The generators are not suitable for serious statistics algorithms
+due to e.g. limited quality of the seed material, and are not at all
+suitable for cryptography.</p>
 
 <p>You can replace the internal random number generator using the
 <code>DUK_USE_GET_RANDOM_DOUBLE</code> config option.</p>


### PR DESCRIPTION
- [x] Add manual test to generate doubles using the original xoroshiro128+ implementation
- [x] Test generated double sequence manually against manual test
- [x] Add 64-bit implementation, all endianness variants
- [x] Add 32-bit implementation, all endianness variants => Skipped, use previous algorithm (Shamir's three-op algorithm) for targets without 64-bit types
- [x] Documentation and/or license changes
- [x] Releases