### PR TITLE
Add convenience error throwers like duk_type_error()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1789,6 +1789,9 @@ Planned
   to duk_ret_t which allows them to be called using the idiom
   "return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid argument");" (GH-1038)
 
+* Add convenience API calls to throw specific error types; for example,
+  duk_type_error(), duk_type_error_va(), duk_range_error(), etc (GH-1040)
+
 * Add convenience API calls duk_get_prop_lstring(), duk_put_prop_lstring(),
   duk_del_prop_lstring(), duk_has_prop_lstring(), duk_get_global_lstring(),
   duk_put_global_lstring() (GH-946, GH-953)

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -299,8 +299,29 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_raw(duk_context *ctx, duk
 #ifdef DUK_API_VARIADIC_MACROS
 #define duk_error(ctx,err_code,...)  \
 	duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_generic_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_eval_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_range_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_reference_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_syntax_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_type_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+#define duk_uri_error(ctx,...)  \
+	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
 #else
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_generic_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_eval_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_range_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_reference_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_syntax_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_type_error_stash(duk_context *ctx, const char *fmt, ...));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_uri_error_stash(duk_context *ctx, const char *fmt, ...));
 /* One problem with this macro is that expressions like the following fail
  * to compile: "(void) duk_error(...)".  But because duk_error() is noreturn,
  * they make little sense anyway.
@@ -309,11 +330,53 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_stash(duk_context *ctx, d
 	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
 	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
 	 duk_error_stash)  /* last value is func pointer, arguments follow in parens */
+#define duk_generic_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_generic_error_stash)
+#define duk_eval_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_eval_error_stash)
+#define duk_range_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_range_error_stash)
+#define duk_reference_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_reference_error_stash)
+#define duk_syntax_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_syntax_error_stash)
+#define duk_type_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_type_error_stash)
+#define duk_uri_error  \
+	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
+	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
+	 duk_uri_error_stash)
 #endif
 
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
 #define duk_error_va(ctx,err_code,fmt,ap)  \
 	duk_error_va_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_generic_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_eval_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_range_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_reference_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_syntax_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_type_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+#define duk_uri_error_va(ctx,fmt,ap)  \
+	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
 
 /*
  *  Other state related functions

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4579,10 +4579,11 @@ DUK_EXTERNAL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, c
 }
 
 #if !defined(DUK_USE_VARIADIC_MACROS)
-DUK_EXTERNAL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...) {
+DUK_NORETURN(DUK_LOCAL_DECL void duk__throw_error_from_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, va_list ap));
+
+DUK_LOCAL void duk__throw_error_from_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, va_list ap) {
 	const char *filename;
 	duk_int_t line;
-	va_list ap;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -4591,13 +4592,41 @@ DUK_EXTERNAL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code,
 	duk_api_global_filename = NULL;
 	duk_api_global_line = 0;
 
-	va_start(ap, fmt);
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
-	va_end(ap);
 	(void) duk_throw(ctx);
-#if 0  /* Never reached; if return present, gcc/clang will complain. */
-	return 0;  /* never reached */
-#endif
+}
+
+#define DUK__ERROR_STASH_SHARED(code) do { \
+		va_list ap; \
+		va_start(ap, fmt); \
+		duk__throw_error_from_stash(ctx, (code), fmt, ap); \
+		va_end(ap); \
+		/* Never reached; if return 0 here, gcc/clang will complain. */ \
+	} while (0)
+
+DUK_EXTERNAL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(err_code);
+}
+DUK_EXTERNAL duk_ret_t duk_generic_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_eval_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_EVAL_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_range_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_RANGE_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_reference_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_REFERENCE_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_syntax_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_SYNTAX_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_type_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_TYPE_ERROR);
+}
+DUK_EXTERNAL duk_ret_t duk_uri_error_stash(duk_context *ctx, const char *fmt, ...) {
+	DUK__ERROR_STASH_SHARED(DUK_ERR_URI_ERROR);
 }
 #endif  /* DUK_USE_VARIADIC_MACROS */
 

