### PR TITLE
Implement WHATWG Encoding API support

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1818,6 +1818,10 @@ Planned
   e.g. "2 ** 10" evaluates to 1024, avoiding the cost of an Ecmascript call to
   Math.pow() while also being more readable (GH-987, GH-997)
 
+* Add TextEncoder and TextDecoder built-ins (the Encoding API) which allow
+  Ecmascript code to read and write text stored in an ArrayBuffer or Duktape
+  buffer (GH-975)
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/config/config-options/DUK_USE_ENCODING_BUILTINS.yaml
+++ b/config/config-options/DUK_USE_ENCODING_BUILTINS.yaml
@@ -1,0 +1,13 @@
+define: DUK_USE_ENCODING_BUILTINS
+introduced: 2.0.0
+default: true
+tags:
+  - encoding-api
+description: >
+  Provide TextEncoder and TextDecoder built-ins (the Encoding API) which allow
+  Ecmascript code to encode and decode text stored in a buffer.  Only UTF-8 is
+  currently supported for decoding.
+
+  DUK_USE_BUFFEROBJECT_SUPPORT is recommended but not required: If it is
+  disabled, TextEncoder will encode to a plain buffer instead of a Uint8Array.
+  TextDecoder always accept plain buffers as input.

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -359,6 +359,20 @@ objects:
         es6: true
         present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
+      # Encoding API
+      - key: "TextEncoder"
+        value:
+          type: object
+          id: bi_textencoder_constructor
+        encoding_api: true
+        present_if: DUK_USE_ENCODING_BUILTINS
+      - key: "TextDecoder"
+        value:
+          type: object
+          id: bi_textdecoder_constructor
+        encoding_api: true
+        present_if: DUK_USE_ENCODING_BUILTINS
+
       # Functions
       - key: "eval"
         value:
@@ -4159,3 +4173,139 @@ objects:
           length: 4
           varargs: false
         nodejs_buffer: true
