### PR TITLE
Update Node.js Buffer gap for Node.js v6.8.1

### DIFF
--- a/doc/buffers.rst
+++ b/doc/buffers.rst
@@ -46,7 +46,7 @@ type so various approaches are used:
 * Node.js Buffer:
 
   - http://nodejs.org/api/buffer.html
-  - https://nodejs.org/docs/v0.12.1/api/buffer.html
+  - https://nodejs.org/docs/v6.8.1/api/buffer.html
   - https://github.com/joyent/node/blob/master/lib/buffer.js
 
 * Duktape has a custom plain buffer type which has a minimal memory footprint:
@@ -1066,7 +1066,7 @@ Current:
 
 Latest at time of writing:
 
-* https://nodejs.org/docs/v6.7.0/api/buffer.html
+* https://nodejs.org/docs/v6.8.1/api/buffer.html
 
 Gap between current implementation and latest:
 
@@ -1097,7 +1097,7 @@ Gap between current implementation and latest:
 * ``Buffer.byteLength(string[, encoding])`` ignores the encoding argument
   and just returns the byte length of the internal string representation
   (CESU-8 typically, but not always).  It also doesn't handle buffer,
-  Uint8Array, etc values which now have special handling in v6.7.0.
+  Uint8Array, etc values which now have special handling in v6.8.1.
 
 * ``Buffer.from()`` is missing.  It can share most code with the constructor.
 
@@ -1108,10 +1108,10 @@ Gap between current implementation and latest:
   used by the implementation (i.e. no "unsafe" buffers are implemented).
 
 * ``SlowBuffer`` is not implemented; it's part of v0.12.1 and deprecated (but
-  present) in v6.7.0.  If deprecated features are supported, it should be
+  present) in v6.8.1.  If deprecated features are supported, it should be
   implemented.
 
-* ``buf.compare()`` has additional arguments in v6.7.0 (source/target indices)
+* ``buf.compare()`` has additional arguments in v6.8.1 (source/target indices)
   which are not implemented.
 
 * ``buf.copy()`` return value has been specified explicitly, must compare
@@ -1134,10 +1134,10 @@ Gap between current implementation and latest:
 * ``buf.lastIndexOf()`` missing.  Note that this is not the same as typed
   array lastIndexOf().
 
-* ``buf.length`` writability comments in v6.7.0 may need documentation.
+* ``buf.length`` writability comments in v6.8.1 may need documentation.
 
 * ``buf.readDoubleBE()``, ``buf.writeDoubleBE()`` and all the other read/write
