### PR TITLE
Reconsider duk_push_string() and duk_push_lstring() NULL pointer handling

### DIFF
--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3239,6 +3239,7 @@ DUK_EXTERNAL const char *duk_push_lstring(duk_context *ctx, const char *str, duk
 	 * a bit dubious.  This is unlike duk_push_string() which pushes a
 	 * 'null' if the input string is a NULL.
 	 */
+	/* FIXME: NULL handling is different from duk_push_string() */
 	if (!str) {
 		len = 0;
 	}
@@ -3264,6 +3265,7 @@ DUK_EXTERNAL const char *duk_push_string(duk_context *ctx, const char *str) {
 	if (str) {
 		return duk_push_lstring(ctx, str, DUK_STRLEN(str));
 	} else {
+		/* FIXME: NULL handling is different from duk_push_string() */
 		duk_push_null(ctx);
 		return NULL;
 	}


### PR DESCRIPTION
Currently duk_push_string() with NULL pointer pushes a `null` while duk_push_lstring() pushes an empty string.

With duk_push_string() an empty string can be pushed as `duk_push_string(ctx, "")` while `null` is pushed with `duk_push_string(ctx, NULL)`.

The duk_push_lstring() behavior could be changed so that `duk_push_lstring(ctx, NULL, 0)` also pushes a `null` while `duk_push_lstring(ctx, <non-NULL>, 0)` pushes an empty string. But this is rather awkward because you need to use a dummy-non-NULL pointer whereas with duk_push_string() the empty string is naturally non-NULL and points to a NUL character.

The other more consistent alternative would be to remove the `null` special case from duk_push_string() so that `duk_push_string(ctx, NULL)` would also push an empty string. This seems like the easier choice. This case was originally added because it made some idioms more convenient for calling code. It also matches `lua_pushstring()` which pushes a `nil` for a C NULL pointer (though maybe `undefined` would be more appropriate than `null` with Duktape).
