### PR TITLE
Minor regexp executor/compiler optimization

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1967,6 +1967,8 @@ Planned
   opcode handler optimizations (GH-903); refcount optimizations (GH-443);
   minor RegExp compile/execute optimizations (GH-974)
 
+* Miscellaneous footprint improvements: RegExp compiler/executor (GH-977)
+
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than
   being declared as actual symbols; this reduces compilation warnings with

--- a/src-input/duk_lexer.h
+++ b/src-input/duk_lexer.h
@@ -328,12 +328,12 @@ typedef void (*duk_re_range_callback)(void *user, duk_codepoint_t r1, duk_codepo
 #define DUK_RETOK_ASSERT_START_NEG_LOOKAHEAD       8
 #define DUK_RETOK_ATOM_PERIOD                      9
 #define DUK_RETOK_ATOM_CHAR                        10
-#define DUK_RETOK_ATOM_DIGIT                       11
-#define DUK_RETOK_ATOM_NOT_DIGIT                   12
-#define DUK_RETOK_ATOM_WHITE                       13
-#define DUK_RETOK_ATOM_NOT_WHITE                   14
-#define DUK_RETOK_ATOM_WORD_CHAR                   15
-#define DUK_RETOK_ATOM_NOT_WORD_CHAR               16
+#define DUK_RETOK_ATOM_DIGIT                       11  /* assumptions in regexp compiler */
+#define DUK_RETOK_ATOM_NOT_DIGIT                   12  /* -""- */
+#define DUK_RETOK_ATOM_WHITE                       13  /* -""- */
+#define DUK_RETOK_ATOM_NOT_WHITE                   14  /* -""- */
+#define DUK_RETOK_ATOM_WORD_CHAR                   15  /* -""- */
+#define DUK_RETOK_ATOM_NOT_WORD_CHAR               16  /* -""- */
 #define DUK_RETOK_ATOM_BACKREFERENCE               17
 #define DUK_RETOK_ATOM_START_CAPTURE_GROUP         18
 #define DUK_RETOK_ATOM_START_NONCAPTURE_GROUP      19

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -103,6 +103,12 @@ DUK_LOCAL void duk__append_7bit(duk_re_compiler_ctx *re_ctx, duk_uint32_t x) {
 #endif
 }
 
+#if 0
+DUK_LOCAL void duk__append_2bytes(duk_re_compiler_ctx *re_ctx, duk_uint8_t x, duk_uint8_t y) {
+	DUK_BW_WRITE_ENSURE_U8_2(re_ctx->thr, &re_ctx->bw, x, y);
+}
+#endif
+
 DUK_LOCAL duk_uint32_t duk__insert_i32(duk_re_compiler_ctx *re_ctx, duk_uint32_t offset, duk_int32_t x) {
 	return duk__insert_u32(re_ctx, offset, duk__encode_i32(x));
 }
@@ -290,6 +296,17 @@ DUK_LOCAL void duk__generate_ranges(void *userdata, duk_codepoint_t r1, duk_code
  *      quantifiers) can; currently quantifiers will taint the result
  *      as complex though.
  */
+
+DUK_LOCAL void duk__append_range_atom_matcher(duk_re_compiler_ctx *re_ctx, duk_small_uint_t re_op, const duk_uint16_t *ranges, duk_small_uint_t count) {
+#if 0
+	DUK_ASSERT(re_op <= 0x7fUL);
+	DUK_ASSERT(count <= 0x7fUL);
+	duk__append_2bytes(re_ctx, (duk_uint8_t) re_op, (duk_uint8_t) count);
+#endif
+	duk__append_reop(re_ctx, re_op);
+	duk__append_7bit(re_ctx, count);
+	duk__append_u16_list(re_ctx, ranges, count * 2);
+}
 
 DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t expect_eof, duk__re_disjunction_info *out_atom_info) {
 	duk_int32_t atom_start_offset = -1;                   /* negative -> no atom matched on previous round */
@@ -603,33 +620,32 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 		case DUK_RETOK_ATOM_NOT_DIGIT: {
 			new_atom_char_length = 1;
 			new_atom_start_offset = (duk_int32_t) DUK__RE_BUFLEN(re_ctx);
-			duk__append_reop(re_ctx,
-			                 (re_ctx->curr_token.t == DUK_RETOK_ATOM_DIGIT) ?
-			                 DUK_REOP_RANGES : DUK_REOP_INVRANGES);
-			duk__append_7bit(re_ctx, sizeof(duk_unicode_re_ranges_digit) / (2 * sizeof(duk_uint16_t)));
-			duk__append_u16_list(re_ctx, duk_unicode_re_ranges_digit, sizeof(duk_unicode_re_ranges_digit) / sizeof(duk_uint16_t));
+			duk__append_range_atom_matcher(re_ctx,
+			                               (re_ctx->curr_token.t == DUK_RETOK_ATOM_DIGIT) ?
+			                               DUK_REOP_RANGES : DUK_REOP_INVRANGES,
+			                               duk_unicode_re_ranges_digit,
+			                               sizeof(duk_unicode_re_ranges_digit) / (2 * sizeof(duk_uint16_t)));
 			break;
 		}
 		case DUK_RETOK_ATOM_WHITE:
 		case DUK_RETOK_ATOM_NOT_WHITE: {
 			new_atom_char_length = 1;
 			new_atom_start_offset = (duk_int32_t) DUK__RE_BUFLEN(re_ctx);
-			duk__append_reop(re_ctx,
-			                 (re_ctx->curr_token.t == DUK_RETOK_ATOM_WHITE) ?
-			                 DUK_REOP_RANGES : DUK_REOP_INVRANGES);
-			duk__append_7bit(re_ctx, sizeof(duk_unicode_re_ranges_white) / (2 * sizeof(duk_uint16_t)));
-			duk__append_u16_list(re_ctx, duk_unicode_re_ranges_white, sizeof(duk_unicode_re_ranges_white) / sizeof(duk_uint16_t));
-			break;
+			duk__append_range_atom_matcher(re_ctx,
+			                               (re_ctx->curr_token.t == DUK_RETOK_ATOM_WHITE) ?
+			                               DUK_REOP_RANGES : DUK_REOP_INVRANGES,
+			                               duk_unicode_re_ranges_white,
+			                               sizeof(duk_unicode_re_ranges_white) / (2 * sizeof(duk_uint16_t)));
 		}
 		case DUK_RETOK_ATOM_WORD_CHAR:
 		case DUK_RETOK_ATOM_NOT_WORD_CHAR: {
 			new_atom_char_length = 1;
 			new_atom_start_offset = (duk_int32_t) DUK__RE_BUFLEN(re_ctx);
-			duk__append_reop(re_ctx,
-			                 (re_ctx->curr_token.t == DUK_RETOK_ATOM_WORD_CHAR) ?
-			                 DUK_REOP_RANGES : DUK_REOP_INVRANGES);
-			duk__append_7bit(re_ctx, sizeof(duk_unicode_re_ranges_wordchar) / (2 * sizeof(duk_uint16_t)));
-			duk__append_u16_list(re_ctx, duk_unicode_re_ranges_wordchar, sizeof(duk_unicode_re_ranges_wordchar) / sizeof(duk_uint16_t));
+			duk__append_range_atom_matcher(re_ctx,
+			                               (re_ctx->curr_token.t == DUK_RETOK_ATOM_WORD_CHAR) ?
+			                               DUK_REOP_RANGES : DUK_REOP_INVRANGES,
+			                               duk_unicode_re_ranges_wordchar,
+			                               sizeof(duk_unicode_re_ranges_wordchar) / (2 * sizeof(duk_uint16_t)));
 			break;
 		}
 		case DUK_RETOK_ATOM_BACKREFERENCE: {


### PR DESCRIPTION
- [x] Shared check for end-of-input, eliminate a few unnecessary comparisons
- [x] Built-in character class emission optimization for regexp compiler
- [x] Releases entry