-  accessors seem to be the same in v6.7.0.   Duktape doesn't implement the
+  accessors seem to be the same in v6.8.1.   Duktape doesn't implement the
   ``noAssert`` argument and always checks the offsets (which should be within
   the specification because:
 
@@ -1150,7 +1150,7 @@ Gap between current implementation and latest:
 
 * ``buf.values()`` missing.
 
-* ``buf.write()`` doesn't implement encoding.  In both v0.12.1 and v6.7.0
+* ``buf.write()`` doesn't implement encoding.  In both v0.12.1 and v6.8.1
   partially encoded characters won't be written at all so that a few bytes at
   the end of the buffer may (apparently) be left untouched on a truncated
   write.  Duktape doesn't currently implement this behavior.

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -230,7 +230,7 @@ changes below.  Here's a summary of changes:
   C code can still do so using ``duk_buffer_to_string()`` (or by direct buffer
   and string operations) and can expose such a binding to Ecmascript code.
 
-* Node.js Buffer binding has been aligned more with Node.js v6.7.0 (from
+* Node.js Buffer binding has been aligned more with Node.js v6.8.1 (from
   Node.js v0.12.1).
 
 * Disabling ``DUK_USE_BUFFEROBJECT_SUPPORT`` allows use of plain buffers in
@@ -266,7 +266,7 @@ To upgrade:
     one-element input array which had special handling in Node.js v0.12.1.
 
   - Review Buffer code for Node.js Buffer changes between Node.js versions
-    v0.12.1 and v6.7.0 in general.
+    v0.12.1 and v6.8.1 in general.
 
 * If you're using plain buffers, review their usage especially in Ecmascript
   code.
@@ -345,7 +345,7 @@ even more detail):
     update, as Node.js Buffer constructor also recognizes ArrayBuffers now.
 
 - ``ArrayBuffer.isView(nodejsBuffer)`` is now true to reflect the fact that
-  Node.js Buffers are Uint8Arrays in Node.js v6.7.0.
+  Node.js Buffers are Uint8Arrays in newer Node.js versions.
 
 * ``new Uint32Array(plainBuffer)`` and other typed array constructors coerce
   the argument plain buffer into an ArrayBuffer instance which is then used

--- a/tests/ecmascript/test-bi-nodejs-buffer-buffer-property.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-buffer-property.js
@@ -1,5 +1,5 @@
 /*
- *  Node.js v6.7.0 buffers are Uint8Array instances and have a .buffer property.
+ *  Node.js v6.8.1 buffers are Uint8Array instances and have a .buffer property.
  */
 
 /*===
@@ -14,7 +14,7 @@ function test() {
     // Property exists.
     print('buffer' in buf);
 
-    // In ES6 this should be false (also in Node.js v6.7.0) because the .buffer
+    // In ES6 this should be false (also in Node.js v6.8.1) because the .buffer
     // property is an inherited accessor.  In the current Duktape implementation
     // it is a concrete property so this is true now.
     print(Object.getOwnPropertyDescriptor(buf, 'buffer') != null);

--- a/tests/ecmascript/test-bi-nodejs-buffer-class.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-class.js
@@ -1,5 +1,5 @@
 /*
- *  Duktape 2.x matches Node.js v6.7.0 where Buffer instances are Uint8Arrays,
+ *  Duktape 2.x matches Node.js v6.8.1 where Buffer instances are Uint8Arrays,
  *  i.e. the internal class is "Uint8Array".
  */
 

--- a/tests/ecmascript/test-bi-nodejs-buffer-concat.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-concat.js
@@ -269,7 +269,7 @@ function concatTest() {
 
     // Length 1 used to have special handling in Node.js v0.12.1: totalLength
     // is ignored and the (only) array element is returned without creating a
-    // copy.  This was changed in later versions and by v6.7.0 (new baseline)
+    // copy.  This was changed in later versions and by v6.8.1 (new baseline)
     // there's no longer special handling.
 
     test([b2], undefined);
@@ -362,7 +362,7 @@ function concatTest() {
     print(b2.length);
 
     // Specific test for 0-length array: totalLength is ignored even in
-    // Node.js v6.7.0 when argument array is zero length.
+    // Node.js v6.8.1 when argument array is zero length.
     b1 = new Buffer('abcdefgh');
     b2 = Buffer.concat([], 100);
     print(Buffer.isBuffer(b2));

--- a/tests/ecmascript/test-bi-nodejs-buffer-instance-enum.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-instance-enum.js
@@ -52,7 +52,7 @@ function enumeratingAndKeysTest() {
 
     b.fill(0x12);
 
-    // Node.js v6.7.0 enumerates index keys, 'buffer', 'parent', and all
+    // Node.js v6.8.1 enumerates index keys, 'buffer', 'parent', and all
     // Buffer.prototype methods (they're enumerable).
     //
     // In Duktape the Buffer.prototype methods are not enumerable as that's

--- a/tests/ecmascript/test-bi-nodejs-buffer-misc-isview.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-misc-isview.js
@@ -1,5 +1,5 @@
 /*
- *  In Node.js v6.7.0 Buffers are Uint8Arrays, so that ArrayBuffer.isView()
+ *  In Node.js v6.8.1 Buffers are Uint8Arrays, so that ArrayBuffer.isView()
  *  is true.
  */
 

--- a/website/guide/intro.html
+++ b/website/guide/intro.html
@@ -62,7 +62,7 @@ engines):</p>
 
 <p>Node.js Buffer support is based on:</p>
 <ul>
-<li> <a href="https://nodejs.org/docs/v0.12.1/api/buffer.html">Buffer Node.js v0.12.1</a></li>
+<li> <a href="https://nodejs.org/docs/v6.8.1/api/buffer.html">Buffer Node.js v6.8.1</a></li>
 </ul>
 
 <h2>Features</h2>
@@ -71,7 +71,7 @@ engines):</p>
 features (some are visible to applications, while others are internal):</p>
 <ul>
 <li>Khronos/ES6 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>
-    and <a href="https://nodejs.org/docs/v0.12.1/api/buffer.html">Node.js Buffer</a> bindings,
+    and <a href="https://nodejs.org/docs/v6.8.1/api/buffer.html">Node.js Buffer</a> bindings,
     plain buffer type (lightweight ArrayBuffer)</li>
 <li>From Ecmascript 2015 (E6): <code>setPrototypeOf</code>/<code>__proto__</code>,
     a subset of <code>Proxy</code> objects, computed property names,

--- a/website/index/index.html
+++ b/website/index/index.html
@@ -43,7 +43,7 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
     <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">Ecmascript 2015 (E6)</a> and
     <a href="http://www.ecma-international.org/ecma-262/7.0/index.html">Ecmascript 2016 (E7)</a></li>
 <li>Khronos/ES6 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>
-    and <a href="https://nodejs.org/docs/v0.12.1/api/buffer.html">Node.js Buffer</a> bindings</li>
+    and <a href="https://nodejs.org/docs/v6.8.1/api/buffer.html">Node.js Buffer</a> bindings</li>
 <li><a href="https://encoding.spec.whatwg.org/#api">Encoding API</a> bindings based on the WHATWG Encoding Living Standard</li>
 <li>Built-in debugger</li>
 <li>Built-in regular expression engine</li>


### PR DESCRIPTION
- [x] Recheck gap description from v6.7.0 to v6.8.1
- [x] Update website, documentation, and tests referring to Node.js snapshot (a bit premature but some behaviors have already been changed)