### PR TITLE
Allow RAM built-in accessors to have a missing setter/getter

### DIFF
--- a/util/makeduk_debug.yaml
+++ b/util/makeduk_debug.yaml
@@ -6,3 +6,4 @@ DUK_USE_DEBUG_LEVEL: 0
 #DUK_USE_DEBUG_LEVEL: 1
 DUK_USE_DEBUG_WRITE:
   verbatim: "#define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) do {fprintf(stderr, \"D%ld %s:%ld (%s): %s\\n\", (long) (level), (file), (long) (line), (func), (msg));} while(0)"
+DUK_USE_ASSERTIONS: true


### PR DESCRIPTION
- [x] Genbuiltins change to allow missing setter/getter, reserve natidx 0 for that
- [x] RAM init code change to special case missing function
- [x] Enable DUK_USE_ASSERTIONS for dukd config (mistakenly disabled at some point)