### PR TITLE
Align argument policy for Object.keys(), Object.seal(), etc. with ES6

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1681,6 +1681,10 @@ Planned
   Buffer.prototype.toString() does UTF-8 decoding (previously buffer data
   was copied into internal string representation as is) (GH-1020)
 
+* Incompatible change: ES6 argument policy for Object.keys() etc. Instead of
+  throwing a TypeError, they now either coerce to an object or treat the
+  primitive as a non-extensible object with no properties (GH-1028)
+
 * Incompatible change: plain pointer values now test true in instanceof
   (plainPointer instanceof Duktape.Pointer === true) (GH-864)
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -585,7 +585,7 @@ objects:
           type: function
           native: duk_bi_object_constructor_keys_shared
           length: 1
-          magic: 1
+          magic: 2
       - key: "is"
         value:
           type: function
@@ -2822,7 +2822,7 @@ objects:
           type: function
           native: duk_bi_object_constructor_keys_shared
           length: 1
-          magic: 0
+          magic: 1
         es6: true
       - key: "preventExtensions"
         value:

--- a/tests/ecmascript/test-bi-object-extensible.js
+++ b/tests/ecmascript/test-bi-object-extensible.js
@@ -47,54 +47,55 @@ try {
 
 /*===
 isExtensible 0
-TypeError
+false
 isExtensible 1
-TypeError
+false
 isExtensible 2
-TypeError
+false
 isExtensible 3
-TypeError
+false
 isExtensible 4
-TypeError
+false
 isExtensible 5
-TypeError
+false
 isExtensible 6
+true
 isExtensible 7
+true
 preventExtensions 0
-TypeError
+undefined
 preventExtensions 1
-TypeError
+null
 preventExtensions 2
-TypeError
+true
 preventExtensions 3
-TypeError
+false
 preventExtensions 4
-TypeError
+123
 preventExtensions 5
-TypeError
+foo
 preventExtensions 6
+1,2,3
 preventExtensions 7
+[object Object]
 ===*/
 
 function coercionTest() {
+    // Note: ES5 behavior was to throw a TypeError for non-object values.  ES6
+    // changes this to treat them as already non-extensible objects instead.
+    // This goes for undefined and null too, even though they are not normally
+    // object coercible!
+
     var values = [ undefined, null, true, false, 123, 'foo', [1,2,3], { foo: 1, bar: 1 } ];
 
     for (i = 0; i < values.length; i++) {
         print('isExtensible', i);
-        try {
-            Object.isExtensible(values[i]);
-        } catch (e) {
-            print(e.name);
-        }
+        print(Object.isExtensible(values[i]));
     }
 
     for (i = 0; i < values.length; i++) {
         print('preventExtensions', i);
-        try {
-            Object.preventExtensions(values[i]);
-        } catch (e) {
-            print(e.name);
-        }
+        print(Object.preventExtensions(values[i]));
     }
 }
 

--- a/tests/ecmascript/test-bi-object-getownpropdesc.js
+++ b/tests/ecmascript/test-bi-object-getownpropdesc.js
@@ -73,10 +73,10 @@ try {
 coercion
 TypeError
 TypeError
-TypeError
-TypeError
-TypeError
-TypeError
+boolean foo undefined ok
+boolean foo undefined ok
+number foo undefined ok
+string foo undefined ok
 object foo undefined ok
 object foo object 1
 function foo undefined ok

--- a/tests/ecmascript/test-bi-object-getownpropnames.js
+++ b/tests/ecmascript/test-bi-object-getownpropnames.js
@@ -54,10 +54,10 @@ coercion
 TypeError
 TypeError
 TypeError
-TypeError
-TypeError
-TypeError
-TypeError
+object
+object
+object
+object
 object
 object
 object
@@ -71,7 +71,7 @@ function coercionTest() {
 
         try {
             if (is_noarg) {
-                t = Object.getOwnPropertyNames(o);
+                t = Object.getOwnPropertyNames();
             } else {
                 t = Object.getOwnPropertyNames(o);
             }

--- a/tests/ecmascript/test-bi-object-getprototypeof.js
+++ b/tests/ecmascript/test-bi-object-getprototypeof.js
@@ -33,10 +33,10 @@ firstarg
 TypeError
 TypeError
 TypeError
-TypeError
-TypeError
-TypeError
-TypeError
+ok
+ok
+ok
+ok
 ok
 ok
 ok

--- a/tests/ecmascript/test-bi-object-keys.js
+++ b/tests/ecmascript/test-bi-object-keys.js
@@ -54,10 +54,10 @@ coercion
 TypeError
 TypeError
 TypeError
-TypeError
-TypeError
-TypeError
-TypeError
+object 0
+object 0
+object 0
+object 3
 object 2
 object 2
 ===*/

--- a/tests/ecmascript/test-bi-object-seal-freeze.js
+++ b/tests/ecmascript/test-bi-object-seal-freeze.js
@@ -212,81 +212,81 @@ try {
 
 /*===
 0 0
-TypeError
+ok
 0 1
-TypeError
+ok
 0 2
-TypeError
+ok
 0 3
-TypeError
+ok
 0 4
-TypeError
+ok
 0 5
-TypeError
+ok
 0 6
 ok
 0 7
 ok
 1 0
-TypeError
+ok
 1 1
-TypeError
+ok
 1 2
-TypeError
+ok
 1 3
-TypeError
+ok
 1 4
-TypeError
+ok
 1 5
-TypeError
+ok
 1 6
 ok
 1 7
 ok
 2 0
-TypeError
+ok
 2 1
-TypeError
+ok
 2 2
-TypeError
+ok
 2 3
-TypeError
+ok
 2 4
-TypeError
+ok
 2 5
-TypeError
+ok
 2 6
 ok
 2 7
 ok
 3 0
-TypeError
+ok
 3 1
-TypeError
+ok
 3 2
-TypeError
+ok
 3 3
-TypeError
+ok
 3 4
-TypeError
+ok
 3 5
-TypeError
+ok
 3 6
 ok
 3 7
 ok
 4 0
-TypeError
+ok
 4 1
-TypeError
+ok
 4 2
-TypeError
+ok
 4 3
-TypeError
+ok
 4 4
-TypeError
+ok
 4 5
-TypeError
+ok
 4 6
 ok
 4 7


### PR DESCRIPTION
ES6 changes the argument policy for functions such as `Object.keys()` and `Object.freeze()` to accept primitive values, treating them as though they were non-extensible objects with no properties, rather than rejecting them with a `TypeError` as in ES5.  This pull implements that change of behavior.

Affected functions:
- [x] `Object.freeze`
- [x] `Object.getOwnPropertyDescriptor`
- [x] `Object.getOwnPropertyNames`
- [x] `Object.getPrototypeOf`
- [x] `Object.isExtensible`
- [x] `Object.isFrozen`
- [x] `Object.isSealed`
- [x] `Object.keys`
- [x] `Object.preventExtensions`
- [x] `Object.seal`

Checklist:
- [x] Review ES 2015 to see exactly which functions are affected
- [x] Implement the argument policy change
- [x] This got a bit awkward in spots, review changes and clean up
- [x] Fix testcases to align with new argument policy
- [x] Verify against ES6 to ensure other behavior matches
=> *Possible issue with freeze/seal, best tackled separately*
- [x] Squash commits and rebase against latest master
- [x] Releases entry
