### PR TITLE
Make (almost) all built-ins optional

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1988,7 +1988,8 @@ Planned
   GH-973); minor RegExp compile/execute optimizations (GH-974)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977),
-  internal duk_dup() variants (GH-990)
+  internal duk_dup() variants (GH-990), allow stripping of (almost) all
+  built-ins for low memory builds (GH-989)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/config/config-options/DUK_USE_ARRAY_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_ARRAY_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_ARRAY_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide an Array built-in.

--- a/config/config-options/DUK_USE_BOOLEAN_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_BOOLEAN_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_BOOLEAN_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a Boolean built-in.

--- a/config/config-options/DUK_USE_DATE_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_DATE_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_DATE_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a Date built-in.

--- a/config/config-options/DUK_USE_DUKTAPE_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_DUKTAPE_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_DUKTAPE_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - duktape
+description: >
+  Provide a Duktape built-in.

--- a/config/config-options/DUK_USE_FUNCTION_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_FUNCTION_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_FUNCTION_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a Function built-in.

--- a/config/config-options/DUK_USE_GLOBAL_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_GLOBAL_BUILTIN.yaml
@@ -1,0 +1,9 @@
+define: DUK_USE_GLOBAL_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide miscellaneous global built-ins like encodeURIComponent(), escape(),
+  Infinity, etc.  This is a catch-all for globals not covered by other options
+  (like DUK_USE_ARRAY_BUILTIN).

--- a/config/config-options/DUK_USE_JSON_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_JSON_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_JSON_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a JSON built-in.

--- a/config/config-options/DUK_USE_JSON_SUPPORT.yaml
+++ b/config/config-options/DUK_USE_JSON_SUPPORT.yaml
@@ -1,0 +1,10 @@
+define: DUK_USE_JSON_SUPPORT
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Enable JSON functionality, affects both Ecmascript and C APIs.
+  Note that disabling DUK_USE_JSON_BUILTIN still leaves the C API intact
+  and pulls in the JSON encoding/decoding functionality; disable this
+  option to remove that too.

--- a/config/config-options/DUK_USE_MATH_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_MATH_BUILTIN.yaml
@@ -5,8 +5,3 @@ tags:
   - ecmascript
 description: >
   Provide a Math built-in.
-
-  When disabled, Math functions will be stubbed out; this improves portability
-  to some very exotic platforms but is not recommended.
-
-# FIXME: document as experimental / obscure?

--- a/config/config-options/DUK_USE_NUMBER_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_NUMBER_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_NUMBER_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a Number built-in.

--- a/config/config-options/DUK_USE_OBJECT_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_OBJECT_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_OBJECT_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide an Object built-in.

--- a/config/config-options/DUK_USE_STRING_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_STRING_BUILTIN.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_STRING_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+description: >
+  Provide a String built-in.

--- a/config/examples/low_memory_strip.yaml
+++ b/config/examples/low_memory_strip.yaml
@@ -27,5 +27,16 @@ DUK_USE_ES6_PROXY: false
 # Don't support non-BMP characters in source code (UTF-8 otherwise OK).
 DUK_USE_SOURCE_NONBMP: false
 
-# Remove Math built-in.
+# Remove built-in bindings.
 DUK_USE_MATH_BUILTIN: false
+DUK_USE_DATE_BUILTIN: false
+DUK_USE_ARRAY_BUILTIN: false
+DUK_USE_STRING_BUILTIN: false
+DUK_USE_BOOLEAN_BUILTIN: false
+DUK_USE_NUMBER_BUILTIN: false
+DUK_USE_FUNCTION_BUILTIN: false
+DUK_USE_OBJECT_BUILTIN: false
+DUK_USE_DUKTAPE_BUILTIN: false
+DUK_USE_JSON_BUILTIN: false
+DUK_USE_JSON_SUPPORT: false   # also disables JSON support for C API
+DUK_USE_GLOBAL_BUILTIN: false

--- a/config/tags.yaml
+++ b/config/tags.yaml
@@ -4,10 +4,16 @@
 #
 
 ecmascript:
-  title: Ecmascript feature options
+  title: Ecmascript Edition 5 options
 
 ecmascript6:
-  title: Ecmascript Edition 6 (ES6) feature options
+  title: Ecmascript Edition 6 (ES6, ES2015) options
+
+ecmascript7:
+  title: Ecmascript Edition 7 (ES7, ES2016) options
+
+duktape:
+  title: Duktape specific options
 
 compliance:
   title: Compliance related options

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -13,7 +13,7 @@ The default Duktape options are quite memory conservative, and significant
 Ecmascript programs can be executed with e.g. 1MB of memory.  Currently
 realistic memory targets are roughly:
 
-* 256-384kB flash memory (code) and 256kB system RAM
+* 256-384kB system flash memory (code) and 256kB system RAM
 
   - Duktape compiled with default options is feasible
 
@@ -22,7 +22,7 @@ realistic memory targets are roughly:
     hardware initialization, communications, etc; 384kB is a more
     realistic flash target
 
-* 256-384kB flash memory (code) and 128kB system RAM
+* 256-384kB system flash memory (code) and 128kB system RAM
 
   - Duktape feature options are needed to reduce memory usage
 
@@ -33,18 +33,25 @@ realistic memory targets are roughly:
     various internal structures (strings, buffers, objects), pointer
     compression, external strings, etc may need to be used
 
