### PR TITLE
Fix regexp executor zero buffer assumption

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1890,6 +1890,9 @@ Planned
   seed mixing; previous algorithm (Shamir's three-op algorithm) is still
   used for low memory targets and targets without 64-bit types (GH-970)
 
+* Fix incorrect buffer zeroing assumption in regexp executor, triggered
+  when DUK_USE_ZERO_BUFFER_DATA is not set (default is set) (GH-978)
+
 * Fix incorrect value stack handling in duk_put_prop_(l)string() and
   duk_put_prop_index() when the target object and the property value
   are in the same value stack slot (which is unusual but conceptually

--- a/tests/ecmascript/test-bug-regexp-executor-zero-buffer-assumption.js
+++ b/tests/ecmascript/test-bug-regexp-executor-zero-buffer-assumption.js
@@ -1,0 +1,15 @@
+/*
+ *  Demonstrate RegExp executor bug in Duktape 1.5.1 when DUK_USE_ZERO_BUFFER_DATA
+ *  is unset.  The internal saved pointers are not zeroed which causes memory unsafe
+ *  behavior when unused captures are processed on a match.
+ *
+ *  https://github.com/svaarala/duktape/pull/978
+ */
+
+/*===
+x,,
+===*/
+
+var re = /x|(y)|(z)/;
+var res = re.exec('x');
+print(res);


### PR DESCRIPTION
RegExp executor had an assumption that buffer data allocated using `duk_push_fixed_buffer()` was zeroed which is not the case when `DUK_USE_ZERO_BUFFER_DATA` is not set (default is set).

Labeled security: if `DUK_USE_ZERO_BUFFER_DATA` is explicitly set to false (non-default value), the initial save pointer array may contain garbage that might get used later.