### PR TITLE
Remove internal support for codepoints above U+10FFFF

### DIFF
--- a/src-input/duk_regexp.h
+++ b/src-input/duk_regexp.h
@@ -2,6 +2,8 @@
  *  Regular expression structs, constants, and bytecode defines.
  */
 
+/* FIXME: avoid extended UTF-8 for regexps. */
+
 #ifndef DUK_REGEXP_H_INCLUDED
 #define DUK_REGEXP_H_INCLUDED
 

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -30,6 +30,8 @@ DUK_INTERNAL const duk_int8_t duk_is_idchar_tab[128] = {
  *  XUTF-8 and CESU-8 encoding/decoding
  */
 
+/* FIXME: remove extended codepoint support but keep CESU-8 support. */
+
 DUK_INTERNAL duk_small_int_t duk_unicode_get_xutf8_length(duk_ucodepoint_t cp) {
 	duk_uint_fast32_t x = (duk_uint_fast32_t) cp;
 	if (x < 0x80UL) {


### PR DESCRIPTION
Duktape currently uses codepoints up to 32 bits for RegExp bytecode, but if that dependency is removed, supporting codepoints only up to U+10FFFF (4 byte sequences) would be enough. This pull is to see what the overall changes are:

- [ ] Add a different variable integer encoding for RegExp bytecode; it can be simpler than UTF-8 because it doesn't have the same decoding resynchronization etc goals.
- [ ] Remove extended codepoint support from duk_unicode_support.c. CESU-8 needs to remain, and since UTF-8 4-byte sequences technically encode up to U+1FFFFF maybe keep them rather than rejecting?
- [ ] Documentation updates

It would be nice if this change would make it easier to support strict UTF-8 encoding and decoding, and conversions between CESU-8 and UTF-8 needed in #975, with little code overlap.