-* 192-256kB flash memory (code) and 96kB system RAM
+* 192-256kB system flash memory (code) and 96kB system RAM
 
   - Requires a bare metal system, possibly a custom C library, etc.
 
   - http://pt.slideshare.net/seoyounghwang77/js-onmicrocontrollers
 
-* 160-192kB flash memory (code) and 64kB system RAM
+* 160-192kB system flash memory (code) and 64kB system RAM
 
   - Requires a bare metal system, possibly a custom C library, etc.
 
   - Requires use of ROM strings and objects to reduce Duktape startup
     RAM usage (which drops to around 2-3kB with ROM strings/objects).
+
+* 128kB system flash memory (code) and 32kB system RAM
+
+  - Requires the above, and removing built-in bindings like the global
+    Object (DUK_USE_OBJECT_BUILTIN), Array (DUK_USE_ARRAY_BUILTIN), etc
+    bindings.  See stripped configuration examples, and add back whatever
+    bindings are absolutely necessary.
 
 There are four basic goals for low memory optimization:
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -24,6 +24,8 @@
 #      use 'disable: true'.
 #    - If the object is dependent on Duktape configuration, you can make the
 #      object optional using e.g. 'present_if: DUK_USE_BUFFEROBJECT_SUPPORT'.
+#      If the value is a list, the object is present if all listed options are
+#      enabled (logical AND).
 #    - If the object needs a DUK_BIDX_xxx define in Duktape source code, which
 #      also implies it'll get a slot in thr->builtins[] array, use 'bidx: true'.
 #
@@ -48,6 +50,7 @@
 #      'disable: true'.
 #    - If the property is dependent on Duktape configuration, you can make the
 #      property optional using e.g. 'present_if: DUK_USE_BUFFEROBJECT_SUPPORT'.
+#      List of options is interpreted as for objects (logical AND).
 #
 # Property value format:
 #
@@ -159,44 +162,55 @@ objects:
           type: double
           bytes: "7ff8000000000000"  # DBL_NAN
         attributes: ""
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "Infinity"
         value:
           type: double
           bytes: "7ff0000000000000"  # DBL_POSITIVE_INFINITY
         attributes: ""
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "undefined"
         value:
           type: undefined
         attributes: ""
+        # This could be stripped when DUK_USE_GLOBAL_BUILTIN is disabled
+        # ("void 0" is the same and safer) but it's commonly used so keep.
 
       - key: "Object"
         value:
           type: object
           id: bi_object_constructor
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "Function"
         value:
           type: object
           id: bi_function_constructor
+        present_if: DUK_USE_FUNCTION_BUILTIN
       - key: "Array"
         value:
           type: object
           id: bi_array_constructor
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "String"
         value:
           type: object
           id: bi_string_constructor
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "Boolean"
         value:
           type: object
           id: bi_boolean_constructor
+        present_if: DUK_USE_BOOLEAN_BUILTIN
       - key: "Number"
         value:
           type: object
           id: bi_number_constructor
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "Date"
         value:
           type: object
           id: bi_date_constructor
+        present_if: DUK_USE_DATE_BUILTIN
       - key: "RegExp"
         value:
           type: object
@@ -239,6 +253,7 @@ objects:
         value:
           type: object
           id: bi_json
+        present_if: DUK_USE_JSON_BUILTIN
 
       # Duktape specific
       - key: "Duktape"
@@ -246,6 +261,8 @@ objects:
           type: object
           id: bi_duktape
         duktape: true
+        # Remains present even when disabled: needed for error augmentation internally.
+        #present_if: DUK_USE_DUKTAPE_BUILTIN
 
       # ES6
       - key: "Proxy"
@@ -349,46 +366,55 @@ objects:
           native: duk_bi_global_object_eval
           length: 1
         autoLightfunc: false  # automatic lightfunc conversion clashes with internal implementation
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "parseInt"
         value:
           type: function
           native: duk_bi_global_object_parse_int
           length: 2
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "parseFloat"
         value:
           type: function
           native: duk_bi_global_object_parse_float
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "isNaN"
         value:
           type: function
           native: duk_bi_global_object_is_nan
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "isFinite"
         value:
           type: function
           native: duk_bi_global_object_is_finite
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "decodeURI"
         value:
           type: function
           native: duk_bi_global_object_decode_uri
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "decodeURIComponent"
         value:
           type: function
           native: duk_bi_global_object_decode_uri_component
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "encodeURI"
         value:
           type: function
           native: duk_bi_global_object_encode_uri
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "encodeURIComponent"
         value:
           type: function
           native: duk_bi_global_object_encode_uri_component
           length: 1
+        present_if: DUK_USE_GLOBAL_BUILTIN
 
       # Non-standard extensions: E5 Sections B.2.1 and B.2.2
       #
@@ -401,14 +427,18 @@ objects:
           native: duk_bi_global_object_escape
           length: 1
         section_b: true
-        present_if: DUK_USE_SECTION_B
+        present_if:
+          - DUK_USE_SECTION_B
+          - DUK_USE_GLOBAL_BUILTIN
       - key: "unescape"
         value:
           type: function
           native: duk_bi_global_object_unescape
           length: 1
         section_b: true
-        present_if: DUK_USE_SECTION_B
+        present_if:
+          - DUK_USE_SECTION_B
+          - DUK_USE_GLOBAL_BUILTIN
 
   - id: bi_global_env
     class: ObjEnv
@@ -430,6 +460,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_OBJECT_BUILTIN
 
     properties:
       - key: "length"
