### PR TITLE
Minor optimizations to RegExp compilation and execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,7 +668,7 @@ linenoise:
 regfuzz-0.1.tar.gz:
 	# https://code.google.com/p/regfuzz/
 	# SHA1: 774be8e3dda75d095225ba699ac59969d92ac970
-	$(WGET) https://regfuzz.googlecode.com/files/regfuzz-0.1.tar.gz -O $@
+	$(WGET) https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/regfuzz/regfuzz-0.1.tar.gz -O $@
 underscore:
 	# http://underscorejs.org/
 	# https://github.com/jashkenas/underscore

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1961,7 +1961,8 @@ Planned
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for
   Array .length coercion (GH-862); value stack operation optimization
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
-  opcode handler optimizations (GH-903); refcount optimizations (GH-443)
+  opcode handler optimizations (GH-903); refcount optimizations (GH-443);
+  minor RegExp compile/execute optimizations (GH-974)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -154,7 +154,15 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 		}
 		re_ctx->steps_count++;
 
+		/* Opcodes are at most 7 bits now so they encode to one byte.  If this
+		 * were not the case or 'pc' is invalid here (due to a bug etc) we'll
+		 * still fail safely through the switch default case.
+		 */
+		DUK_ASSERT(pc[0] <= 0x7fU);
+#if 0
 		op = (duk_small_int_t) duk__bc_get_u32(re_ctx, &pc);
+#endif
+		op = *pc++;
 
 		DUK_DDD(DUK_DDDPRINT("match: rec=%ld, steps=%ld, pc (after op)=%ld, sp=%ld, op=%ld",
 		                     (long) re_ctx->recursion_depth,

--- a/tests/perf/test-regexp-case-insensitive.js
+++ b/tests/perf/test-regexp-case-insensitive.js
@@ -4,7 +4,6 @@
  */
 function test() {
     var i;
-    var src = [];
     for (i = 0; i < 1e2; i++) {
         // Use a RegExp constructor call rather than a literal to ensure the
         // RegExp is compiled on every loop.

--- a/tests/perf/test-regexp-compile.js
+++ b/tests/perf/test-regexp-compile.js
@@ -1,0 +1,34 @@
+function test() {
+    var i;
+    var src = '[a-z]foo.bar.quux.baz{1,3}[a-zA-Z0-9]+$';
+    var re;
+
+    for (i = 0; i < 1e4; i++) {
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+        re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src); re = new RegExp(src);
+    }
+}
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-regexp-execute.js
+++ b/tests/perf/test-regexp-execute.js
@@ -1,0 +1,34 @@
+function test() {
+    var i;
+    var re = /[a-z]foo.bar.quux.baz{1,3}[a-zA-Z0-9]+$/;
+    var t;
+    var txt = 'gfoo!bar!quux!bazzzABBA';
+    for (i = 0; i < 1e4; i++) {
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+        t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt); t = re.exec(txt);
+    }
+}
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
Some minor improvements to RegExp compilation and execution. For example, take advantage of the fact that regexp opcodes are small (well within 7 bits) so they can be emitted as is without UTF-8 encoding.