### PR TITLE
Add duk_ret_t return value to duk_{throw,error,error_va,fatal}() prototype

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1785,6 +1785,10 @@ Planned
   in line with how application code detects active features and reduces
   footprint (GH-988)
 
+* Change return from of duk_throw(), duk_error(), and duk_fatal() from void
+  to duk_ret_t which allows them to be called using the idiom
+  "return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid argument");" (GH-1038)
+
 * Add convenience API calls duk_get_prop_lstring(), duk_put_prop_lstring(),
   duk_del_prop_lstring(), duk_has_prop_lstring(), duk_get_global_lstring(),
   duk_put_global_lstring() (GH-946, GH-953)

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -601,6 +601,23 @@ To upgrade:
   to accept also ``TypeError`` or ``RangeError``.  (In general depending on a
   specific error type should be only be done when it's absolute necessary.)
 
+duk_error(), duk_error_va(), duk_throw(), duk_fatal() have a return value
+-------------------------------------------------------------------------
+
+The prototype return value for these error throwers was changed from ``void``
+to ``duk_ret_t`` which allows for idioms like::
+
+    if (argvalue < 0) {
+        return duk_error(ctx, DUK_ERR_TYPE_ERROR,
+                         "invalid arg: %d", (int) argvalue);
+    }
+
+To upgrade:
+
+* Without an explicit cast to ``(void) duk_error(...)`` you may get some new
+  compiler warnings.  Fix by adding the void cast, or convert the call sites
+  to use the ``return duk_error(...)`` idiom where applicable.
+
 duk_dump_context_stdout() and duk_dump_context_stderr() removed
 ---------------------------------------------------------------
 

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -291,16 +291,16 @@ DUK_EXTERNAL_DECL void duk_gc(duk_context *ctx, duk_uint_t flags);
  *  Error handling
  */
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_throw(duk_context *ctx));
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_fatal(duk_context *ctx, const char *err_msg));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_throw(duk_context *ctx));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg));
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
 
 #ifdef DUK_API_VARIADIC_MACROS
 #define duk_error(ctx,err_code,...)  \
 	duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
 #else
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...));
 /* One problem with this macro is that expressions like the following fail
  * to compile: "(void) duk_error(...)".  But because duk_error() is noreturn,
  * they make little sense anyway.
@@ -311,7 +311,7 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_stash(duk_context *ctx, duk_er
 	 duk_error_stash)  /* last value is func pointer, arguments follow in parens */
 #endif
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
 #define duk_error_va(ctx,err_code,fmt,ap)  \
 	duk_error_va_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4485,7 +4485,7 @@ DUK_INTERNAL void duk_unpack(duk_context *ctx) {
  *  Error throwing
  */
 
-DUK_EXTERNAL void duk_throw(duk_context *ctx) {
+DUK_EXTERNAL duk_ret_t duk_throw(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
@@ -4522,9 +4522,12 @@ DUK_EXTERNAL void duk_throw(duk_context *ctx) {
 
 	duk_err_longjmp(thr);
 	DUK_UNREACHABLE();
+#if 0  /* Never reached; if return present, gcc/clang will complain. */
+	return 0;
+#endif
 }
 
-DUK_EXTERNAL void duk_fatal(duk_context *ctx, const char *err_msg) {
+DUK_EXTERNAL duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -4548,16 +4551,22 @@ DUK_EXTERNAL void duk_fatal(duk_context *ctx, const char *err_msg) {
 	for (;;) {
 		/* loop forever, don't return (function marked noreturn) */
 	}
+#if 0  /* Never reached; if return present, gcc/clang will complain. */
+	return 0;  /* never reached */
+#endif
 }
 
-DUK_EXTERNAL void duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap) {
+DUK_EXTERNAL duk_ret_t duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
-	duk_throw(ctx);
+	(void) duk_throw(ctx);
+#if 0  /* Never reached; if return present, gcc/clang will complain. */
+	return 0;  /* never reached */
+#endif
 }
 
-DUK_EXTERNAL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...) {
+DUK_EXTERNAL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...) {
 	va_list ap;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -4565,11 +4574,14 @@ DUK_EXTERNAL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const 
 	va_start(ap, fmt);
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
 	va_end(ap);
-	duk_throw(ctx);
+	(void) duk_throw(ctx);
+#if 0  /* Never reached; if return present, gcc/clang will complain. */
+	return 0;  /* never reached */
+#endif
 }
 
 #if !defined(DUK_USE_VARIADIC_MACROS)
-DUK_EXTERNAL void duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...) {
+DUK_EXTERNAL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...) {
 	const char *filename;
 	duk_int_t line;
 	va_list ap;
@@ -4584,7 +4596,10 @@ DUK_EXTERNAL void duk_error_stash(duk_context *ctx, duk_errcode_t err_code, cons
 	va_start(ap, fmt);
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
 	va_end(ap);
-	duk_throw(ctx);
+	(void) duk_throw(ctx);
+#if 0  /* Never reached; if return present, gcc/clang will complain. */
+	return 0;  /* never reached */
+#endif
 }
 #endif  /* DUK_USE_VARIADIC_MACROS */
 

--- a/src-input/duk_error_longjmp.c
+++ b/src-input/duk_error_longjmp.c
@@ -7,7 +7,7 @@
 
 #if defined(DUK_USE_PREFER_SIZE)
 DUK_LOCAL void duk__uncaught_minimal(duk_hthread *thr) {
-	duk_fatal((duk_context *) thr, "uncaught error");
+	(void) duk_fatal((duk_context *) thr, "uncaught error");
 }
 #endif
 
@@ -19,7 +19,7 @@ DUK_LOCAL void duk__uncaught_readable(duk_hthread *thr) {
 	summary = duk_push_string_tval_readable((duk_context *) thr, &thr->heap->lj.value1);
 	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
 	buf[sizeof(buf) - 1] = (char) 0;
-	duk_fatal((duk_context *) thr, (const char *) buf);
+	(void) duk_fatal((duk_context *) thr, (const char *) buf);
 }
 #endif
 
@@ -32,7 +32,7 @@ DUK_LOCAL void duk__uncaught_error_aware(duk_hthread *thr) {
 	DUK_ASSERT(summary != NULL);
 	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
 	buf[sizeof(buf) - 1] = (char) 0;
-	duk_fatal((duk_context *) thr, (const char *) buf);
+	(void) duk_fatal((duk_context *) thr, (const char *) buf);
 }
 #endif
 

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -156,6 +156,6 @@ DUK_INTERNAL void duk_error_throw_from_negative_rc(duk_hthread *thr, duk_ret_t r
 	 *  minimal: they're only really useful for low memory targets.
 	 */
 
-	duk_error_raw(ctx, -rc, NULL, 0, "error (rc %ld)", (long) rc);
+	(void) duk_error_raw(ctx, -rc, NULL, 0, "error (rc %ld)", (long) rc);
 	DUK_UNREACHABLE();
 }

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -7824,7 +7824,7 @@ DUK_INTERNAL void duk_js_compile(duk_hthread *thr, const duk_uint8_t *src_buffer
 
 	if (safe_rc != DUK_EXEC_SUCCESS) {
 		DUK_D(DUK_DPRINT("compilation failed: %!T", duk_get_tval(ctx, -1)));
-		duk_throw(ctx);
+		(void) duk_throw(ctx);
 	}
 
 	/* [ ... template ] */

--- a/tests/api/test-error.c
+++ b/tests/api/test-error.c
@@ -1,43 +1,61 @@
 /*===
-*** test_1 (duk_pcall)
+*** test_range_error (duk_pcall)
 ==> rc=1
 ToString(error): RangeError: range error: 123
 name: RangeError
 message: range error: 123
 code: undefined
 fileName is a string: 1
-lineNumber: 45
+lineNumber: 63
 isNative: undefined
-*** test_2 (duk_pcall)
+*** test_arbitrary_code (duk_pcall)
 ==> rc=1
 ToString(error): Error: arbitrary error code
 name: Error
 message: arbitrary error code
 code: undefined
 fileName is a string: 1
-lineNumber: 56
+lineNumber: 74
 isNative: undefined
-*** test_3 (duk_pcall)
+*** test_null_message (duk_pcall)
 ==> rc=1
 ToString(error): TypeError: 6
 name: TypeError
 message: 6
 code: undefined
 fileName is a string: 1
-lineNumber: 68
+lineNumber: 86
 isNative: undefined
-*** test_4 (duk_pcall)
+*** test_vararg (duk_pcall)
 ==> rc=1
 ToString(error): RangeError: my error 123 234 foobar
 name: RangeError
 message: my error 123 234 foobar
 code: undefined
 fileName is a string: 1
-lineNumber: 79
+lineNumber: 97
+isNative: undefined
+*** test_error_return (duk_pcall)
+==> rc=1
+ToString(error): URIError: invalid argument uri
+name: URIError
+message: invalid argument uri
+code: undefined
+fileName is a string: 1
+lineNumber: 124
+isNative: undefined
+*** test_error_va_return (duk_pcall)
+==> rc=1
+ToString(error): RangeError: my error 123 234 foobar
+name: RangeError
+message: my error 123 234 foobar
+code: undefined
+fileName is a string: 1
+lineNumber: 104
 isNative: undefined
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx, void *udata) {
+static duk_ret_t test_range_error(duk_context *ctx, void *udata) {
 	(void) udata;
 
 	duk_set_top(ctx, 0);
@@ -48,7 +66,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	return 0;
 }
 
-static duk_ret_t test_2(duk_context *ctx, void *udata) {
+static duk_ret_t test_arbitrary_code(duk_context *ctx, void *udata) {
 	(void) udata;
 
 	duk_set_top(ctx, 0);
@@ -59,7 +77,7 @@ static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	return 0;
 }
 
-static duk_ret_t test_3(duk_context *ctx, void *udata) {
+static duk_ret_t test_null_message(duk_context *ctx, void *udata) {
 	(void) udata;
 
 	duk_set_top(ctx, 0);
@@ -72,23 +90,45 @@ static duk_ret_t test_3(duk_context *ctx, void *udata) {
 }
 
 /* Vararg */
-static void my_error(duk_context *ctx, duk_errcode_t errcode, const char *fmt, ...) {
+static void my_error_1(duk_context *ctx, duk_errcode_t errcode, const char *fmt, ...) {
 	va_list ap;
 
 	va_start(ap, fmt);
 	duk_error_va(ctx, errcode, fmt, ap);
 	va_end(ap);
 }
+static duk_ret_t my_error_2(duk_context *ctx, duk_errcode_t errcode, const char *fmt, ...) {
+	va_list ap;
 
-static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	va_start(ap, fmt);
+	return duk_error_va(ctx, errcode, fmt, ap);
+	va_end(ap);
+}
+
+static duk_ret_t test_vararg(duk_context *ctx, void *udata) {
 	(void) udata;
 
 	duk_set_top(ctx, 0);
 
-	my_error(ctx, DUK_ERR_RANGE_ERROR, "my error %d %d %s", 123, 234, "foobar");
+	my_error_1(ctx, DUK_ERR_RANGE_ERROR, "my error %d %d %s", 123, 234, "foobar");
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
+}
+
+static duk_ret_t test_error_return(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_set_top(ctx, 0);
+
+	return duk_error(ctx, DUK_ERR_URI_ERROR, "invalid argument uri");
+}
+
+static duk_ret_t test_error_va_return(duk_context *ctx, void *udata) {
+	(void) udata;
+	duk_set_top(ctx, 0);
+
+	return my_error_2(ctx, DUK_ERR_RANGE_ERROR, "my error %d %d %s", 123, 234, "foobar");
 }
 
 void dump_error(duk_context *ctx) {
@@ -136,8 +176,10 @@ void test(duk_context *ctx) {
 	duk_int_t rc;
 
 	/* special test macro because of dump_error() */
-	TEST(test_1);
-	TEST(test_2);
-	TEST(test_3);
-	TEST(test_4);
+	TEST(test_range_error);
+	TEST(test_arbitrary_code);
+	TEST(test_null_message);
+	TEST(test_vararg);
+	TEST(test_error_return);
+	TEST(test_error_va_return);
 }

--- a/tests/api/test-fatal-return.c
+++ b/tests/api/test-fatal-return.c
@@ -1,0 +1,28 @@
+/*===
+my_func
+fatal error: my reason
+===*/
+
+void my_fatal_handler(void *udata, const char *msg) {
+	(void) udata;
+
+	printf("fatal error: %s\n", msg);
+
+	/* A fatal error handler must not return, so exit here */
+	exit(0);
+}
+
+static duk_ret_t my_func(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	printf("my_func\n");
+	return duk_fatal(ctx, "my reason");
+}
+
+void test(duk_context *ctx) {
+	duk_context *new_ctx;
+
+	new_ctx = duk_create_heap(NULL, NULL, NULL, NULL, my_fatal_handler);
+	duk_safe_call(new_ctx, my_func, NULL, 0, 1);
+	printf("duk_safe_call() returned, should not happen\n");
+}

--- a/tests/api/test-throw.c
+++ b/tests/api/test-throw.c
@@ -1,9 +1,11 @@
 /*===
-*** test_1 (duk_safe_call)
+*** test_basic (duk_safe_call)
 ==> rc=1, result='throw me'
+*** test_return (duk_safe_call)
+==> rc=1, result='throw me too'
 ===*/
 
-static duk_ret_t test_1(duk_context *ctx, void *udata) {
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	(void) udata;
 
 	duk_push_string(ctx, "throw me");
@@ -11,6 +13,14 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	return 0;
 }
 
+static duk_ret_t test_return(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_string(ctx, "throw me too");
+	return duk_throw(ctx);
+}
+
 void test(duk_context *ctx) {
-	TEST_SAFE_CALL(test_1);
+	TEST_SAFE_CALL(test_basic);
+	TEST_SAFE_CALL(test_return);
 }

--- a/website/api/duk_error.yaml
+++ b/website/api/duk_error.yaml
@@ -1,7 +1,7 @@
 name: duk_error
 
 proto: |
-  void duk_error(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...);
+  duk_ret_t duk_error(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...);
 
 stack: |
   [ ... ] -> [ ... err! ]
@@ -19,6 +19,14 @@ summary: |
   <p>To push an Error object to the stack without throwing it, use
   <code><a href="#duk_push_error_object">duk_push_error_object()</a></code>.
   </p>
+
+  <p>Even though the function never returns, the prototype describes a return
+  value which allows code such as:</p>
+  <pre class="c-code">
+  if (argvalue &lt; 0) {
+      return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid argument value: %d", (int) argvalue);
+  }
+  </pre>
 
 example: |
   duk_error(ctx, DUK_ERR_RANGE_ERROR, "argument out of range: %d", (int) argval);

--- a/website/api/duk_error_va.yaml
+++ b/website/api/duk_error_va.yaml
@@ -1,7 +1,7 @@
 name: duk_error_va
 
 proto: |
-  void duk_error_va(duk_context *ctx, duk_errcode_t err_code, const char *fmt, va_list ap);
+  duk_ret_t duk_error_va(duk_context *ctx, duk_errcode_t err_code, const char *fmt, va_list ap);
 
 stack: |
   [ ... ] -> [ ... err! ]

--- a/website/api/duk_fatal.yaml
+++ b/website/api/duk_fatal.yaml
@@ -1,7 +1,7 @@
 name: duk_fatal
 
 proto: |
-  void duk_fatal(duk_context *ctx, const char *err_msg);
+  duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg);
 
 summary: |
   <p>Call fatal error handler with an optional message (<code>err_msg</code>
@@ -13,6 +13,13 @@ summary: |
   and error catching API calls) are bypassed, and finalizers are not executed.
   You should only call this function when a truly fatal, unrecoverable error
   has occurred.</p>
+
+  <p>Even though the function never returns, the prototype describes a return
+  value which allows code such as:</p>
+  <pre class="c-code">
+  if (argvalue &lt; 0) {
+      return duk_fatal(ctx, "argvalue invalid, cannot continue execution");
+  }
 
 example: |
   duk_fatal(ctx, "assumption failed");

--- a/website/api/duk_throw.yaml
+++ b/website/api/duk_throw.yaml
@@ -1,13 +1,22 @@
 name: duk_throw
 
 proto: |
-  void duk_throw(duk_context *ctx);
+  duk_ret_t duk_throw(duk_context *ctx);
 
 stack: |
   [ ... val! ]
 
 summary: |
   <p>Throw the value on top of the stack.  This call never returns.</p>
+
+  <p>Even though the function never returns, the prototype describes a return
+  value which allows code such as:</p>
+  <pre class="c-code">
+  if (argvalue &lt; 0) {
+      duk_push_error_object(ctx, DUK_ERR_TYPE_ERROR, "invalid argument: %d", (int) argvalue);
+      return duk_throw(ctx);
+  }
+  </pre>
 
 example: |
   /* Throw a string value; equivalent to the Ecmascript code:


### PR DESCRIPTION
While the functions never return, a `duk_ret_t` return value allows application code to do something like:

```c
if (argvalue < 0) {
    return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid arg: %d", (int) argvalue);
}
```

If this is not the case and the compiler doesn't support noreturn functions, application code needs an explicit return after a `duk_error()` to prevent potential compiler warnings (e.g. use of uninitialized variables) when the compiler thinks execution will resume after the error.

Same treatment for `duk_error_va()`, `duk_throw()`, and `duk_fatal()`.

Tasks:
- [x] API changes
- [x] Testcases
- [x] API documentation changes
- [x] 2.x migration note (just a note there's a return value now)
- [x] Releases entry