--- a/tests/api/test-error-convenience.c
+++ b/tests/api/test-error-convenience.c
@@ -1,0 +1,168 @@
+/*
+ *  Convenience error throwers.
+ */
+
+/*===
+*** test_generic_error (duk_safe_call)
+==> rc=1, result='Error: my error: 123'
+*** test_eval_error (duk_safe_call)
+==> rc=1, result='EvalError: my error: 123'
+*** test_range_error (duk_safe_call)
+==> rc=1, result='RangeError: my error: 123'
+*** test_reference_error (duk_safe_call)
+==> rc=1, result='ReferenceError: my error: 123'
+*** test_syntax_error (duk_safe_call)
+==> rc=1, result='SyntaxError: my error: 123'
+*** test_type_error (duk_safe_call)
+==> rc=1, result='TypeError: my error: 123'
+*** test_uri_error (duk_safe_call)
+==> rc=1, result='URIError: my error: 123'
+*** test_generic_error_va (duk_safe_call)
+==> rc=1, result='Error: my error: 123'
+*** test_eval_error_va (duk_safe_call)
+==> rc=1, result='EvalError: my error: 123'
+*** test_range_error_va (duk_safe_call)
+==> rc=1, result='RangeError: my error: 123'
+*** test_reference_error_va (duk_safe_call)
+==> rc=1, result='ReferenceError: my error: 123'
+*** test_syntax_error_va (duk_safe_call)
+==> rc=1, result='SyntaxError: my error: 123'
+*** test_type_error_va (duk_safe_call)
+==> rc=1, result='TypeError: my error: 123'
+*** test_uri_error_va (duk_safe_call)
+==> rc=1, result='URIError: my error: 123'
+===*/
+
+/* Non-vararg calls. */
+
+static duk_ret_t test_generic_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_generic_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_eval_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_eval_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_range_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_range_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_reference_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_reference_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_syntax_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_syntax_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_type_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_type_error(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t test_uri_error(duk_context *ctx, void *udata) {
+	(void) udata;
+	return duk_uri_error(ctx, "my error: %d", 123);
+}
+
+/* Vararg calls. */
+
+static duk_ret_t throw_generic_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_generic_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_generic_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_generic_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_eval_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_eval_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_eval_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_eval_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_range_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_range_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_range_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_range_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_reference_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_reference_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_reference_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_reference_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_syntax_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_syntax_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_syntax_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_syntax_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_type_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_type_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_type_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_type_va(ctx, "my error: %d", 123);
+}
+
+static duk_ret_t throw_uri_va(duk_context *ctx, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	return duk_uri_error_va(ctx, fmt, ap);
+	va_end(ap);
+}
+static duk_ret_t test_uri_error_va(duk_context *ctx, void *udata) {
+	(void) udata;
+	return throw_uri_va(ctx, "my error: %d", 123);
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_generic_error);
+	TEST_SAFE_CALL(test_eval_error);
+	TEST_SAFE_CALL(test_range_error);
+	TEST_SAFE_CALL(test_reference_error);
+	TEST_SAFE_CALL(test_syntax_error);
+	TEST_SAFE_CALL(test_type_error);
+	TEST_SAFE_CALL(test_uri_error);
+
+	TEST_SAFE_CALL(test_generic_error_va);
+	TEST_SAFE_CALL(test_eval_error_va);
+	TEST_SAFE_CALL(test_range_error_va);
+	TEST_SAFE_CALL(test_reference_error_va);
+	TEST_SAFE_CALL(test_syntax_error_va);
+	TEST_SAFE_CALL(test_type_error_va);
+	TEST_SAFE_CALL(test_uri_error_va);
+}

--- a/website/api/duk_error.yaml
+++ b/website/api/duk_error.yaml
@@ -38,5 +38,12 @@ seealso:
   - duk_error_va
   - duk_throw
   - duk_push_error_object
+  - duk_generic_error
+  - duk_eval_error
+  - duk_range_error
+  - duk_reference_error
+  - duk_syntax_error
+  - duk_type_error
+  - duk_uri_error
 
 introduced: 1.0.0

--- a/website/api/duk_error_va.yaml
+++ b/website/api/duk_error_va.yaml
@@ -27,5 +27,12 @@ seealso:
   - duk_error
   - duk_throw
   - duk_push_error_object
+  - duk_generic_error_va
+  - duk_eval_error_va
+  - duk_range_error_va
+  - duk_reference_error_va
+  - duk_syntax_error_va
+  - duk_type_error_va
+  - duk_uri_error_va
 
 introduced: 1.1.0

