### PR TITLE
Use some internal duk_dup() helper variants for smaller footprint

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1980,7 +1980,8 @@ Planned
   opcode handler optimizations (GH-903); refcount optimizations (GH-443,
   GH-973); minor RegExp compile/execute optimizations (GH-974)
 
-* Miscellaneous footprint improvements: RegExp compiler/executor (GH-977)
+* Miscellaneous footprint improvements: RegExp compiler/executor (GH-977),
+  internal duk_dup() variants (GH-990)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -575,7 +575,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 		                                    DUK_HOBJECT_FLAG_EXTENSIBLE |
 		                                    DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
 		                                    proto);
-		duk_dup(ctx, -2);                                 /* -> [ func funcname env funcname ] */
+		duk_dup_m2(ctx);                                  /* -> [ func funcname env funcname ] */
 		duk_dup(ctx, idx_base);                           /* -> [ func funcname env funcname func ] */
 		duk_xdef_prop(ctx, -3, DUK_PROPDESC_FLAGS_NONE);  /* -> [ func funcname env ] */
 		duk_xdef_prop_stridx(ctx, idx_base, DUK_STRIDX_INT_LEXENV, DUK_PROPDESC_FLAGS_WC);
@@ -589,7 +589,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);
 
 	duk_push_object(ctx);
-	duk_dup(ctx, -2);
+	duk_dup_m2(ctx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* func.prototype.constructor = func */
 	duk_compact(ctx, -1);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -166,8 +166,8 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
 	                              -1);  /* no prototype, updated below */
 
-	duk_dup(ctx, -2);
-	duk_dup(ctx, -3);
+	duk_dup_m2(ctx);
+	duk_dup_m3(ctx);
 
 	/* [ ... new_glob new_env new_glob new_glob ] */
 

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -28,6 +28,14 @@ duk_bool_t duk_valstack_resize_raw(duk_context *ctx,
                                    duk_size_t min_new_size,
                                    duk_small_uint_t flags);
 
