### PR TITLE
Remove 1:1 buffer-to-string coercion in Node.js Buffer.prototype.toString()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1677,7 +1677,9 @@ Planned
 
 * Incompatible change: Node.js Buffer binding aligned with Node.js v6.7.0
   (from v0.12.1): Buffer.concat() special case for 1-element array removed
-  (GH-1004), Buffer now inherits from Uint8Array (GH-1008)
+  (GH-1004); Buffer now inherits from Uint8Array (GH-1008);
+  Buffer.prototype.toString() does UTF-8 decoding (previously buffer data
+  was copied into internal string representation as is) (GH-1020)
 
 * Incompatible change: plain pointer values now test true in instanceof
   (plainPointer instanceof Duktape.Pointer === true) (GH-864)

--- a/doc/buffers.rst
+++ b/doc/buffers.rst
@@ -1146,7 +1146,8 @@ Gap between current implementation and latest:
 
 * ``buf.swap16()``, ``buf.swap32()``, ``buf.swap64()`` missing.
 
-* ``buf.toString()`` doesn't implement encoding.
+* ``buf.toString()`` always decodes the buffer using UTF-8 (with replacement
+  characters for invalid sequences), and ignores the encoding argument.
 
 * ``buf.values()`` missing.
 

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -231,7 +231,8 @@ changes below.  Here's a summary of changes:
   and string operations) and can expose such a binding to Ecmascript code.
 
 * Node.js Buffer binding has been aligned more with Node.js v6.8.1 (from
-  Node.js v0.12.1).
+  Node.js v0.12.1) and some (but not all) behavior differences to actual
+  Node.js have been fixed.
 
 * Disabling ``DUK_USE_BUFFEROBJECT_SUPPORT`` allows use of plain buffers in
   the C API, and allows manipulation of plain buffers in Ecmascript code via
@@ -255,7 +256,7 @@ To upgrade:
     has the default prototype for the result type (e.g. ``Uint8Array.prototype``)
     rather than being copied from the argument.
 
-* If you're using the Node.js Buffer binding, XXX.
+* If you're using the Node.js Buffer binding, review the following:
 
   - Node.js Buffer ``.slice()`` handling of arguments inheriting from a Buffer
     (rather than being a direct instance) has been fixed so that the result has
@@ -264,6 +265,9 @@ To upgrade:
 
   - Node.js Buffer ``.concat()`` always returns a buffer copy, even for a
     one-element input array which had special handling in Node.js v0.12.1.
+
+  - Node.hs Buffer.prototype ``.toString()`` now decodes the input buffer
+    using UTF-8, emitting replacement characters for invalid UTF-8 sequences.
 
   - Review Buffer code for Node.js Buffer changes between Node.js versions
     v0.12.1 and v6.8.1 in general.

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -59,4 +59,6 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
                                   duk_idx_t idx_space,
                                   duk_small_uint_t flags);
 
+DUK_INTERNAL_DECL duk_ret_t duk_textdecoder_decode_utf8_nodejs(duk_context *ctx);
+
 #endif  /* DUK_BUILTIN_PROTOS_H_INCLUDED */

--- a/tests/ecmascript/test-bi-nodejs-buffer-bytelength.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-bytelength.js
@@ -19,7 +19,7 @@ byteLength test
 7 ascii 9
 7 dummy 9
 0
-16
+48
 123456
 10
 13