--- a/website/api/duk_eval_error.yaml
+++ b/website/api/duk_eval_error.yaml
@@ -1,0 +1,23 @@
+name: duk_eval_error
+
+proto: |
+  duk_ret_t duk_eval_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_EVAL_ERROR</code>.</p>
+
+example: |
+  return duk_eval_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_eval_error_va.yaml
+++ b/website/api/duk_eval_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_eval_error_va
+
+proto: |
+  duk_ret_t duk_eval_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_EVAL_ERROR</code>.</p>
+
+example: |
+  void my_eval_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_eval_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_generic_error.yaml
+++ b/website/api/duk_generic_error.yaml
@@ -1,0 +1,23 @@
+name: duk_generic_error
+
+proto: |
+  duk_ret_t duk_generic_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_ERROR</code>.</p>
+
+example: |
+  return duk_generic_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_generic_error_va.yaml
+++ b/website/api/duk_generic_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_generic_error_va
+
+proto: |
+  duk_ret_t duk_generic_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_ERROR</code>.</p>
+
+example: |
+  void my_generic_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_generic_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_range_error.yaml
+++ b/website/api/duk_range_error.yaml
@@ -1,0 +1,23 @@
+name: duk_range_error
+
+proto: |
+  duk_ret_t duk_range_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_RANGE_ERROR</code>.</p>
+
+example: |
+  return duk_range_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_range_error_va.yaml
+++ b/website/api/duk_range_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_range_error_va
+
+proto: |
+  duk_ret_t duk_range_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_RANGE_ERROR</code>.</p>
+
+example: |
+  void my_range_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_range_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_reference_error.yaml
+++ b/website/api/duk_reference_error.yaml
@@ -1,0 +1,23 @@
+name: duk_reference_error
+
+proto: |
+  duk_ret_t duk_reference_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_REFERENCE_ERROR</code>.</p>
+
+example: |
+  return duk_reference_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_reference_error_va.yaml
+++ b/website/api/duk_reference_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_reference_error_va
+
+proto: |
+  duk_ret_t duk_reference_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_REFERENCE_ERROR</code>.</p>
+
+example: |
+  void my_reference_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_reference_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_syntax_error.yaml
+++ b/website/api/duk_syntax_error.yaml
@@ -1,0 +1,23 @@
+name: duk_syntax_error
+
+proto: |
+  duk_ret_t duk_syntax_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_SYNTAX_ERROR</code>.</p>
+
+example: |
+  return duk_syntax_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_syntax_error_va.yaml
+++ b/website/api/duk_syntax_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_syntax_error_va
+
+proto: |
+  duk_ret_t duk_syntax_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_SYNTAX_ERROR</code>.</p>
+
+example: |
+  void my_syntax_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_syntax_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_type_error.yaml
+++ b/website/api/duk_type_error.yaml
@@ -1,0 +1,23 @@
+name: duk_type_error
+
+proto: |
+  duk_ret_t duk_type_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_TYPE_ERROR</code>.</p>
+
+example: |
+  return duk_type_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_type_error_va.yaml
+++ b/website/api/duk_type_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_type_error_va
+
+proto: |
+  duk_ret_t duk_type_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_TYPE_ERROR</code>.</p>
+
+example: |
+  void my_type_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_type_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0

--- a/website/api/duk_uri_error.yaml
+++ b/website/api/duk_uri_error.yaml
@@ -1,0 +1,23 @@
+name: duk_uri_error
+
+proto: |
+  duk_ret_t duk_uri_error(duk_context *ctx, const char *fmt, ...);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error">duk_error()</a></code> with an error code
+  <code>DUK_ERR_URI_ERROR</code>.</p>
+
+example: |
+  return duk_uri_error(ctx, "my error: %d", (int) argval);
+
+tags:
+  - error
+
+seealso:
+  - duk_error
+
+introduced: 2.0.0

--- a/website/api/duk_uri_error_va.yaml
+++ b/website/api/duk_uri_error_va.yaml
@@ -1,0 +1,30 @@
+name: duk_uri_error_va
+
+proto: |
+  duk_ret_t duk_uri_error_va(duk_context *ctx, const char *fmt, va_list ap);
+
+stack: |
+  [ ... ] -> [ ... err! ]
+
+summary: |
+  <p>Convenience API call, equivalent to
+  <code><a href="#duk_error_va">duk_error_va()</a></code> with an error code
+  <code>DUK_ERR_URI_ERROR</code>.</p>
+
+example: |
+  void my_uri_error(duk_context *ctx, const char *fmt, ...) {
+      va_list ap;
+
+      va_start(ap, fmt);
+      duk_uri_error_va(ctx, fmt, ap);
+      va_end(ap);
+  }
+
+tags:
+  - error
+  - vararg
+
+seealso:
+  - duk_error_va
+
+introduced: 2.0.0


### PR DESCRIPTION
This allows an easy-to-read application call site like:

```c
if (argvalue < 0) {
    return duk_type_error(ctx, "invalid arg: %d", (int) argvalue);
}
```

Tasks:
- [x] Add API calls
- [x] API documentation
- [x] Test with and without varargs manually
- [x] Releases entry