### PR TITLE
Implement ES6 Promise support

### DIFF
--- a/config/config-options/DUK_USE_PROMISE_BUILTIN.yaml
+++ b/config/config-options/DUK_USE_PROMISE_BUILTIN.yaml
@@ -1,0 +1,9 @@
+define: DUK_USE_PROMISE_BUILTIN
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript
+  - ecmascript6
+description: >
+  Provide a Promise built-in which allows Ecmascript code to create and use ES6
+  Promise objects.

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -265,6 +265,12 @@ objects:
         #present_if: DUK_USE_DUKTAPE_BUILTIN
 
       # ES6
+      - key: "Promise"
+        value:
+          type: object
+          id: bi_promise_constructor
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
       - key: "Proxy"
         value:
           type: object
@@ -2629,6 +2635,98 @@ objects:
   #
   #  ES6
   #
+
+  - id: bi_promise_constructor
+    class: Function
+    internal_prototype: bi_function_prototype
+    native: duk_bi_promise_constructor
+    callable: true
+    constructable: true
+    es6: true
+    bidx: true
+    present_if: DUK_USE_PROMISE_BUILTIN
+
+    properties:
+      - key: "length"
+        value: 1
+        attributes: ""
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "prototype"
+        value:
+          type: object
+          id: bi_promise_prototype
+        attributes: ""
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "name"
+        value: "Promise"
+        attributes: ""
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "all"
+        value:
+          type: function
+          native: duk_bi_promise_all
+          length: 1
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "race"
+        value:
+          type: function
+          native: duk_bi_promise_race
+          length: 1
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "reject"
+        value:
+          type: function
+          native: duk_bi_promise_resolve_shared
+          magic: 1
+          length: 1
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "resolve"
+        value:
+          type: function
+          native: duk_bi_promise_resolve_shared
+          magic: 0
+          length: 1
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+
+  - id: bi_promise_prototype
+    class: Object
+    internal_prototype: bi_object_prototype
+    es6: true
+    bidx: true
+    present_if: DUK_USE_PROMISE_BUILTIN
+
+    properties:
+      - key: "constructor"
+        value:
+          type: object
+          id: bi_promise_constructor
+        attributes: "wc"
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "catch"
+        value:
+          type: function
+          native: duk_bi_promise_prototype_catch
+          length: 1
+        attributes: "wc"
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+      - key: "then"
+        value:
+          type: function
+          native: duk_bi_promise_prototype_then
+          length: 2
+        attributes: "wc"
+        es6: true
+        present_if: DUK_USE_PROMISE_BUILTIN
+
 
   - id: bi_proxy_constructor
     class: Function