@@ -528,6 +559,7 @@ objects:
     class: Object
     # internal_prototype: null
     bidx: true
+    # Present even when DUK_USE_OBJECT_BUILTIN disabled.
 
     properties:
       - key: "constructor"
@@ -535,6 +567,7 @@ objects:
           type: object
           id: bi_object_constructor
         attributes: "wc"
+        present_if: DUK_USE_OBJECT_BUILTIN
 
       - key: "__proto__"
         value:
@@ -547,37 +580,44 @@ objects:
           setter_magic: 0
         attributes: "c"  # configurable in ES6, also V8
         es6: true  # also non-standard legacy
+        present_if: DUK_USE_OBJECT_BUILTIN
 
       - key: "toString"
         value:
           type: function
           native: duk_bi_object_prototype_to_string
           length: 0
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "toLocaleString"
         value:
           type: function
           native: duk_bi_object_prototype_to_locale_string
           length: 0
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "valueOf"
         value:
           type: function
           native: duk_bi_object_prototype_value_of
           length: 0
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "hasOwnProperty"
         value:
           type: function
           native: duk_bi_object_prototype_has_own_property
           length: 1
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "isPrototypeOf"
         value:
           type: function
           native: duk_bi_object_prototype_is_prototype_of
           length: 1
+        present_if: DUK_USE_OBJECT_BUILTIN
       - key: "propertyIsEnumerable"
         value:
           type: function
           native: duk_bi_object_prototype_property_is_enumerable
           length: 1
+        present_if: DUK_USE_OBJECT_BUILTIN
 
   - id: bi_function_constructor
     class: Function
@@ -587,6 +627,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_FUNCTION_BUILTIN
 
     properties:
       - key: "length"
@@ -612,16 +653,20 @@ objects:
     callable: true
     constructable: false  # Note: differs from other global Function classed objects (matches e.g. V8 behavior).
     bidx: true
+    nargs: 0  # given explicitly because .length is optional
+    # Present even when DUK_USE_FUNCTION_BUILTIN disabled.
 
     properties:
       - key: "length"
         value: 0
         attributes: ""
+        present_if: DUK_USE_FUNCTION_BUILTIN
       - key: "constructor"
         value:
           type: object
           id: bi_function_constructor
         attributes: "wc"
+        present_if: DUK_USE_FUNCTION_BUILTIN
 
       # Each built-in of class Function has a "name" which is
       # non-writable (the empty string above).  Function.prototype
@@ -633,6 +678,7 @@ objects:
       - key: "name"
         value: ""
         attributes: "w"
+        #present_if: DUK_USE_FUNCTION_BUILTIN  # Kept even when prototype is otherwise empty to guarantee a .name for functions
 
       # test262 ch15/15.3/15.3.4/15.3.4.2/S15.3.4.2_A11 checks that Function.prototype.toString.length
       # is zero, cannot find specification support for that but 0 is a good value.
@@ -641,23 +687,27 @@ objects:
           type: function
           native: duk_bi_function_prototype_to_string
           length: 0
+        present_if: DUK_USE_FUNCTION_BUILTIN
       - key: "apply"
         value:
           type: function
           native: duk_bi_function_prototype_apply
           length: 2
+        present_if: DUK_USE_FUNCTION_BUILTIN
       - key: "call"
         value:
           type: function
           native: duk_bi_function_prototype_call
           length: 1
           varargs: true
+        present_if: DUK_USE_FUNCTION_BUILTIN
       - key: "bind"
         value:
           type: function
           native: duk_bi_function_prototype_bind
           length: 1
           varargs: true
+        present_if: DUK_USE_FUNCTION_BUILTIN
 
   - id: bi_array_constructor
     class: Function
@@ -667,6 +717,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_ARRAY_BUILTIN
 
     properties:
       - key: "length"
@@ -690,6 +741,7 @@ objects:
     class: Array
     internal_prototype: bi_object_prototype
     bidx: true
+    # Present even when DUK_USE_ARRAY_BUILTIN disabled.
 
     # An array prototype is an Array itself.  It has a length property initialized to 0,
     # with property attributes: writable, non-configurable, non-enumerable.  The attributes
@@ -706,72 +758,85 @@ objects:
           type: object
           id: bi_array_constructor
         attributes: "wc"
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "toString"
         value:
           type: function
           native: duk_bi_array_prototype_to_string
           length: 0
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "toLocaleString"
         value:
           type: function
           native: duk_bi_array_prototype_join_shared
           length: 0
           magic: 1  # magic: to_locale_string, here 1
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "concat"
         value:
           type: function
           native: duk_bi_array_prototype_concat
           length: 1
           varargs: true
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "join"
         value:
           type: function
           native: duk_bi_array_prototype_join_shared
           length: 1
           magic: 0  # magic: to_locale_string, here 0
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "pop"
         value:
           type: function
           native: duk_bi_array_prototype_pop
           length: 0
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "push"
         value:
           type: function
           native: duk_bi_array_prototype_push
           length: 1
           varargs: true
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "reverse"
         value:
           type: function
           native: duk_bi_array_prototype_reverse
           length: 0
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "shift"
         value:
           type: function
           native: duk_bi_array_prototype_shift
           length: 0
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "slice"
         value:
           type: function
           native: duk_bi_array_prototype_slice
           length: 2
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "sort"
         value:
           type: function
           native: duk_bi_array_prototype_sort
           length: 1
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "splice"
         value:
           type: function
           native: duk_bi_array_prototype_splice
           length: 2
           varargs: true
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "unshift"
         value:
           type: function
           native: duk_bi_array_prototype_unshift
           length: 1
           varargs: true
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "indexOf"
         value:
           type: function