@@ -64,10 +64,9 @@ function byteLengthTest() {
 
     // Buffers b1 and b3 are ASCII compatible.  Their byteLength() will match
     // the input byte length.  For buffer b2 (16 bytes) Node.js returns 48,
-    // presumably because the string is invalid UTF-8 and coerces to 16 U+FFFD
-    // characters, which are then UTF-8 encoded into 48 bytes.
-    //
-    // Duktape returns 16 for buffer b2 too.
+    // because the string is invalid UTF-8 and coerces to 16 U+FFFD replacement
+    // characters, which are then UTF-8 encoded into 48 bytes.  Duktape 2.x
+    // matches this behavior.
 
     [ b1, b2, b3,
       { valueOf: function () { return 'dummydummy'; }, toString: function () { return 'dummydummy'; } },  // 10 bytes

--- a/tests/ecmascript/test-bi-nodejs-buffer-tostring.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-tostring.js
@@ -1,9 +1,20 @@
 /*
  *  Node.js Buffer toString()
+ *
+ *  In Duktape 2.x Node.js Buffer.prototype.toString() does an actual UTF-8
+ *  decoding.
  */
 
 /*@include util-buffer.js@*/
 /*@include util-string.js@*/
+
+function makeBuffer(bytes) {
+    var buf = new Buffer(bytes.length);
+    for (var i = 0; i < bytes.length; i++) {
+        buf[i] = (typeof bytes[i] === 'number' ? bytes[i] : bytes[i].charCodeAt(0));
+    }
+    return buf;
+}
 
 /*===
 node.js Buffer toString() test
@@ -17,9 +28,9 @@ true
 "EFG"
 "E"
 "<U+CAFE>A"
-"<U+D800><U+DFFF>"
-"<Error>ABC"
-"ABB<Error>"
+"<U+FFFD><U+FFFD><U+FFFD><U+FFFD><U+FFFD><U+FFFD>"
+"<U+FFFD>ABC"
+"<U+FFFD><U+FFFD>B<U+FFFD>"
 "DEFG"
 NONE NONE "DEFG"
 NONE undefined "DEFG"
@@ -247,16 +258,16 @@ function nodejsBufferToStringTest() {
 
     // When the buffer data is legal UTF-8 and the chosen encoding
     // is UTF-8 (default), Duktape internal representation is correct
-    // as is.  Here the 4-byte data is U+CAFE U+0041.
+    // as is.  Here the 4-byte data is U+CAFE U+0041.  (Since Duktape 2.x
+    // there's an explicit UTF-8 decoding + CESU-8 encoding process.)
     b = new Buffer(4);
     b[0] = 0xec; b[1] = 0xab; b[2] = 0xbe; b[3] = 0x41;
     safePrintString(b.toString());
 
-    // When the buffer data is not legal UTF-8 Node.js behavior is
-    // interesting and a bit inconsistent with other API calls:
-    // CESU-8 encoded strings are accepted as is.  Here U+D800 U+DFFF
-    // encoded as CESU-8 is ED A0 80 ED BF BF and the string that comes
-    // back is U+D800 U+DFFF with both Node.js and Duktape.
+    // When the buffer data is not legal UTF-8 replacement characters
+    // (U+FFFD) are emitted.  In this case the input is a CESU-8 encoded
+    // surrogate pair which is entirely invalid UTF-8.  In this case one
+    // replacement character gets emitted for each byte.
     b = new Buffer(6);
     b[0] = 0xed; b[1] = 0xa0; b[2] = 0x80;
     b[3] = 0xed; b[4] = 0xbf; b[5] = 0xbf;
@@ -264,11 +275,7 @@ function nodejsBufferToStringTest() {
 
     // Here the buffer data is invalid UTF-8 and invalid CESU-8.
     // Node.js replaces the offending character (0xff) with U+FFFD
-    // (replacement character).  Duktape currently allows as is.
-
-    // XXX: current output is odd because charCodeAt() doesn't
-    // work well now for invalid strings.
-
+    // (replacement character).
     b = new Buffer(4);
     b[0] = 0xff; b[1] = 0x41; b[2] = 0x42; b[3] = 0x43;
     safePrintString(b.toString());
@@ -276,11 +283,8 @@ function nodejsBufferToStringTest() {
     // Invalid continuation characters.  Node.js seems to scan for
     // the next valid starting byte and each offending byte causes
     // a new U+FFFD to be emitted (here U+FFFD U+FFFD U+0042 U+FFFD).
-    // Duktape currently allows the bytes as is.
-
-    // XXX: current output is odd because charCodeAt() doesn't
-    // work well now for invalid strings.
-
+    // While there are differences in replacement character handling,
+    // here the result agrees between Node.js and Duktape.
     b = new Buffer(4);
     b[0] = 0xc1; b[1] = 0xc1; b[2] = 0x42; b[3] = 0xc1;
     safePrintString(b.toString());
@@ -335,6 +339,440 @@ function nodejsBufferToStringTest() {
 try {
     print('node.js Buffer toString() test');
     nodejsBufferToStringTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+all bytes test
+256
+8396352
+===*/
+
+// Just a simple test which decodes a buffer containing all 256 byte values.
+
+function allBytesTest() {
+    var buf = new Buffer(256);
+    var i;
+
+    for (i = 0; i < 256; i++) {
+        buf[i] = i;
+    };
+
+    var str = buf.toString();
+    print(str.length);
+
+    var cpsum = 0;
+    for (i = 0; i < str.length; i++) {
+        cpsum += str.charCodeAt(i);
+    }
+    print(cpsum);
+}
+
+try {
+    print('all bytes test');
+    allBytesTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+0 120
+1 120
+2 120
+3 120
+4 120
+5 120
+6 120
+7 120
+8 120
+9 120
+10 120
+11 120
+12 120
+13 120
+14 120
+15 120
+16 120
+17 120
+18 120
+19 120
+20 120
+21 120
+22 120
+23 120
+24 120
+25 120
+26 120
+27 120
+28 120
+29 120
+30 120
+31 120
+32 120
+33 120
+34 120
+35 120
+36 120
+37 120
+38 120
+39 120
+40 120
+41 120
+42 120
+43 120
+44 120
+45 120
+46 120
+47 120
+48 120
+49 120
+50 120
+51 120
+52 120
+53 120
+54 120
+55 120
+56 120
+57 120
+58 120
+59 120
+60 120
+61 120
+62 120
+63 120
+64 120
+65 120
+66 120
+67 120
+68 120
+69 120
+70 120
+71 120
+72 120
+73 120
+74 120
+75 120
+76 120
+77 120
+78 120
+79 120
+80 120
+81 120
+82 120
+83 120
+84 120
+85 120
+86 120
+87 120
+88 120
+89 120
+90 120
+91 120
+92 120
+93 120
+94 120
+95 120
+96 120
+97 120
+98 120
+99 120
+100 120
+101 120
+102 120
+103 120
+104 120
+105 120
+106 120
+107 120
+108 120
+109 120
+110 120
+111 120
+112 120
+113 120
+114 120
+115 120
+116 120
+117 120
+118 120
+119 120
+120 120
+121 120
+122 120
+123 120
+124 120
+125 120
+126 120
+127 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533 120
+65533
+65533 65533
+65533 102 111 111 65533
+===*/
+
+function miscDecodeTest() {
+    var i;
+
+    function test(bytes) {
+        var buf = makeBuffer(bytes);
+        console.log(Array.prototype.map.call(buf.toString(), function (v) { return v.charCodeAt(0); }).join(' '));
+    }
+
+    // All initial bytes.
+    for (i = 0; i < 256; i++) {
+        test([ i, 'x' ]);
+    }
+
+    // Truncated codepoint(s).
+    //
+    // Duktape (and Firefox) TextDecoder() -- which is used for Node.js Buffer
+    // .toString() now -- emit a single replacement character for the truncated
+    // sequence EC AB.  Chrome and Node.js v6.7.0 emit two.  Duktape behavior
+    // matches WHATWG Encoding API.
+
+    test([ 0xec, 0xab ]);
+    test([ 0xec, 0xab, 0xec, 0xab ]);
+    test([ 0xec, 0xab, 'f', 'o', 'o', 0xec, 0xab ]);
+}
+
+try {
+    miscDecodeTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+replacement character policy
+65533 65533
+97 65533 65533 65533 98
+65533 65533 65533
+===*/
+
+// There are a few different replacement character strategies.  Unicode
+// Technical Committee recommends (http://www.unicode.org/review/pr-121.html):
+//
+//     Replace each maximal subpart of the ill-formed subsequence by a
+//     single U+FFFD.
+//
+// For example, UTF-8 for U+CAFE is EC AB BE.  A byte sequence containing
+// two truncated sequences EC AB EC AB could be decoded as:
+//
+//     1. U+FFFD (replace entire sequence)
+//     2. U+FFFD U+FFFD (replace each "maximal subpart")
+//     3. U+FFFD U+FFFD U+FFFD U+FFFD (replace each byte)
+//
+// Unicode Technical Committee recommends approach 2; Firefox does so too.
+// V8 seems to use approach 3, which also affects the Node.js Buffer binding.
+//
+// Duktape's Buffer .toString() will thus use fewer replacement characters
+// than Node.js (at least up to v6.8.1).
+//
+// WHATWG Encoding specification has a required algorithm for decoding (as far
+// as outcomes are concerned) which provides approach 2.  So that behavior is
+// required for TextDecoder() in any case.
+
+function replacementCharacterPolicyTest() {
+    // Truncated U+CAFE test.
+    var buf = new Buffer(4);
+    buf[0] = 0xec;
+    buf[1] = 0xab;
+    buf[2] = 0xec;
+    buf[3] = 0xab;
+    var res = buf.toString();
+    print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
+
+    // Test from http://www.unicode.org/review/pr-121.html.
+    var buf = new Buffer(8);
+    buf[0] = 0x61;
+    buf[1] = 0xF1;
+    buf[2] = 0x80;
+    buf[3] = 0x80;
+    buf[4] = 0xE1;
+    buf[5] = 0x80;
+    buf[6] = 0xC2;
+    buf[7] = 0x62;
+    var res = buf.toString();
+    print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
+
+    // Interesting special case: ED A0 80 is a CESU-8 encoded surrogate pair.
+    // Because ED is not a valid initial UTF-8 byte at all, the sequence
+    // generates three replacement characters.
+    var buf = new Buffer(3);
+    buf[0] = 0xed;
+    buf[1] = 0xa0;
+    buf[2] = 0x80;
+    var res = buf.toString();
+    print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
+}
+
+try {
+    print('replacement character policy');
+    replacementCharacterPolicyTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+bom handling
+"<U+FEFF>"
+"<U+FEFF>AB"
+"@<U+FEFF>AB"
+===*/
+
+function bomTest() {
+    var res;
+
+    // Just a BOM and nothing else -> Node.js doesn't strip the BOM:
+    // > new Buffer(new Uint8Array([ 0xef, 0xbb, 0xbf ])).toString()
+    // ''
+    // > new Buffer(new Uint8Array([ 0xef, 0xbb, 0xbf ])).toString().length
+    // 1
+    // > new Buffer(new Uint8Array([ 0xef, 0xbb, 0xbf ])).toString().charCodeAt(0)
+    // 65279
+
+    res = new Buffer(new Uint8Array([ 0xef, 0xbb, 0xbf ])).toString();
+    safePrintString(res);
+
+    // BOM + followup characters, BOM is kept.
+    res = new Buffer(new Uint8Array([ 0xef, 0xbb, 0xbf, 0x41, 0x42 ])).toString();
+    safePrintString(res);
+
+    // BOM inside a string, BOM is kept.
+    res = new Buffer(new Uint8Array([ 0x40, 0xef, 0xbb, 0xbf, 0x41, 0x42 ])).toString();
+    safePrintString(res);
+}
+
+try {
+    print('bom handling');
+    bomTest();
 } catch (e) {
     print(e.stack || e);
 }

--- a/tests/ecmascript/test-bi-textdecoder.js
+++ b/tests/ecmascript/test-bi-textdecoder.js
@@ -311,6 +311,7 @@ try {
 replacement character policy
 65533 65533
 97 65533 65533 65533 98
+65533 65533 65533
 ===*/
 
 // There are a few different replacement character strategies.  Unicode
@@ -328,6 +329,10 @@ replacement character policy
 //
 // Unicode Technical Committee recommends approach 2; Firefox does so too.
 // V8 seems to use approach 3.
+//
+// WHATWG Encoding specification has a required algorithm for decoding (as far
+// as outcomes are concerned) which provides approach 2.  So that behavior is
+// required here.
 
 function replacementCharacterPolicyTest() {
     // Truncated U+CAFE test.
@@ -337,6 +342,13 @@ function replacementCharacterPolicyTest() {
 
     // Test from http://www.unicode.org/review/pr-121.html.
     var u8 = new Uint8Array([ 0x61, 0xF1, 0x80, 0x80, 0xE1, 0x80, 0xC2, 0x62 ]);
+    var res = new TextDecoder().decode(u8);
+    print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
+
+    // Interesting special case: ED A0 80 is a CESU-8 encoded surrogate pair.
+    // Because ED is not a valid initial UTF-8 byte at all, the sequence
+    // generates three replacement characters; Firefox agrees.
+    var u8 = new Uint8Array([ 0xed, 0xa0, 0x80 ]);
     var res = new TextDecoder().decode(u8);
     print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
 }

--- a/tests/ecmascript/test-dev-buffer-to-string.js
+++ b/tests/ecmascript/test-dev-buffer-to-string.js
@@ -8,10 +8,12 @@
 /*===
 4 "\xffabc"
 |c3bf616263|
-4 "\xffabc"
-|ff616263|
-4 "\xffabc"
-|ff616263|
+4 "\ufffdabc"
+|efbfbd616263|
+4 "\ufffdabc"
+|efbfbd616263|
+4 "\ufffdabc"
+|efbfbd616263|
 4 "\xffabc"
 |ff616263|
 ===*/
@@ -34,9 +36,11 @@ function test() {
     print(s.length, Duktape.enc('jx', s));
     print(Duktape.enc('jx', stringToBuffer(s)));
 
-    // Non-standard, works in both Duktape 1.x and 2.x: Node.js Buffer
-    // string coercion is 1:1 into the internal key representation with
-    // no encoding (which differs from Node.js and is to be fixed).
+    // Node.js Buffer .toString() coercion decodes a buffer as UTF-8, emitting
+    // replacement characters for invalid sequences.  Duktape 2.x follows this
+    // behavior so one cannot create for example "internal keys".  (Duktape 1.x
+    // used the buffer as-is as the string internal representation which *did*
+    // allow internal keys to be created.)
 
     b = new Buffer(4);
     b[0] = 0xff;
@@ -52,6 +56,14 @@ function test() {
 
     b = new Uint8Array([ 0xff, 0x61, 0x62, 0x63 ]);
     s = Buffer.prototype.toString.call(b);
+    print(s.length, Duktape.enc('jx', s));
+    print(Duktape.enc('jx', stringToBuffer(s)));
+
+    // WHATWG Encoding API is supported in Duktape 2.x.
+
+    dec = new TextDecoder();
+    b = new Uint8Array([ 0xff, 0x61, 0x62, 0x63 ]);
+    s = dec.decode(b);
     print(s.length, Duktape.enc('jx', s));
     print(Duktape.enc('jx', stringToBuffer(s)));
 

--- a/tests/ecmascript/test-dev-string-to-buffer.js
+++ b/tests/ecmascript/test-dev-string-to-buffer.js
@@ -19,6 +19,7 @@ function test() {
     // string can be converted to an array using Array.prototype.map().  The
     // buffer bytes will be uint8-converted codepoints, not 1:1 with the
     // internal string representation (and not UTF-8 either).
+
     s = '\xfffoo';
     b = new Uint8Array(Array.prototype.map.call(s, function (v) {
         return v.charCodeAt(0);
@@ -30,6 +31,9 @@ function test() {
     // representation as is (this differs from Node.js).  For standard strings
     // this means that the buffer gets a CESU-8 representation of the string
     // (same as UTF-8 except for the surrogate pair range).
+    //
+    // Note that this allows an internal string to be converted into a buffer
+    // as is which is *not* a sandboxing issue like the reverse operation.
 
     s = '\xfffoo';
     b = new Buffer(s);

--- a/website/guide/custombehavior.html
+++ b/website/guide/custombehavior.html
@@ -250,8 +250,11 @@ differences include:</p>
     0x00 rather than throwing a TypeError.</li>
 <li>Duktape only supports the <code>"utf8"</code> encoding (and accepts no
     spelling variants).  Most API calls ignore an encoding argument, and
-    use the Duktape internal string representation (CESU-8 / extended UTF-8)
-    for string-to-buffer conversion.</li>
+    use UTF-8 implicitly for string-to-buffer coercion.</li>
+<li>UTF-8 decoding replacement character approach follows
+    <a href="http://unicode.org/review/pr-121.html">Unicode Technical Committee Recommended Practice for Replacement Characters</a>
+    which matches WHATWG Encoding API specification but differs from Node.js
+    (at least up to version v6.8.1).</li>
 <li>Node.js Buffer has additional <code>byteLength</code> (matching
     <code>length</code>), <code>byteOffset</code> (= 0), and
     <code>BYTES_PER_ELEMENT</code> (= 1) properties.</li>

--- a/website/guide/duktapebuiltins.html
+++ b/website/guide/duktapebuiltins.html
@@ -136,6 +136,7 @@ The first argument is a format (currently supported are "hex", "base64",
 "jx" and "jc"), second argument is the value to encode, and any further
 arguments are format specific.</p>
 
+<!-- XXX: maybe remove support for non-buffer inputs? -->
 <p>For "hex" and "base64", buffer values are encoded as is, other values
 are string coerced and the internal byte representation (extended UTF-8)
 is then encoded.  The result is a string.  For example, to encode a string
@@ -168,10 +169,10 @@ print(typeof result, result);  // prints 'object foo'
 <p>If you wish to get back a string value, you can coerce the plain buffer to
 a string e.g. as follows:</p>
 <pre class="ecmascript-code">
-// Use Node.js Buffer binding for buffer-to-string coercion.  The buffer
-// data is decoded as UTF-8 and re-encoded into an Ecmascript string (with
-// surrogate pairs used for non-BMP codepoints).
-var result = Buffer.from(Duktape.dec('base64', 'Zm9v')).toString();
+// Use TextDecoder which decodes the input as UTF-8.  You can also use
+// the Node.js Buffer binding to achieve a similar result.
+
+var result = new TextDecoder().decode(Duktape.dec('base64', 'Zm9v'));
 print(typeof result, result);  // prints 'string foo'
 </pre>
 

--- a/website/guide/internalproperties.html
+++ b/website/guide/internalproperties.html
@@ -85,25 +85,26 @@ duk_push_string(ctx, "\xff" "myprop");
 
 <p>Internal strings cannot be created from Ecmascript code using the default
 built-ins alone.  However, application code can easily add such a binding
-using the C API (this must be considered in sandboxing).</p>
+using the C API which must be considered in sandboxing.</p>
 
 <p>There's no special access control for internal properties: if user code has
 access to the property name (string), it can read/write the property value.
-Any code with the ability to create or use buffers can potentially create an
-internal string by converting a buffer into a string.  However, standard Ecmascript
-code with no access to buffer values or ability to create them cannot create internal
-strings (or any invalid UTF-8 strings in general).  When sandboxing, ensure that
-the sandboxed code has no access to the <code>Duktape</code> built-in or any
-buffer values.</p>
+The default Ecmascript built-ins don't provide a way of creating an internal
+string: buffer-to-string coercions always involve an encoding such as UTF-8
+which will reject or replace invalid byte sequences.  However, C code can
+easily create internal strings.  When sandboxing, ensure that custom C bindings
+don't accidentally provide a mechanism to create internal strings by e.g.
+converting a buffer as-is to a string.</p>
 
-<p>As a concrete example, the internal value of a <code>Date</code> can be
-accessed as follows:</p>
+<p>As a concrete example the internal value of a <code>Date</code> instance
+can be accessed as follows:</p>
 <pre class="ecmascript-code">
-// Print the internal timestamp of a Date instance.  User code should NEVER
-// actually do this because the internal properties may change between
-// versions in an arbitrary manner!
+// Print the internal timestamp of a Date instance.  Assumes a hypothetical
+// rawBufferToString() custom C binding which takes an input buffer and pushes
+// the bytes as-is as a string using duk_push_lstring(), thus creating an
+// internal string.
 
-var key = Duktape.dec('hex', 'ff56616c7565');  // \xFFValue
+var key = rawBufferToString(Duktape.dec('hex', 'ff56616c7565'));  // \xFFValue
 var dt = new Date(123456);
 print('internal value is:', dt[key]);  // prints 123456
 </pre>

--- a/website/guide/sandboxing.html
+++ b/website/guide/sandboxing.html
@@ -16,5 +16,5 @@ See
 for a detailed discussion of how to implement sandboxing.</p>
 
 <div class="note">
-Sandboxing support in Duktape 1.3 is still a work in progress.
+Sandboxing support in Duktape 2.0 is still a work in progress.
 </div>


### PR DESCRIPTION
- [x] Rework encoding API to provide a shared buffer-to-string helper for Node.js Buffer code (even when Encoding API is disabled)
- [x] Change `Buffer.prototype.toString()` to decode the buffer as UTF-8 and encode output using CESU-8. This prevents buffer code from creating internal strings, and also aligns the Buffer .toString() operation with Node.js.
- [x] Website updates for buffer coercions
- [x] Website: document difference to Node.js replacement character behavior
- [x] Internal document updates, e.g. sandboxing, buffer future work status
- [x] 2.0 migration note
- [x] Releases entry