### PR TITLE
Small cleanups to ES6 Reflect built-in

### DIFF
--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -9,8 +9,8 @@ spirit to Lua's.
 Duktape supports the full E5/E5.1 feature set including errors, Unicode
 strings, and regular expressions, a subset of Ecmascript 2015 (E6) and
 Ecmascript 2016 (E7) features (e.g. computed property names, Proxy objects,
-exponentiation operator), Khronos/ES6 ArrayBuffer/TypedView, Node.js Buffer,
-and WHATWG Encoding API living standard.
+exponentiation operator, Reflect), Khronos/ES6 ArrayBuffer/TypedView, Node.js
+Buffer, and WHATWG Encoding API living standard.
 
 Duktape also provides a number of custom features such as error tracebacks,
 additional data types for better C integration, combined reference counting

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -198,6 +198,8 @@ DUK_INTERNAL_DECL void duk_unpack(duk_context *ctx);
 
 DUK_INTERNAL_DECL void duk_require_constructor_call(duk_context *ctx);
 
+DUK_INTERNAL_DECL void duk_require_constructable(duk_context *ctx, duk_idx_t idx);
+
 /* Raw internal valstack access macros: access is unsafe so call site
  * must have a guarantee that the index is valid.  When that is the case,
  * using these macro results in faster and smaller code than duk_get_tval().

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1605,6 +1605,18 @@ DUK_EXTERNAL void duk_require_function(duk_context *ctx, duk_idx_t idx) {
 	}
 }
 
+DUK_INTERNAL_DECL void duk_require_constructable(duk_context *ctx, duk_idx_t idx) {
+	duk_hobject *h;
+
+	h = duk_require_hobject_accept_mask(ctx, idx, DUK_TYPE_MASK_LIGHTFUNC);
+	if (h == NULL) {
+		return;  /* Lightfuncs are constructable. */
+	}
+	if (!DUK_HOBJECT_HAS_CONSTRUCTABLE(h)) {
+		DUK_ERROR_REQUIRE_TYPE_INDEX((duk_hthread *) ctx, idx, "constructable", DUK_STR_NOT_CONSTRUCTABLE);
+	}
+}
+
 DUK_EXTERNAL duk_context *duk_get_context(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -171,6 +171,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 	duk_idx_t i;
 	duk_int_t magic;
 	duk_idx_t nargs;
+	duk_uint_t mask;
 
 	magic = duk_get_current_magic(ctx);
 	switch (magic) {
@@ -218,12 +219,11 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 
 	/* [ func thisArg? argArray ] */
 
-	if (duk_is_null_or_undefined(ctx, idx_args)) {
+	mask = duk_get_type_mask(ctx, idx_args);
+	if (mask & (DUK_TYPE_MASK_NULL | DUK_TYPE_MASK_UNDEFINED)) {
 		DUK_DDD(DUK_DDDPRINT("argArray is null/undefined, no args"));
 		len = 0;
-	} else if (!duk_is_object(ctx, idx_args)) {
-		goto type_error;
-	} else {
+	} else if (mask & DUK_TYPE_MASK_OBJECT) {
 		DUK_DDD(DUK_DDDPRINT("argArray is an object"));
 
 		/* XXX: make this an internal helper */
@@ -237,6 +237,8 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 		for (i = 0; i < len; i++) {
 			duk_get_prop_index(ctx, idx_args, i);
 		}
+	} else {
+		goto type_error;
 	}
 	duk_remove(ctx, idx_args);
 	DUK_ASSERT_TOP(ctx, idx_args + len);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -187,7 +187,8 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 		idx_args = 2;
 		break;
 	}
-	case 2: {  /* Reflect.construct() */
+	default: {  /* Reflect.construct() */
+		DUK_ASSERT(magic == 2);
 		nargs = duk_get_top(ctx);
 		if (nargs < 2) {
 			DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -12,7 +12,6 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype(duk_context *ctx) {
 }
 
 #if defined(DUK_USE_FUNCTION_BUILTIN)
-
 DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h_sourcecode;
@@ -89,7 +88,9 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 
 	return 1;
 }
+#endif  /* DUK_USE_FUNCTION_BUILTIN */
 
+#if defined(DUK_USE_FUNCTION_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_function_prototype_to_string(duk_context *ctx) {
 	duk_tval *tv;
 
@@ -297,7 +298,9 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_call(duk_context *ctx) {
 	duk_call_method(ctx, nargs - 1);
 	return 1;
 }
+#endif  /* DUK_USE_FUNCTION_BUILTIN */
 
+#if defined(DUK_USE_FUNCTION_BUILTIN)
 /* XXX: the implementation now assumes "chained" bound functions,
  * whereas "collapsed" bound functions (where there is ever only
  * one bound function which directly points to a non-bound, final
@@ -394,5 +397,4 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 
 	return 1;
 }
-
 #endif  /* DUK_USE_FUNCTION_BUILTIN */

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -176,21 +176,19 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 
 	magic = duk_get_current_magic(ctx);
 	switch (magic) {
-	case 0: {  /* Function.prototype.apply() */
+	case 0:  /* Function.prototype.apply() */
 		DUK_ASSERT_TOP(ctx, 2);  /* not a vararg function */
 		duk_push_this(ctx);
 		duk_insert(ctx, 0);
-		DUK_ASSERT_TOP(ctx, 3);
-		idx_args = 2;
-		break;
-	}
-	case 1: {  /* Reflect.apply() */
+		/* Fall through intentionally for shared handling. */
+	case 1:  /* Reflect.apply(); Function.prototype.apply() after 'this' fixup. */
 		DUK_ASSERT_TOP(ctx, 3);  /* not a vararg function */
 		idx_args = 2;
+		duk_require_callable(ctx, 0);
 		break;
-	}
-	default: {  /* Reflect.construct() */
+	default:  /* Reflect.construct() */
 		DUK_ASSERT(magic == 2);
+		duk_require_constructable(ctx, 0);
 		nargs = duk_get_top(ctx);
 		if (nargs < 2) {
 			DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
@@ -202,9 +200,6 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 		idx_args = 1;
 		break;
 	}
-	}
-
-	duk_require_callable(ctx, 0);
 
 	if (magic != 2) {
 		DUK_DDD(DUK_DDDPRINT("func=%!iT, thisArg=%!iT, argArray=%!iT",

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -254,7 +254,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx
 	DUK_ASSERT_TOP(ctx, 0);
 	(void) duk_push_this_coercible_to_object(ctx);
 	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_TO_STRING);
+#if 0  /* This is mentioned explicitly in the E5.1 spec, but duk_call_method() checks for it in practice. */
 	duk_require_callable(ctx, 1);
+#endif
 	duk_dup_0(ctx);  /* -> [ O toString O ] */
 	duk_call_method(ctx, 0);  /* XXX: call method tail call? */
 	return 1;
@@ -546,11 +548,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_extensible(duk_context *ctx)
 	duk_hobject *h;
 
 	h = duk_require_hobject_accept_mask(ctx, 0, DUK_TYPE_MASK_LIGHTFUNC | DUK_TYPE_MASK_BUFFER);
-	if (h == NULL) {
-		duk_push_false(ctx);
-	} else {
-		duk_push_boolean(ctx, DUK_HOBJECT_HAS_EXTENSIBLE(h));
-	}
+	duk_push_boolean(ctx, h != NULL && DUK_HOBJECT_HAS_EXTENSIBLE(h));
 	return 1;
 }
 

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -152,7 +152,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_context *
 			                                        &get,
 			                                        &set);
 
-			/* [ hobject props enum(props) key desc value? getter? setter? ] */
+			/* [ hobject props enum(props) key desc [multiple values] ] */
 
 			if (pass == 0) {
 				continue;

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -488,8 +488,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_context *ct
 	 */
 	obj = duk_require_hobject_promote_mask(ctx, 0, DUK_TYPE_MASK_LIGHTFUNC | DUK_TYPE_MASK_BUFFER);
 	DUK_ASSERT(obj != NULL);
-	(void) duk_to_string(ctx, 1);
-	key = duk_require_hstring(ctx, 1);
+	key = duk_to_hstring(ctx, 1);
 	(void) duk_require_hobject(ctx, 2);
 
 	DUK_ASSERT(obj != NULL);
@@ -515,7 +514,8 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_context *ct
 	 *  Use Object.defineProperty() helper for the actual operation.
 	 */
 
-	throw_flag = (magic == 0);
+	DUK_ASSERT(magic == 0 || magic == 1);
+	throw_flag = magic ^ 1;
 	ret = duk_hobject_define_property_helper(ctx,
 	                                         defprop_flags,
 	                                         obj,

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -13,7 +13,6 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_string(duk_context *ctx) {
 }
 
 #if defined(DUK_USE_OBJECT_BUILTIN)
-
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor(duk_context *ctx) {
 	duk_uint_t arg_mask;
 
@@ -51,7 +50,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor(duk_context *ctx) {
 	                       DUK_BIDX_OBJECT_PROTOTYPE);
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_create(duk_context *ctx) {
 	duk_tval *tv;
 	duk_hobject *proto = NULL;
@@ -95,7 +96,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_create(duk_context *ctx) {
 
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_context *ctx) {
 	duk_small_uint_t pass;
 	duk_uint_t defprop_flags;
@@ -179,7 +182,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_context *
 	duk_dup_0(ctx);
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_seal_freeze_shared(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *h;
@@ -228,7 +233,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_seal_freeze_shared(duk_context 
  fail_cannot_freeze:
 	DUK_DCERROR_TYPE_INVALID_ARGS(thr);  /* XXX: proper error message */
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_sealed_frozen_shared(duk_context *ctx) {
 	duk_hobject *h;
 	duk_bool_t is_frozen;
@@ -249,7 +256,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_sealed_frozen_shared(duk_con
 	}
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 0);
 	(void) duk_push_this_coercible_to_object(ctx);
@@ -261,13 +270,17 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx
 	duk_call_method(ctx, 0);  /* XXX: call method tail call? */
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_value_of(duk_context *ctx) {
 	/* For lightfuncs and plain buffers, returns Object() coerced. */
 	(void) duk_push_this_coercible_to_object(ctx);
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_is_prototype_of(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *h_v;
@@ -290,19 +303,21 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_is_prototype_of(duk_context *ctx)
 	duk_push_boolean(ctx, duk_hobject_prototype_chain_contains(thr, DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h_v), h_obj, 0 /*ignore_loop*/));
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_has_own_property(duk_context *ctx) {
 	return duk_hobject_object_ownprop_helper(ctx, 0 /*required_desc_flags*/);
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_property_is_enumerable(duk_context *ctx) {
 	return duk_hobject_object_ownprop_helper(ctx, DUK_PROPDESC_FLAG_ENUMERABLE /*required_desc_flags*/);
 }
-
 #endif  /* DUK_USE_OBJECT_BUILTIN */
 
 #if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
-
 /* Shared helper to implement Object.getPrototypeOf and the ES6
  * Object.prototype.__proto__ getter.
  *
@@ -351,7 +366,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_getprototype_shared(duk_context *ctx) {
 	}
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 /* Shared helper to implement ES6 Object.setPrototypeOf and
  * Object.prototype.__proto__ setter.
  *
@@ -451,7 +468,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 		return 1;
 	}
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_context *ctx) {
 	/*
 	 *  magic = 0: Object.defineProperty()
@@ -536,12 +555,16 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_context *ct
 	}
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_get_own_property_descriptor(duk_context *ctx) {
 	/* XXX: no need for indirect call */
 	return duk_hobject_object_get_own_property_descriptor(ctx);
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_extensible(duk_context *ctx) {
 	duk_hobject *h;
 
@@ -549,7 +572,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_extensible(duk_context *ctx)
 	duk_push_boolean(ctx, h != NULL && DUK_HOBJECT_HAS_EXTENSIBLE(h));
 	return 1;
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 /* Shared helper for Object.getOwnPropertyNames() and Object.keys().
  * Magic: 0=getOwnPropertyNames, 1=Object.keys.
  */
@@ -651,7 +676,9 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 
 	return duk_hobject_get_enumerated_keys(ctx, enum_flags);
 }
+#endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
+#if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_prevent_extensions(duk_context *ctx) {
 	/*
 	 *  magic = 0: Object.preventExtensions()
@@ -684,5 +711,4 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_prevent_extensions(duk_context 
 	}
 	return 1;
 }
-
 #endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -320,8 +320,6 @@ DUK_INTERNAL duk_ret_t duk_bi_object_getprototype_shared(duk_context *ctx) {
 	duk_hobject *proto;
 	duk_tval *tv;
 
-	DUK_UNREF(thr);
-
 	if (duk_get_current_magic(ctx) == 0) {
 		tv = DUK_HTHREAD_THIS_PTR(thr);
 	} else {

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -318,8 +318,8 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_property_is_enumerable(duk_contex
 #endif  /* DUK_USE_OBJECT_BUILTIN */
 
 #if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
-/* Shared helper to implement Object.getPrototypeOf and the ES6
- * Object.prototype.__proto__ getter.
+/* Shared helper to implement Object.getPrototypeOf,
+ * Object.prototype.__proto__ getter, and Reflect.getPrototypeOf.
  *
  * http://www.ecma-international.org/ecma-262/6.0/index.html#sec-get-object.prototype.__proto__
  */
@@ -369,8 +369,8 @@ DUK_INTERNAL duk_ret_t duk_bi_object_getprototype_shared(duk_context *ctx) {
 #endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
 
 #if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
-/* Shared helper to implement ES6 Object.setPrototypeOf and
- * Object.prototype.__proto__ setter.
+/* Shared helper to implement ES6 Object.setPrototypeOf,
+ * Object.prototype.__proto__ setter, and Reflect.setPrototypeOf.
  *
  * http://www.ecma-international.org/ecma-262/6.0/index.html#sec-get-object.prototype.__proto__
  * http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.setprototypeof
@@ -390,7 +390,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 	duk_uint_t mask;
 	duk_int_t magic;
 
-	/* Preliminaries for __proto__ and setPrototypeOf (E6 19.1.2.18 steps 1-4) */
+	/* Preliminaries for __proto__ and setPrototypeOf (E6 19.1.2.18 steps 1-4). */
 	magic = duk_get_current_magic(ctx);
 	if (magic == 0) {
 		duk_push_this_check_object_coercible(ctx);
@@ -434,7 +434,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 	}
 	DUK_ASSERT(h_obj != NULL);
 
-	/* [[SetPrototypeOf]] standard behavior, E6 9.1.2 */
+	/* [[SetPrototypeOf]] standard behavior, E6 9.1.2. */
 	/* TODO: implement Proxy object support here */
 
 	if (h_new_proto == DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h_obj)) {
@@ -444,7 +444,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_setprototype_shared(duk_context *ctx) {
 		goto fail_nonextensible;
 	}
 	for (h_curr = h_new_proto; h_curr != NULL; h_curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h_curr)) {
-		/* Loop prevention */
+		/* Loop prevention. */
 		if (h_curr == h_obj) {
 			goto fail_loop;
 		}

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -20,8 +20,8 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_delete_property(duk_context *ctx) {
 
     thr = (duk_hthread *) ctx;
     DUK_ASSERT(thr != NULL);
-    tv_obj = duk_require_tval(ctx, 0);
-    tv_key = duk_require_tval(ctx, 1);
+    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
     ret = duk_hobject_delprop(thr, tv_obj, tv_key, 0 /*throw_flag*/);
     duk_push_boolean(ctx, ret);
     return 1;
@@ -48,8 +48,8 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_get(duk_context *ctx) {
 
     thr = (duk_hthread *) ctx;
     DUK_ASSERT(thr != NULL);
-    tv_obj = duk_require_tval(ctx, 0);
-    tv_key = duk_require_tval(ctx, 1);
+    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
     (void) duk_hobject_getprop(thr, tv_obj, tv_key);
     return 1;
 }
@@ -68,8 +68,8 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_has(duk_context *ctx) {
 
     thr = (duk_hthread *) ctx;
     DUK_ASSERT(thr != NULL);
-    tv_obj = duk_require_tval(ctx, 0);
-    tv_key = duk_require_tval(ctx, 1);
+    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
     ret = duk_hobject_hasprop(thr, tv_obj, tv_key);
     duk_push_boolean(ctx, ret);
     return 1;
@@ -98,9 +98,9 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_set(duk_context *ctx) {
 
     thr = (duk_hthread *) ctx;
     DUK_ASSERT(thr != NULL);
-    tv_obj = duk_require_tval(ctx, 0);
-    tv_key = duk_require_tval(ctx, 1);
-    tv_val = duk_require_tval(ctx, 2);
+    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
+    tv_val = DUK_GET_TVAL_POSIDX(ctx, 2);
     ret = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, 0 /*throw_flag*/);
     duk_push_boolean(ctx, ret);
     return 1;

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -1,6 +1,9 @@
 /*
  *  'Reflect' built-in (ES7 Section 26.1)
  *  http://www.ecma-international.org/ecma-262/7.0/#sec-reflect-object
+ *
+ *  Many Reflect built-in functions are provided by shared helpers in
+ *  duk_bi_object.c or duk_bi_function.c.
  */
 
 #include "duk_internal.h"

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -50,7 +50,7 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_get(duk_context *ctx) {
 	DUK_ASSERT(thr != NULL);
 	tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
 	tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
-	(void) duk_hobject_getprop(thr, tv_obj, tv_key);
+	(void) duk_hobject_getprop(thr, tv_obj, tv_key);  /* This could also be a duk_get_prop(). */
 	return 1;
 }
 

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -7,102 +7,102 @@
 
 #if defined(DUK_USE_REFLECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_reflect_object_delete_property(duk_context *ctx) {
-    duk_hthread *thr;
-    duk_tval *tv_obj;
-    duk_tval *tv_key;
-    duk_bool_t ret;
+	duk_hthread *thr;
+	duk_tval *tv_obj;
+	duk_tval *tv_key;
+	duk_bool_t ret;
 
-    DUK_ASSERT_TOP(ctx, 2);
-    (void) duk_require_hobject(ctx, 0);
-    (void) duk_to_string(ctx, 1);
+	DUK_ASSERT_TOP(ctx, 2);
+	(void) duk_require_hobject(ctx, 0);
+	(void) duk_to_string(ctx, 1);
 
-    /* [ target key ] */
+	/* [ target key ] */
 
-    thr = (duk_hthread *) ctx;
-    DUK_ASSERT(thr != NULL);
-    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
-    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
-    ret = duk_hobject_delprop(thr, tv_obj, tv_key, 0 /*throw_flag*/);
-    duk_push_boolean(ctx, ret);
-    return 1;
+	thr = (duk_hthread *) ctx;
+	DUK_ASSERT(thr != NULL);
+	tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+	tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
+	ret = duk_hobject_delprop(thr, tv_obj, tv_key, 0 /*throw_flag*/);
+	duk_push_boolean(ctx, ret);
+	return 1;
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_reflect_object_get(duk_context *ctx) {
-    duk_hthread *thr;
-    duk_tval *tv_obj;
-    duk_tval *tv_key;
-    duk_idx_t nargs;
+	duk_hthread *thr;
+	duk_tval *tv_obj;
+	duk_tval *tv_key;
+	duk_idx_t nargs;
 
-    nargs = duk_get_top(ctx);
-    if (nargs < 2) {
-        DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
-    }
-    (void) duk_require_hobject(ctx, 0);
-    (void) duk_to_string(ctx, 1);
-    if (nargs >= 3 && !duk_strict_equals(ctx, 0, 2)) {
-        /* XXX: [[Get]] receiver currently unsupported */
-        DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
-    }
+	nargs = duk_get_top(ctx);
+	if (nargs < 2) {
+		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
+	}
+	(void) duk_require_hobject(ctx, 0);
+	(void) duk_to_string(ctx, 1);
+	if (nargs >= 3 && !duk_strict_equals(ctx, 0, 2)) {
+		/* XXX: [[Get]] receiver currently unsupported */
+		DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+	}
 
-    /* [ target key receiver? ...? ] */
+	/* [ target key receiver? ...? ] */
 
-    thr = (duk_hthread *) ctx;
-    DUK_ASSERT(thr != NULL);
-    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
-    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
-    (void) duk_hobject_getprop(thr, tv_obj, tv_key);
-    return 1;
+	thr = (duk_hthread *) ctx;
+	DUK_ASSERT(thr != NULL);
+	tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+	tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
+	(void) duk_hobject_getprop(thr, tv_obj, tv_key);
+	return 1;
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_reflect_object_has(duk_context *ctx) {
-    duk_hthread *thr;
-    duk_tval *tv_obj;
-    duk_tval *tv_key;
-    duk_bool_t ret;
+	duk_hthread *thr;
+	duk_tval *tv_obj;
+	duk_tval *tv_key;
+	duk_bool_t ret;
 
-    DUK_ASSERT_TOP(ctx, 2);
-    (void) duk_require_hobject(ctx, 0);
-    (void) duk_to_string(ctx, 1);
+	DUK_ASSERT_TOP(ctx, 2);
+	(void) duk_require_hobject(ctx, 0);
+	(void) duk_to_string(ctx, 1);
 
-    /* [ target key ] */
+	/* [ target key ] */
 
-    thr = (duk_hthread *) ctx;
-    DUK_ASSERT(thr != NULL);
-    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
-    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
-    ret = duk_hobject_hasprop(thr, tv_obj, tv_key);
-    duk_push_boolean(ctx, ret);
-    return 1;
+	thr = (duk_hthread *) ctx;
+	DUK_ASSERT(thr != NULL);
+	tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+	tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
+	ret = duk_hobject_hasprop(thr, tv_obj, tv_key);
+	duk_push_boolean(ctx, ret);
+	return 1;
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_reflect_object_set(duk_context *ctx) {
-    duk_hthread *thr;
-    duk_tval *tv_obj;
-    duk_tval *tv_key;
-    duk_tval *tv_val;
-    duk_idx_t nargs;
-    duk_bool_t ret;
+	duk_hthread *thr;
+	duk_tval *tv_obj;
+	duk_tval *tv_key;
+	duk_tval *tv_val;
+	duk_idx_t nargs;
+	duk_bool_t ret;
 
-    nargs = duk_get_top(ctx);
-    if (nargs < 3) {
-        DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
-    }
-    (void) duk_require_hobject(ctx, 0);
-    (void) duk_to_string(ctx, 1);
-    if (nargs >= 4 && !duk_strict_equals(ctx, 0, 3)) {
-        /* XXX: [[Set]] receiver currently unsupported */
-        DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
-    }
+	nargs = duk_get_top(ctx);
+	if (nargs < 3) {
+		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
+	}
+	(void) duk_require_hobject(ctx, 0);
+	(void) duk_to_string(ctx, 1);
+	if (nargs >= 4 && !duk_strict_equals(ctx, 0, 3)) {
+		/* XXX: [[Set]] receiver currently unsupported */
+		DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
+	}
 
-    /* [ target key value receiver? ...? ] */
+	/* [ target key value receiver? ...? ] */
 
-    thr = (duk_hthread *) ctx;
-    DUK_ASSERT(thr != NULL);
-    tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
-    tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
-    tv_val = DUK_GET_TVAL_POSIDX(ctx, 2);
-    ret = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, 0 /*throw_flag*/);
-    duk_push_boolean(ctx, ret);
-    return 1;
+	thr = (duk_hthread *) ctx;
+	DUK_ASSERT(thr != NULL);
+	tv_obj = DUK_GET_TVAL_POSIDX(ctx, 0);
+	tv_key = DUK_GET_TVAL_POSIDX(ctx, 1);
+	tv_val = DUK_GET_TVAL_POSIDX(ctx, 2);
+	ret = duk_hobject_putprop(thr, tv_obj, tv_key, tv_val, 0 /*throw_flag*/);
+	duk_push_boolean(ctx, ret);
+	return 1;
 }
 #endif  /* DUK_USE_REFLECT_BUILTIN */

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -5002,7 +5002,8 @@ void duk_hobject_prepare_property_descriptor(duk_context *ctx,
 }
 
 /*
- *  Object.defineProperty() related helper  (E5 Section 15.2.3.6)
+ *  Object.defineProperty() related helper (E5 Section 15.2.3.6).
+ *  Also handles ES6 Reflect.defineProperty().
  *
  *  Inlines all [[DefineOwnProperty]] exotic behaviors.
  *
@@ -5084,14 +5085,14 @@ duk_bool_t duk_hobject_define_property_helper(duk_context *ctx,
 	                     "has_value=%ld value=%!T "
 	                     "has_get=%ld get=%p=%!O "
 	                     "has_set=%ld set=%p=%!O "
-	                     "arr_idx=%ld",
+	                     "arr_idx=%ld throw_flag=!%ld",
 	                     (long) has_enumerable, (long) is_enumerable,
 	                     (long) has_configurable, (long) is_configurable,
 	                     (long) has_writable, (long) is_writable,
 	                     (long) has_value, (duk_tval *) (idx_value >= 0 ? duk_get_tval(ctx, idx_value) : NULL),
 	                     (long) has_get, (void *) get, (duk_heaphdr *) get,
 	                     (long) has_set, (void *) set, (duk_heaphdr *) set,
-	                     (long) arr_idx));
+	                     (long) arr_idx, (long) throw_flag));
 
 	/*
 	 *  Array exotic behaviors can be implemented at this point.  The local variables

--- a/tests/ecmascript/test-bi-reflect-apply-construct.js
+++ b/tests/ecmascript/test-bi-reflect-apply-construct.js
@@ -3,6 +3,8 @@
  *  Reflect.construct()
  */
 
+print=console.log
+
 /*===
 func() called with 2 args
 Casper the friendly ghost
@@ -85,6 +87,7 @@ last arg: kittiez r food 4 cowz
 true
 Hi, my name is Kittycow the kitty-eating cow
 Kittycow says: MOOOOOOoooooooooooooo...
+TypeError
 ===*/
 
 function constructTest() {
@@ -125,6 +128,24 @@ function constructTest() {
     var cow = Reflect.construct(Person, argList);
     print(cow instanceof Person);
     cow.talk();
+
+    // Construct must check that first argument is constructable before
+    // processing the arguments object.
+    var nonConstructable = Math.cos;  // built-in which is callable but not constructable
+    try {
+        var argObject = {};
+        Object.defineProperties(argObject, {
+            length: { value: 3 },
+            0: { get: function () { print('get 0'); return 'foo'; } },
+            1: { get: function () { print('get 1'); return 'bar'; } },
+            2: { get: function () { print('get 2'); return 'quux'; } }
+        })
+        Reflect.construct(nonConstructable, argObject);
+        print('never here');
+    } catch (e) {
+        //print(e.stack);
+        print(e.name);
+    }
 }
 
 try {

--- a/tests/ecmascript/test-bi-reflect-apply-construct.js
+++ b/tests/ecmascript/test-bi-reflect-apply-construct.js
@@ -87,7 +87,6 @@ last arg: kittiez r food 4 cowz
 true
 Hi, my name is Kittycow the kitty-eating cow
 Kittycow says: MOOOOOOoooooooooooooo...
-TypeError
 ===*/
 
 function constructTest() {
@@ -128,24 +127,6 @@ function constructTest() {
     var cow = Reflect.construct(Person, argList);
     print(cow instanceof Person);
     cow.talk();
-
-    // Construct must check that first argument is constructable before
-    // processing the arguments object.
-    var nonConstructable = Math.cos;  // built-in which is callable but not constructable
-    try {
-        var argObject = {};
-        Object.defineProperties(argObject, {
-            length: { value: 3 },
-            0: { get: function () { print('get 0'); return 'foo'; } },
-            1: { get: function () { print('get 1'); return 'bar'; } },
-            2: { get: function () { print('get 2'); return 'quux'; } }
-        })
-        Reflect.construct(nonConstructable, argObject);
-        print('never here');
-    } catch (e) {
-        //print(e.stack);
-        print(e.name);
-    }
 }
 
 try {

--- a/tests/ecmascript/test-bi-reflect-arg-policy.js
+++ b/tests/ecmascript/test-bi-reflect-arg-policy.js
@@ -108,6 +108,7 @@ TypeError
 TypeError
 TypeError
 TypeError
+TypeError
 ===*/
 
 function argPolicyTest() {
@@ -187,6 +188,24 @@ function argPolicyTest() {
             print(e.name);
         }
     });
+
+    // Construct must check that first argument is constructable before
+    // processing the arguments object.
+    var nonConstructable = Math.cos;  // built-in which is callable but not constructable
+    try {
+        var argObject = {};
+        Object.defineProperties(argObject, {
+            length: { value: 3 },
+            0: { get: function () { print('get 0'); return 'foo'; } },
+            1: { get: function () { print('get 1'); return 'bar'; } },
+            2: { get: function () { print('get 2'); return 'quux'; } }
+        })
+        Reflect.construct(nonConstructable, argObject);
+        print('never here');
+    } catch (e) {
+        //print(e.stack);
+        print(e.name);
+    }
 }
 
 try {


### PR DESCRIPTION
Some compile warning and other small cleanups to the ES6 Reflect built-in. Some of the changes are to code already in master prior to Reflect, but were convenient to improve at the same time.