@@ -779,6 +844,7 @@ objects:
           length: 1
           varargs: true
           magic: 1  # magic: idx_step = +1
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "lastIndexOf"
         value:
           type: function
@@ -786,6 +852,7 @@ objects:
           length: 1
           varargs: true
           magic: -1  # magic: idx_step = -1
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "every"
         value:
           type: function
@@ -795,6 +862,7 @@ objects:
           magic:
             type: array_iter
             funcname: "every"  # BI_ARRAY_ITER_EVERY
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "some"
         value:
           type: function
@@ -804,6 +872,7 @@ objects:
           magic:
             type: array_iter
             funcname: "some"  # BI_ARRAY_ITER_SOME
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "forEach"
         value:
           type: function
@@ -813,6 +882,7 @@ objects:
           magic:
             type: array_iter
             funcname: "forEach"  # BI_ARRAY_ITER_FOREACH
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "map"
         value:
           type: function
@@ -822,6 +892,7 @@ objects:
           magic:
             type: array_iter
             funcname: "map"  # BI_ARRAY_ITER_MAP
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "filter"
         value:
           type: function
@@ -831,6 +902,7 @@ objects:
           magic:
             type: array_iter
             funcname: filter  # BI_ARRAY_ITER_FILTER
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "reduce"
         value:
           type: function
@@ -838,6 +910,7 @@ objects:
           length: 1
           varargs: true
           magic: 1  # magic: idx_step = +1
+        present_if: DUK_USE_ARRAY_BUILTIN
       - key: "reduceRight"
         value:
           type: function
@@ -845,6 +918,7 @@ objects:
           length: 1
           varargs: true
           magic: -1  # magic: idx_step = -1
+        present_if: DUK_USE_ARRAY_BUILTIN
 
   - id: bi_string_constructor
     class: Function
@@ -854,6 +928,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_STRING_BUILTIN
 
     properties:
       - key: "length"
@@ -890,6 +965,7 @@ objects:
     class: String
     internal_prototype: bi_object_prototype
     bidx: true
+    # Present even when DUK_USE_STRING_BUILTIN disabled.
 
     # String prototype is a String instance and must have length value 0.
     # This is supplied by the String instance virtual properties and does
@@ -907,6 +983,7 @@ objects:
           type: object
           id: bi_string_constructor
         attributes: "wc"
+        present_if: DUK_USE_STRING_BUILTIN
 
       # Internal empty string value.  Note that this value is not writable
       # which prevents a String instance's internal value also from being
@@ -922,27 +999,32 @@ objects:
           type: function
           native: duk_bi_string_prototype_to_string
           length: 0
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "valueOf"
         value:
           type: function
           native: duk_bi_string_prototype_to_string  # share native function, behavior is identical
           length: 0
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "charAt"
         value:
           type: function
           native: duk_bi_string_prototype_char_at
           length: 1
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "charCodeAt"
         value:
           type: function
           native: duk_bi_string_prototype_char_code_at
           length: 1
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "concat"
         value:
           type: function
           native: duk_bi_string_prototype_concat
           length: 1
           varargs: true
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "indexOf"
         value:
           type: function
@@ -950,6 +1032,7 @@ objects:
           length: 1
           nargs: 2
           magic: 0  # magic = 0 -> indexOf
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "lastIndexOf"
         value:
           type: function
@@ -957,72 +1040,87 @@ objects:
           length: 1
           nargs: 2
           magic: 1  # magic = 1 -> lastIndexOf
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "localeCompare"
         value:
           type: function
           native: duk_bi_string_prototype_locale_compare
           length: 1
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "match"
         value:
           type: function
           native: duk_bi_string_prototype_match
           length: 1
-        present_if: DUK_USE_REGEXP_SUPPORT
+        present_if:
+          - DUK_USE_STRING_BUILTIN
+          - DUK_USE_REGEXP_SUPPORT
       - key: "replace"
         value:
           type: function
           native: duk_bi_string_prototype_replace
           length: 2
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "search"
         value:
           type: function
           native: duk_bi_string_prototype_search
           length: 1
-        present_if: DUK_USE_REGEXP_SUPPORT
+        present_if:
+          - DUK_USE_STRING_BUILTIN
+          - DUK_USE_REGEXP_SUPPORT
       - key: "slice"
         value:
           type: function
           native: duk_bi_string_prototype_slice
           length: 2
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "split"
         value:
           type: function
           native: duk_bi_string_prototype_split
           length: 2
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "substring"
         value:
           type: function
           native: duk_bi_string_prototype_substring
           length: 2
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "toLowerCase"
         value:
           type: function
           native: duk_bi_string_prototype_caseconv_shared
           length: 0
           magic: 0  # magic = uppercase
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "toLocaleLowerCase"
         value:
           type: function
           native: duk_bi_string_prototype_caseconv_shared
           length: 0
           magic: 0  # magic = uppercase; no locale specific conversion now
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "toUpperCase"
         value:
           type: function
           native: duk_bi_string_prototype_caseconv_shared
           length: 0
           magic: 1  # magic = uppercase
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "toLocaleUpperCase"
         value:
           type: function
           native: duk_bi_string_prototype_caseconv_shared
           length: 0
           magic: 1  # magic = uppercase; no locale specific conversion now
