### PR TITLE
Add ES6 computed property name support

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1800,6 +1800,9 @@ Planned
   won't backtrack on e.g. an invalid hex escape and treat it literally
   (GH-926)
 
+* Add support for ES6 computed property names in object literals, e.g.
+  "{ [1+2]: 'three' }" (GH-985)
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4640,6 +4640,10 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			 * it would not work correctly if there are inherited
 			 * properties in Object.prototype which might e.g.
 			 * prevent a key from being added.
+			 *
+			 * With ES6 computed property names the literal keys
+			 * may be arbitrary values and need to be ToPropertyKey()
+			 * coerced at runtime.
 			 */
 			do {
 				/* XXX: faster initialization (direct access or better primitives) */

--- a/tests/ecmascript/test-dev-object-literal-computed.js
+++ b/tests/ecmascript/test-dev-object-literal-computed.js
@@ -1,0 +1,68 @@
+/*
+ *  ES6 computed property name.
+ */
+
+/*===
+{"3":"three","5":"five"}
+three
+five
+toString 1
+toString 2
+{"tostring1":"value1","tostring2":"value2"}
+undefined
+value1
+undefined
+value2
+{"[object Object]":"object","1,2,3,4":"array"}
+URIError
+===*/
+
+function computedPropertyName() {
+    var res;
+
+    // Simple example.
+    try {
+        res = eval('({ [1+2]: "three", [2+3]: "five" })');
+        print(JSON.stringify(res));
+        print(res[3]);
+        print(res['5']);
+    } catch (e) {
+        print(e.stack || e);
+    }
+
+    // Expression values are ToPropertyKey() coerced in order.  Before ES6
+    // Symbols that means ToString() in practice.
+    try {
+        res = eval('({ [ { valueOf: function () { print("valueOf 1"); return "valueof1"; }, toString: function () { print("toString 1"); return "tostring1"; } } ]: "value1", [ { valueOf: function () { print("valueOf 2"); return "valueof2"; }, toString: function () { print("toString 2"); return "tostring2"; } } ]: "value2" })');
+        print(JSON.stringify(res));
+        print(res.valueof1);
+        print(res.tostring1);
+        print(res.valueof2);
+        print(res.tostring2);
+    } catch (e) {
+        print(e.stack || e);
+    }
+
+    // If an object is used as the computed key, it coerces to the string
+    // '[object Object]'.  An Array coerces to a comma joined list.
+    try {
+        res = eval('({ [{}]: "object", [[1,2,3,4]]: "array" })');
+        print(JSON.stringify(res));
+    } catch (e) {
+        print(e.stack || e);
+    }
+
+    // An error may be thrown.
+    try {
+        res = eval('({ [{}]: "object", [decodeURIComponent("%XX")]: "other" })');
+        print(JSON.stringify(res));
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    computedPropertyName();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Add support for ES6 computed property names like:

```js
var obj = { [1+2]: 'three' };
print(obj[3]);  // three
```

This syntax is quite useful with symbols because one can then:

```js
var obj = {
    foo: 'normal property',
    [ Symbol.for('mySymbol') ]: 'symbol property'
};
```

Implements part of #271.

Tasks:
- [x] Compiler change
- [ ] Config option?
- [x] Testcase
- [ ] Website ES6 section
- [ ] Releases entry
