### PR TITLE
Closed form offset calculation for RegExp compiler

### DIFF
--- a/tests/ecmascript/test-dev-regexp-negative-jump-offset.js
+++ b/tests/ecmascript/test-dev-regexp-negative-jump-offset.js
@@ -1,0 +1,59 @@
+/*
+ *  Exercise some corner cases for RegExp compiler negative jump offset
+ *  computation.
+ */
+
+/*===
+62
+1021
+32764
+1048571
+33554426
+1073741817 skipped
+done
+===*/
+
+var dot64M = '.';
+while (dot64M.length < 64 * 1024 * 1024) {
+    //print(dot64M.length);
+    dot64M = dot64M + dot64M;
+}
+
+function build(n) {
+    var any = dot64M.substr(0, n);
+    var re_str = '^(?:' + any + ')+x$';
+    var input = any + any + 'x';
+    return { re_str: re_str, input: input };
+}
+
+function test() {
+    [ 0x3e, 0x3fd, 0x7ffc, 0xffffb, 0x1fffffa, 0x3ffffff9 ].forEach(function (v) {
+        var i;
+
+        if (v >= 64 * 1024 * 1024) {
+            print(v, 'skipped');  // cannot test
+            return;
+        }
+
+        print(v);
+        for (i = -100; i <= 3; i++) {
+            if (v + i < 1) { continue; }
+            //print(v, v.toString(16), i);
+            var t = build(v + i);
+            //print(Duktape.enc('jx', t));
+            var re = new RegExp(t.re_str);
+            var res = re.test(t.input);
+            //print(v, i, v + i, res);
+            if (res !== true) {
+                throw new Error('failed for v + i = ' + (v + i));
+            }
+        }
+    });
+}
+
+try {
+    test();
+    print('done');
+} catch (e) {
+    print((e.stack || e).substr(0, 1000));
+}

--- a/util/re_neg_jump_offset.py
+++ b/util/re_neg_jump_offset.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python2
+
+def xutf8len(x):
+    if x < 0x80: return 1
+    if x < 0x800: return 2
+    if x < 0x10000: return 3
+    if x < 0x200000: return 4
+    if x < 0x4000000: return 5
+    if x < 0x80000000: return 6
+    return 7
+
+def enci32(x):
+    if x >= 0: return x
+    return (-x) * 2 + 1
+
+def skipadjust(x):
+    if x >= 0: return 0
+    t = xutf8len(enci32(x))
+    t = xutf8len(enci32(x - t))  # byte length of encoded, adjusted skip
+    return t
+
+def adjusted(skip):
+    return skip - skipadjust(skip)
+
+# Binary search for lowest negative skip offset which, when adjusted for
+# encoding length, encodes to numbytes.
+def binsearch(numbytes):
+    a = -1
+    b = -0xffffffff
+
+    while a - b > 1:
+        c = (a + b) / 2
+        n = skipadjust(c)
+        #print(a, b, c, n, numbytes)
+        if n > numbytes:
+            b = c
+        else:
+            a = c
+    if skipadjust(a) == numbytes:
+        return a
+    else:
+        return b
+
+def closed1(skip):
+    if skip >= 0: return skip
+    if skip >= -0x3e: skip -= 1
+    elif skip >= -0x3fd: skip -= 2
+    elif skip >= -0x7ffc: skip -= 3
+    elif skip >= -0xffffb: skip -= 4
+    elif skip >= -0x1fffffa: skip -= 5
+    elif skip >= -0x3ffffff9: skip -= 6
+    else: skip -= 7
+    return skip
+
+def closed2(skip):
+    if skip >= 0: return skip
+    skip -= 1
+    if skip < -0x3f: skip -= 1
+    if skip < -0x3ff: skip -= 1
+    if skip < -0x7fff: skip -= 1
+    if skip < -0xfffff: skip -= 1
+    if skip < -0x1ffffff: skip -= 1
+    if skip < -0x3fffffff: skip -= 1
+    return skip
+
+def main():
+    def validate(skip):
+        print('validate: skip %d -> adjusted %d, closed1 %d, closed2 %d' % (skip, adjusted(skip), closed1(skip), closed2(skip)))
+        assert(adjusted(skip) == closed1(skip))
+        assert(adjusted(skip) == closed2(skip))
+
+    for i in xrange(1, 7):
+        n = binsearch(i)
+        print('lowest unadjusted skip offset for %d byte encoding: 0x%x' % (i, n))
+        for j in xrange(-1, 2):
+            validate(n + j)
+
+    print('spot checks')
+    validate(-0x7fffffff)
+    validate(-0x80000000)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Small tweak to use a closed form solution rather than an iterative one. Code is slightly smaller and avoids a few unnecessary internal helper calls.