+        present_if: DUK_USE_STRING_BUILTIN
       - key: "trim"
         value:
           type: function
           native: duk_bi_string_prototype_trim
           length: 0
+        present_if: DUK_USE_STRING_BUILTIN
 
       # Non-standard extension: E5 Section B.2.3
 
@@ -1032,7 +1130,9 @@ objects:
           native: duk_bi_string_prototype_substr
           length: 2
         section_b: true
-        present_if: DUK_USE_SECTION_B
+        present_if:
+          - DUK_USE_STRING_BUILTIN
+          - DUK_USE_SECTION_B
 
   - id: bi_boolean_constructor
     class: Function
@@ -1041,6 +1141,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_BOOLEAN_BUILTIN
 
     properties:
       - key: "length"
@@ -1059,6 +1160,7 @@ objects:
     class: Boolean
     internal_prototype: bi_object_prototype
     bidx: true
+    # Present even when DUK_USE_BOOLEAN_BUILTIN disabled.
 
     properties:
       - key: "constructor"
@@ -1066,6 +1168,7 @@ objects:
           type: object
           id: bi_boolean_constructor
         attributes: "wc"
+        present_if: DUK_USE_BOOLEAN_BUILTIN
 
       # Internal false boolean value.  Note that this value is not writable
       # which prevents a Boolean instance's internal value also from being
@@ -1082,12 +1185,14 @@ objects:
           native: duk_bi_boolean_prototype_tostring_shared
           length: 0
           magic: 1  # magic = coerce_tostring
+        present_if: DUK_USE_BOOLEAN_BUILTIN
       - key: "valueOf"
         value:
           type: function
           native: duk_bi_boolean_prototype_tostring_shared
           length: 0
           magic: 0  # magic = coerce_tostring
+        present_if: DUK_USE_BOOLEAN_BUILTIN
 
   - id: bi_number_constructor
     class: Function
@@ -1097,6 +1202,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_NUMBER_BUILTIN
 
     properties:
       - key: "length"
@@ -1140,6 +1246,7 @@ objects:
     class: Number
     internal_prototype: bi_object_prototype
     bidx: true
+    # Present even when DUK_USE_NUMBER_BUILTIN disabled.
 
     properties:
       - key: "constructor"
@@ -1147,6 +1254,7 @@ objects:
           type: object
           id: bi_number_constructor
         attributes: "wc"
+        present_if: DUK_USE_NUMBER_BUILTIN
 
     # Internal 0.0 number value.  Note that this value is not writable
     # which prevents a Number instance's internal value also from being
@@ -1162,31 +1270,37 @@ objects:
           type: function
           native: duk_bi_number_prototype_to_string
           length: 1
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "toLocaleString"
         value:
           type: function
           native: duk_bi_number_prototype_to_locale_string
           length: 1
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "valueOf"
         value:
           type: function
           native: duk_bi_number_prototype_value_of
           length: 0
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "toFixed"
         value:
           type: function
           native: duk_bi_number_prototype_to_fixed
           length: 1
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "toExponential"
         value:
           type: function
           native: duk_bi_number_prototype_to_exponential
           length: 1
+        present_if: DUK_USE_NUMBER_BUILTIN
       - key: "toPrecision"
         value:
           type: function
           native: duk_bi_number_prototype_to_precision
           length: 1
+        present_if: DUK_USE_NUMBER_BUILTIN
 
   - id: bi_date_constructor
     class: Function
@@ -1196,6 +1310,7 @@ objects:
     callable: true
     constructable: true
     bidx: true
+    present_if: DUK_USE_DATE_BUILTIN
 
     properties:
       - key: "length"
@@ -1231,6 +1346,7 @@ objects:
     class: Date
     internal_prototype: bi_object_prototype
     bidx: true
+    present_if: DUK_USE_DATE_BUILTIN
 
     # The Date prototype is an instance of Date with [[PrimitiveValue]] NaN.
     #
@@ -2206,6 +2322,9 @@ objects:
     class: JSON
     internal_prototype: bi_object_prototype
     bidx: true
+    present_if:
+      - DUK_USE_JSON_BUILTIN
+      - DUK_USE_JSON_SUPPORT
 
     # apparently no external "prototype" property
     # apparently no external "constructor" property
@@ -2250,6 +2369,7 @@ objects:
     internal_prototype: bi_object_prototype
     duktape: true
     bidx: true
+    #present_if: DUK_USE_DUKTAPE_BUILTIN  # Present even when properties disabled, error augmentation relies on it
 
     # There are a few properties not listed here:
     #   - "version" is added from parameter file automatically.
@@ -2261,31 +2381,36 @@ objects:
           type: object
           id: bi_pointer_constructor
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "Thread"
         value:
           type: object
           id: bi_thread_constructor
         duktape: true
-        present_if: DUK_USE_COROUTINE_SUPPORT
-
+        present_if:
+          - DUK_USE_COROUTINE_SUPPORT
+          - DUK_USE_DUKTAPE_BUILTIN
       - key: "info"
         value:
           type: function
           native: duk_bi_duktape_object_info
           length: 1
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "act"
         value:
           type: function
           native: duk_bi_duktape_object_act
           length: 1
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "gc"
         value:
           type: function
           native: duk_bi_duktape_object_gc
           length: 1
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "fin"
         value:
           type: function
@@ -2293,7 +2418,9 @@ objects:
           length: 0
           varargs: true
         duktape: true
