### PR TITLE
Add support for truly optional built-ins

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1772,6 +1772,12 @@ Planned
   [[DefaultValue]] specification algorithm removed in ES6 (it was folded
   to ToPrimitive()), use duk_to_primitive() instead (GH-984)
 
+* Add support for dropping built-in bindings entirely when they are disabled
+  in configuration, e.g. the Proxy and buffer object bindings will be absent
+  instead of being replaced by functions throwing an error; this is more
+  in line with how application code detects active features and reduces
+  footprint (GH-988)
+
 * Add convenience API calls duk_get_prop_lstring(), duk_put_prop_lstring(),
   duk_del_prop_lstring(), duk_has_prop_lstring(), duk_get_global_lstring(),
   duk_put_global_lstring() (GH-946, GH-953)

--- a/config/examples/low_memory_strip.yaml
+++ b/config/examples/low_memory_strip.yaml
@@ -26,3 +26,6 @@ DUK_USE_ES6_PROXY: false
 
 # Don't support non-BMP characters in source code (UTF-8 otherwise OK).
 DUK_USE_SOURCE_NONBMP: false
+
+# Remove Math built-in.
+DUK_USE_MATH_BUILTIN: false

--- a/doc/duk-config.rst
+++ b/doc/duk-config.rst
@@ -136,8 +136,7 @@ but also ``duktape.c`` and ``duktape.h`` to be included in your build.
 
 You can override individual defines using in several ways (see "Option
 overrides" section below for more details): C compiler format (-D and -U
-options), YAML config through a file or inline, or verbatim fixup header
-through a file or inline.
+options) and YAML config through a file or inline.
 
 If you're building Duktape as a DLL, you should use the ``--dll`` option::
 
@@ -186,8 +185,7 @@ in config option metadata files in ``config/config-options/``.
 
 You can override individual defines using in several ways (see "Option
 overrides" section below for more details): C compiler format (-D and -U
-options), YAML config through a file or inline, or verbatim fixup header
-through a file or inline.
+options) or YAML config through a file or inline.
 
 Some changes such as reworking ``#include`` statements cannot be represented
 as override files; you'll need to edit the resulting config header manually
@@ -210,17 +208,18 @@ an autodetect or barebones ``duk_config.h`` header:
       --option-file my_config.yaml
       --option-yaml 'DUK_USE_FASTINT: true'
 
-* Verbatim fixup header lines read from a file or given inline on the command
-  line::
-
-      --fixup-file my_custom.h
-      --fixup-line '#undef DUK_USE_JX'
+* A verbatim fixup header can declare custom prototypes and include custom
+  headers, and can tweak ``DUK_USE_xxx`` options.  However, since Duktape 2.x
+  some config options control automatic pruning of built-in objects and
+  properties, and such options (like ``DUK_USE_BUFFEROBJECT_SUPPORT``)
+  **MUST NOT** be modified by fixups.  It's thus recommended to modify options
+  via the C compiler format or YAML.
 
 These option formats can be mixed which allows you to specify an option
 baseline (say ``--option-file low_memory.yaml``) and then apply
 further overrides in various ways.  All forced options in C compiler
 format and YAML format are processed first, with the last override
-winning.  Fixup headers are then emitted in order.
+winning.
 
 C compiler format
 -----------------
@@ -326,10 +325,13 @@ Fixup header
 In addition to YAML-based option overrides, genconfig has an option for
 appending direct "fixup headers" to deal with situations which cannot be
 handled with individual option overrides.  For example, you may want to
-inject specific environment sanity checks, or set config option values
-based on environment #ifdefs.  This mechanism is similar to Duktape 1.x
-``duk_custom.h`` header, and you can in fact use ``duk_custom.h`` headers
-directly as inputs.
+inject specific environment sanity checks.  This mechanism is similar to
+Duktape 1.x ``duk_custom.h`` header.
+
+Since Duktape 2.x some config options control automatic pruning of built-in
+objects and properties, and such options (like ``DUK_USE_BUFFEROBJECT_SUPPORT``)
+**MUST NOT** be modified by fixups.  It's thus recommended to modify options
+via the C compiler format or YAML metadata files.
 
 Fixup headers are emitted after all individual option overrides (in either
 C compiler or YAML format) have been resolved, but before emitting option

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -109,6 +109,42 @@ To upgrade:
   - Finally, you can remove your custom header and add the equivalent options
     to ``tools/configure.py`` when possible.
 
+Built-ins disabled in configuration are now absent
+--------------------------------------------------
+
+If a built-in is disabled when running ``configure.py``, it won't be present
+in the Ecmascript environment.  For example, with ``-UDUK_USE_ES6_PROXY``::
+
+    duk> new Proxy()
+    ReferenceError: identifier 'Proxy' undefined
+        at [anon] (duk_js_var.c:1262) internal
+        at global (input:1) preventsyield
+    duk> typeof Proxy
+    = "undefined"
+
+In Duktape 1.x the binding was present but would just throw an Error when
+invoked::
+
+    duk> new Proxy()
+    Error: unknown error (rc -1)
+        at Proxy () native strict construct preventsyield
+        at global (input:1) preventsyield
+    duk> typeof Proxy
+    = "function"
+
+The revised behavior saves footprint and allows scripts to detect
+supported built-ins reliably using e.g.::
+
+    if (typeof Proxy === 'function') {
+        // supported
+    }
+
+To upgrade:
+
+* In most cases no action is needed.  If your code relies on the builtins
+  being present but throwing an error (which seems unlikely), such call
+  sites need to be fixed.
+
 Tooling changes
 ---------------
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -22,6 +22,10 @@
 #      - constructable: true/false, depending on function
 #    - To disable an object without removing its metadata, you can
 #      use 'disable: true'.