+
+  #
+  # Encoding API
+  #
+
+  - id: bi_textencoder_constructor
+    class: Function
+    internal_prototype: bi_function_prototype
+    nargs: 0
+    native: duk_bi_textencoder_constructor
+    callable: true
+    constructable: true
+    bidx: true
+    encoding_api: true
+    present_if: DUK_USE_ENCODING_BUILTINS
+
+    properties:
+      - key: "length"
+        value: 0
+        attributes: ""
+        encoding_api: true
+      - key: "prototype"
+        value:
+          type: object
+          id: bi_textencoder_prototype
+        attributes: ""
+        encoding_api: true
+      - key: "name"
+        value: "TextEncoder"
+        attributes: ""
+        encoding_api: true
+
+  - id: bi_textencoder_prototype
+    internal_prototype: bi_object_prototype
+    class: Object
+    bidx: true
+    encoding_api: true
+    present_if: DUK_USE_ENCODING_BUILTINS
+
+    properties:
+      - key: "constructor"
+        value:
+          type: object
+          id: bi_textencoder_constructor
+        attributes: "wc"
+        encoding_api: true
+      - key: "encoding"
+        value:
+          type: accessor
+          getter: duk_bi_textencoder_prototype_encoding_getter
+          getter_nargs: 0
+          getter_magic: 0
+        attributes: "ec"
+        encoding_api: true
+      - key: "encode"
+        value:
+          type: function
+          native: duk_bi_textencoder_prototype_encode
+          length: 0
+          nargs: 1
+        attributes: "wec"
+        encoding_api: true
+
+  - id: bi_textdecoder_constructor
+    class: Function
+    internal_prototype: bi_function_prototype
+    nargs: 2
+    native: duk_bi_textdecoder_constructor
+    callable: true
+    constructable: true
+    bidx: true
+    encoding_api: true
+    present_if: DUK_USE_ENCODING_BUILTINS
+
+    properties:
+      - key: "length"
+        value: 0
+        attributes: ""
+        encoding_api: true
+      - key: "prototype"
+        value:
+          type: object
+          id: bi_textdecoder_prototype
+        attributes: ""
+        encoding_api: true
+      - key: "name"
+        value: "TextDecoder"
+        attributes: ""
+        encoding_api: true
+
+  - id: bi_textdecoder_prototype
+    internal_prototype: bi_object_prototype
+    class: Object
+    bidx: true
+    encoding_api: true
+    present_if: DUK_USE_ENCODING_BUILTINS
+
+    properties:
+      - key: "constructor"
+        value:
+          type: object
+          id: bi_textdecoder_constructor
+        attributes: "wc"
+        encoding_api: true
+      - key: "encoding"
+        value:
+          type: accessor
+          getter: duk_bi_textdecoder_prototype_encoding_getter
+          getter_nargs: 0
+          getter_magic: 0
+        attributes: "ec"
+        encoding_api: true
+      - key: "fatal"
+        value:
+          type: accessor
+          getter: duk_bi_textdecoder_prototype_fatal_getter
+          getter_nargs: 0
+          getter_magic: 0
+        attributes: "ec"
+        encoding_api: true
+      - key: "ignoreBOM"
+        value:
+          type: accessor
+          getter: duk_bi_textdecoder_prototype_ignorebom_getter
+          getter_nargs: 0
+          getter_magic: 0
+        attributes: "ec"
+        encoding_api: true
+      - key: "decode"
+        value:
+          type: function
+          native: duk_bi_textdecoder_prototype_decode
+          length: 0
+          nargs: 2
+        attributes: "wec"
+        encoding_api: true

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -1,0 +1,372 @@
+/*
+ *  WHATWG Encoding API built-ins
+ *
+ *  API specification: https://encoding.spec.whatwg.org/#api
+ *  Web IDL: https://www.w3.org/TR/WebIDL/
+ */
+
+#include "duk_internal.h"
+
+#if defined(DUK_USE_ENCODING_BUILTINS)
+typedef struct {
+	duk_uint8_t *out;      /* where to write next byte(s) */
+	duk_codepoint_t lead;  /* lead surrogate */
+} duk__encode_context;
+
+typedef struct {
+	duk_bool_t bom_seen;
+	duk_bool_t fatal;
+	duk_bool_t ignore_bom;
+
+	/* UTF-8 decoding state */
+	duk_codepoint_t codepoint;  /* built up incrementally */
+	duk_int_t needed;           /* how many more bytes we need */
+	duk_uint8_t upper;          /* max value of next byte (decode error otherwise) */
+	duk_uint8_t lower;          /* min value of next byte (ditto) */
+} duk__decode_context;
+
+#define DUK__U8_CONTINUE   0  /* continue to next byte */
+#define DUK__U8_CODEPOINT  1  /* have codepoint */
+#define DUK__U8_ERROR      2  /* decoding error */
+#define DUK__U8_RETRY      3  /* retry last byte, constraint: RETRY > ERROR */
+
+DUK_LOCAL void duk__utf8_decode_init(duk__decode_context *dec_ctx) {
+	dec_ctx->codepoint = 0x0000L;
+	dec_ctx->needed = 0;
+	dec_ctx->upper = 0xbf;
+	dec_ctx->lower = 0x80;
+	dec_ctx->bom_seen = 0;
+}
+
+DUK_LOCAL int duk__utf8_decode_next(duk__decode_context *dec_ctx, duk_uint8_t byte, duk_codepoint_t *cp) {
+	/*
+	 *  UTF-8 algorithm based on the Encoding specification:
+	 *  https://encoding.spec.whatwg.org/#utf-8-decoder
+	 */
+
+	if (dec_ctx->needed == 0) {
+		/* process initial byte */
+		if (byte <= 0x7f) {
+			/* U+0000-U+007F, 1 byte (ASCII) */
+			*cp = (duk_codepoint_t) byte;
+			return DUK__U8_CODEPOINT;
+		} else if (byte >= 0xc2 && byte <= 0xdf) {
+			/* U+0080-U+07FF, 2 bytes */
+			dec_ctx->needed = 1;
+			dec_ctx->codepoint = byte & 0x1f;
+			return DUK__U8_CONTINUE;
+		} else if (byte >= 0xe0 && byte <= 0xef) {
+			/* U+0800-U+FFFF, 3 bytes */
+			if (byte == 0xe0) {
+				dec_ctx->lower = 0xa0;
+			} else if (byte == 0xed) {
+				dec_ctx->upper = 0x9f;
+			}
+			dec_ctx->needed = 2;
+			dec_ctx->codepoint = byte & 0xf;
+			return DUK__U8_CONTINUE;
+		} else if (byte >= 0xf0 && byte <= 0xf4) {
+			/* U+010000-U+10FFFF, 4 bytes */
+			if (byte == 0xf0) {
+				dec_ctx->lower = 0x90;
+			} else if (byte == 0xf4) {
+				dec_ctx->upper = 0x8f;
+			}
+			dec_ctx->needed = 3;
+			dec_ctx->codepoint = byte & 0x7;
+			return DUK__U8_CONTINUE;
+		} else {
+			/* not a legal initial byte */
+			return DUK__U8_ERROR;
+		}
+	} else {
+		/* process continuation byte */
+		if (byte >= dec_ctx->lower && byte <= dec_ctx->upper) {
+			dec_ctx->lower = 0x80;
+			dec_ctx->upper = 0xbf;
+			dec_ctx->codepoint = (dec_ctx->codepoint << 6) | (byte & 0x3f);
+			if (--dec_ctx->needed > 0) {
+				/* need more bytes */
+				return DUK__U8_CONTINUE;
+			} else {
+				/* got a codepoint */
+				*cp = dec_ctx->codepoint;
+				dec_ctx->codepoint = 0x0000L;
+				dec_ctx->needed = 0;
+				return DUK__U8_CODEPOINT;
+			}
+		} else {
+			/* We just encountered an illegal UTF-8 continuation byte.  This might
+			 * be the initial byte of the next character; if we return a plain
+			 * error status and the decoder is in replacement mode, the character
+			 * will be masked.  We still need to alert the caller to the error
+			 * though.
+			 */
+			dec_ctx->codepoint = 0x0000L;
+			dec_ctx->needed = 0;
+			dec_ctx->lower = 0x80;
+			dec_ctx->upper = 0xbf;
+			return DUK__U8_RETRY;
+		}
+	}
+}
+
+DUK_LOCAL void duk__utf8_encode_char(void *udata, duk_codepoint_t codepoint) {
+	duk__encode_context *enc_ctx;
+
+	enc_ctx = (duk__encode_context *) udata;
+	if (codepoint > 0x10ffffL) {
+		/* cannot legally encode in UTF-8 */
+		enc_ctx->out += duk_unicode_encode_xutf8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, enc_ctx->out);
+	} else if (codepoint >= 0xd800L && codepoint <= 0xdbffL) {
+		/* high surrogate */
+		if (enc_ctx->lead != 0x0000L) {
+			/* consecutive high surrogates, consider first one unpaired */
+			enc_ctx->out += duk_unicode_encode_xutf8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, enc_ctx->out);
+		}
+		enc_ctx->lead = codepoint;
+	} else if (codepoint >= 0xdc00L && codepoint <= 0xdfffL) {
+		/* low surrogate */
+		if (enc_ctx->lead != 0x0000L) {
+			codepoint = 0x010000L | ((enc_ctx->lead - 0xd800L) << 10) | (codepoint - 0xdc00L);
+			enc_ctx->out += duk_unicode_encode_xutf8(codepoint, enc_ctx->out);
+			enc_ctx->lead = 0x0000L;
+		} else {
+			/* unpaired low surrogate */
+			enc_ctx->out += duk_unicode_encode_xutf8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, enc_ctx->out);
+		}
+	} else {
+		if (enc_ctx->lead != 0x0000L) {
+			/* unpaired high surrogate */
+			enc_ctx->out += duk_unicode_encode_xutf8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, enc_ctx->out);
+			enc_ctx->lead = 0x0000L;
+		}
+		enc_ctx->out += duk_unicode_encode_xutf8(codepoint, enc_ctx->out);
+	}
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textencoder_constructor(duk_context *ctx) {
+	/*
+	 *  TextEncoder currently requires no persistent state, so the constructor
+	 *  does nothing on purpose.
+	 */
+
+	if (!duk_is_constructor_call(ctx)) {
+		duk_error(ctx, DUK_ERR_TYPE_ERROR, "constructor must use 'new'");
+	}
+	return 0;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encoding_getter(duk_context *ctx) {
+	duk_push_string(ctx, "utf-8");
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_context *ctx) {
+	duk__encode_context enc_ctx;
+	duk_size_t len;
+	duk_uint8_t *output;
+
+	if (!duk_is_undefined(ctx, 0)) {
+		duk_to_string(ctx, 0);
+	} else {
+		duk_push_string(ctx, "");
+		duk_replace(ctx, 0);
+	}
+
+	len = duk_get_length(ctx, 0);
+	if (len >= DUK_HBUFFER_MAX_BYTELEN / 3) {
+		duk_error(ctx, DUK_ERR_TYPE_ERROR, "input too large");
+	}
+
+	/* Allowance is 3*len because all bytes can potentially be replaced with
+	 * U+FFFD--which rather inconveniently encodes to 3 bytes in UTF-8.
+	 *
+	 * XXX: The buffer allocation strategy used here is rather inefficient.
+	 * Maybe switch to a chunk-based strategy, or preprocess the string to
+	 * figure out the space needed ahead of time?
+	 */
+	output = (duk_uint8_t *) duk_push_dynamic_buffer(ctx, 3 * len);
+
+	/* XXX: duk_decode_string() is used to process the input string.  For strings
+	 * originating in C, this means we will see the string the same way Ecmascript
+	 * code would.  But maybe we need something stricter in this case?
+	 */
+	enc_ctx.lead = 0x0000L;
+	enc_ctx.out = output;
+	duk_decode_string(ctx, 0, duk__utf8_encode_char, (void *) &enc_ctx);
+	if (enc_ctx.lead != 0x0000L) {
+		/* unpaired high surrogate at end of string */
+		enc_ctx.out += duk_unicode_encode_xutf8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, enc_ctx.out);
+		DUK_ASSERT(enc_ctx.out <= output + (3 * len));
+	}
+
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
+	duk_push_buffer_object(ctx, -1, 0, (duk_size_t) (enc_ctx.out - output), DUK_BUFOBJ_UINT8ARRAY);
+#else
+	/* shrink buffer to include only the encoded text */
+	duk_resize_buffer(ctx, -1, (duk_size_t) (enc_ctx.out - output));
+#endif
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_context *ctx) {
+	duk__decode_context *dec_ctx;
+	duk_bool_t fatal = 0;
+	duk_bool_t ignore_bom = 0;
+
+	if (!duk_is_constructor_call(ctx)) {
+		duk_error(ctx, DUK_ERR_TYPE_ERROR, "constructor must use 'new'");
+	}
+	if (!duk_is_undefined(ctx, 0)) {
+		/* XXX: for now, 'label' argument is ignored */
+		duk_to_string(ctx, 0);
+	}
+	if (!duk_is_null_or_undefined(ctx, 1)) {
+		if (duk_get_prop_string(ctx, 1, "fatal")) {
+			fatal = duk_to_boolean(ctx, -1);
+		}
+		if (duk_get_prop_string(ctx, 1, "ignoreBOM")) {
+			ignore_bom = duk_to_boolean(ctx, -1);
+		}
+	}
+
+	dec_ctx = (duk__decode_context *) duk_push_fixed_buffer(ctx, sizeof(duk__decode_context));
+	dec_ctx->fatal = fatal;
+	dec_ctx->ignore_bom = ignore_bom;
+	duk__utf8_decode_init(dec_ctx);
+
+	duk_push_this(ctx);
+	duk_dup(ctx, -2);
+	duk_put_prop_string(ctx, -2, "\xff" "Context");
+	return 0;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textdecoder_prototype_encoding_getter(duk_context *ctx) {
+	duk__decode_context *dec_ctx;
+
+	duk_push_this(ctx);
+	duk_get_prop_string(ctx, -1, "\xff" "Context");
+	dec_ctx = (duk__decode_context *) duk_require_buffer(ctx, -1, NULL);
+	DUK_ASSERT(dec_ctx != NULL);
+
+	/* XXX: change to look up from dec_ctx once other encodings are supported */
+	DUK_UNREF(dec_ctx);
+	duk_push_string(ctx, "utf-8");
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textdecoder_prototype_fatal_getter(duk_context *ctx) {
+	duk__decode_context *dec_ctx;
+
+	duk_push_this(ctx);
+	duk_get_prop_string(ctx, -1, "\xff" "Context");
+	dec_ctx = (duk__decode_context *) duk_require_buffer(ctx, -1, NULL);
+	DUK_ASSERT(dec_ctx != NULL);
+
+	duk_push_boolean(ctx, dec_ctx->fatal);
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textdecoder_prototype_ignorebom_getter(duk_context *ctx) {
+	duk__decode_context *dec_ctx;
+
+	duk_push_this(ctx);
+	duk_get_prop_string(ctx, -1, "\xff" "Context");
+	dec_ctx = (duk__decode_context *) duk_require_buffer(ctx, -1, NULL);
+
+	duk_push_boolean(ctx, dec_ctx->ignore_bom);
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_textdecoder_prototype_decode(duk_context *ctx) {
+	const duk_uint8_t *input = (const duk_uint8_t *) "";
+	duk__decode_context *dec_ctx;
+	duk_size_t len = 0;
+	duk_bool_t stream = 0;
+	duk_codepoint_t codepoint;
+	int ret;
+	duk_uint8_t *output;
+	const duk_uint8_t *in;
+	duk_uint8_t *out;
+
+	if (!duk_is_undefined(ctx, 0)) {
+		input = (const duk_uint8_t *) duk_require_buffer_data(ctx, 0, &len);
+	}
+	if (!duk_is_null_or_undefined(ctx, 1)) {
+		if (duk_get_prop_string(ctx, 1, "stream")) {
+			stream = duk_to_boolean(ctx, -1);
+		}
+	}
+	duk_push_this(ctx);
+	duk_get_prop_string(ctx, -1, "\xff" "Context");
+	dec_ctx = (duk__decode_context *) duk_require_buffer(ctx, -1, NULL);
+	DUK_ASSERT(dec_ctx != NULL);
+
+	if (len >= (DUK_HBUFFER_MAX_BYTELEN / 3) - 3) {
+		duk_error(ctx, DUK_ERR_TYPE_ERROR, "input too large");
+	}
+
+	/* Allowance is 3*len in the general case because all bytes may potentially
+	 * become U+FFFD.  If the first byte completes a non-BMP codepoint it will
+	 * decode to a CESU-8 surrogate pair (6 bytes) so we allow 3 extra bytes to
+	 * compensate: (1*3)+3 = 6.  Non-BMP codepoints are safe otherwise because
+	 * the 4->6 expansion is well under the 3x allowance.
+	 *
+	 * XXX: As with TextEncoder, need a better buffer allocation strategy here.
+	 */
+	output = (duk_uint8_t *) duk_push_fixed_buffer(ctx, 3 + (3 * len));
+
+	in = input;
+	out = output;
+	DUK_ASSERT(DUK__U8_RETRY > DUK__U8_ERROR);
+	while (in < input + len) {
+		ret = duk__utf8_decode_next(dec_ctx, *in++, &codepoint);
+		if (ret == DUK__U8_CONTINUE) {
+			continue;
+		}
+		if (ret >= DUK__U8_ERROR) {
+			/* decoding error */
+			DUK_ASSERT(ret == DUK__U8_ERROR || ret == DUK__U8_RETRY);
+			if (dec_ctx->fatal) {
+				/* fatal mode: throw a TypeError */
+				goto fatal;
+			} else {
+				/* replacement mode: replace with U+FFFD */
+				codepoint = DUK_UNICODE_CP_REPLACEMENT_CHARACTER;
+			}
+		}
+		if (ret == DUK__U8_RETRY) {
+			--in;  /* retry last byte */
+		}
+		if (!dec_ctx->bom_seen) {
+			dec_ctx->bom_seen = 1;
+			if (codepoint == 0xfeffL && !dec_ctx->ignore_bom) {
+				continue;
+			}
+		}
+		out += duk_unicode_encode_cesu8(codepoint, out);
+		DUK_ASSERT(out <= output + (3 + (3 * len)));
+	}
+
+	if (!stream) {
+		if (dec_ctx->needed != 0) {
+			/* truncated sequence at end of buffer */
+			if (dec_ctx->fatal) {
+				goto fatal;
+			} else {
+				out += duk_unicode_encode_cesu8(DUK_UNICODE_CP_REPLACEMENT_CHARACTER, out);
+				DUK_ASSERT(out <= output + (3 + (3 * len)));
+			}
+		}
+		duk__utf8_decode_init(dec_ctx);
+	}
+
+	duk_push_lstring(ctx, (const char *) output, (duk_size_t) (out - output));
+	return 1;
+
+fatal:
+	duk_error(ctx, DUK_ERR_TYPE_ERROR, "cannot decode as utf-8");
+	DUK_UNREACHABLE();
+}
+#endif  /* DUK_USE_ENCODING_BUILTINS */

--- a/tests/ecmascript/test-bi-textdecoder.js
+++ b/tests/ecmascript/test-bi-textdecoder.js
@@ -1,0 +1,177 @@
+/*
+ *  TextDecoder
+ */
+
+/*===
+basic decode
+utf-8
+false
+false
+2
+55357 56375
+true
+5
+65533 65 66 67 68
+true
+0
+true
+===*/
+
+function decodeTest() {
+    var decoder;
+    var ref, input, output;
+
+    decoder = new TextDecoder();  // defaults to UTF-8
+    print(decoder.encoding);
+    print(decoder.fatal);
+    print(decoder.ignoreBOM);
+
+    // non-BMP codepoint should become a surrogate pair
+    input = new Uint8Array([ 0xf0, 0x9f, 0x90, 0xb7 ]);
+    ref = "\ud83d\udc37";
+    output = decoder.decode(input);
+    print(output.length);  // should be 2
+    print(output.charCodeAt(0), output.charCodeAt(1));
+    print(output === ref);
+
+    // incomplete codepoint should not mask characters
+    input = new Uint8Array([ 0xf0, 0x41, 0x42, 0x43, 0x44 ]);
+    ref = "\ufffdABCD";
+    output = decoder.decode(input);
+    print(output.length);
+    print(output.charCodeAt(0), output.charCodeAt(1), output.charCodeAt(2), output.charCodeAt(3), output.charCodeAt(4));
+    print(output === ref);
+
+    // no argument is the same as an empty buffer
+    ref = "";
+    output = decoder.decode();
+    print(output.length);
+    print(output === ref);
+
+}
+
+try {
+    print("basic decode");
+    decodeTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+fatal mode
+true
+false
+foo
+true
+TypeError
+===*/
+
+function fatalTest() {
+    var fatal, nonFatal;
+    var ref, input, output;
+
+    fatal = new TextDecoder('utf-8', { fatal: true });
+    print(fatal.fatal);
+    nonFatal = new TextDecoder('utf-8', { fatal: false });
+    print(nonFatal.fatal);
+
+    // well-formed input, should not throw
+    input = new Uint8Array([ 0x66, 0x6f, 0x6f ]);
+    ref = "foo";
+    output = fatal.decode(input);
+    print(output);
+
+    // buffer contains invalid UTF-8 code unit 0xFF
+    input = new Uint8Array([ 0x62, 0x61, 0x72, 0xff ]);
+    ref = "bar\ufffd";
+    print(nonFatal.decode(input) === ref);
+    try {
+        print(fatal.decode(input));
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    print("fatal mode");
+    fatalTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+ignore BOM
+false
+true
+true
+true
+===*/
+
+function ignoreBOMTest() {
+    var stripBOM, keepBOM;
+    var ref, input, output;
+
+    var stripBOM = new TextDecoder('utf-8', { ignoreBOM: false });
+    print(stripBOM.ignoreBOM);
+    var keepBOM = new TextDecoder('utf-8', { ignoreBOM: true });
+    print(keepBOM.ignoreBOM);
+
+    input = new Uint8Array([ 0xef, 0xbb, 0xbf, 0x42, 0x4f, 0x4d ]);
+    ref = "\ufeffBOM";
+    output = keepBOM.decode(input);
+    print(output === ref);
+    ref = "BOM";
+    output = stripBOM.decode(input);
+    print(output === ref);
+}
+
+try {
+    print("ignore BOM");
+    ignoreBOMTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+streaming
+true
+true
+===*/
+
+function streamTest()
+{
+    var decoder;
+    var ref, input, output;
+
+    // include a multi-byte character to test streaming correctness
+    decoder = new TextDecoder();
+    ref = "pig \ud83d\udc37";
+    input = new Uint8Array([ 0x70, 0x69, 0x67, 0x20, 0xf0, 0x9f, 0x90, 0xb7 ]);
+    output = "";
+    for (var i = 0; i < input.length; ++i) {
+        var byte = input.subarray(i, i + 1);
+        output += decoder.decode(byte, { stream: true });
+    }
+    output += decoder.decode();
+    print(output === ref);
+
+    // incomplete codepoint at end of string is caught in final decode().
+    // note that it's safe to reuse the decoder instance for another go as long
+    // as the last call to decode() was with {stream:false} (the default).
+    ref = "pig \ud83d\udc37\ufffd";
+    input = new Uint8Array([ 0x70, 0x69, 0x67, 0x20, 0xf0, 0x9f, 0x90, 0xb7, 0xf0 ]);
+    output = "";
+    for (var i = 0; i < input.length; ++i) {
+        var byte = input.subarray(i, i + 1);
+        output += decoder.decode(byte, { stream: true });
+    }
+    output += decoder.decode();
+    print(output === ref);
+}
+
+try {
+    print("streaming");
+    streamTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-textencoder.js
+++ b/tests/ecmascript/test-bi-textencoder.js
@@ -1,0 +1,77 @@
+/*
+ *  TextEncoder
+ */
+
+// determine if two arrays contain the same values, used here to compare buffers
+function equiv(arr1, arr2) {
+    if (arr1.prototype !== arr2.prototype) {
+        return false;
+    }
+    if (arr1.length !== arr2.length) {
+        return false;
+    }
+    for (i = 0; i < arr1.length; ++i) {
+        if (arr1[i] !== arr2[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/*===
+basic encode
+utf-8
+true
+4
+true
+10
+true
+6
+true
+0
+true
+===*/
+
+function encodeTest() {
+    var encoder;
+    var ref, input, output;
+
+    encoder = new TextEncoder();
+    print(encoder.encoding);  // always "utf-8"
+
+    // non-BMP surrogate pair should become a single codepoint
+    input = "\ud83d\udc37";
+    ref = new Uint8Array([ 0xf0, 0x9f, 0x90, 0xb7 ]);
+    output = encoder.encode(input);
+    print(output instanceof Uint8Array);
+    print(output.length);  // should be 4
+    print(equiv(output, ref));
+
+    // unpaired surrogate halves should become U+FFFD
+    input = "\ud83dABCD\udc37";
+    ref = new Uint8Array([ 0xef, 0xbf, 0xbd, 0x41, 0x42, 0x43, 0x44, 0xef, 0xbf, 0xbd ]);
+    output = encoder.encode(input);
+    print(output.length);
+    print(equiv(output, ref));
+
+    // consecutive high surrogates should not be combined
+    input = "\ud83d\ud83d";
+    ref = new Uint8Array([ 0xef, 0xbf, 0xbd, 0xef, 0xbf, 0xbd ]);
+    output = encoder.encode(input);
+    print(output.length);
+    print(equiv(output, ref));
+
+    // no argument is the same as an empty string
+    ref = new Uint8Array(0);
+    output = encoder.encode();
+    print(output.length);
+    print(equiv(output, ref));
+
+}
+
+try {
+    print("basic encode");
+    encodeTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -412,6 +412,7 @@ def main():
         'duk_bi_date_unix.c',
         'duk_bi_date_windows.c',
         'duk_bi_duktape.c',
+        'duk_bi_encoding.c',
         'duk_bi_error.c',
         'duk_bi_function.c',
         'duk_bi_global.c',

--- a/util/dist.py
+++ b/util/dist.py
@@ -321,6 +321,7 @@ def main():
         'duk_bi_date_unix.c',
         'duk_bi_date_windows.c',
         'duk_bi_duktape.c',
+        'duk_bi_encoding.c',
         'duk_bi_error.c',
         'duk_bi_function.c',
         'duk_bi_global.c',

--- a/website/index/index.html
+++ b/website/index/index.html
@@ -44,6 +44,7 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
     <a href="http://www.ecma-international.org/ecma-262/7.0/index.html">Ecmascript 2016 (E7)</a></li>
 <li>Khronos/ES6 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>
     and <a href="https://nodejs.org/docs/v0.12.1/api/buffer.html">Node.js Buffer</a> bindings</li>
+<li><a href="https://encoding.spec.whatwg.org/#api">Encoding API</a> bindings based on the WHATWG Encoding Living Standard.</li>
 <li>Built-in debugger</li>
 <li>Built-in regular expression engine</li>
 <li>Built-in Unicode support</li>


### PR DESCRIPTION
Implements #961.
 
Add `TextEncoder` and `TextDecoder` built-ins as described by the WHATWG Encoding specification.  For this pull, only UTF-8/CESU-8 support is implemented.  UTF-16 and all legacy encodings are left as future work.

Specification:
https://encoding.spec.whatwg.org/#api

Checklist:
- [x] Implement the WHATWG Encoding API: `TextEncoder` and `TextDecoder`
- [x] Config option - `DUK_USE_ENCODING_BUILTINS`
- [x] Support Encoding API with bufferobjects disabled?  Bindings could then work with plain buffers instead of Uint8Arrays (out of spec).
- [x] Node.js Buffer `.toString()` can share code with `TextDecoder`? => Save for later
- [x] Test cases for both encode and decode
- [x] Website note (Encoding API listed in features)
- [x] RELEASES entry