### PR TITLE
Fix a potential memory safety issue in TextDecoder decode()

### DIFF
--- a/tests/ecmascript/test-bi-textdecoder.js
+++ b/tests/ecmascript/test-bi-textdecoder.js
@@ -347,3 +347,45 @@ try {
 } catch (e) {
     print(e.stack || e);
 }
+
+/*===
+argument coercion order
+invalid 1st arg
+TypeError
+invalid 2nd arg
+opts.stream read
+URIError
+===*/
+
+// Argument coercion order: left to right.
+
+function argumentCoercionOrderTest() {
+    var opts = {};
+    Object.defineProperty(opts, 'stream', {
+        get: function () { print('opts.stream read'); throw new URIError('aiee'); }
+    });
+
+    // Must fail before side effect on 2nd argument.
+    print('invalid 1st arg');
+    try {
+        new TextDecoder().decode(123, opts);
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+
+    print('invalid 2nd arg');
+    try {
+        new TextDecoder().decode(new Uint8Array([ 1, 2, 3 ]), opts);
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    print('argument coercion order');
+    argumentCoercionOrderTest();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Avoid potential for memory unsafe behavior if parsing decode options or pushing a fixed output buffer cause a side effect which invalidates the input buffer pointer.

The fix assumes that argument type check order is not strictly in order; the WHATWG specification doesn't seem to guarantee a specific order which is useful here. If this isn't correct, the type check needs to happen first, while the actual data pointer is looked up just before the decoding process.

If the algorithm is later converted into a chunked + bufwriter based process, the input base pointer needs to be looked up on every resize. The input length also needs to be revalidated at every resize because a side effect may indeed resize the input buffer to be smaller so that a previously looked up length is no longer valid.