### PR TITLE
Add internal support for [[Get]]/[[Set]] receiver

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2019,3 +2019,6 @@ Planned
 * Internal change: rework tagged value (duk_tval) fastint/integer handling
   macros to avoid multiple evaluation of argument(s) and for easier mixing
   of fastint and non-fastint aware code (GH-702)
+
+* Internal change: Add support for a receiver object in get/putprop operations,
+  needed by several ES6+ algorithms (GH-1027)

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -27,7 +27,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	tv_obj = duk_require_tval(ctx, obj_idx);
 	tv_key = duk_require_tval(ctx, -1);
 
-	rc = duk_hobject_getprop(thr, tv_obj, tv_key);
+	rc = duk_hobject_getprop(thr, tv_obj, tv_key, tv_obj);
 	DUK_ASSERT(rc == 0 || rc == 1);
 	/* a value is left on stack regardless of rc */
 
@@ -114,7 +114,7 @@ DUK_LOCAL duk_bool_t duk__put_prop_shared(duk_context *ctx, duk_idx_t obj_idx, d
 	tv_val = duk_require_tval(ctx, idx_key ^ 1);
 	throw_flag = duk_is_strict_call(ctx);
 
-	rc = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, throw_flag);
+	rc = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, tv_obj, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
 	duk_pop_2(ctx);  /* remove key and value */

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1952,7 +1952,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 	DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv_holder));
 	tv_key = DUK_GET_TVAL_NEGIDX(ctx, -1);
 	DUK_ASSERT(DUK_TVAL_IS_STRING(tv_key));
-	(void) duk_hobject_getprop(thr, tv_holder, tv_key);
+	(void) duk_hobject_getprop(thr, tv_holder, tv_key, tv_holder);
 
 	/* -> [ ... key val ] */
 

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -873,8 +873,8 @@ DUK_INTERNAL_DECL duk_bool_t duk_hobject_get_own_propdesc(duk_hthread *thr, duk_
 	duk_hobject_find_existing_entry_tval_ptr((heap), (obj), DUK_HEAP_STRING_INT_VALUE((heap)))
 
 /* core property functions */
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key);
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_val, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_recv);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_val, duk_tval *tv_recv, duk_bool_t throw_flag);
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_bool_t throw_flag);
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key);
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2277,25 +2277,27 @@ DUK_LOCAL duk_bool_t duk__putprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
  *  GETPROP: Ecmascript property read.
  */
 
-DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key) {
+DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_recv) {
 	duk_context *ctx = (duk_context *) thr;
 	duk_tval tv_obj_copy;
 	duk_tval tv_key_copy;
+	duk_tval tv_recv_copy;
 	duk_hobject *curr = NULL;
 	duk_hstring *key = NULL;
 	duk_uint32_t arr_idx = DUK__NO_ARRAY_INDEX;
 	duk_propdesc desc;
 	duk_uint_t sanity;
 
-	DUK_DDD(DUK_DDDPRINT("getprop: thr=%p, obj=%p, key=%p (obj -> %!T, key -> %!T)",
-	                     (void *) thr, (void *) tv_obj, (void *) tv_key,
-	                     (duk_tval *) tv_obj, (duk_tval *) tv_key));
+	DUK_DDD(DUK_DDDPRINT("getprop: thr=%p, obj=%p, key=%p, recv=%p (obj -> %!T, key -> %!T, recv -> %!T)",
+	                     (void *) thr, (void *) tv_obj, (void *) tv_key, (void *) tv_recv,
+	                     (duk_tval *) tv_obj, (duk_tval *) tv_key, (duk_tval *) tv_recv));
 
 	DUK_ASSERT(ctx != NULL);
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(thr->heap != NULL);
 	DUK_ASSERT(tv_obj != NULL);
 	DUK_ASSERT(tv_key != NULL);
+	DUK_ASSERT(tv_recv != NULL);
 
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
 
@@ -2310,8 +2312,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 	DUK_TVAL_SET_TVAL(&tv_obj_copy, tv_obj);
 	DUK_TVAL_SET_TVAL(&tv_key_copy, tv_key);
+	DUK_TVAL_SET_TVAL(&tv_recv_copy, tv_recv);
 	tv_obj = &tv_obj_copy;
 	tv_key = &tv_key_copy;
+	tv_recv = &tv_recv_copy;
 
 	/*
 	 *  Coercion and fast path processing
@@ -2660,7 +2664,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 			duk_pop(ctx);                     /* [key undefined] -> [key] */
 			duk_push_hobject(ctx, desc.get);
-			duk_push_tval(ctx, tv_obj);       /* note: original, uncoerced base */
+			duk_push_tval(ctx, tv_recv);      /* note: original, uncoerced base */
 #ifdef DUK_USE_NONSTD_GETTER_KEY_ARGUMENT
 			duk_dup_m3(ctx);
 			duk_call_method(ctx, 1);          /* [key getter this key] -> [key retval] */
@@ -3293,11 +3297,12 @@ DUK_LOCAL duk_bool_t duk__handle_put_array_length(duk_hthread *thr, duk_hobject 
  *      (We currently make a copy of all of the input values to avoid issues.)
  */
 
-DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_val, duk_bool_t throw_flag) {
+DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tval *tv_val, duk_tval *tv_recv, duk_bool_t throw_flag) {
 	duk_context *ctx = (duk_context *) thr;
 	duk_tval tv_obj_copy;
 	duk_tval tv_key_copy;
 	duk_tval tv_val_copy;
+	duk_tval tv_recv_copy;
 	duk_hobject *orig = NULL;  /* NULL if tv_obj is primitive */
 	duk_hobject *curr;
 	duk_hstring *key = NULL;
@@ -3309,10 +3314,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	duk_uint_t sanity;
 	duk_uint32_t new_array_length = 0;  /* 0 = no update */
 
-	DUK_DDD(DUK_DDDPRINT("putprop: thr=%p, obj=%p, key=%p, val=%p, throw=%ld "
-	                     "(obj -> %!T, key -> %!T, val -> %!T)",
-	                     (void *) thr, (void *) tv_obj, (void *) tv_key, (void *) tv_val,
-	                     (long) throw_flag, (duk_tval *) tv_obj, (duk_tval *) tv_key, (duk_tval *) tv_val));
+	DUK_DDD(DUK_DDDPRINT("putprop: thr=%p, obj=%p, key=%p, val=%p, recv=%p, throw=%ld "
+	                     "(obj -> %!T, key -> %!T, val -> %!T, recv -> %!T)",
+	                     (void *) thr, (void *) tv_obj, (void *) tv_key, (void *) tv_val, (void *) tv_recv,
+	                     (long) throw_flag, (duk_tval *) tv_obj, (duk_tval *) tv_key, (duk_tval *) tv_val, (duk_tval *) tv_recv));
 
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(thr->heap != NULL);
@@ -3320,6 +3325,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_ASSERT(tv_obj != NULL);
 	DUK_ASSERT(tv_key != NULL);
 	DUK_ASSERT(tv_val != NULL);
+	DUK_ASSERT(tv_recv != NULL);
 
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
 
@@ -3334,9 +3340,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_TVAL_SET_TVAL(&tv_obj_copy, tv_obj);
 	DUK_TVAL_SET_TVAL(&tv_key_copy, tv_key);
 	DUK_TVAL_SET_TVAL(&tv_val_copy, tv_val);
+	DUK_TVAL_SET_TVAL(&tv_recv_copy, tv_recv);
 	tv_obj = &tv_obj_copy;
 	tv_key = &tv_key_copy;
 	tv_val = &tv_val_copy;
+	tv_recv = &tv_recv_copy;
 
 	/*
 	 *  Coercion and fast path processing.
@@ -3654,15 +3662,15 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 				goto fail_no_setter;
 			}
 			duk_push_hobject(ctx, setter);
-			duk_push_tval(ctx, tv_obj);  /* note: original, uncoerced base */
-			duk_push_tval(ctx, tv_val);  /* [key setter this val] */
+			duk_push_tval(ctx, tv_recv);  /* note: original, uncoerced base */
+			duk_push_tval(ctx, tv_val);   /* [key setter this val] */
 #ifdef DUK_USE_NONSTD_SETTER_KEY_ARGUMENT
 			duk_dup_m4(ctx);
-			duk_call_method(ctx, 2);     /* [key setter this val key] -> [key retval] */
+			duk_call_method(ctx, 2);      /* [key setter this val key] -> [key retval] */
 #else
-			duk_call_method(ctx, 1);     /* [key setter this val] -> [key retval] */
+			duk_call_method(ctx, 1);      /* [key setter this val] -> [key retval] */
 #endif
-			duk_pop(ctx);                /* ignore retval -> [key] */
+			duk_pop(ctx);                 /* ignore retval -> [key] */
 			goto success_no_arguments_exotic;
 		}
 
@@ -4756,6 +4764,7 @@ DUK_INTERNAL void duk_hobject_set_length(duk_hthread *thr, duk_hobject *obj, duk
 	                           DUK_GET_TVAL_NEGIDX(ctx, -3),
 	                           DUK_GET_TVAL_NEGIDX(ctx, -2),
 	                           DUK_GET_TVAL_NEGIDX(ctx, -1),
+	                           DUK_GET_TVAL_NEGIDX(ctx, -3),
 	                           0);
 	duk_pop_n(ctx, 3);
 }
