### PR TITLE
Make exponentiation operator (** and **=) optional

### DIFF
--- a/config/config-options/DUK_USE_ES7_EXP_OPERATOR.yaml
+++ b/config/config-options/DUK_USE_ES7_EXP_OPERATOR.yaml
@@ -1,0 +1,10 @@
+define: DUK_USE_ES7_EXP_OPERATOR
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+  - ecmascript7
+description: >
+  Support the ES7 exponentation operator (** and **=).  This is optional
+  because the operator pulls in pow() which may have a significant footprint
+  impact on bare metal platforms.

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -89,3 +89,4 @@ DUK_USE_REGEXP_CANON_WORKAROUND: false
 DUK_USE_COROUTINE_SUPPORT: false
 DUK_USE_SOURCE_NONBMP: false  # <300 bytes footprint
 DUK_USE_ES6_PROXY: false  # roughly 2kB footprint
+DUK_USE_ES7_EXP_OPERATOR: false  # pulls in pow()

--- a/config/tags.yaml
+++ b/config/tags.yaml
@@ -9,6 +9,9 @@ ecmascript:
 ecmascript6:
   title: Ecmascript Edition 6 (ES6) feature options
 
+ecmascript7:
+  title: Ecmascript Edition 7 (ES7) feature options
+
 compliance:
   title: Compliance related options
 

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -3950,10 +3950,12 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 	/* EXPONENTIATION EXPRESSION */
 
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 	case DUK_TOK_EXP: {
 		args = (DUK_OP_EXP << 8) + DUK__BP_EXPONENTIATION - 1;  /* UnaryExpression */
 		goto binary;
 	}
+#endif
 
 	/* MULTIPLICATIVE EXPRESSION */
 
@@ -4144,11 +4146,13 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 		args = (DUK_OP_MOD << 8) + DUK__BP_ASSIGNMENT - 1;
 		goto assign;
 	}
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 	case DUK_TOK_EXP_EQ: {
 		/* right associative */
 		args = (DUK_OP_EXP << 8) + DUK__BP_ASSIGNMENT - 1;
 		goto assign;
 	}
+#endif
 	case DUK_TOK_ALSHIFT_EQ: {
 		/* right associative */
 		args = (DUK_OP_BASL << 8) + DUK__BP_ASSIGNMENT - 1;

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -84,9 +84,11 @@ DUK_LOCAL DUK__INLINE_PERF duk_double_t duk__compute_mod(duk_double_t d1, duk_do
 	return (duk_double_t) DUK_FMOD((double) d1, (double) d2);
 }
 
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 DUK_LOCAL DUK__INLINE_PERF duk_double_t duk__compute_exp(duk_double_t d1, duk_double_t d2) {
 	return (duk_double_t) duk_js_arith_pow((double) d1, (double) d2);
 }
+#endif
 
 DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_fast_t idx_z) {
 	/*
@@ -325,10 +327,12 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tv
 		du.d = duk__compute_mod(d1, d2);
 		break;
 	}
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 	case DUK_OP_EXP >> 2: {
 		du.d = duk__compute_exp(d1, d2);
 		break;
 	}
+#endif
 	default: {
 		DUK_UNREACHABLE();
 		du.d = DUK_DOUBLE_NAN;  /* should not happen */
@@ -3152,10 +3156,13 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 		case DUK_OP_MOD_CR:
 		case DUK_OP_MOD_RC:
 		case DUK_OP_MOD_CC:
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 		case DUK_OP_EXP_RR:
 		case DUK_OP_EXP_CR:
 		case DUK_OP_EXP_RC:
-		case DUK_OP_EXP_CC: {
+		case DUK_OP_EXP_CC:
+#endif  /* DUK_USE_ES7_EXP_OPERATOR */
+		{
 			/* XXX: could leave value on stack top and goto replace_top_a; */
 			duk__vm_arith_binary_op(thr, DUK__REGCONSTP_B(ins), DUK__REGCONSTP_C(ins), DUK_DEC_A(ins), op);
 			break;
@@ -3225,6 +3232,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			duk__vm_arith_binary_op(thr, DUK__CONSTP_B(ins), DUK__CONSTP_C(ins), DUK_DEC_A(ins), DUK_OP_MOD);
 			break;
 		}
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 		case DUK_OP_EXP_RR: {
 			duk__vm_arith_binary_op(thr, DUK__REGP_B(ins), DUK__REGP_C(ins), DUK_DEC_A(ins), DUK_OP_EXP);
 			break;
@@ -3241,6 +3249,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			duk__vm_arith_binary_op(thr, DUK__CONSTP_B(ins), DUK__CONSTP_C(ins), DUK_DEC_A(ins), DUK_OP_EXP);
 			break;
 		}
+#endif  /* DUK_USE_ES7_EXP_OPERATOR */
 #endif  /* DUK_USE_EXEC_PREFER_SIZE */
 
 #if defined(DUK_USE_EXEC_PREFER_SIZE)
@@ -4923,6 +4932,12 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 		}
 
 #if !defined(DUK_USE_EXEC_PREFER_SIZE)
+#if !defined(DUK_USE_ES7_EXP_OPERATOR)
+		case DUK_OP_EXP_RR:
+		case DUK_OP_EXP_CR:
+		case DUK_OP_EXP_RC:
+		case DUK_OP_EXP_CC:
+#endif
 		case DUK_OP_UNUSED194:
 		case DUK_OP_UNUSED195:
 		case DUK_OP_UNUSED196:

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -1035,11 +1035,14 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		}
 		break;
 	case DUK_ASC_STAR:  /* '*' */
+#if defined(DUK_USE_ES7_EXP_OPERATOR)
 		if (DUK__L1() == '*' && DUK__L2() == '=') {
 			advtok = DUK__ADVTOK(3, DUK_TOK_EXP_EQ);
 		} else if (DUK__L1() == '*') {
 			advtok = DUK__ADVTOK(2, DUK_TOK_EXP);
-		} else if (DUK__L1() == '=') {
+		} else
+#endif
+		if (DUK__L1() == '=') {
 			advtok = DUK__ADVTOK(2, DUK_TOK_MUL_EQ);
 		} else {
 			advtok = DUK__ADVTOK(1, DUK_TOK_MUL);


### PR DESCRIPTION
The ES7 exponentiation operator pulls in native `pow()` which has a significant footprint impact on bare metal low memory targets. Removing Math built-ins is not enough to remove the dependency when the operator is supported, so make the operator itself optional.