-        present_if: DUK_USE_FINALIZER_SUPPORT
+        present_if:
+          - DUK_USE_FINALIZER_SUPPORT
+          - DUK_USE_DUKTAPE_BUILTIN
       - key: "enc"
         value:
           type: function
@@ -2301,6 +2428,7 @@ objects:
           length: 0
           varargs: true
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "dec"
         value:
           type: function
@@ -2308,12 +2436,14 @@ objects:
           length: 0
           varargs: true
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "compact"
         value:
           type: function
           native: duk_bi_duktape_object_compact
           length: 1
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
 
   - id: bi_thread_constructor
     class: Function
@@ -2372,6 +2502,7 @@ objects:
     internal_prototype: bi_object_prototype
     duktape: true
     bidx: true
+    # Present even when DUK_USE_DUKTAPE_BUILTIN disabled.
 
     # Must be present even if coroutines are disabled for inheritance.
     # Because Duktape.Thread.prototype is missing, the only way to access
@@ -2392,7 +2523,9 @@ objects:
           id: bi_thread_constructor
         attributes: "wc"
         duktape: true
-        present_if: DUK_USE_COROUTINE_SUPPORT
+        present_if:
+          - DUK_USE_COROUTINE_SUPPORT
+          - DUK_USE_DUKTAPE_BUILTIN
 
       # toString() and valueOf() are inherited from Object.prototype
 
@@ -2427,6 +2560,7 @@ objects:
     internal_prototype: bi_object_prototype
     duktape: true
     bidx: true
+    # Present even when DUK_USE_DUKTAPE_BUILTIN disabled.
 
     properties:
       - key: "constructor"
@@ -2435,6 +2569,7 @@ objects:
           id: bi_pointer_constructor
         attributes: "wc"
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
 
       - key: "toString"
         value:
@@ -2443,6 +2578,7 @@ objects:
           length: 0
           magic: 1  # magic = to_string
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
       - key: "valueOf"
         value:
           type: function
@@ -2450,6 +2586,7 @@ objects:
           length: 0
           magic: 0  # magic = to_string
         duktape: true
+        present_if: DUK_USE_DUKTAPE_BUILTIN
 
   # This is an Error *instance* used to avoid allocation when a "double error" occurs.
   # The object is "frozen and sealed" to avoid code accidentally modifying the instance.
@@ -2576,7 +2713,7 @@ objects:
     typedarray: true
     es6: true
     bidx: true
-    present_if: DUK_USE_BUFFEROBJECT_SUPPORT
+    # Present even when DUK_USE_BUFFEROBJECT_SUPPORT is disabled.
 
     properties:
       - key: "constructor"
@@ -2586,6 +2723,7 @@ objects:
         attributes: "wc"
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
       - key: "slice"
         value:
@@ -2596,6 +2734,7 @@ objects:
           magic: 2  # magic: 0x01=isView, 0x02=create copy
         typedarray: true
         es6: true
+        present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
   - id: bi_dataview_constructor
     class: Function

--- a/src-input/duk_api_codec.c
+++ b/src-input/duk_api_codec.c
@@ -596,6 +596,7 @@ DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t idx) {
 	DUK_ERROR_TYPE(thr, DUK_STR_DECODE_FAILED);
 }
 