+#    - If the object is dependent on Duktape configuration, you can make the
+#      object optional using e.g. 'present_if: DUK_USE_BUFFEROBJECT_SUPPORT'.
+#    - If the object needs a DUK_BIDX_xxx define in Duktape source code, which
+#      also implies it'll get a slot in thr->builtins[] array, use 'bidx: true'.
 #
 # Property format:
 #
@@ -42,6 +46,8 @@
 #      is related to a specific standard
 #    - To disable a property without removing its metadata, you can use
 #      'disable: true'.
+#    - If the property is dependent on Duktape configuration, you can make the
+#      property optional using e.g. 'present_if: DUK_USE_BUFFEROBJECT_SUPPORT'.
 #
 # Property value format:
 #
@@ -145,6 +151,7 @@ objects:
   - id: bi_global
     class: global
     internal_prototype: bi_object_prototype
+    bidx: true
 
     properties:
       - key: "NaN"
@@ -194,6 +201,7 @@ objects:
         value:
           type: object
           id: bi_regexp_constructor
+        present_if: DUK_USE_REGEXP_SUPPORT
       - key: "Error"
         value:
           type: object
@@ -226,6 +234,7 @@ objects:
         value:
           type: object
           id: bi_math
+        present_if: DUK_USE_MATH_BUILTIN
       - key: "JSON"
         value:
           type: object
@@ -244,6 +253,7 @@ objects:
           type: object
           id: bi_proxy_constructor
         es6: true
+        present_if: DUK_USE_ES6_PROXY
 
       # Node.js Buffer
       - key: "Buffer"
@@ -251,6 +261,7 @@ objects:
           type: object
           id: bi_nodejs_buffer_constructor
         nodejs_buffer: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
       # TypedArray
       - key: "ArrayBuffer"
@@ -259,66 +270,77 @@ objects:
           id: bi_arraybuffer_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "DataView"
         value:
           type: object
           id: bi_dataview_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Int8Array"
         value:
           type: object
           id: bi_int8array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Uint8Array"
         value:
           type: object
           id: bi_uint8array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Uint8ClampedArray"
         value:
           type: object
           id: bi_uint8clampedarray_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Int16Array"
         value:
           type: object
           id: bi_int16array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Uint16Array"
         value:
           type: object
           id: bi_uint16array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Int32Array"
         value:
           type: object
           id: bi_int32array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Uint32Array"
         value:
           type: object
           id: bi_uint32array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Float32Array"
         value:
           type: object
           id: bi_float32array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
       - key: "Float64Array"
         value:
           type: object
           id: bi_float64array_constructor
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
       # Functions
       - key: "eval"
@@ -379,16 +401,19 @@ objects:
           native: duk_bi_global_object_escape
           length: 1
         section_b: true
+        present_if: DUK_USE_SECTION_B
       - key: "unescape"
         value:
           type: function
           native: duk_bi_global_object_unescape
           length: 1
         section_b: true
+        present_if: DUK_USE_SECTION_B
 
   - id: bi_global_env
     class: ObjEnv
     duktape: true
+    bidx: true
 
     properties:
       - key: "\u00ffTarget"
@@ -404,6 +429,7 @@ objects:
     native: duk_bi_object_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -501,6 +527,7 @@ objects:
   - id: bi_object_prototype
     class: Object
     # internal_prototype: null
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -559,6 +586,7 @@ objects:
     native: duk_bi_function_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -583,6 +611,7 @@ objects:
     native: duk_bi_function_prototype
     callable: true
     constructable: false  # Note: differs from other global Function classed objects (matches e.g. V8 behavior).
+    bidx: true
 
     properties:
       - key: "length"
@@ -637,6 +666,7 @@ objects:
     native: duk_bi_array_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -659,6 +689,7 @@ objects:
   - id: bi_array_prototype
     class: Array
     internal_prototype: bi_object_prototype
+    bidx: true
 
     # An array prototype is an Array itself.  It has a length property initialized to 0,
     # with property attributes: writable, non-configurable, non-enumerable.  The attributes
@@ -822,6 +853,7 @@ objects:
     native: duk_bi_string_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -852,10 +884,12 @@ objects:
           length: 1
           varargs: false
         duktape: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
   - id: bi_string_prototype
     class: String
     internal_prototype: bi_object_prototype
+    bidx: true
 
     # String prototype is a String instance and must have length value 0.
     # This is supplied by the String instance virtual properties and does
@@ -933,6 +967,7 @@ objects:
           type: function
           native: duk_bi_string_prototype_match
           length: 1
+        present_if: DUK_USE_REGEXP_SUPPORT
       - key: "replace"
         value:
           type: function
@@ -943,6 +978,7 @@ objects:
           type: function
           native: duk_bi_string_prototype_search
           length: 1
+        present_if: DUK_USE_REGEXP_SUPPORT
       - key: "slice"
         value:
           type: function
@@ -996,6 +1032,7 @@ objects:
           native: duk_bi_string_prototype_substr
           length: 2
         section_b: true
+        present_if: DUK_USE_SECTION_B
 
   - id: bi_boolean_constructor
     class: Function
@@ -1003,6 +1040,7 @@ objects:
     native: duk_bi_boolean_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -1020,6 +1058,7 @@ objects:
   - id: bi_boolean_prototype
     class: Boolean
     internal_prototype: bi_object_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1057,6 +1096,7 @@ objects:
     native: duk_bi_number_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -1099,6 +1139,7 @@ objects:
   - id: bi_number_prototype
     class: Number
     internal_prototype: bi_object_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1154,6 +1195,7 @@ objects:
     native: duk_bi_date_constructor
     callable: true
     constructable: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -1188,6 +1230,7 @@ objects:
   - id: bi_date_prototype
     class: Date
     internal_prototype: bi_object_prototype
+    bidx: true
 
     # The Date prototype is an instance of Date with [[PrimitiveValue]] NaN.
     #
@@ -1541,6 +1584,8 @@ objects:
     native: duk_bi_regexp_constructor
     callable: true
     constructable: true
