### PR TITLE
Fix <op>= RHS/LHS eval order

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1903,6 +1903,9 @@ Planned
   seed mixing; previous algorithm (Shamir's three-op algorithm) is still
   used for low memory targets and targets without 64-bit types (GH-970)
 
+* Fix incorrect evaluation order of X <op>= Y expressions when the RHS
+  (Y) mutates the value of X (GH-992)
+
 * Fix incorrect buffer zeroing assumption in regexp executor, triggered
   when DUK_USE_ZERO_BUFFER_DATA is not set (default is set) (GH-978)
 

--- a/doc/test262-known-issues.yaml
+++ b/doc/test262-known-issues.yaml
@@ -42,10 +42,6 @@
   test: "ch15/15.4/15.4.4/15.4.4.7/S15.4.4.7_A4_T3"
   knownissue: "Duktape Array.prototype.push() doesn't allow Array length to grow beyond 2**32-1"
 -
-  test: "ch15/15.10/15.10.2/S15.10.2_A1_T1"
-  knownissue: "XML Shallow Parsing with Regular Expression: [^]]*]([^]]+])*]+.  The intent of [^]] is probably [^\\]].  An unescaped ']' is not allowed in a character class, so the expression is parsed as [^] (empty inverted class) followed by a literal ']', which is a SyntaxError.  There are two other literal ']' issues.  The RegExp can be fixed to: /[^\\]]*\\]([^\\]]+\\])*\\]+/."
-  regexp_leniency: true
--
   test: "ch15/15.10/15.10.2/15.10.2.5/S15.10.2.5_A1_T5"
   diagnosed: "Duktape bug, matching /(a*)b\\1+/ against 'baaaac' causes first capture to match the empty string; the '\\1+' part will then use the '+' quantifier over the empty string.  As there is no handling to empty quantified now, Duktape bails out with a RangeError."
   regexp_empty_quantified": true
@@ -64,9 +60,6 @@
 -
   test: "ch15/15.10/15.10.2/15.10.2.13/S15.10.2.13_A1_T16"
   knownissue: "uses invalid DecimalEscape inside a character class, '/[\\12-\\14]/'"
--
-  test: "ch15/15.10/15.10.2/15.10.2.6/S15.10.2.6_A4_T7"
-  knownissue: "the test case has unescaped invalid PatternCharacters (^, ] {, }) which follow the escaped '\\['"
 -
   test: "ch15/15.10/15.10.2/15.10.2.9/S15.10.2.9_A1_T4"
   knownissue: "invalid backreference '\\2', RegExp only has one capture; in E5.1 this is a SyntaxError"

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -4333,7 +4333,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 			h_varname = duk_get_hstring(ctx, left->x1.valstack_idx);
 			DUK_ASSERT(h_varname != NULL);
 			if (duk__hstring_is_eval_or_arguments_in_strict_mode(comp_ctx, h_varname)) {
-				/* E5 Section 11.13.1 (and others for other assignments), step 4 */
+				/* E5 Section 11.13.1 (and others for other assignments), step 4. */
 				goto syntax_error_lvalue;
 			}
 			duk_dup(ctx, left->x1.valstack_idx);
@@ -4361,47 +4361,78 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 				 */
 				duk_reg_t reg_temp;
 
-				/* FIXME: safe but inefficient */
 				reg_temp = DUK__ALLOCTEMP(comp_ctx);
 
 				if (reg_varbind >= 0) {
 					duk_reg_t reg_res;
+					duk_reg_t reg_src;
+					duk_int_t pc_temp_load;
+					duk_int_t pc_before_rhs;
+					duk_int_t pc_after_rhs;
 
 					if (toplevel_assign) {
 						/* 'reg_varbind' is the operation result and can also
 						 * become the expression value for top level assignments
 						 * such as: "var x; x += y;".
 						 */
+						DUK_DD(DUK_DDPRINT("<op>= expression is top level, write directly to reg_varbind"));
 						reg_res = reg_varbind;
 					} else {
 						/* Not safe to use 'reg_varbind' as assignment expression
 						 * value, so go through a temp.
 						 */
-						reg_res = DUK__ALLOCTEMP(comp_ctx);
-						/* FIXME: suboptimal, reg_res should be < reg_temp, and reg_temp reset */
+						DUK_DD(DUK_DDPRINT("<op>= expression is not top level, write to reg_temp"));
+						reg_res = reg_temp;  /* reg_res should be smallest possible */
+						reg_temp = DUK__ALLOCTEMP(comp_ctx);
 					}
 
+					/* Try to optimize X <op>= Y for reg-bound
+					 * variables.  Detect side-effect free RHS
+					 * narrowly by seeing whether it emits code.
+					 * If not, rewind the code emitter and overwrite
+					 * the unnecessary temp reg load.
+					 */
+
+					pc_temp_load = duk__get_current_pc(comp_ctx);
 					duk__emit_a_bc(comp_ctx,
 					               DUK_OP_LDREG,
 					               (duk_regconst_t) reg_temp,
 					               reg_varbind);
 
+					pc_before_rhs = duk__get_current_pc(comp_ctx);
 					duk__expr_toregconst(comp_ctx, res, args_rbp /*rbp_flags*/);
 					DUK_ASSERT(res->t == DUK_IVAL_PLAIN && res->x1.t == DUK_ISPEC_REGCONST);
+					pc_after_rhs = duk__get_current_pc(comp_ctx);
+
+					DUK_DD(DUK_DDPRINT("pc_temp_load=%ld, pc_before_rhs=%ld, pc_after_rhs=%ld",
+					                   (long) pc_temp_load, (long) pc_before_rhs,
+					                   (long) pc_after_rhs));
+
+					if (pc_after_rhs == pc_before_rhs) {
+						/* Note: if the reg_temp load generated shuffling
+						 * instructions, we may need to rewind more than
+						 * one instruction, so use explicit PC computation.
+						 */
+						DUK_DD(DUK_DDPRINT("rhs is side effect free, rewind and avoid unnecessary temp for reg-based <op>="));
+						DUK_BW_ADD_PTR(comp_ctx->thr, &comp_ctx->curr_func.bw_code, (pc_temp_load - pc_before_rhs) * sizeof(duk_compiler_instr));
+						reg_src = reg_varbind;
+					} else {
+						DUK_DD(DUK_DDPRINT("rhs evaluation emitted code, not sure if rhs is side effect free; use temp reg for LHS"));
+						reg_src = reg_temp;
+					}
 
 					duk__emit_a_b_c(comp_ctx,
 					                args_op | DUK__EMIT_FLAG_BC_REGCONST,
 					                (duk_regconst_t) reg_res,
-					                (duk_regconst_t) reg_temp,
+					                (duk_regconst_t) reg_src,
 					                res->x1.regconst);
-#if 0
-					duk__emit_a_b_c(comp_ctx,
-					                args_op | DUK__EMIT_FLAG_BC_REGCONST,
-					                (duk_regconst_t) reg_res,
-					                (duk_regconst_t) reg_varbind,
-					                res->x1.regconst);
-#endif
+
 					res->x1.regconst = (duk_regconst_t) reg_res;
+
+					/* Ensure compact use of temps. */
+					if (DUK__ISTEMP(comp_ctx, reg_res)) {
+						DUK__SETTEMP(comp_ctx, reg_res + 1);
+					}
 				} else {
 					/* When LHS is not register bound, always go through a
 					 * temporary.  No optimization for top level assignment.
@@ -4547,15 +4578,16 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 			duk_regconst_t rc_res;
 
-			/* first evaluate LHS fully to ensure all side effects are out */
+			/* First evaluate LHS fully to ensure all side effects are out. */
 			duk__ivalue_toplain_ignore(comp_ctx, left);
 
-			/* then evaluate RHS fully (its value becomes the expression value too) */
+			/* Then evaluate RHS fully (its value becomes the expression value too).
+			 * Technically we'd need the side effect safety check here too, but because
+			 * we always throw using INVLHS the result doesn't matter.
+			 */
 			rc_res = duk__expr_toregconst(comp_ctx, res, args_rbp /*rbp_flags*/);
 
 			duk__emit_op_only(comp_ctx, DUK_OP_INVLHS);
-
-			/* XXX: this value is irrelevant because of INVLHS? */
 
 			res->t = DUK_IVAL_PLAIN;
 			res->x1.t = DUK_ISPEC_REGCONST;

--- a/tests/ecmascript/test-bug-op-assign-eval-order.js
+++ b/tests/ecmascript/test-bug-op-assign-eval-order.js
@@ -1,0 +1,34 @@
+/*
+ *  In X <op>= Y the LHS value should be evaluated first, before evaluating
+ *  the RHS.  Duktape 1.5.x and before evaluates RHS first, which matters in
+ *  some chained <op>= statements.
+ *
+ *  See: https://github.com/svaarala/duktape/pull/987#issuecomment-251432738.
+ */
+
+/*===
+Write x: 10
+TEST
+Read x: 10
+Read x: 10
+Write x: 40
+Write x: 50
+Read x: 50
+Final x: 50
+===*/
+
+if (typeof print === 'undefined') { print = console.log; }
+
+var obj = {};
+var my_x;
+Object.defineProperty(obj, 'x', {
+    set: function (v) { print('Write x:', v); my_x = v; return true; },
+    get: function () { print('Read x:', my_x); return my_x; }
+});
+
+with (obj) {
+    x = 10;
+    print('TEST');
+    x += (x *= 4);
+}
+print('Final x:', obj.x);

--- a/tests/ecmascript/test-dev-assign-eval-order-5.js
+++ b/tests/ecmascript/test-dev-assign-eval-order-5.js
@@ -1,0 +1,164 @@
+/*
+ *  In X <op>= Y the LHS value should be evaluated first, before evaluating
+ *  the RHS.
+ */
+
+/*===
+slow path variable LHS
+Write x: 10
+TEST
+Read x: 10
+Read x: 10
+Write x: 40
+Write x: 50
+Read x: 50
+Final x: 50
+===*/
+
+if (typeof print === 'undefined') { print = console.log; }
+
+// Slow path variable LHS.  Use 'with' statement to record side effects.
+function slowPathVariableLhsTest() {
+    var obj = {};
+    var my_x;
+    Object.defineProperty(obj, 'x', {
+        set: function (v) { print('Write x:', v); my_x = v; return true; },
+        get: function () { print('Read x:', my_x); return my_x; }
+    });
+
+    with (obj) {
+        x = 10;
+        print('TEST');
+        x += (x *= 4);
+    }
+    print('Final x:', obj.x);
+}
+
+try {
+    print('slow path variable LHS');
+    slowPathVariableLhsTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+fast path variable LHS
+Final x: 50
+===*/
+
+// Fast path variable LHS.
+function fastPathVariableLhsTest() {
+    var x = 10;
+    x += (x *= 4);
+    print('Final x:', x);
+}
+
+try {
+    print('fast path variable LHS');
+    fastPathVariableLhsTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+property access LHS
+Final x: 50
+===*/
+
+// Property access LHS.
+function propertyAccessLhsTest() {
+    var obj = { x: 10 };
+    obj.x += (obj.x *= 4);
+    print('Final x:', obj.x);
+}
+
+try {
+    print('property access LHS');
+    propertyAccessLhsTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+function LHS
+lhs1
+lhs2
+ReferenceError
+lhs1
+lhs2
+ReferenceError
+done
+===*/
+
+// Function as LHS; RHS must be evaluated but a runtime error occurs.
+// V8 seems to skip RHS evaluation (maybe this has changed in ES6?).
+
+function functionLhsTest() {
+    function dummy() {}
+
+    try {
+        dummy() = (print('lhs1') + print('lhs2'));
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+
+    try {
+        dummy() += (print('lhs1') + print('lhs2'));
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+    print('done');
+}
+
+try {
+    print('function LHS');
+    functionLhsTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+optimization
+4
+400
+404
+2040
+10200foobarquux
+10200foobarquuxfoobarquux10
+===*/
+
+// This is just to inspect bytecode manually for most obvious cases.
+function optimizationTest() {
+    var x;
+    var y = 10;
+
+    print(x = 4);
+    x = 4;
+    print(x = 4 * 100);
+    x = 4 * 100;
+
+    print(x += 4);
+    x += 4;
+
+    print(x += x *= 4);
+    x += x *= 4;
+
+    print(x += 'foo' + 'bar' + 'quux');
+    x += 'foo' + 'bar' + 'quux';
+
+    // Even this evaluates to an optimal sequence: the RHS is 'y' which is
+    // a register bound variable so no code is emitted to access it during
+    // the RHS evaluation (RHS result is simply an ivalue pointing to the
+    // register).  So, x += y is safe to execute without a temporary.
+    print(x += y);
+    x += y;
+}
+
+try {
+    print('optimization');
+    optimizationTest();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
In `x <op>= y` the value of `x` (LHS) should be evaluated before RHS. This sometimes matters when chained `<op>=` expressions are used, see https://github.com/svaarala/duktape/pull/987#issuecomment-251432738.

Tasks:
- [x] Add bug testcase
- [x] Extend bug testcase to cover all LHS cases (reg-bound variable, slow path variable, property, etc)
- [x] Slow but correct fix, check bytecode
- [x] Optimize for common cases if possible
- [x] Fix backtracking issue if temp reg load is shuffled
- [x] Run shuffle torture test
- [x] Releases entry