+#if defined(DUK_USE_JSON_SUPPORT)
 DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t idx) {
 #ifdef DUK_USE_ASSERTIONS
 	duk_idx_t top_at_entry;
@@ -641,3 +642,14 @@ DUK_EXTERNAL void duk_json_decode(duk_context *ctx, duk_idx_t idx) {
 
 	DUK_ASSERT(duk_get_top(ctx) == top_at_entry);
 }
+#else  /* DUK_USE_JSON_SUPPORT */
+DUK_EXTERNAL const char *duk_json_encode(duk_context *ctx, duk_idx_t idx) {
+	DUK_UNREF(idx);
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+
+DUK_EXTERNAL void duk_json_decode(duk_context *ctx, duk_idx_t idx) {
+	DUK_UNREF(idx);
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+#endif  /* DUK_USE_JSON_SUPPORT */

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -45,6 +45,8 @@
  */
 #define  DUK__ARRAY_MID_JOIN_LIMIT  4096
 
+#if defined(DUK_USE_ARRAY_BUILTIN)
+
 /*
  *  Shared helpers.
  */
@@ -1607,3 +1609,5 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_reduce_shared(duk_context *ctx) {
  type_error:
 	return DUK_RET_TYPE_ERROR;
 }
+
+#endif  /* DUK_USE_ARRAY_BUILTIN */

--- a/src-input/duk_bi_boolean.c
+++ b/src-input/duk_bi_boolean.c
@@ -4,6 +4,8 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_BOOLEAN_BUILTIN)
+
 /* Shared helper to provide toString() and valueOf().  Checks 'this', gets
  * the primitive value to stack top, and optionally coerces with ToString().
  */
@@ -66,3 +68,5 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_constructor(duk_context *ctx) {
 
 	return 1;
 }
+
+#endif  /* DUK_USE_BOOLEAN_BUILTIN */

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -13,6 +13,8 @@
 
 #include "duk_internal.h"
 
+/* XXX: currently defines unnecessary symbols when DUK_USE_DATE_BUILTIN is disabled. */
+
 /*
  *  Forward declarations
  */
@@ -224,7 +226,7 @@ DUK_LOCAL duk_bool_t duk__parse_string_iso8601_subset(duk_context *ctx, const ch
 				DUK_DDD(DUK_DDDPRINT("too many digits -> reject"));
 				goto reject;
 			}
-			if (part_idx == DUK__PI_MILLISECOND /*msec*/ && ndigits >= 3) {
+			if (part_idx == DUK__PI_MILLISECOND && ndigits >= 3) {
 				/* ignore millisecond fractions after 3 */
 			} else {
 				accum = accum * 10 + ((duk_int_t) ch) - ((duk_int_t) DUK_ASC_0) + 0x00;
@@ -1404,6 +1406,7 @@ DUK_LOCAL duk_small_uint_t duk__date_get_indirect_magic(duk_context *ctx) {
 	return (duk_small_uint_t) duk__date_magics[magicidx];
 }
 
+#if defined(DUK_USE_DATE_BUILTIN)
 /*
  *  Constructor calls
  */
@@ -1704,3 +1707,5 @@ DUK_INTERNAL duk_ret_t duk_bi_date_prototype_set_time(duk_context *ctx) {
 
 	return 1;
 }
+
+#endif  /* DUK_USE_DATE_BUILTIN */

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -11,6 +11,8 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_DUKTAPE_BUILTIN)
+
 /* Raw helper to extract internal information / statistics about a value.
  * The return values are version specific and must not expose anything
  * that would lead to security issues (e.g. exposing compiled function
@@ -323,3 +325,5 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_compact(duk_context *ctx) {
 	duk_compact(ctx, 0);
 	return 1;  /* return the argument object */
 }
+
+#endif  /* DUK_USE_DUKTAPE_BUILTIN */

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -4,6 +4,15 @@
 
 #include "duk_internal.h"
 
+/* Needed even when Function built-in is disabled. */
+DUK_INTERNAL duk_ret_t duk_bi_function_prototype(duk_context *ctx) {
+	/* ignore arguments, return undefined (E5 Section 15.3.4) */
+	DUK_UNREF(ctx);
+	return 0;
+}
+
+#if defined(DUK_USE_FUNCTION_BUILTIN)
+
 DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h_sourcecode;
@@ -79,12 +88,6 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	/* [ body formals source template closure ] */
 
 	return 1;
-}
-
-DUK_INTERNAL duk_ret_t duk_bi_function_prototype(duk_context *ctx) {
-	/* ignore arguments, return undefined (E5 Section 15.3.4) */
-	DUK_UNREF(ctx);
-	return 0;
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_function_prototype_to_string(duk_context *ctx) {
@@ -344,3 +347,5 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
  type_error:
 	return DUK_RET_TYPE_ERROR;
 }
+
+#endif  /* DUK_USE_FUNCTION_BUILTIN */

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -16,6 +16,8 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_JSON_SUPPORT)
+
 /*
  *  Local defines and forward declarations.
  */
@@ -3140,6 +3142,8 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 	DUK_ASSERT(duk_get_top(ctx) == entry_top + 1);
 }
 
+#if defined(DUK_USE_JSON_BUILTIN)
+
 /*
  *  Entry points
  */
@@ -3160,3 +3164,7 @@ DUK_INTERNAL duk_ret_t duk_bi_json_object_stringify(duk_context *ctx) {
 	                             0 /*flags*/);
 	return 1;
 }