+    bidx: true
+    present_if: DUK_USE_REGEXP_SUPPORT
 
     properties:
       - key: "length"
@@ -1558,6 +1603,8 @@ objects:
   - id: bi_regexp_prototype
     class: RegExp
     internal_prototype: bi_object_prototype
+    bidx: true
+    present_if: DUK_USE_REGEXP_SUPPORT
 
     properties:
       - key: "constructor"
@@ -1628,6 +1675,7 @@ objects:
     magic:
       type: bidx
       id: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1645,6 +1693,7 @@ objects:
   - id: bi_error_prototype
     class: Error
     internal_prototype: bi_object_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1733,6 +1782,7 @@ objects:
     magic:
       type: bidx
       id: bi_eval_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1750,6 +1800,7 @@ objects:
   - id: bi_eval_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1771,6 +1822,7 @@ objects:
     magic:
       type: bidx
       id: bi_range_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1788,6 +1840,7 @@ objects:
   - id: bi_range_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1809,6 +1862,7 @@ objects:
     magic:
       type: bidx
       id: bi_reference_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1826,6 +1880,7 @@ objects:
   - id: bi_reference_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1847,6 +1902,7 @@ objects:
     magic:
       type: bidx
       id: bi_syntax_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1864,6 +1920,7 @@ objects:
   - id: bi_syntax_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1885,6 +1942,7 @@ objects:
     magic:
       type: bidx
       id: bi_type_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1902,6 +1960,7 @@ objects:
   - id: bi_type_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1923,6 +1982,7 @@ objects:
     magic:
       type: bidx
       id: bi_uri_error_prototype
+    bidx: true
 
     properties:
       - key: "length"
@@ -1940,6 +2000,7 @@ objects:
   - id: bi_uri_error_prototype
     class: Error
     internal_prototype: bi_error_prototype
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -1955,6 +2016,8 @@ objects:
   - id: bi_math
     class: Math
     internal_prototype: bi_object_prototype
+    bidx: true
+    present_if: DUK_USE_MATH_BUILTIN
 
     # apparently no external "prototype" property
     # apparently no external "constructor" property
@@ -2142,6 +2205,7 @@ objects:
   - id: bi_json
     class: JSON
     internal_prototype: bi_object_prototype
+    bidx: true
 
     # apparently no external "prototype" property
     # apparently no external "constructor" property
@@ -2165,6 +2229,7 @@ objects:
     native: duk_bi_type_error_thrower
     callable: true
     constructable: false  # This is not clearly specified, but [[Construct]] is not set in E5 Section 13.2.3.
+    bidx: true
 
     properties:
       - key: "length"
@@ -2184,6 +2249,7 @@ objects:
     class: Object
     internal_prototype: bi_object_prototype
     duktape: true
+    bidx: true
 
     # There are a few properties not listed here:
     #   - "version" is added from parameter file automatically.
@@ -2200,6 +2266,7 @@ objects:
           type: object
           id: bi_thread_constructor
         duktape: true
+        present_if: DUK_USE_COROUTINE_SUPPORT
 
       - key: "info"
         value:
@@ -2226,6 +2293,7 @@ objects:
           length: 0
           varargs: true
         duktape: true
+        present_if: DUK_USE_FINALIZER_SUPPORT
       - key: "enc"
         value:
           type: function
@@ -2255,6 +2323,8 @@ objects:
     callable: true
     constructable: true
     duktape: true
+    bidx: true
+    present_if: DUK_USE_COROUTINE_SUPPORT
 
     properties:
       - key: "length"
@@ -2280,6 +2350,7 @@ objects:
           length: 2
         duktape: true
         autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
+        present_if: DUK_USE_COROUTINE_SUPPORT
       - key: "resume"
         value:
           type: function
@@ -2287,17 +2358,25 @@ objects:
           length: 3
         duktape: true
         autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
+        present_if: DUK_USE_COROUTINE_SUPPORT
       - key: "current"
         value:
           type: function
           native: duk_bi_thread_current
           length: 0
         duktape: true
+        present_if: DUK_USE_COROUTINE_SUPPORT
 
   - id: bi_thread_prototype
     class: Thread
     internal_prototype: bi_object_prototype
     duktape: true
+    bidx: true
+
+    # Must be present even if coroutines are disabled for inheritance.
+    # Because Duktape.Thread.prototype is missing, the only way to access
+    # the prototype to e.g. add methods is to look it up from a thread
+    # instance.
 
     # Note: we don't keep up with the E5 convention that prototype objects
     # are some faux instances of their type (e.g. Date.prototype is a Date
@@ -2313,6 +2392,7 @@ objects:
           id: bi_thread_constructor
         attributes: "wc"
         duktape: true
+        present_if: DUK_USE_COROUTINE_SUPPORT
 
       # toString() and valueOf() are inherited from Object.prototype
 
@@ -2324,6 +2404,7 @@ objects:
     callable: true
     constructable: true
     duktape: true
+    bidx: true
 
     properties:
       - key: "length"
@@ -2345,6 +2426,7 @@ objects:
     class: Pointer
     internal_prototype: bi_object_prototype
     duktape: true
+    bidx: true
 
     properties:
       - key: "constructor"
@@ -2378,6 +2460,7 @@ objects:
     internal_prototype: bi_error_prototype
     extensible: false
     duktape: true
+    bidx: true
 
     # Note: this is the only non-extensible built-in, so there is special
     # post-tweak in duk_hthread_builtins.c to handle this.
@@ -2404,6 +2487,8 @@ objects:
     callable: true
     constructable: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_ES6_PROXY
 
     properties:
       - key: "length"