--- a/src-input/duk_bi_promise.c
+++ b/src-input/duk_bi_promise.c
@@ -1,0 +1,307 @@
+/*
+ *  Promise built-ins (ES7 Section 25.4)
+ *  http://www.ecma-international.org/ecma-262/7.0/#sec-promise-objects
+ *
+ *  Also refer to the Promises/A+ specification, which Ecmascript Promises are
+ *  based on:
+ *  https://promisesaplus.com/
+ */
+
+#include "duk_internal.h"
+
+#define DUK__PS_PENDING (0)
+#define DUK__PS_FULFILL (1)
+#define DUK__PS_REJECT  (2)
+
+typedef struct {
+	duk_uint8_t handled;
+	duk_uint8_t state;
+} duk__promise;
+
+DUK_LOCAL void duk__perform_promise_then(duk_context *ctx);
+DUK_LOCAL void duk__trigger_promise_reactions(duk_context *ctx, duk_idx_t idx);
+
+#if defined(DUK_USE_PROMISE_BUILTIN)
+DUK_LOCAL void duk__push_promise(duk_context *ctx)
+{
+	/*
+	 *  [ ... ] -> [ ... promise ]
+	 */
+
+	duk__promise *prom;
+
+	duk_push_object_helper(ctx,
+	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT),
+	                       DUK_BIDX_PROMISE_PROTOTYPE);
+
+	/*  [ ... promise ] */
+
+	prom = (duk__promise *) duk_push_fixed_buffer(ctx, sizeof(duk__promise));
+	prom->state = DUK__PS_PENDING;
+	prom->handled = 0;
+	duk_put_prop_string(ctx, -2, "\xff" "PromData");
+
+	duk_push_array(ctx);
+	duk_put_prop_string(ctx, -2, "\xff" "FulfillActs");
+
+	duk_push_array(ctx);
+	duk_put_prop_string(ctx, -2, "\xff" "RejectActs");
+
+	/*  [ ... promise ] */
+}
+
+DUK_LOCAL duk_bool_t duk__is_promise(duk_context *ctx, duk_idx_t idx) {
+	return duk_is_object(ctx, idx) &&
+	       duk_has_prop_string(ctx, idx, "\xff" "PromData");
+}
+
+DUK_LOCAL duk__promise *duk__require_promise(duk_context *ctx, duk_idx_t idx) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk__promise *prom;
+
+	if (!(duk__is_promise(ctx, idx))) {
+		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "promise", DUK_STR_NOT_PROMISE);
+	}
+
+	duk_get_prop_string(ctx, idx, "\xff" "PromData");
+	prom = (duk__promise *) duk_require_buffer(ctx, -1, NULL);
+	duk_pop(ctx);
+	return prom;
+}
+
+DUK_LOCAL void duk__settle_promise(duk_context *ctx, duk_idx_t idx, duk_uint8_t state) {
+	/*
+	 *  [ ... promise ... value ] -> [ ... promise ... ]
+	 */
+
+	duk__promise *prom;
+
+	DUK_ASSERT(state == DUK__PS_FULFILL || state == DUK__PS_REJECT);
+
+	idx = duk_require_normalize_index(ctx, idx);
+	prom = duk__require_promise(ctx, idx);
+	if (prom->state != DUK__PS_PENDING) {
+		duk_pop(ctx);
+		return;  /* nop, already settled */
+	}
+
+	prom->state = state;
+	duk_put_prop_string(ctx, idx, "\xff" "Value");
+	duk__trigger_promise_reactions(ctx, idx);
+}
+
+DUK_LOCAL duk_ret_t duk__promise_settler(duk_context *ctx) {
+	duk_uint8_t state;
+
+	DUK_ASSERT_TOP(ctx, 1);
+
+	duk_push_current_function(ctx);
+	state = (duk_uint8_t) duk_get_magic(ctx, -1);
+	duk_get_prop_string(ctx, -1, "\xff" "Promise");
+	duk_dup(ctx, 0);
+	duk__settle_promise(ctx, -2, state);
+	return 0;
+}
+
+DUK_LOCAL void duk__push_promise_settler(duk_context *ctx, duk_idx_t idx_prom, duk_uint8_t state) {
+	idx_prom = duk_require_normalize_index(ctx, idx_prom);
+	duk_push_c_function(ctx, duk__promise_settler, 1);
+	duk_set_magic(ctx, -1, (duk_int_t) state);
+	duk_put_prop_string(ctx, -1, "\xff" "Promise");
+}
+
+/*
+ *  PerformPromiseThen (ES7 Section 25.4.5.3.1)
+ *
+ *  There are some slight differences to the algorithm described in ES7 in an
+ *  effort to save footprint.  In particular, we avoid the PromiseCapability
+ *  concept entirely and just compose the result promise on the fly.
+ */
+DUK_LOCAL void duk__perform_promise_then(duk_context *ctx) {
+	/*
+	 *  [ ... promise onFulfilled onRejected ] -> [ ... newPromise ]
+	 */
+
+	duk_uarridx_t len;
+	duk_idx_t idx_prom;
+	duk_idx_t idx_fulfill_func;
+	duk_idx_t idx_reject_func;
+	duk__promise *prom;
+
+	idx_prom = duk_require_normalize_index(ctx, -3);
+	idx_fulfill_func = duk_require_normalize_index(ctx, -2);
+	idx_reject_func = duk_require_normalize_index(ctx, -1);
+
+	prom = duk__require_promise(ctx, idx_prom);
+
+	/* Steps 3-9 */
+	if (duk_is_callable(ctx, idx_fulfill_func)) {
+		duk_get_prop_string(ctx, idx_prom, "\xff" "FulfillActs");
+		len = (duk_uarridx_t) duk_get_length(ctx, -1);
+		duk_dup(ctx, idx_fulfill_func);
+		duk_put_prop_index(ctx, -2, len);
+		duk_pop(ctx);
+	}
+	if (duk_is_callable(ctx, idx_reject_func)) {
+		duk_get_prop_string(ctx, idx_prom, "\xff" "RejectActs");
+		len = (duk_uarridx_t) duk_get_length(ctx, -1);
+		duk_dup(ctx, idx_reject_func);
+		duk_put_prop_index(ctx, -2, len);
+		duk_pop(ctx);
+	}
+	duk__trigger_promise_reactions(ctx, idx_prom);
+
+	/* Step 10 */
+	prom->handled = 1;
+
+	/* [ ... promise ] */
+
+	duk__push_promise(ctx);
+	duk__push_promise_settler(ctx, -1, DUK__PS_FULFILL);
+	duk__push_promise_settler(ctx, -2, DUK__PS_REJECT);
+}
+
+/*
+ *  TriggerPromiseReactions (ES7 25.4.1.8)
+ */
+DUK_LOCAL void duk__trigger_promise_reactions(duk_context *ctx, duk_idx_t idx) {
+	duk__promise *prom;
+
+	idx = duk_require_normalize_index(ctx, idx);
+	prom = duk__require_promise(ctx, idx);
+	if (prom->state != DUK__PS_PENDING) {
+		duk_get_prop_string(ctx, idx, "\xff" "Value");
+	} else {
+		/* pending promise, do nothing */
+		return;
+	}
+
+	/* [ ... value ] */
+
+	DUK_ASSERT(prom->state == DUK__PS_FULFILL || prom->state == DUK_PS_REJECT);
+	if (prom->state == DUK__PS_FULFILL) {
+		duk_get_prop_string(ctx, idx, "\xff" "FulfillActs");
+	} else {
+		duk_get_prop_string(ctx, idx, "\xff" "RejectActs");
+	}
+
+	/* FIXME: deferred promise reactions */
+	duk_enum(ctx, -1, DUK_ENUM_ARRAY_INDICES_ONLY);
+	while (duk_next(ctx, -1, 1)) {
+		/* [ ... value handlers enum idx func ] */
+
+		duk_dup(ctx, -5);  /* value */
+		duk_call(ctx, 1);
+		duk_pop_2(ctx);
+	}
+	duk_set_length(ctx, -2, 0);
+
+	/* [ ... value handlers enum ] */
+
+	duk_pop_n(ctx, 3);
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_constructor(duk_context *ctx) {
+	DUK_ASSERT_TOP(ctx, 1);
+
+	/* [ executorFunc ] */
+
+	duk_require_constructor_call(ctx);
+	duk_require_callable(ctx, 0);
+
+	duk__push_promise(ctx);
+
+	/* [ executorFunc promise ] */
+
+	duk_dup(ctx, 0);
+	duk__push_promise_settler(ctx, -2, DUK__PS_FULFILL);
+	duk__push_promise_settler(ctx, -2, DUK__PS_REJECT);
+	if (duk_pcall(ctx, 2) != 0) {
+		/* If the executor function throws, reject the promise with whatever
+		 * was thrown as the reason value.
+		 */
+		duk__settle_promise(ctx, -2, DUK__PS_REJECT);
+	} else {
+		/* don't need return value */
+		duk_pop(ctx);
+	}
+
+	/* [ executorFunc promise ] */
+
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_all(duk_context *ctx) {
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_race(duk_context *ctx) {
+	DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_resolve_shared(duk_context *ctx) {
+	/*
+	 *  magic = 0: Promise.resolve()
+	 *  magic = 1: Promise.reject()
+	 */
+	duk_int_t magic;
+
+	duk_tval *tv_ctor;
+	duk_tval *tv_this;
+
+	magic = duk_get_current_magic(ctx);
+	DUK_ASSERT_TOP(ctx, 1);
+	DUK_ASSERT(magic == 0 || magic == 1);
+
+	/* [ value ] */
+
+	/* ES7 Sections 25.4.4.4, 25.4.4.5 */
+	duk_push_this(ctx);
+	duk_require_hobject(ctx, -1);  /* Step 2 */
+	if (magic == 0 && duk__is_promise(ctx, 0)) {
+		duk_get_prop_string(ctx, 0, "constructor");
+		tv_ctor = DUK_GET_TVAL_NEGIDX(ctx, -1);
+		tv_this = DUK_GET_TVAL_NEGIDX(ctx, -2);
+		if (duk_js_samevalue(tv_ctor, tv_this)) {  /* Step 3b */
+			duk_pop_2(ctx);
+			return 1;
+		}
+	}
+
+	duk__push_promise(ctx);
+	duk_dup(ctx, 0);
+	duk__settle_promise(ctx, -2, magic == 0 ?
+	                    DUK__PS_FULFILL : DUK__PS_REJECT);
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_prototype_catch(duk_context *ctx) {
+	DUK_ASSERT_TOP(ctx, 1);
+
+	/* [ onRejected ] */
+
+	/* Unusually for an Ecmascript built-in, .catch() must call .then()
+	 * polymorphically.  See ES7 Section 25.4.5.1.
+	 */
+	duk_get_prop_string(ctx, 0, "then");
+	duk_push_this(ctx);
+	duk_push_undefined(ctx);
+	duk_dup(ctx, 0);
+	duk_call_method(ctx, 2);
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_promise_prototype_then(duk_context *ctx) {
+	DUK_ASSERT_TOP(ctx, 2);
+
+	duk_push_this(ctx);
+	duk__require_promise(ctx, -1);
+	duk_insert(ctx, 0);
+
+	/* [ promise onFulfilled onRejected ] */
+
+	duk__perform_promise_then(ctx);
+	return 1;
+}
+#endif

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -52,6 +52,7 @@
 #define DUK_STR_NOT_C_FUNCTION                   "unexpected type"
 #define DUK_STR_NOT_FUNCTION                     "unexpected type"
 #define DUK_STR_NOT_REGEXP                       "unexpected type"
+#define DUK_STR_NOT_PROMISE                      "unexpected type"
 #define DUK_STR_TOPRIMITIVE_FAILED               "coercion to primitive failed"
 #define DUK_STR_NUMBER_OUTSIDE_RANGE             "number outside range"
 #define DUK_STR_NOT_OBJECT_COERCIBLE             "not object coercible"

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -421,6 +421,7 @@ def main():
         'duk_bi_number.c',
         'duk_bi_object.c',
         'duk_bi_pointer.c',
+        'duk_bi_promise.c',
         'duk_bi_protos.h',
         'duk_bi_reflect.c',
         'duk_bi_regexp.c',

--- a/util/dist.py
+++ b/util/dist.py
@@ -330,6 +330,7 @@ def main():
         'duk_bi_number.c',
         'duk_bi_object.c',
         'duk_bi_pointer.c',
+        'duk_bi_promise.c',
         'duk_bi_protos.h',
         'duk_bi_proxy.c',
         'duk_bi_reflect.c',


### PR DESCRIPTION
_Work in progress._

Implement support for ES6+ Promises.  Promises allow async code to be written in a linear fashion like sync code.

Checklist:
- [ ] Implement `Promise`, all ES7 bindings
- [ ] C API for promises?
- [ ] `Promise.prototype.done()`?  Investigate pros and cons, as many devs dislike it
- [ ] If async resolve implemented here, need an API to dispatch Jobs, e.g. `duk_perform_jobs()`
- [ ] Testcases
- [ ] RELEASES entry