### PR TITLE
Faster debugger paused check in refzero handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2012,7 +2012,8 @@ Planned
   Array .length coercion (GH-862); value stack operation optimization
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
   opcode handler optimizations (GH-903); refcount optimizations (GH-443,
-  GH-973); minor RegExp compile/execute optimizations (GH-974, GH-1033)
+  GH-973, GH-1042); minor RegExp compile/execute optimizations (GH-974,
+  GH-1033)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977);
   internal duk_dup() variants (GH-990); allow stripping of (almost) all

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -84,7 +84,7 @@ DUK_EXTERNAL void duk_debugger_attach(duk_context *ctx,
 
 	/* Start in paused state. */
 	heap->dbg_processing = 0;
-	heap->dbg_paused = 1;
+	DUK_HEAP_SET_DEBUGGER_PAUSED(heap);
 	heap->dbg_state_dirty = 1;
 	heap->dbg_force_restart = 0;
 	heap->dbg_step_type = 0;

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -463,6 +463,10 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
  *  from being moved around in heap linked lists.
  */
 
+/* The suppress condition is important to performance.  The flags being tested
+ * are in the same duk_heap field so a single TEST instruction (on x86) tests
+ * for them.
+ */
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 #define DUK__RZ_SUPPRESS_COND() \
 	(DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap) || DUK_HEAP_IS_PAUSED(heap))

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1790,7 +1790,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 	 */
 
 	process_messages = 0;
-	if (thr->heap->dbg_state_dirty || thr->heap->dbg_paused || thr->heap->dbg_detaching) {
+	if (thr->heap->dbg_state_dirty || DUK_HEAP_HAS_DEBUGGER_PAUSED(thr->heap) || thr->heap->dbg_detaching) {
 		/* Enter message processing loop for sending Status notifys and
 		 * to finish a pending detach.
 		 */
@@ -1861,7 +1861,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 		      thr->heap->dbg_step_type == DUK_STEP_TYPE_OVER) &&
 		     thr->heap->dbg_step_thread == thr &&
 		     thr->heap->dbg_step_csindex == thr->callstack_top - 1) ||
-		     thr->heap->dbg_paused) {
+		     DUK_HEAP_HAS_DEBUGGER_PAUSED(thr->heap)) {
 			*out_immediate = 1;
 		}
 
@@ -2113,7 +2113,7 @@ DUK_LOCAL void duk__executor_recheck_debugger(duk_hthread *thr, duk_activation *
 	 * Step out is handled by callstack unwind.
 	 */
 	if (act->flags & (DUK_ACT_FLAG_BREAKPOINT_ACTIVE) ||
-	    thr->heap->dbg_paused ||
+	    DUK_HEAP_HAS_DEBUGGER_PAUSED(thr->heap) ||
 	    (thr->heap->dbg_step_type != DUK_STEP_TYPE_OUT &&
 	     thr->heap->dbg_step_csindex == thr->callstack_top - 1)) {
 		/* We'll need to interrupt early so recompute the init


### PR DESCRIPTION
When debugging is enabled the check to skip refzero handling is:

```c
(DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap) || DUK_HEAP_IS_PAUSED(heap))
```

But because "mark-and-sweep running" is a heap flag and "debugger is paused" is a separate `duk_heap` field, this compiles into awkward code:

```
  4037aa:       f6 03 01                testb  $0x1,(%rbx)
  4037ad:       75 31                   jne    4037e0 <duk_hstring_refzero+0x40>
  4037af:       8b 93 14 01 00 00       mov    0x114(%rbx),%edx
  4037b5:       85 d2                   test   %edx,%edx
  4037b7:       75 27                   jne    4037e0 <duk_hstring_refzero+0x40>
```

This pull changes `heap->dbg_paused` into a heap flag which improves the check to:

```
  4037aa:       f6 03 41                testb  $0x41,(%rbx)
  4037ad:       75 27                   jne    4037d6 <duk_hstring_refzero+0x36>
```

It would be better if the entire dbg_paused check was omitted (it should be implied by mark-and-sweep being disabled, at least right now). But for processors with a bit field test primitive there should be no practical difference.

Tasks:

- [x] Convert dbg_paused flag
- [x] Convert other heap binary flags too if it improves footprint (the remaining flags are performance insensitive) => separate pull
- [ ] Manual performance test run
- [x] Manual debugger smoke test
- [x] Releases entry