@@ -2434,6 +2519,8 @@ objects:
     constructable: true
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -2488,6 +2575,8 @@ objects:
     internal_prototype: bi_object_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -2517,6 +2606,8 @@ objects:
     constructable: true
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -2543,6 +2634,8 @@ objects:
     internal_prototype: bi_object_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -2792,6 +2885,8 @@ objects:
     # no external_constructor (specific views provide it)
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "set"
@@ -2825,6 +2920,8 @@ objects:
       shift: 0
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -2855,6 +2952,8 @@ objects:
     class: Object
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -2878,6 +2977,8 @@ objects:
       shift: 0
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -2908,6 +3009,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -2931,6 +3034,8 @@ objects:
       shift: 0
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -2961,6 +3066,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -2984,6 +3091,8 @@ objects:
       shift: 1
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3014,6 +3123,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3037,6 +3148,8 @@ objects:
       shift: 1
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3067,6 +3180,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3090,6 +3205,8 @@ objects:
       shift: 2
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3120,6 +3237,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3143,6 +3262,8 @@ objects:
       shift: 2
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3173,6 +3294,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3196,6 +3319,8 @@ objects:
       shift: 2
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3226,6 +3351,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3249,6 +3376,8 @@ objects:
       shift: 3
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3279,6 +3408,8 @@ objects:
     internal_prototype: bi_typedarray_prototype
     typedarray: true
     es6: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3301,6 +3432,8 @@ objects:
     callable: true
     constructable: true
     nodejs_buffer: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "length"
@@ -3359,6 +3492,8 @@ objects:
     internal_prototype: bi_object_prototype
     class: Object
     nodejs_buffer: true
+    bidx: true
+    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
       - key: "constructor"
@@ -3895,139 +4030,3 @@ objects:
           length: 4
           varargs: false
         nodejs_buffer: true
