### PR TITLE
Align Buffer.concat() behavior for one-element arrays with Node.js v6.7.0

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1674,6 +1674,10 @@ Planned
   methods, and String.fromBuffer()); this reduces code footprint by around
   1.2 kB (GH-889)
 
+* Incompatible change: Node.js Buffer binding aligned with Node.js v6.7.0
+  (from v0.12.1): Buffer.concat() special case for 1-element array removed
+  (GH-1004)
+
 * Incompatible change: plain pointer values now test true in instanceof
   (plainPointer instanceof Duktape.Pointer === true) (GH-864)
 

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -227,6 +227,9 @@ changes below.  Here's a summary of changes:
   string by copying the buffer bytes directly into the string internal
   representation.
 
+* Node.js Buffer binding has been aligned more with Node.js v6.7.0 (from
+  Node.js v0.12.1).
+
 * Disabling ``DUK_USE_BUFFEROBJECT_SUPPORT`` allows use of plain buffers in
   the C API, and allows manipulation of plain buffers in Ecmascript code via
   their virtual properties (index properties, ``.length``, etc).  Plain buffers
@@ -256,6 +259,9 @@ To upgrade:
     (rather than being a direct instance) has been fixed so that the result has
     the default prototype (``Buffer.prototype``) rather than being copied from
     the argument.
+
+  - Node.js Buffer ``.concat()`` always returns a buffer copy, even for a
+    one-element input array which had special handling in Node.js v0.12.1.
 
 * If you're using plain buffers, review their usage especially in Ecmascript
   code.

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -2181,15 +2181,9 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_context *ctx) {
 		total_length += h_bufobj->length;
 		duk_pop(ctx);
 	}
-	if (n == 1) {
-		/* For the case n==1 Node.js doesn't seem to type check
-		 * the sole member but we do it before returning it.
-		 * For this case only the original buffer object is
-		 * returned (not a copy).
-		 */
-		duk_get_prop_index(ctx, 0, 0);
-		return 1;
-	}
+	/* In Node.js v0.12.1 a 1-element array is special and won't create a
+	 * copy, this was fixed later so an explicit check no longer needed.
+	 */
 
 	/* User totalLength overrides a computed length, but we'll check
 	 * every copy in the copy loop.  Note that duk_to_uint() can

--- a/tests/ecmascript/test-bi-nodejs-buffer-concat.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-concat.js
@@ -35,23 +35,23 @@ true object
 1 bytes: 22
 1 bytes: 5a
 0 bytes: 
-1 bytes: 5a
+1 bytes: 22
 16 bytes: 4142434445464748494a4b4c4d4e4f50
 8 bytes: 4445464748494a4b
 array length: 1, totalLength: 0
 true object
-1 bytes: 22
-1 bytes: 5a
 0 bytes: 
-1 bytes: 5a
+0 bytes: 
+0 bytes: 
+1 bytes: 22
 16 bytes: 4142434445464748494a4b4c4d4e4f50
 8 bytes: 4445464748494a4b
 array length: 1, totalLength: 10
 true object
-1 bytes: 22
-1 bytes: 5a
+10 bytes: 22000000000000000000
+10 bytes: 5a000000000000000000
 0 bytes: 
-1 bytes: 5a
+1 bytes: 22
 16 bytes: 4142434445464748494a4b4c4d4e4f50
 8 bytes: 4445464748494a4b
 array length: 4, totalLength: undefined
@@ -204,14 +204,17 @@ TypeError
 TypeError
 TypeError
 TypeError
+true
+false
+8
+true
+false
+100
+true
+0
 ===*/
 
-/* Buffer.concat().
- *
- * concat() has an interesting behavior: for an input list of length 1 the
- * first entry is returned (without copying!).  For an input list of length
- * > 1 a new buffer is created.
- */
+/* Buffer.concat(). */
 
 function concatTest() {
     var b1 = new Buffer(0);
@@ -264,8 +267,10 @@ function concatTest() {
     test([], 0);
     test([], 10);
 
-    // Length 1; totalLength is ignored and the (only) array
-    // element is returned without creating a copy.
+    // Length 1 used to have special handling in Node.js v0.12.1: totalLength
+    // is ignored and the (only) array element is returned without creating a
+    // copy.  This was changed in later versions and by v6.7.0 (new baseline)
+    // there's no longer special handling.
 
     test([b2], undefined);
     test([b2], 0);
@@ -341,6 +346,27 @@ function concatTest() {
             print(e.name);
         }
     });
+
+    // Specific test for 1-length array.
+    b1 = new Buffer('abcdefgh');
+    b2 = Buffer.concat([ b1 ]);
+    print(Buffer.isBuffer(b2));
+    print(b1 === b2);  // always a copy
+    print(b2.length);
+
+    // totalLength is respected with array length >= 1.
+    b1 = new Buffer('abcdefgh');
+    b2 = Buffer.concat([ b1 ], 100);
+    print(Buffer.isBuffer(b2));
+    print(b1 === b2);  // always a copy
+    print(b2.length);
+
+    // Specific test for 0-length array: totalLength is ignored even in
+    // Node.js v6.7.0 when argument array is zero length.
+    b1 = new Buffer('abcdefgh');
+    b2 = Buffer.concat([], 100);
+    print(Buffer.isBuffer(b2));
+    print(b2.length);
 }
 
 try {


### PR DESCRIPTION
`Buffer.concat()` always returns a copy, even for an one-element array argument.

- [x] Fix behavior
- [x] Fix testcases
- [x] Migration notes
- [x] Release notes