+
+#endif  /* DUK_USE_JSON_BUILTIN */
+
+#endif  /* DUK_USE_JSON_SUPPORT */

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -4,6 +4,8 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_NUMBER_BUILTIN)
+
 DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_context *ctx) {
 	duk_hobject *h;
 
@@ -238,3 +240,5 @@ DUK_INTERNAL duk_ret_t duk_bi_number_prototype_to_precision(duk_context *ctx) {
 	duk_to_string(ctx, -1);
 	return 1;
 }
+
+#endif  /* DUK_USE_NUMBER_BUILTIN */

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -4,6 +4,16 @@
 
 #include "duk_internal.h"
 
+/* Needed even when Object built-in disabled. */
+DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_string(duk_context *ctx) {
+	duk_tval *tv;
+	tv = DUK_HTHREAD_THIS_PTR((duk_hthread *) ctx);
+	duk_push_class_string_tval(ctx, tv);
+	return 1;
+}
+
+#if defined(DUK_USE_OBJECT_BUILTIN)
+
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor(duk_context *ctx) {
 	duk_uint_t arg_mask;
 
@@ -65,11 +75,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_getprototype_shared(duk_context *ctx) {
 
 	switch (DUK_TVAL_GET_TAG(tv)) {
 	case DUK_TAG_BUFFER:
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		proto = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
-#else
-		proto = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
-#endif
 		break;
 	case DUK_TAG_LIGHTFUNC:
 		proto = thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE];
@@ -133,12 +139,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 		duk_hobject *curr_proto;
 		curr_proto = thr->builtins[(mask & DUK_TYPE_MASK_LIGHTFUNC) ?
 		                               DUK_BIDX_FUNCTION_PROTOTYPE :
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
-		                               DUK_BIDX_ARRAYBUFFER_PROTOTYPE
-#else
-		                               DUK_BIDX_OBJECT_PROTOTYPE
-#endif
-		                          ];
+		                               DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
 		if (h_new_proto == curr_proto) {
 			goto skip;
 		}
@@ -585,13 +586,6 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 	return duk_hobject_get_enumerated_keys(ctx, enum_flags);
 }
 
-DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_string(duk_context *ctx) {
-	duk_tval *tv;
-	tv = DUK_HTHREAD_THIS_PTR((duk_hthread *) ctx);
-	duk_push_class_string_tval(ctx, tv);
-	return 1;
-}
-
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 0);
 	(void) duk_push_this_coercible_to_object(ctx);
@@ -640,3 +634,5 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_has_own_property(duk_context *ctx
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_property_is_enumerable(duk_context *ctx) {
 	return duk_hobject_object_ownprop_helper(ctx, DUK_PROPDESC_FLAG_ENUMERABLE /*required_desc_flags*/);
 }
+
+#endif  /* DUK_USE_OBJECT_BUILTIN */

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -13,6 +13,8 @@
 
 #include "duk_internal.h"
 
+#if defined(DUK_USE_STRING_BUILTIN)
+
 /*
  *  Constructor
  */
@@ -1308,3 +1310,5 @@ DUK_INTERNAL duk_ret_t duk_bi_string_frombuffer(duk_context *ctx) {
 	return 1;
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
+
+#endif  /* DUK_USE_STRING_BUILTIN */

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -952,4 +952,12 @@ DUK_INTERNAL_DECL duk_uint_fast32_t duk_hobject_pc2line_query(duk_context *ctx, 
 /* misc */
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_prototype_chain_contains(duk_hthread *thr, duk_hobject *h, duk_hobject *p, duk_bool_t ignore_loop);
 
+#if !defined(DUK_USE_OBJECT_BUILTIN)
+/* These declarations are needed when related built-in is disabled and
+ * genbuiltins.py won't automatically emit the declerations.
+ */
+DUK_INTERNAL_DECL duk_ret_t duk_bi_object_prototype_to_string(duk_context *ctx);
+DUK_INTERNAL_DECL duk_ret_t duk_bi_function_prototype(duk_context *ctx);
+#endif
+
 #endif  /* DUK_HOBJECT_H_INCLUDED */

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2589,11 +2589,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 
 		DUK_DDD(DUK_DDDPRINT("base object is a buffer, start lookup from ArrayBuffer prototype"));
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		curr = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
-#else
-		curr = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
-#endif
 		goto lookup;  /* avoid double coercion */
 	}
 
@@ -2832,11 +2828,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 			rc = 1;
 			goto pop_and_return;
 		}
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		obj = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
-#else
-		obj = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
-#endif
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv_obj)) {
 		arr_idx = duk__push_tval_to_hstring_arr_idx(ctx, tv_key, &key);
 		if (duk__key_is_lightfunc_ownprop(thr, key)) {
@@ -3583,11 +3575,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 
 		DUK_DDD(DUK_DDDPRINT("base object is a buffer, start lookup from buffer prototype"));
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		curr = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
-#else
-		curr = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
-#endif
 		goto lookup;  /* avoid double coercion */
 	}
 

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -652,8 +652,10 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 	 *    conditional in init data.
 	 */
 
+#if defined(DUK_USE_DATE_BUILTIN)
 	duk_get_prop_stridx(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_UTC_STRING);
 	duk_xdef_prop_stridx(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_GMT_STRING, DUK_PROPDESC_FLAGS_WC);
+#endif
 
 	h = duk_require_hobject(ctx, DUK_BIDX_DOUBLE_ERROR);
 	DUK_ASSERT(h != NULL);

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1061,11 +1061,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 		DUK_ASSERT(val != NULL);
 		break;
 	case DUK_TAG_BUFFER:
-#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 		val = thr->builtins[DUK_BIDX_ARRAYBUFFER_PROTOTYPE];
-#else
-		val = thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE];
-#endif
 		DUK_ASSERT(val != NULL);
 		break;
 	case DUK_TAG_POINTER:


### PR DESCRIPTION
Make almost all built-in objects optional and configurable via config options (e.g. `DUK_USE_ARRAY_BUILTIN`).

When a certain built-in is disabled, the global property (`Array` for example) is removed.

Prototype objects are kept when a primitive type relates to it (e.g. Array prototype is kept, but `Array.prototype` doesn't exist). The prototype object is also scrubbed of any function properties so it's empty except for a few mandatory properties. This approach allows user code to attach custom properties to e.g. array prototype (it can be accessed as `Object.getPrototypeof([]).customMethod = ...` or via the C API) and they will work for array instances. An alternative approach would be to remove the prototypes too and make e.g. array instances inherit directly from Object.prototype (or if that's removed, from nothing). But the prototypes are pretty small and quite useful to leave behind so that approach is now used.

- [x] Global; catch-all for stuff like encodeURIComponent(), escape() etc, global object itself remains and e.g. `globalObject.undefined` remains because it's so commonly assumed
- [x] Object
- [x] Array
- [x] Function
- [x] Math
- [x] Date
- [x] JSON
- [x] Boolean
- [x] Number
- [x] String
- [x] Duktape
- [x] Make JSON actually optional, so that C API will throw "unsupported" when JSON support is disabled (this should be separate from the JSON built-in object)
- [x] Leave Error constructors and prototypes alone for now; there'd be various good alternatives to them (e.g. all constructors pointing to a shared `Error` constructor) but better done separately.
- [x] Resolve FIXMEs
- [x] Need support for compound "present if" expressions, maybe just add some generic evaluable syntax
- [x] Low memory documentation update, 128kB system flash and 32kB system RAM should now be possible (barely, of course)
- [x] Releases entry