-
-#
-#  Built-ins table.  The ordering determines ordering for the DUK_BIDX_XXX constants.
-#
-
-builtins:
-  - id: bi_global
-  - id: bi_global_env
-  - id: bi_object_constructor
-  - id: bi_object_prototype
-  - id: bi_function_constructor
-  - id: bi_function_prototype
-  - id: bi_array_constructor
-  - id: bi_array_prototype
-  - id: bi_string_constructor
-  - id: bi_string_prototype
-  - id: bi_boolean_constructor
-  - id: bi_boolean_prototype
-  - id: bi_number_constructor
-  - id: bi_number_prototype
-  - id: bi_date_constructor
-  - id: bi_date_prototype
-  - id: bi_regexp_constructor
-  - id: bi_regexp_prototype
-  - id: bi_error_constructor
-  - id: bi_error_prototype
-  - id: bi_eval_error_constructor
-  - id: bi_eval_error_prototype
-  - id: bi_range_error_constructor
-  - id: bi_range_error_prototype
-  - id: bi_reference_error_constructor
-  - id: bi_reference_error_prototype
-  - id: bi_syntax_error_constructor
-  - id: bi_syntax_error_prototype
-  - id: bi_type_error_constructor
-  - id: bi_type_error_prototype
-  - id: bi_uri_error_constructor
-  - id: bi_uri_error_prototype
-  - id: bi_math
-  - id: bi_json
-  - id: bi_type_error_thrower
-
-  # es6
-  - id: bi_proxy_constructor
-    es6: true
-
-  # Duktape custom
-  - id: bi_duktape
-    duktape: true
-  - id: bi_thread_constructor
-    duktape: true
-  - id: bi_thread_prototype
-    duktape: true
-  - id: bi_pointer_constructor
-    duktape: true
-  - id: bi_pointer_prototype
-    duktape: true
-  - id: bi_double_error
-    duktape: true
-
-  # TypedArray
-  - id: bi_arraybuffer_constructor
-    typedarray: true
-    es6: true
-  - id: bi_arraybuffer_prototype
-    typedarray: true
-    es6: true
-  - id: bi_dataview_constructor
-    typedarray: true
-    es6: true
-  - id: bi_dataview_prototype
-    typedarray: true
-    es6: true
-  - id: bi_typedarray_prototype
-    typedarray: true
-    es6: true
-  - id: bi_int8array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_int8array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_uint8array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_uint8array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_uint8clampedarray_constructor
-    typedarray: true
-    es6: true
-  - id: bi_uint8clampedarray_prototype
-    typedarray: true
-    es6: true
-  - id: bi_int16array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_int16array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_uint16array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_uint16array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_int32array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_int32array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_uint32array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_uint32array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_float32array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_float32array_prototype
-    typedarray: true
-    es6: true
-  - id: bi_float64array_constructor
-    typedarray: true
-    es6: true
-  - id: bi_float64array_prototype
-    typedarray: true
-    es6: true
-
-  # Node.js Buffer
-  - id: bi_nodejs_buffer_constructor
-    nodejs_buffer: true
-  - id: bi_nodejs_buffer_prototype
-    nodejs_buffer: true

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -605,11 +605,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_constructor(duk_context *ctx) {
 
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -662,11 +657,6 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_constructor(duk_context *ctx) {
 
  fail_length:
 	return DUK_RET_RANGE_ERROR;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1042,11 +1032,6 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
  fail_arguments:
 	return DUK_RET_RANGE_ERROR;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
@@ -1105,11 +1090,6 @@ DUK_INTERNAL duk_ret_t duk_bi_dataview_constructor(duk_context *ctx) {
 	DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_dataview_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -1128,11 +1108,6 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_isview(duk_context *ctx) {
 	duk_push_boolean(ctx, ret);
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_isview(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -1143,11 +1118,6 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_isview(duk_context *ctx) {
 DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_allocplain(duk_context *ctx) {
 	duk__hbufobj_fixed_from_argvalue(ctx);
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_allocplain(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1177,11 +1147,6 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_plainof(duk_context *ctx) {
 		duk_push_hbuffer(ctx, h_bufobj->buf);
 	}
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_plainof(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1253,11 +1218,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tostring(duk_context *ctx) {
  type_error:
 	return DUK_RET_TYPE_ERROR;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tostring(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -1305,11 +1265,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tojson(duk_context *ctx) {
 	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_DATA);
 
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tojson(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1369,11 +1324,6 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_compare_shared(duk_context *ctx) {
 	}
 
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_buffer_compare_shared(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1452,11 +1402,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_fill(duk_context *ctx) {
 	duk_push_this(ctx);
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_fill(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -1503,11 +1448,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_write(duk_context *ctx) {
 
 	duk_push_uint(ctx, length);
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_write(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1618,11 +1558,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_copy(duk_context *ctx) {
 
  fail_bounds:
 	return DUK_RET_RANGE_ERROR;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_copy(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -1920,11 +1855,6 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_context *ctx) {
 
 	return 0;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -2132,11 +2062,6 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 	DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
-	(void) ctx;
-	return DUK_RET_TYPE_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -2153,11 +2078,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_is_encoding(duk_context *ctx) {
 	DUK_ASSERT(duk_is_string(ctx, 0));  /* guaranteed by duk_to_string() */
 	duk_push_boolean(ctx, DUK_STRCMP(encoding, "utf8") == 0);
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_is_encoding(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -2189,11 +2109,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_is_buffer(duk_context *ctx) {
 	duk_push_boolean(ctx, ret);
 	return 1;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_is_buffer(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
@@ -2224,11 +2139,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_byte_length(duk_context *ctx) {
 	DUK_UNREF(str);
 	duk_push_size_t(ctx, len);
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_byte_length(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -2343,11 +2253,6 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_context *ctx) {
 	duk_pop(ctx);  /* pop plain buffer, now reachable through h_bufres */
 
 	return 1;  /* return h_bufres */
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -2633,11 +2538,6 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_context *ctx) {
 
 	return DUK_RET_RANGE_ERROR;
 }
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
@@ -2915,10 +2815,5 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_context *ctx) {
 		return 1;
 	}
 	return DUK_RET_RANGE_ERROR;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -223,10 +223,6 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
 		return 1;
 	}
 }
-#else  /* DUK_USE_FINALIZER_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
-	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
-}
 #endif  /* DUK_USE_FINALIZER_SUPPORT */
 
 DUK_INTERNAL duk_ret_t duk_bi_duktape_object_enc(duk_context *ctx) {

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -70,7 +70,7 @@ DUK_LOCAL const duk_uint8_t duk__decode_uri_component_reserved_table[16] = {
 	DUK__MKBITS(0, 0, 0, 0, 0, 0, 0, 0), DUK__MKBITS(0, 0, 0, 0, 0, 0, 0, 0),  /* 0x70-0x7f */
 };
 
-#ifdef DUK_USE_SECTION_B
+#if defined(DUK_USE_SECTION_B)
 /* E5.1 Section B.2.2, step 7. */
 DUK_LOCAL const duk_uint8_t duk__escape_unescaped_table[16] = {
 	DUK__MKBITS(0, 0, 0, 0, 0, 0, 0, 0), DUK__MKBITS(0, 0, 0, 0, 0, 0, 0, 0),  /* 0x00-0x0f */
@@ -341,7 +341,7 @@ DUK_LOCAL void duk__transform_callback_decode_uri(duk__transform_context *tfm_ct
 	DUK_ERROR_URI(tfm_ctx->thr, DUK_STR_INVALID_INPUT);
 }
 
-#ifdef DUK_USE_SECTION_B
+#if defined(DUK_USE_SECTION_B)
 DUK_LOCAL void duk__transform_callback_escape(duk__transform_context *tfm_ctx, const void *udata, duk_codepoint_t cp) {
 	DUK_UNREF(udata);
 
@@ -698,22 +698,12 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_encode_uri_component(duk_context *ct
 	return duk__transform_helper(ctx, duk__transform_callback_encode_uri, (const void *) duk__encode_uricomponent_unescaped_table);
 }
 
-#ifdef DUK_USE_SECTION_B
+#if defined(DUK_USE_SECTION_B)
 DUK_INTERNAL duk_ret_t duk_bi_global_object_escape(duk_context *ctx) {
 	return duk__transform_helper(ctx, duk__transform_callback_escape, (const void *) NULL);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_global_object_unescape(duk_context *ctx) {
 	return duk__transform_helper(ctx, duk__transform_callback_unescape, (const void *) NULL);
-}
-#else  /* DUK_USE_SECTION_B */
-DUK_INTERNAL duk_ret_t duk_bi_global_object_escape(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_global_object_unescape(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_SECTION_B */

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2591,12 +2591,14 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		 * explicitly).
 		 */
 
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		if (duk_hobject_hasprop_raw(js_ctx->thr,
 		                            js_ctx->thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE],
 		                            DUK_HTHREAD_STRING_TO_JSON(js_ctx->thr))) {
 			DUK_DD(DUK_DDPRINT("value is a plain buffer and there's an inherited .toJSON, abort fast path"));
 			goto abort_fastpath;
 		}
+#endif
 
 #if defined(DUK_USE_JX) || defined(DUK_USE_JC)
 		if (js_ctx->flag_ext_custom_or_compatible) {

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -322,33 +322,4 @@ DUK_INTERNAL duk_ret_t duk_bi_math_object_random(duk_context *ctx) {
 	return 1;
 }
 
-#else  /* DUK_USE_MATH_BUILTIN */
-
-/* A stubbed built-in is useful for e.g. compilation torture testing with BCC. */
-
-DUK_INTERNAL duk_ret_t duk_bi_math_object_onearg_shared(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_math_object_twoarg_shared(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_math_object_max(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_math_object_min(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_math_object_random(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
 #endif  /* DUK_USE_MATH_BUILTIN */

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -65,7 +65,11 @@ DUK_INTERNAL duk_ret_t duk_bi_object_getprototype_shared(duk_context *ctx) {
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
 	case DUK_TAG_BUFFER:
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		proto = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#else
+		proto = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
+#endif
 		break;
 	case DUK_TAG_LIGHTFUNC:
 		proto = thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE];
@@ -129,7 +133,12 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 		duk_hobject *curr_proto;
 		curr_proto = thr->builtins[(mask & DUK_TYPE_MASK_LIGHTFUNC) ?
 		                               DUK_BIDX_FUNCTION_PROTOTYPE :
-		                               DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
+		                               DUK_BIDX_ARRAYBUFFER_PROTOTYPE
+#else
+		                               DUK_BIDX_OBJECT_PROTOTYPE
+#endif
+		                          ];
 		if (h_new_proto == curr_proto) {
 			goto skip;
 		}

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -64,9 +64,4 @@ DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
 
 	return 1;  /* replacement handler */
 }
-#else  /* DUK_USE_ES6_PROXY */
-DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_ES6_PROXY */

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -4,7 +4,7 @@
 
 #include "duk_internal.h"
 
-#ifdef DUK_USE_REGEXP_SUPPORT
+#if defined(DUK_USE_REGEXP_SUPPORT)
 
 DUK_LOCAL void duk__get_this_regexp(duk_context *ctx) {
 	duk_hobject *h;
@@ -182,28 +182,6 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_to_string(duk_context *ctx) {
 #endif
 
 	return 1;
-}
-
-#else  /* DUK_USE_REGEXP_SUPPORT */
-
-DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_exec(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_test(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_to_string(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 
 #endif  /* DUK_USE_REGEXP_SUPPORT */

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -251,11 +251,6 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_substr(duk_context *ctx) {
 	duk_substring(ctx, -1, (duk_size_t) start_pos, (duk_size_t) end_pos);
 	return 1;
 }
-#else  /* DUK_USE_SECTION_B */
-DUK_INTERNAL duk_ret_t duk_bi_string_prototype_substr(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_SECTION_B */
 
 DUK_INTERNAL duk_ret_t duk_bi_string_prototype_slice(duk_context *ctx) {
@@ -1153,11 +1148,6 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_search(duk_context *ctx) {
 	DUK_ASSERT(duk_is_number(ctx, -1));
 	return 1;
 }
-#else  /* DUK_USE_REGEXP_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_string_prototype_search(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif  /* DUK_USE_REGEXP_SUPPORT */
 
 #ifdef DUK_USE_REGEXP_SUPPORT
@@ -1231,11 +1221,6 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
 	}
 
 	return 1;  /* return 'res_arr' or 'null' */
-}
-#else  /* DUK_USE_REGEXP_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_REGEXP_SUPPORT */
 
@@ -1321,10 +1306,5 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_locale_compare(duk_context *ctx) 
 DUK_INTERNAL duk_ret_t duk_bi_string_frombuffer(duk_context *ctx) {
 	duk_buffer_to_string(ctx, 0);
 	return 1;
-}
-#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
-DUK_INTERNAL duk_ret_t duk_bi_string_frombuffer(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -32,11 +32,6 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
 
 	return 1;  /* return thread */
 }
-#else
-DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif
 
 /*
@@ -193,11 +188,6 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
-#else
-DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif
 
 /*
@@ -313,21 +303,11 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 	DUK_ERROR_TYPE(thr, "invalid state");
 	return 0;  /* never here */
 }
-#else
-DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
-}
 #endif
 
 #if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_current(duk_context *ctx) {
 	duk_push_current_thread(ctx);
 	return 1;
-}
-#else
-DUK_INTERNAL duk_ret_t duk_bi_thread_current(duk_context *ctx) {
-	DUK_UNREF(ctx);
-	return DUK_RET_ERROR;
 }
 #endif

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2589,7 +2589,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 
 		DUK_DDD(DUK_DDDPRINT("base object is a buffer, start lookup from ArrayBuffer prototype"));
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		curr = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#else
+		curr = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
+#endif
 		goto lookup;  /* avoid double coercion */
 	}
 
@@ -2828,7 +2832,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 			rc = 1;
 			goto pop_and_return;
 		}
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		obj = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#else
+		obj = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
+#endif
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv_obj)) {
 		arr_idx = duk__push_tval_to_hstring_arr_idx(ctx, tv_key, &key);
 		if (duk__key_is_lightfunc_ownprop(thr, key)) {
@@ -3575,7 +3583,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 
 		DUK_DDD(DUK_DDDPRINT("base object is a buffer, start lookup from buffer prototype"));
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		curr = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#else
+		curr = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
+#endif
 		goto lookup;  /* avoid double coercion */
 	}
 

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1061,7 +1061,11 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 		DUK_ASSERT(val != NULL);
 		break;
 	case DUK_TAG_BUFFER:
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		val = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
+#else
+		val = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
+#endif
 		DUK_ASSERT(val != NULL);
 		break;
 	case DUK_TAG_POINTER:

--- a/src-input/duk_regexp.h
+++ b/src-input/duk_regexp.h
@@ -74,9 +74,11 @@ struct duk_re_compiler_ctx {
  *  Prototypes
  */
 
+#if defined(DUK_USE_REGEXP_SUPPORT)
 DUK_INTERNAL_DECL void duk_regexp_compile(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_regexp_create_instance(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_regexp_match(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_regexp_match_force_global(duk_hthread *thr);  /* hacky helper for String.prototype.split() */
+#endif
 
 #endif  /* DUK_REGEXP_H_INCLUDED */

--- a/src-input/duk_unicode.h
+++ b/src-input/duk_unicode.h
@@ -228,7 +228,9 @@ DUK_INTERNAL_DECL duk_small_int_t duk_unicode_is_identifier_start(duk_codepoint_
 DUK_INTERNAL_DECL duk_small_int_t duk_unicode_is_identifier_part(duk_codepoint_t cp);
 DUK_INTERNAL_DECL duk_small_int_t duk_unicode_is_letter(duk_codepoint_t cp);
 DUK_INTERNAL_DECL void duk_unicode_case_convert_string(duk_hthread *thr, duk_bool_t uppercase);
+#if defined(DUK_USE_REGEXP_SUPPORT)
 DUK_INTERNAL_DECL duk_codepoint_t duk_unicode_re_canonicalize_char(duk_hthread *thr, duk_codepoint_t cp);
 DUK_INTERNAL_DECL duk_small_int_t duk_unicode_re_is_wordchar(duk_codepoint_t cp);
+#endif
 
 #endif  /* DUK_UNICODE_H_INCLUDED */

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -605,7 +605,7 @@ DUK_INTERNAL duk_small_int_t duk_unicode_is_identifier_start(duk_codepoint_t cp)
 
 	/* Non-ASCII slow path (range-by-range linear comparison), very slow */
 
-#ifdef DUK_USE_SOURCE_NONBMP
+#if defined(DUK_USE_SOURCE_NONBMP)
 	if (duk__uni_range_match(duk_unicode_ids_noa,
 	                         (duk_size_t) sizeof(duk_unicode_ids_noa),
 	                         (duk_codepoint_t) cp)) {
@@ -695,7 +695,7 @@ DUK_INTERNAL duk_small_int_t duk_unicode_is_identifier_part(duk_codepoint_t cp) 
 
 	/* Non-ASCII slow path (range-by-range linear comparison), very slow */
 
-#ifdef DUK_USE_SOURCE_NONBMP
+#if defined(DUK_USE_SOURCE_NONBMP)
 	if (duk__uni_range_match(duk_unicode_ids_noa,
 	                         sizeof(duk_unicode_ids_noa),
 	                         (duk_codepoint_t) cp) ||
@@ -754,7 +754,7 @@ DUK_INTERNAL duk_small_int_t duk_unicode_is_letter(duk_codepoint_t cp) {
 
 	/* Non-ASCII slow path (range-by-range linear comparison), very slow */
 
-#ifdef DUK_USE_SOURCE_NONBMP
+#if defined(DUK_USE_SOURCE_NONBMP)
 	if (duk__uni_range_match(duk_unicode_ids_noa,
 	                         sizeof(duk_unicode_ids_noa),
 	                         (duk_codepoint_t) cp) &&
@@ -1059,7 +1059,7 @@ DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_small_in
 	duk_remove(ctx, -2);
 }
 
-#ifdef DUK_USE_REGEXP_SUPPORT
+#if defined(DUK_USE_REGEXP_SUPPORT)
 
 /*
  *  Canonicalize() abstract operation needed for canonicalization of individual

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -568,6 +568,7 @@ def main():
     cmd = [
         sys.executable, os.path.join(script_path, 'genconfig.py'),
         '--output', os.path.join(tempdir, 'duk_config.h.tmp'),
+        '--output-active-options', os.path.join(tempdir, 'duk_config_active_options.json'),
         '--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch
     ]
     cmd += forward_genconfig_options()
@@ -634,12 +635,13 @@ def main():
         '--duk-version', str(duk_version)
     ]
     cmd += [
-        '--used-stridx-metadata=' + os.path.join(tempdir, 'duk_used_stridx_bidx_defs.json.tmp'),
-        '--strings-metadata=' + os.path.join(srcdir, 'strings.yaml'),
-        '--objects-metadata=' + os.path.join(srcdir, 'builtins.yaml'),
-        '--out-header=' + os.path.join(tempdir, 'src', 'duk_builtins.h'),
-        '--out-source=' + os.path.join(tempdir, 'src', 'duk_builtins.c'),
-        '--out-metadata-json=' + os.path.join(tempdir, 'genbuiltins_metadata.json')
+        '--used-stridx-metadata', os.path.join(tempdir, 'duk_used_stridx_bidx_defs.json.tmp'),
+        '--strings-metadata', os.path.join(srcdir, 'strings.yaml'),
+        '--objects-metadata', os.path.join(srcdir, 'builtins.yaml'),
+        '--active-options', os.path.join(tempdir, 'duk_config_active_options.json'),
+        '--out-header', os.path.join(tempdir, 'src', 'duk_builtins.h'),
+        '--out-source', os.path.join(tempdir, 'src', 'duk_builtins.c'),
+        '--out-metadata-json', os.path.join(tempdir, 'genbuiltins_metadata.json')
     ]
     cmd.append('--ram-support')  # enable by default
     if opts.rom_support:
@@ -731,12 +733,12 @@ def main():
         res = exec_get_stdout([
             sys.executable,
             os.path.join(script_path, 'extract_chars.py'),
-            '--unicode-data=' + os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
-            '--include-categories=' + incl,
-            '--exclude-categories=' + excl,
-            '--out-source=' + os.path.join(tempdir, 'duk_unicode_%s.c.tmp' % suffix),
-            '--out-header=' + os.path.join(tempdir, 'duk_unicode_%s.h.tmp' % suffix),
-            '--table-name=' + 'duk_unicode_%s' % suffix
+            '--unicode-data', os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
+            '--include-categories', incl,
+            '--exclude-categories', excl,
+            '--out-source', os.path.join(tempdir, 'duk_unicode_%s.c.tmp' % suffix),
+            '--out-header', os.path.join(tempdir, 'duk_unicode_%s.h.tmp' % suffix),
+            '--table-name', 'duk_unicode_%s' % suffix
         ])
         with open(os.path.join(tempdir, suffix + '.txt'), 'wb') as f:
             f.write(res)
@@ -747,12 +749,12 @@ def main():
             sys.executable,
             os.path.join(script_path, 'extract_caseconv.py'),
             '--command=caseconv_bitpacked',
-            '--unicode-data=' + os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
-            '--special-casing=' + special_casing,
-            '--out-source=' + os.path.join(tempdir, 'duk_unicode_caseconv.c.tmp'),
-            '--out-header=' + os.path.join(tempdir, 'duk_unicode_caseconv.h.tmp'),
-            '--table-name-lc=duk_unicode_caseconv_lc',
-            '--table-name-uc=duk_unicode_caseconv_uc'
+            '--unicode-data', os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
+            '--special-casing', special_casing,
+            '--out-source', os.path.join(tempdir, 'duk_unicode_caseconv.c.tmp'),
+            '--out-header', os.path.join(tempdir, 'duk_unicode_caseconv.h.tmp'),
+            '--table-name-lc', 'duk_unicode_caseconv_lc',
+            '--table-name-uc', 'duk_unicode_caseconv_uc'
         ])
         with open(os.path.join(tempdir, 'caseconv.txt'), 'wb') as f:
             f.write(res)
@@ -762,11 +764,11 @@ def main():
             sys.executable,
             os.path.join(script_path, 'extract_caseconv.py'),
             '--command=re_canon_lookup',
-            '--unicode-data=' + os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
-            '--special-casing=' + special_casing,
-            '--out-source=' + os.path.join(tempdir, 'duk_unicode_re_canon_lookup.c.tmp'),
-            '--out-header=' + os.path.join(tempdir, 'duk_unicode_re_canon_lookup.h.tmp'),
-            '--table-name-re-canon-lookup=duk_unicode_re_canon_lookup'
+            '--unicode-data', os.path.join(tempdir, 'UnicodeData-expanded.tmp'),
+            '--special-casing', special_casing,
+            '--out-source', os.path.join(tempdir, 'duk_unicode_re_canon_lookup.c.tmp'),
+            '--out-header', os.path.join(tempdir, 'duk_unicode_re_canon_lookup.h.tmp'),
+            '--table-name-re-canon-lookup', 'duk_unicode_re_canon_lookup'
         ])
         with open(os.path.join(tempdir, 'caseconv_re_canon_lookup.txt'), 'wb') as f:
             f.write(res)

--- a/util/example_user_builtins1.yaml
+++ b/util/example_user_builtins1.yaml
@@ -275,6 +275,7 @@ objects:
     replace: true
     class: Error
     internal_prototype: bi_object_prototype
+    bidx: true   # Duktape internals use DUK_BIDX_ERROR_PROTOTYPE, so this must be present
 
     properties:
       - key: "constructor"
@@ -290,6 +291,7 @@ objects:
   - id: bi_json
     disable: true  # disabled in metadata, so no effect unless commented out
     replace: true
+    bidx: true
 
     class: Object
     internal_prototype: bi_object_prototype
@@ -301,9 +303,19 @@ objects:
   # Example of how to delete an existing built-in object entirely.  Dangling
   # references are automatically deleted with a note in the build log.
   #
-  # This doesn't currently work very well for Duktape built-ins because most
-  # built-ins are expected to be present in Duktape internals (and they have
-  # a DUK_BIDX_xxx index).
+  # This doesn't always work very well for Duktape built-ins: if a certain
+  # feature is enabled Duktape internals may expect some built-in objects to
+  # be present and have a DUK_BIDX_xxx define.  For example, when
+  # DUK_USE_BUFFEROBJECT_SUPPORT is enabled, Duktape internals expect e.g.
+  # DUK_BIDX_UINT8ARRAY_PROTOTYPE to be present.
+  #
+  # In these cases you can replace the object with an empty one, but it still
+  # needs to be present, and it will need to have 'bidx: true' which indicates
+  # the object needs a DUK_BIDX_xxx constant and a place in thr->builtins[].
+  # If the feature is disabled, the internal references won't be active and
+  # the related built-ins can be removed, and are in fact automatically removed
+  # based on 'present_if' metadata (e.g. 'present_if:
+  # DUK_USE_BUFFEROBJECT_SUPPORT' for buffers, for example).
   #
   # Deleting user objects may be useful e.g. if a base YAML file provides your
   # custom built-ins and a target specific YAML file removes bindings not


### PR DESCRIPTION
Add support for objects and properties not needed by the active configuration to be entirely dropped from the build:

- [x] Add integration between genconfig.py and genbuiltins.py which allows the set of "active config options" to be conveyed to genbuiltins.py.
- [x] Add genbuiltins.py support for `present_if: DUK_USE_xxx` notation for objects and properties.
- [x] Add genbuiltins.py support for removing explicitly disabled from the "needs bidx" list. If Duktape source code then refers to the related bidx, compilation will fail.
- [x] Add builtins metadata for dropping Proxy when not supported
- [x] Add builtins metadata for dropping bufferobjects when not supported
- [x] Add builtins metadata for dropping Math when not supported
- [x] Add builtins metadata for dropping coroutine methods when not supported
- [x] Add builtins metadata for dropping Section B functions when not supported
- [x] Add builtins metadata for dropping RegExp when not supported
- [x] Add builtins metadata for dropping Duktape.fin when not supported
- [x] Remove the throwing built-in functions for disabled config which has metadata support, they're now dead code unless there's a config mismatch
- [x] Some source fixes for dropping bufferobjects entirely; current implementation depended on DUK_BIDX_ARRAYBUFFER_PROTOTYPE even when bufferobjects were disabled. (This could be reverted and the ArrayBuffer prototype made an empty object instead, which would allow user code to add inherited methods for buffers.)
- [x] Maybe add configure.py option to skip dropping unused objects/properties, may be useful with fixups. => Not an option if the "throwing" variants are no longer present when a certain feature is disabled.
- [x] Solution or documentation for fixup limitation. => Documentation.
- [x] Documentation updates.
- [x] 2.x migration note: disabled objects no longer present.
- [x] Releases entry.

There are some limitations still in the pull:
- When using a fixup to enable/disable a feature covered by `present_if` the result will be a build failure. Genconfig.py cannot reliably figure out the final active configuration when fixups are present - even if the final header including the fixup were scanned, a fixup may include further headers which are not known at genconfig time.

Fixes #874. Implements part of #956.