+DUK_INTERNAL_DECL void duk_dup_0(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_dup_1(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_dup_2(duk_context *ctx);
+/* duk_dup_m1() would be same as duk_dup_top() */
+DUK_INTERNAL_DECL void duk_dup_m2(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_dup_m3(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_dup_m4(duk_context *ctx);
+
 #if defined(DUK_USE_VERBOSE_ERRORS) && defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL const char *duk_get_type_name(duk_context *ctx, duk_idx_t idx);
 #endif

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -858,6 +858,9 @@ DUK_EXTERNAL void duk_dup(duk_context *ctx, duk_idx_t from_idx) {
 }
 
 DUK_EXTERNAL void duk_dup_top(duk_context *ctx) {
+#if defined(DUK_USE_PREFER_SIZE)
+	duk_dup(ctx, -1);
+#else
 	duk_hthread *thr;
 	duk_tval *tv_from;
 	duk_tval *tv_to;
@@ -876,6 +879,26 @@ DUK_EXTERNAL void duk_dup_top(duk_context *ctx) {
 	DUK_ASSERT(tv_to != NULL);
 	DUK_TVAL_SET_TVAL(tv_to, tv_from);
 	DUK_TVAL_INCREF(thr, tv_to);  /* no side effects */
+#endif
+}
+
+DUK_INTERNAL void duk_dup_0(duk_context *ctx) {
+	duk_dup(ctx, 0);
+}
+DUK_INTERNAL void duk_dup_1(duk_context *ctx) {
+	duk_dup(ctx, 1);
+}
+DUK_INTERNAL void duk_dup_2(duk_context *ctx) {
+	duk_dup(ctx, 2);
+}
+DUK_INTERNAL void duk_dup_m2(duk_context *ctx) {
+	duk_dup(ctx, -2);
+}
+DUK_INTERNAL void duk_dup_m3(duk_context *ctx) {
+	duk_dup(ctx, -3);
+}
+DUK_INTERNAL void duk_dup_m4(duk_context *ctx) {
+	duk_dup(ctx, -4);
 }
 
 DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_idx) {

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -351,7 +351,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_join_shared(duk_context *ctx) {
 	                     DUK__ARRAY_MID_JOIN_LIMIT : len) + 4;
 	duk_require_stack(ctx, valstack_required);
 
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 
 	/* [ sep ToObject(this) len sep ] */
 
@@ -365,7 +365,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_join_shared(duk_context *ctx) {
 			DUK_DDD(DUK_DDDPRINT("mid/final join, count=%ld, idx=%ld, len=%ld",
 			                     (long) count, (long) idx, (long) len));
 			duk_join(ctx, (duk_idx_t) count);  /* -> [ sep ToObject(this) len str ] */
-			duk_dup(ctx, 0);                   /* -> [ sep ToObject(this) len str sep ] */
+			duk_dup_0(ctx);                    /* -> [ sep ToObject(this) len str sep ] */
 			duk_insert(ctx, -2);               /* -> [ sep ToObject(this) len sep str ] */
 			count = 1;
 		}
@@ -1443,11 +1443,11 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_iter_shared(duk_context *ctx) {
 		 * effects.
 		 */
 
-		duk_dup(ctx, 0);
-		duk_dup(ctx, 1);
-		duk_dup(ctx, -3);
+		duk_dup_0(ctx);
+		duk_dup_1(ctx);
+		duk_dup_m3(ctx);
 		duk_push_u32(ctx, i);
-		duk_dup(ctx, 2);  /* [ ... val callback thisArg val i obj ] */
+		duk_dup_2(ctx);  /* [ ... val callback thisArg val i obj ] */
 		duk_call_method(ctx, 3); /* -> [ ... val retval ] */
 
 		switch (iter_type) {
@@ -1476,7 +1476,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_iter_shared(duk_context *ctx) {
 		case DUK__ITER_FILTER:
 			bval = duk_to_boolean(ctx, -1);
 			if (bval) {
-				duk_dup(ctx, -2);  /* orig value */
+				duk_dup_m2(ctx);  /* orig value */
 				duk_xdef_prop_index_wec(ctx, 4, (duk_uarridx_t) k);
 				k++;
 				res_length = k;
@@ -1547,7 +1547,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_reduce_shared(duk_context *ctx) {
 
 	have_acc = 0;
 	if (nargs >= 2) {
-		duk_dup(ctx, 1);
+		duk_dup_1(ctx);
 		have_acc = 1;
 	}
 	DUK_DDD(DUK_DDDPRINT("have_acc=%ld, acc=%!T",
@@ -1581,11 +1581,11 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_reduce_shared(duk_context *ctx) {
 			DUK_ASSERT_TOP(ctx, 5);
 		} else {
 			DUK_ASSERT_TOP(ctx, 5);
-			duk_dup(ctx, 0);
+			duk_dup_0(ctx);
 			duk_dup(ctx, 4);
 			duk_get_prop_index(ctx, 2, (duk_uarridx_t) i);
 			duk_push_u32(ctx, i);
-			duk_dup(ctx, 2);
+			duk_dup_2(ctx);
 			DUK_DDD(DUK_DDDPRINT("calling reduce function: func=%!T, prev=%!T, curr=%!T, idx=%!T, obj=%!T",
 			                     (duk_tval *) duk_get_tval(ctx, -5), (duk_tval *) duk_get_tval(ctx, -4),
 			                     (duk_tval *) duk_get_tval(ctx, -3), (duk_tval *) duk_get_tval(ctx, -2),

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -1469,7 +1469,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_iter_shared(duk_context *ctx) {
 			/* nop */
 			break;
 		case DUK__ITER_MAP:
-			duk_dup(ctx, -1);
+			duk_dup_top(ctx);
 			duk_xdef_prop_index_wec(ctx, 4, (duk_uarridx_t) i);  /* retval to result[i] */
 			res_length = i + 1;
 			break;

--- a/src-input/duk_bi_boolean.c
+++ b/src-input/duk_bi_boolean.c
@@ -60,7 +60,7 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_constructor(duk_context *ctx) {
 
 		DUK_HOBJECT_SET_CLASS_NUMBER(h_this, DUK_HOBJECT_CLASS_BOOLEAN);
 
-		duk_dup(ctx, 0);  /* -> [ val obj val ] */
+		duk_dup_0(ctx);  /* -> [ val obj val ] */
 		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);  /* XXX: proper flags? */
 	}  /* unbalanced stack */
 

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -561,7 +561,7 @@ DUK_LOCAL duk_hbuffer *duk__hbufobj_fixed_from_argvalue(duk_context *ctx) {
 	}
 	case DUK_TYPE_STRING: {
 		/* ignore encoding for now */
-		duk_dup(ctx, 0);
+		duk_dup_0(ctx);
 		(void) duk_to_buffer(ctx, -1, &buf_size);
 		break;
 	}
@@ -811,7 +811,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 			DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
 
 			/* Set .buffer to the argument ArrayBuffer. */
-			duk_dup(ctx, 0);
+			duk_dup_0(ctx);
 			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 			duk_compact(ctx, -1);
 			return 1;
@@ -912,7 +912,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 	DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
 
 	/* Set .buffer */
-	duk_dup(ctx, -2);
+	duk_dup_m2(ctx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 	duk_compact(ctx, -1);
 
@@ -1083,7 +1083,7 @@ DUK_INTERNAL duk_ret_t duk_bi_dataview_constructor(duk_context *ctx) {
 	 * See: test-bug-dataview-buffer-prop.js.
 	 */
 
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 	duk_compact(ctx, -1);
 

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -1557,7 +1557,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_prototype_to_json(duk_context *ctx) {
 	duk_pop(ctx);
 
 	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_TO_ISO_STRING);
-	duk_dup(ctx, -2);  /* -> [ O toIsoString O ] */
+	duk_dup_m2(ctx);  /* -> [ O toIsoString O ] */
 	duk_call_method(ctx, 0);
 	return 1;
 }

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -129,7 +129,7 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_info(duk_context *ctx) {
 		duk_dup(ctx, i);
 		duk_put_prop_index(ctx, 1, i - 2);
 	}
-	duk_dup(ctx, 1);
+	duk_dup_1(ctx);
 	return 1;
 }
 

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -28,7 +28,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_constructor_shared(duk_context *ctx) {
 	 */
 	if (!duk_is_undefined(ctx, 0)) {
 		duk_to_string(ctx, 0);
-		duk_dup(ctx, 0);  /* [ message error message ] */
+		duk_dup_0(ctx);  /* [ message error message ] */
 		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	}
 
@@ -352,7 +352,7 @@ DUK_LOCAL duk_ret_t duk__error_setter_helper(duk_context *ctx, duk_small_uint_t 
 
 	duk_push_this(ctx);
 	duk_push_hstring_stridx(ctx, (duk_small_int_t) stridx_key);
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 
 	/* [ ... obj key value ] */
 

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -42,9 +42,9 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	 * It will fail in corner cases; see test-dev-func-cons-args.js.
 	 */
 	duk_push_string(ctx, "function(");
-	duk_dup(ctx, 1);
+	duk_dup_1(ctx);
 	duk_push_string(ctx, "){");
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 	duk_push_string(ctx, "}");
 	duk_concat(ctx, 5);
 
@@ -282,10 +282,10 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 	DUK_ASSERT(h_bound != NULL);
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
-	duk_dup(ctx, -2);  /* func */
+	duk_dup_m2(ctx);  /* func */
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 
-	duk_dup(ctx, 0);   /* thisArg */
+	duk_dup_0(ctx);   /* thisArg */
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_push_array(ctx);

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -628,7 +628,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_int(duk_context *ctx) {
 		radix = 10;
 	}
 
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 	duk_numconv_parse(ctx, radix, s2n_flags);
 	return 1;
 

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1004,8 +1004,8 @@ DUK_LOCAL void duk__dec_reviver_walk(duk_json_dec_ctx *js_ctx) {
 				                     (duk_tval *) duk_get_tval(ctx, -2), (duk_tval *) duk_get_tval(ctx, -1)));
 
 				/* [ ... holder name val enum obj_key ] */
-				duk_dup(ctx, -3);
-				duk_dup(ctx, -2);
+				duk_dup_m3(ctx);
+				duk_dup_m2(ctx);
 
 				/* [ ... holder name val enum obj_key val obj_key ] */
 				duk__dec_reviver_walk(js_ctx);
@@ -1968,8 +1968,8 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 		if (duk_is_callable(ctx, -1)) {  /* toJSON() can also be a lightfunc */
 			DUK_DDD(DUK_DDDPRINT("value is object, has callable toJSON() -> call it"));
 			/* XXX: duk_dup_unvalidated(ctx, -2) etc. */
-			duk_dup(ctx, -2);         /* -> [ ... key val toJSON val ] */
-			duk_dup(ctx, -4);         /* -> [ ... key val toJSON val key ] */
+			duk_dup_m2(ctx);          /* -> [ ... key val toJSON val ] */
+			duk_dup_m4(ctx);          /* -> [ ... key val toJSON val key ] */
 			duk_call_method(ctx, 1);  /* -> [ ... key val val' ] */
 			duk_remove(ctx, -2);      /* -> [ ... key val' ] */
 		} else {
@@ -1986,8 +1986,8 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 		DUK_DDD(DUK_DDDPRINT("replacer is set, call replacer"));
 		duk_push_hobject(ctx, js_ctx->h_replacer);  /* -> [ ... key val replacer ] */
 		duk_dup(ctx, idx_holder);                   /* -> [ ... key val replacer holder ] */
-		duk_dup(ctx, -4);                           /* -> [ ... key val replacer holder key ] */
-		duk_dup(ctx, -4);                           /* -> [ ... key val replacer holder key val ] */
+		duk_dup_m4(ctx);                            /* -> [ ... key val replacer holder key ] */
+		duk_dup_m4(ctx);                            /* -> [ ... key val replacer holder key val ] */
 		duk_call_method(ctx, 2);                    /* -> [ ... key val val' ] */
 		duk_remove(ctx, -2);                        /* -> [ ... key val' ] */
 	}
@@ -2777,7 +2777,7 @@ void duk_bi_json_parse_helper(duk_context *ctx,
 		js_ctx->idx_reviver = idx_reviver;
 
 		duk_push_object(ctx);
-		duk_dup(ctx, -2);  /* -> [ ... val root val ] */
+		duk_dup_m2(ctx);  /* -> [ ... val root val ] */
 		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_EMPTY_STRING);  /* default attrs ok */
 		duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);  /* -> [ ... val root "" ] */
 

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -81,7 +81,7 @@ DUK_INTERNAL duk_ret_t duk_bi_number_constructor(duk_context *ctx) {
 	DUK_ASSERT(DUK_HOBJECT_GET_CLASS_NUMBER(h_this) == DUK_HOBJECT_CLASS_NUMBER);
 	DUK_ASSERT(DUK_HOBJECT_HAS_EXTENSIBLE(h_this));
 
-	duk_dup(ctx, 0);  /* -> [ val obj val ] */
+	duk_dup_0(ctx);  /* -> [ val obj val ] */
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	return 0;  /* no return value -> don't replace created value */
 }

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -376,7 +376,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_context *
 	 *  Return target object
 	 */
 
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 	return 1;
 }
 
@@ -599,7 +599,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx
 	if (!duk_is_callable(ctx, 1)) {
 		return DUK_RET_TYPE_ERROR;
 	}
-	duk_dup(ctx, 0);  /* -> [ O toString O ] */
+	duk_dup_0(ctx);  /* -> [ O toString O ] */
 	duk_call_method(ctx, 0);  /* XXX: call method tail call? */
 	return 1;
 }

--- a/src-input/duk_bi_pointer.c
+++ b/src-input/duk_bi_pointer.c
@@ -28,7 +28,7 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_constructor(duk_context *ctx) {
 		                       DUK_BIDX_POINTER_PROTOTYPE);
 
 		/* Pointer object internal value is immutable */
-		duk_dup(ctx, 0);
+		duk_dup_0(ctx);
 		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	}
 	/* Note: unbalanced stack on purpose */

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -55,11 +55,11 @@ DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
 	 */
 
 	/* Proxy target */
-	duk_dup(ctx, 0);
+	duk_dup_0(ctx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 
 	/* Proxy handler */
-	duk_dup(ctx, 1);
+	duk_dup_1(ctx);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_HANDLER, DUK_PROPDESC_FLAGS_NONE);
 
 	return 1;  /* replacement handler */

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -31,7 +31,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 		/* Called as a function, pattern has [[Class]] "RegExp" and
 		 * flags is undefined -> return object as is.
 		 */
-		duk_dup(ctx, 0);
+		duk_dup_0(ctx);
 		return 1;
 	}
 
@@ -61,7 +61,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 		if (duk_is_undefined(ctx, 0)) {
 			duk_push_string(ctx, "");
 		} else {
-			duk_dup(ctx, 0);
+			duk_dup_0(ctx);
 			duk_to_string(ctx, -1);
 		}
 		if (duk_is_undefined(ctx, 1)) {

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -38,7 +38,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_constructor(duk_context *ctx) {
 		                       DUK_BIDX_STRING_PROTOTYPE);
 
 		/* String object internal value is immutable */
-		duk_dup(ctx, 0);
+		duk_dup_0(ctx);
 		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	}
 	/* Note: unbalanced stack on purpose */
@@ -521,8 +521,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 
 #ifdef DUK_USE_REGEXP_SUPPORT
 		if (is_regexp) {
-			duk_dup(ctx, 0);
-			duk_dup(ctx, 2);
+			duk_dup_0(ctx);
+			duk_dup_2(ctx);
 			duk_regexp_match(thr);  /* [ ... regexp input ] -> [ res_obj ] */
 			if (!duk_is_object(ctx, -1)) {
 				duk_pop(ctx);
@@ -585,7 +585,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 			while (p <= p_end) {
 				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
 				if (DUK_MEMCMP((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
-					duk_dup(ctx, 0);
+					duk_dup_0(ctx);
 					h_match = duk_get_hstring(ctx, -1);
 					DUK_ASSERT(h_match != NULL);
 #ifdef DUK_USE_REGEXP_SUPPORT
@@ -626,7 +626,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 
 			/* regexp res_obj is at index 4 */
 
-			duk_dup(ctx, 1);
+			duk_dup_1(ctx);
 			idx_args = duk_get_top(ctx);
 
 #ifdef DUK_USE_REGEXP_SUPPORT
@@ -642,10 +642,10 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 			{  /* unconditionally */
 #endif  /* DUK_USE_REGEXP_SUPPORT */
 				/* match == search string, by definition */
-				duk_dup(ctx, 0);
+				duk_dup_0(ctx);
 			}
 			duk_push_int(ctx, match_start_coff);
-			duk_dup(ctx, 2);
+			duk_dup_2(ctx);
 
 			/* [ ... replacer match [captures] match_char_offset input ] */
 
@@ -843,13 +843,13 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 		 * whether separator is undefined.  Since this is side effect free, we can
 		 * skip the ToString() here.
 		 */
-		duk_dup(ctx, 2);
+		duk_dup_2(ctx);
 		duk_put_prop_index(ctx, 3, 0);
 		return 1;
 	} else if (duk_get_hobject_with_class(ctx, 0, DUK_HOBJECT_CLASS_REGEXP) != NULL) {
 #ifdef DUK_USE_REGEXP_SUPPORT
 		duk_push_hobject_bidx(ctx, DUK_BIDX_REGEXP_CONSTRUCTOR);
-		duk_dup(ctx, 0);
+		duk_dup_0(ctx);
 		duk_new(ctx, 1);  /* [ ... RegExp val ] -> [ ... res ] */
 		duk_replace(ctx, 0);
 		/* lastIndex is initialized to zero by new RegExp() */
@@ -887,8 +887,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 
 #ifdef DUK_USE_REGEXP_SUPPORT
 		if (is_regexp) {
-			duk_dup(ctx, 0);
-			duk_dup(ctx, 2);
+			duk_dup_0(ctx);
+			duk_dup_2(ctx);
 			duk_regexp_match_force_global(thr);  /* [ ... regexp input ] -> [ res_obj ] */
 			if (!duk_is_object(ctx, -1)) {
 				duk_pop(ctx);
@@ -1135,8 +1135,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_search(duk_context *ctx) {
 	 * configurable and may have been changed.
 	 */
 
-	duk_dup(ctx, 0);
-	duk_dup(ctx, 1);  /* [ ... re_obj input ] */
+	duk_dup_0(ctx);
+	duk_dup_1(ctx);  /* [ ... re_obj input ] */
 	duk_regexp_match(thr);  /* -> [ ... res_obj ] */
 
 	if (!duk_is_object(ctx, -1)) {
@@ -1189,8 +1189,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
 	for (;;) {
 		DUK_ASSERT_TOP(ctx, 3);
 
-		duk_dup(ctx, 0);
-		duk_dup(ctx, 1);
+		duk_dup_0(ctx);
+		duk_dup_1(ctx);
 		duk_regexp_match(thr);  /* -> [ ... regexp string ] -> [ ... res_obj ] */
 
 		if (!duk_is_object(ctx, -1)) {

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1041,7 +1041,7 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 	duk_debug_write_int(thr, fatal);
 
 	/* Report thrown value to client coerced to string */
-	duk_dup(ctx, -1);
+	duk_dup_top(ctx);
 	duk__debug_write_hstring_safe_top(thr);
 	duk_pop(ctx);
 

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -585,7 +585,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 		duk_push_hstring(ctx, res);
 		if (get_value) {
 			duk_push_hobject(ctx, enum_target);
-			duk_dup(ctx, -2);      /* -> [... enum key enum_target key] */
+			duk_dup_m2(ctx);       /* -> [... enum key enum_target key] */
 			duk_get_prop(ctx, -2); /* -> [... enum key enum_target val] */
 			duk_remove(ctx, -2);   /* -> [... enum key val] */
 			duk_remove(ctx, -3);   /* -> [... key val] */

--- a/src-input/duk_hobject_finalizer.c
+++ b/src-input/duk_hobject_finalizer.c
@@ -41,7 +41,7 @@ DUK_LOCAL duk_ret_t duk__finalize_helper(duk_context *ctx, void *udata) {
 		DUK_DDD(DUK_DDDPRINT("-> no finalizer or finalizer not callable"));
 		return 0;
 	}
-	duk_dup(ctx, -2);
+	duk_dup_m2(ctx);
 	duk_push_boolean(ctx, DUK_HEAP_HAS_FINALIZER_NORESCUE(thr->heap));
 	DUK_DDD(DUK_DDDPRINT("-> finalizer found, calling finalizer"));
 	duk_call(ctx, 2);  /* [ ... obj finalizer obj heapDestruct ]  -> [ ... obj retval ] */

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2666,7 +2666,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			duk_push_hobject(ctx, desc.get);
 			duk_push_tval(ctx, tv_obj);       /* note: original, uncoerced base */
 #ifdef DUK_USE_NONSTD_GETTER_KEY_ARGUMENT
-			duk_dup(ctx, -3);
+			duk_dup_m3(ctx);
 			duk_call_method(ctx, 1);          /* [key getter this key] -> [key retval] */
 #else
 			duk_call_method(ctx, 0);          /* [key getter this] -> [key retval] */
@@ -3669,7 +3669,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 			duk_push_tval(ctx, tv_obj);  /* note: original, uncoerced base */
 			duk_push_tval(ctx, tv_val);  /* [key setter this val] */
 #ifdef DUK_USE_NONSTD_SETTER_KEY_ARGUMENT
-			duk_dup(ctx, -4);
+			duk_dup_m4(ctx);
 			duk_call_method(ctx, 2);     /* [key setter this val key] -> [key retval] */
 #else
 			duk_call_method(ctx, 1);     /* [key setter this val] -> [key retval] */
@@ -4904,7 +4904,7 @@ DUK_INTERNAL duk_ret_t duk_hobject_object_get_own_property_descriptor(duk_contex
 		}
 		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_SET);
 	} else {
-		duk_dup(ctx, -2);  /* [obj key value desc value] */
+		duk_dup_m2(ctx);  /* [obj key value desc value] */
 		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_VALUE);
 		duk_push_boolean(ctx, DUK_PROPDESC_IS_WRITABLE(&pd));
 		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_WRITABLE);

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -127,7 +127,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	                       -1);  /* no prototype */
 	h1 = duk_get_hobject(ctx, -1);
 	DUK_ASSERT(h1 != NULL);
-	duk_dup(ctx, -2);
+	duk_dup_m2(ctx);
 	duk_dup_top(ctx);  /* -> [ ... new_global new_globalenv new_global new_global ] */
 	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 	duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
@@ -610,7 +610,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			duk_push_int(ctx, c_length);
 			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
 
-			duk_dup(ctx, -2);
+			duk_dup_m2(ctx);
 			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
 
 			/* XXX: other properties of function instances; 'arguments', 'caller'. */

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -128,7 +128,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	h1 = duk_get_hobject(ctx, -1);
 	DUK_ASSERT(h1 != NULL);
 	duk_dup(ctx, -2);
-	duk_dup(ctx, -1);  /* -> [ ... new_global new_globalenv new_global new_global ] */
+	duk_dup_top(ctx);  /* -> [ ... new_global new_globalenv new_global new_global ] */
 	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 	duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -232,7 +232,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 			duk_get_prop_index(ctx, i_formals, idx);
 			DUK_ASSERT(duk_is_string(ctx, -1));
 
-			duk_dup(ctx, -1);  /* [ ... name name ] */
+			duk_dup_top(ctx);  /* [ ... name name ] */
 
 			if (!duk_has_prop(ctx, i_mappednames)) {
 				/* steps 11.c.ii.1 - 11.c.ii.4, but our internal book-keeping
@@ -246,14 +246,14 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 				DUK_DDD(DUK_DDDPRINT("set mappednames[%s]=%ld",
 				                     (const char *) duk_get_string(ctx, -1),
 				                     (long) idx));
-				duk_dup(ctx, -1);                      /* name */
+				duk_dup_top(ctx);                      /* name */
 				(void) duk_push_uint_to_hstring(ctx, (duk_uint_t) idx);  /* index */
 				duk_xdef_prop_wec(ctx, i_mappednames);  /* out of spec, must be configurable */
 
 				DUK_DDD(DUK_DDDPRINT("set map[%ld]=%s",
 				                     (long) idx,
 				                     duk_get_string(ctx, -1)));
-				duk_dup(ctx, -1);         /* name */
+				duk_dup_top(ctx);         /* name */
 				duk_xdef_prop_index_wec(ctx, i_map, (duk_uarridx_t) idx);  /* out of spec, must be configurable */
 			} else {
 				/* duk_has_prop() popped the second 'name' */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -2860,7 +2860,7 @@ DUK_LOCAL duk_bool_t duk__nud_object_literal_key_check(duk_compiler_ctx *comp_ct
 	 *    PropertyNameAndValueList: PropertyNameAndValueList , PropertyAssignment
 	 */
 
-	duk_dup(ctx, -1);       /* [ ... key_obj key key ] */
+	duk_dup_top(ctx);       /* [ ... key_obj key key ] */
 	duk_get_prop(ctx, -3);  /* [ ... key_obj key val ] */
 	key_flags = duk_to_int(ctx, -1);
 	duk_pop(ctx);           /* [ ... key_obj key ] */
@@ -2894,7 +2894,7 @@ DUK_LOCAL duk_bool_t duk__nud_object_literal_key_check(duk_compiler_ctx *comp_ct
 	                     (duk_tval *) duk_get_tval(ctx, -1),
 	                     (unsigned long) key_flags,
 	                     (unsigned long) new_key_flags));
-	duk_dup(ctx, -1);
+	duk_dup_top(ctx);
 	duk_push_int(ctx, new_key_flags);   /* [ ... key_obj key key flags ] */
 	duk_put_prop(ctx, -4);              /* [ ... key_obj key ] */
 

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4018,7 +4018,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 				duk_push_tval(ctx, DUK__REGP(bc));
 				duk_to_object(ctx, -1);
-				duk_dup(ctx, -1);
+				duk_dup_top(ctx);
 
 				/* [ ... env target ] */
 				/* [ ... env target target ] */

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -252,7 +252,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			 * e.g. non-writable, but just in case).
 			 */
 			duk_get_prop_stridx(ctx, -2, DUK_STRIDX_NAME);       /* -> [ ... closure template env funcname ] */
-			duk_dup(ctx, -4);                                    /* -> [ ... closure template env funcname closure ] */
+			duk_dup_m4(ctx);                                     /* -> [ ... closure template env funcname closure ] */
 			duk_xdef_prop(ctx, -3, DUK_PROPDESC_FLAGS_NONE);     /* -> [ ... closure template env ] */
 			/* env[funcname] = closure */
 
@@ -376,7 +376,7 @@ void duk_js_push_closure(duk_hthread *thr,
 
 	if (add_auto_proto) {
 		duk_push_object(ctx);  /* -> [ ... closure template newobj ] */
-		duk_dup(ctx, -3);          /* -> [ ... closure template newobj closure ] */
+		duk_dup_m3(ctx);       /* -> [ ... closure template newobj closure ] */
 		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* -> [ ... closure template newobj ] */
 		duk_compact(ctx, -1);  /* compact the prototype */
 		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);     /* -> [ ... closure template ] */

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -936,7 +936,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		duk_push_u32(ctx, char_offset);
 		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INDEX);
 
-		duk_dup(ctx, -4);
+		duk_dup_m4(ctx);
 		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INPUT);
 
 		for (i = 0; i < re_ctx.nsaved; i += 2) {


### PR DESCRIPTION
A little footprint experimentation for using specialized dup helpers internally, e.g. `duk_dup_m2(ctx)` == `duk_dup(ctx, -2)`. Saves around 100-200 bytes depending on configuration.