### PR TITLE
Another duk_error() et al return value approach

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1787,7 +1787,8 @@ Planned
 
 * Change return from of duk_throw(), duk_error(), and duk_fatal() from void
   to duk_ret_t which allows them to be called using the idiom
-  "return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid argument");" (GH-1038)
+  "return duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid argument");"
+  (GH-1038, GH-1041)
 
 * Add convenience API calls to throw specific error types; for example,
   duk_type_error(), duk_type_error_va(), duk_range_error(), etc (GH-1040)

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -2,14 +2,14 @@
  *  BEGIN PUBLIC API
  */
 
-#ifndef DUK_API_PUBLIC_H_INCLUDED
+#if !defined(DUK_API_PUBLIC_H_INCLUDED)
 #define DUK_API_PUBLIC_H_INCLUDED
 
 /*
  *  Avoid C++ name mangling
  */
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -18,7 +18,7 @@ extern "C" {
  */
 
 #undef DUK_API_VARIADIC_MACROS
-#ifdef DUK_USE_VARIADIC_MACROS
+#if defined(DUK_USE_VARIADIC_MACROS)
 #define DUK_API_VARIADIC_MACROS
 #endif
 
@@ -291,29 +291,40 @@ DUK_EXTERNAL_DECL void duk_gc(duk_context *ctx, duk_uint_t flags);
  *  Error handling
  */
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_throw(duk_context *ctx));
-DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_throw_raw(duk_context *ctx));
+#define duk_throw(ctx) \
+	(duk_throw_raw((ctx)), (duk_ret_t) 0)
+DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_fatal_raw(duk_context *ctx, const char *err_msg));
+#define duk_fatal(ctx,err_msg) \
+	(duk_fatal_raw((ctx), (err_msg)), (duk_ret_t) 0)
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
-
-#ifdef DUK_API_VARIADIC_MACROS
+#if defined(DUK_API_VARIADIC_MACROS)
+DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
 #define duk_error(ctx,err_code,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_generic_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_eval_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_range_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_reference_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_syntax_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_type_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_uri_error(ctx,...)  \
-	duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
-#else
+	(duk_error_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
+#else  /* DUK_API_VARIADIC_MACROS */
+/* For legacy compilers without variadic macros a macro hack is used to allow
+ * variable arguments.  While the macro allows "return duk_error(...)", it
+ * will fail with e.g. "(void) duk_error(...)".  The calls are noreturn but
+ * with a return value to allow the "return duk_error(...)" idiom.  This may
+ * cause some compiler warnings, but without noreturn the generated code is
+ * often worse.  The same approach as with variadic macros (using
+ * "(duk_error(...), 0)") won't work due to the macro hack structure.
+ */
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_stash(duk_context *ctx, duk_errcode_t err_code, const char *fmt, ...));
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_generic_error_stash(duk_context *ctx, const char *fmt, ...));
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_eval_error_stash(duk_context *ctx, const char *fmt, ...));
@@ -322,10 +333,6 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_reference_error_stash(duk_conte
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_syntax_error_stash(duk_context *ctx, const char *fmt, ...));
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_type_error_stash(duk_context *ctx, const char *fmt, ...));
 DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_uri_error_stash(duk_context *ctx, const char *fmt, ...));
-/* One problem with this macro is that expressions like the following fail
- * to compile: "(void) duk_error(...)".  But because duk_error() is noreturn,
- * they make little sense anyway.
- */
 #define duk_error  \
 	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
 	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
@@ -358,25 +365,25 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_uri_error_stash(duk_context *ct
 	(duk_api_global_filename = (const char *) (DUK_FILE_MACRO), \
 	 duk_api_global_line = (duk_int_t) (DUK_LINE_MACRO), \
 	 duk_uri_error_stash)
-#endif
+#endif  /* DUK_API_VARIADIC_MACROS */
 
-DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
+DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
 #define duk_error_va(ctx,err_code,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_generic_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_eval_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_EVAL_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_range_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_RANGE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_reference_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_REFERENCE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_syntax_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_SYNTAX_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_type_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_TYPE_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_uri_error_va(ctx,fmt,ap)  \
-	duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap))
+	(duk_error_va_raw((ctx), (duk_errcode_t) DUK_ERR_URI_ERROR, (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 
 /*
  *  Other state related functions
@@ -476,7 +483,7 @@ DUK_EXTERNAL_DECL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t fla
 
 DUK_EXTERNAL_DECL duk_idx_t duk_push_error_object_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...);
 
-#ifdef DUK_API_VARIADIC_MACROS
+#if defined(DUK_API_VARIADIC_MACROS)
 #define duk_push_error_object(ctx,err_code,...)  \
 	duk_push_error_object_raw((ctx), (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__)
 #else
@@ -1052,7 +1059,7 @@ DUK_EXTERNAL_DECL const void * const duk_rom_compressed_pointers[];
  *  C++ name mangling
  */
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 /* end 'extern "C"' wrapper */
 }
 #endif

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4483,7 +4483,7 @@ DUK_INTERNAL void duk_unpack(duk_context *ctx) {
  *  Error throwing
  */
 
-DUK_EXTERNAL duk_ret_t duk_throw(duk_context *ctx) {
+DUK_EXTERNAL void duk_throw_raw(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
@@ -4520,12 +4520,9 @@ DUK_EXTERNAL duk_ret_t duk_throw(duk_context *ctx) {
 
 	duk_err_longjmp(thr);
 	DUK_UNREACHABLE();
-#if 0  /* Never reached; if return present, gcc/clang will complain. */
-	return 0;
-#endif
 }
 
-DUK_EXTERNAL duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg) {
+DUK_EXTERNAL void duk_fatal_raw(duk_context *ctx, const char *err_msg) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -4549,22 +4546,16 @@ DUK_EXTERNAL duk_ret_t duk_fatal(duk_context *ctx, const char *err_msg) {
 	for (;;) {
 		/* loop forever, don't return (function marked noreturn) */
 	}
-#if 0  /* Never reached; if return present, gcc/clang will complain. */
-	return 0;  /* never reached */
-#endif
 }
 
-DUK_EXTERNAL duk_ret_t duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap) {
+DUK_EXTERNAL void duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap) {
 	DUK_ASSERT_CTX_VALID(ctx);
 
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
 	(void) duk_throw(ctx);
-#if 0  /* Never reached; if return present, gcc/clang will complain. */
-	return 0;  /* never reached */
-#endif
 }
 
-DUK_EXTERNAL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...) {
+DUK_EXTERNAL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...) {
 	va_list ap;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -4573,9 +4564,6 @@ DUK_EXTERNAL duk_ret_t duk_error_raw(duk_context *ctx, duk_errcode_t err_code, c
 	duk_push_error_object_va_raw(ctx, err_code, filename, line, fmt, ap);
 	va_end(ap);
 	(void) duk_throw(ctx);
-#if 0  /* Never reached; if return present, gcc/clang will complain. */
-	return 0;  /* never reached */
-#endif
 }
 
 #if !defined(DUK_USE_VARIADIC_MACROS)


### PR DESCRIPTION
Try to fix MSVC warning of a noreturn function having a return value in its prototype.