### PR TITLE
Fix String.fromCharCode() coercion to ToUint16() when standard behavior enabled

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1934,6 +1934,11 @@ Planned
   seed mixing; previous algorithm (Shamir's three-op algorithm) is still
   used for low memory targets and targets without 64-bit types (GH-970)
 
+* Fix String.fromCharCode() behavior for non-BMP characters when standard
+  behavior is enabled (DUK_USE_NONSTD_STRING_FROMCHARCODE_32BIT disabled):
+  use ToUint16() + CESU-8 rather than ToUint32() + CESU-8 which produces
+  two codepoints for non-BMP characters (GH-1046)
+
 * Fix incorrect evaluation order of X <op>= Y expressions when the RHS
   (Y) mutates the value of X (GH-992)
 

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -81,7 +81,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_constructor_from_char_code(duk_context *ctx
 		cp = (duk_ucodepoint_t) duk_to_uint32(ctx, i);
 		DUK_BW_WRITE_ENSURE_XUTF8(thr, bw, cp);
 #else
-		cp = (duk_ucodepoint_t) duk_to_uint32(ctx, i);
+		cp = (duk_ucodepoint_t) duk_to_uint16(ctx, i);
 		DUK_BW_WRITE_ENSURE_CESU8(thr, bw, cp);
 #endif
 	}


### PR DESCRIPTION
When standard behavior is enabled (DUK_USE_NONSTD_STRING_FROMCHARCODE_32BIT) ToUint32() + CESU-8 was used which emits two characters for each non-BMP codepoint. The standard behavior is disabled by default (ToUint32() + UTF-8 is the default) so this only has an effect if specifically enabling the standard behavior.

- [x] Fix bug
- [x] Manual test (no regression coverage now for this non-default option)
- [x] Releases entry