@@ -4781,7 +4790,8 @@ DUK_INTERNAL duk_uint32_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *
 	duk_push_hstring_stridx(ctx, DUK_STRIDX_LENGTH);
 	(void) duk_hobject_getprop(thr,
 	                           DUK_GET_TVAL_NEGIDX(ctx, -2),
-	                           DUK_GET_TVAL_NEGIDX(ctx, -1));
+	                           DUK_GET_TVAL_NEGIDX(ctx, -1),
+							   DUK_GET_TVAL_NEGIDX(ctx, -2));
 	val = duk_to_number(ctx, -1);
 	duk_pop_n(ctx, 3);
 

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -3518,7 +3518,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 
 			tv_obj = DUK__REGCONSTP_B(ins);
 			tv_key = DUK__REGCONSTP_C(ins);
-			rc = duk_hobject_getprop(thr, tv_obj, tv_key);  /* -> [val] */
+			rc = duk_hobject_getprop(thr, tv_obj, tv_key, tv_obj);  /* -> [val] */
 			DUK_UNREF(rc);  /* ignore */
 			tv_obj = NULL;  /* invalidated */
 			tv_key = NULL;  /* invalidated */
@@ -3541,7 +3541,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			DUK_ASSERT(tv_val != NULL);
 			tv_obj = DUK__REGCONSTP_B(ins);
 			tv_key = DUK__REGCONSTP_C(ins);
-			rc = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, DUK__STRICT());
+			rc = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, tv_obj, DUK__STRICT());
 			DUK_UNREF(rc);  /* ignore */
 			tv_obj = NULL;  /* invalidated */
 			tv_key = NULL;  /* invalidated */
@@ -3567,7 +3567,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 		 * B -> object reg/const (may be const e.g. in "'foo'[1]") \
 		 * C -> key reg/const \
 		 */ \
-		(void) duk_hobject_getprop(thr, (barg), (carg)); \
+		(void) duk_hobject_getprop(thr, (barg), (carg), (barg)); \
 		DUK__REPLACE_TOP_A_BREAK(); \
 	}
 #define DUK__PUTPROP_BODY(aarg,barg,carg) { \
@@ -3578,7 +3578,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 		 * Note: intentional difference to register arrangement \
 		 * of e.g. GETPROP; 'A' must contain a register-only value. \
 		 */ \
-		(void) duk_hobject_putprop(thr, (aarg), (barg), (carg), DUK__STRICT()); \
+		(void) duk_hobject_putprop(thr, (aarg), (barg), (carg), (aarg), DUK__STRICT()); \
 		break; \
 	}
 #define DUK__DELPROP_BODY(barg,carg) { \

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -1247,7 +1247,7 @@ duk_bool_t duk__getvar_helper(duk_hthread *thr,
 
 			DUK_TVAL_SET_OBJECT(&tv_tmp_obj, ref.holder);
 			DUK_TVAL_SET_STRING(&tv_tmp_key, name);
-			(void) duk_hobject_getprop(thr, &tv_tmp_obj, &tv_tmp_key);  /* [this value] */
+			(void) duk_hobject_getprop(thr, &tv_tmp_obj, &tv_tmp_key, &tv_tmp_obj);  /* [this value] */
 
 			/* ref.value, ref.this.binding invalidated here by getprop call */
 
@@ -1366,7 +1366,7 @@ void duk__putvar_helper(duk_hthread *thr,
 
 			DUK_TVAL_SET_OBJECT(&tv_tmp_obj, ref.holder);
 			DUK_TVAL_SET_STRING(&tv_tmp_key, name);
-			(void) duk_hobject_putprop(thr, &tv_tmp_obj, &tv_tmp_key, val, strict);
+			(void) duk_hobject_putprop(thr, &tv_tmp_obj, &tv_tmp_key, val, &tv_tmp_obj, strict);
 
 			/* ref.value and ref.this_binding invalidated here */
 		}
@@ -1390,7 +1390,7 @@ void duk__putvar_helper(duk_hthread *thr,
 
 	DUK_TVAL_SET_OBJECT(&tv_tmp_obj, thr->builtins[DUK_BIDX_GLOBAL]);
 	DUK_TVAL_SET_STRING(&tv_tmp_key, name);
-	(void) duk_hobject_putprop(thr, &tv_tmp_obj, &tv_tmp_key, val, 0);  /* 0 = no throw */
+	(void) duk_hobject_putprop(thr, &tv_tmp_obj, &tv_tmp_key, val, &tv_tmp_obj, 0 /*throw_flag*/);
 
 	/* NB: 'val' may be invalidated here because put_value may realloc valstack,
 	 * caller beware.


### PR DESCRIPTION
Prerequisite for #1025, this pull adds a `tv_recv` argument for `duk_hobject_{get|put}prop()` which corresponds to the _Receiver_ argument for [[Get]] and [[Set]], needed by several ES6+ algorithms and methods:
- http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
- http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver

Checklist:
- [x] Add support for _Receiver_ argument of [[Get]]
- [ ] Add support for _Receiver_ argument of [[Set]]
- [x] RELEASES entry
