### PR TITLE
Add ES6 String.prototype.repeat()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1836,8 +1836,8 @@ Planned
   and identifiers, no RegExp support yet (requires RegExp /u Unicode mode)
   (GH-1001)
 
-* Add support for ES6 String.prototype.codePointAt() and String.fromCodePoint()
-  (GH-1043, GH-1049)
+* Add support for ES6 String.prototype.codePointAt(), String.fromCodePoint(),
+  and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)
 
 * Add TextEncoder and TextDecoder built-ins (the Encoding API) which allow
   Ecmascript code to read and write text stored in an ArrayBuffer or a plain

--- a/doc/code-issues.rst
+++ b/doc/code-issues.rst
@@ -1287,6 +1287,13 @@ conservative and may indicate overflow even when one wouldn't occur::
   }
   z = x * y;
 
+One can also simply test by division (but careful for division-by-zero)::
+
+  z = x * y;
+  if (x != 0 && z / x != y) {
+          /* Overflow. */
+  }
+
 For 32-bit types the check is actually exact, see test in::
 
   misc/c_overflow_test.py 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -1153,6 +1153,15 @@ objects:
           native: duk_bi_string_prototype_trim
           length: 0
         present_if: DUK_USE_STRING_BUILTIN
+      - key: "repeat"
+        value:
+          type: function
+          native: duk_bi_string_prototype_repeat
+          length: 1
+          nargs: 1
+        present_if:
+          - DUK_USE_ES6
+          - DUK_USE_STRING_BUILTIN
 
       # Non-standard extension: E5 Section B.2.3
 

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -38,7 +38,7 @@ DUK_LOCAL duk_uint8_t *duk__load_buffer_raw(duk_context *ctx, duk_uint8_t *p) {
 	duk_uint8_t *buf;
 
 	len = DUK_RAW_READ_U32_BE(p);
-	buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);
+	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, (duk_size_t) len);
 	DUK_ASSERT(buf != NULL);
 	DUK_MEMCPY((void *) buf, (const void *) p, (size_t) len);
 	p += len;
@@ -451,7 +451,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	DUK_ASSERT(!DUK_HOBJECT_HAS_EXOTIC_ARGUMENTS(&h_fun->obj));
 
 	/* Create function 'data' buffer but don't attach it yet. */
-	fun_data = (duk_uint8_t *) duk_push_fixed_buffer(ctx, data_size);
+	fun_data = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, data_size);
 	DUK_ASSERT(fun_data != NULL);
 
 	/* Load bytecode instructions. */

--- a/src-input/duk_api_codec.c
+++ b/src-input/duk_api_codec.c
@@ -399,7 +399,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t idx) {
 		goto type_error;
 	}
 	dstlen = (srclen + 2) / 3 * 4;
-	dst = (duk_uint8_t *) duk_push_fixed_buffer(ctx, dstlen);
+	dst = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, dstlen);
 
 	duk__base64_encode_helper((const duk_uint8_t *) src, srclen, dst);
 
@@ -474,7 +474,7 @@ DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT(inp != NULL || len == 0);
 
 	/* Fixed buffer, no zeroing because we'll fill all the data. */
-	buf = (duk_uint8_t *) duk_push_buffer_raw(ctx, len * 2, DUK_BUF_FLAG_NOZERO /*flags*/);
+	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, len * 2);
 	DUK_ASSERT(buf != NULL);
 
 #if defined(DUK_USE_HEX_FASTPATH)
@@ -536,7 +536,7 @@ DUK_EXTERNAL void duk_hex_decode(duk_context *ctx, duk_idx_t idx) {
 	}
 
 	/* Fixed buffer, no zeroing because we'll fill all the data. */
-	buf = (duk_uint8_t *) duk_push_buffer_raw(ctx, len / 2, DUK_BUF_FLAG_NOZERO /*flags*/);
+	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, len / 2);
 	DUK_ASSERT(buf != NULL);
 
 #if defined(DUK_USE_HEX_FASTPATH)

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -161,6 +161,9 @@ DUK_INTERNAL_DECL void duk_push_lightfunc_tostring(duk_context *ctx, duk_tval *t
 DUK_INTERNAL_DECL duk_hbufobj *duk_push_bufobj_raw(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
 #endif
 
+#define duk_push_fixed_buffer_nozero(ctx,size) \
+	duk_push_buffer_raw((ctx), (size), DUK_BUF_FLAG_NOZERO)
+
 DUK_INTERNAL_DECL const char *duk_push_string_readable(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL const char *duk_push_string_tval_readable(duk_context *ctx, duk_tval *tv);
 DUK_INTERNAL_DECL const char *duk_push_string_tval_readable_error(duk_context *ctx, duk_tval *tv);

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -64,7 +64,7 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_context *ctx, duk_idx_t count_in,
 	                     (unsigned long) count, (unsigned long) len));
 
 	/* use stack allocated buffer to ensure reachability in errors (e.g. intern error) */
-	buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, len);
+	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, len);
 	DUK_ASSERT(buf != NULL);
 
 	/* [... (sep) str1 str2 ... strN buf] */

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -549,7 +549,7 @@ DUK_LOCAL duk_hbuffer *duk__hbufobj_fixed_from_argvalue(duk_context *ctx) {
 		(void) duk_get_prop_string(ctx, 0, "length");
 		len = duk_to_int_clamped(ctx, -1, 0, DUK_INT_MAX);
 		duk_pop(ctx);
-		buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);
+		buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, (duk_size_t) len);  /* no zeroing, all indices get initialized */
 		for (i = 0; i < len; i++) {
 			/* XXX: fast path for array or buffer arguments? */
 			duk_get_prop_index(ctx, 0, (duk_uarridx_t) i);
@@ -1170,7 +1170,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tostring(duk_context *ctx) {
 	                                     &end_offset);
 
 	slice_length = (duk_size_t) (end_offset - start_offset);
-	buf_slice = (duk_uint8_t *) duk_push_fixed_buffer(ctx, slice_length);
+	buf_slice = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, slice_length);  /* all bytes initialized below */
 	DUK_ASSERT(buf_slice != NULL);
 
 	/* Neutered or uncovered, TypeError. */
@@ -1755,7 +1755,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_context *ctx) {
 			duk_uint8_t *p_src_copy;
 
 			DUK_DDD(DUK_DDDPRINT("there is overlap, make a copy of the source"));
-			p_src_copy = (duk_uint8_t *) duk_push_fixed_buffer(ctx, src_length);
+			p_src_copy = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, src_length);
 			DUK_ASSERT(p_src_copy != NULL);
 			DUK_MEMCPY((void *) p_src_copy, (const void *) p_src_base, (size_t) src_length);
 
@@ -1884,7 +1884,7 @@ DUK_LOCAL void duk__arraybuffer_plain_slice(duk_context *ctx, duk_hbuffer *h_val
 	DUK_ASSERT(end_offset >= start_offset);
 	slice_length = (duk_uint_t) (end_offset - start_offset);
 
-	p_copy = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) slice_length);
+	p_copy = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, (duk_size_t) slice_length);
 	DUK_ASSERT(p_copy != NULL);
 	copy_length = slice_length;
 
@@ -2007,7 +2007,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 		duk_uint8_t *p_copy;
 		duk_size_t copy_length;
 
-		p_copy = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) slice_length);
+		p_copy = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) slice_length);  /* must be zeroed, not all bytes always copied */
 		DUK_ASSERT(p_copy != NULL);
 
 		/* Copy slice, respecting underlying buffer limits; remainder
@@ -2194,7 +2194,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_context *ctx) {
 	                               DUK_BIDX_NODEJS_BUFFER_PROTOTYPE);
 	DUK_ASSERT(h_bufres != NULL);
 
-	p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, total_length);
+	p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, total_length);  /* must be zeroed, all bytes not necessarily written over */
 	DUK_ASSERT(p != NULL);
 	space_left = total_length;
 

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -222,7 +222,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_context *ctx, duk__decode_context *de
 	 */
 
 	if (duk_is_undefined(ctx, 0)) {
-		duk_push_fixed_buffer(ctx, 0);
+		duk_push_fixed_buffer_nozero(ctx, 0);
 		duk_replace(ctx, 0);
 	}
 	(void) duk_require_buffer_data(ctx, 0, &len);  /* Need 'len', avoid pointer. */
@@ -253,7 +253,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_context *ctx, duk__decode_context *de
 	if (len >= (DUK_HBUFFER_MAX_BYTELEN / 3) - 3) {
 		DUK_ERROR_TYPE((duk_hthread *) ctx, DUK_STR_RESULT_TOO_LONG);
 	}
-	output = (duk_uint8_t *) duk_push_fixed_buffer(ctx, 3 + (3 * len));
+	output = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, 3 + (3 * len));  /* used parts will be always manually written over */
 
 	input = (const duk_uint8_t *) duk_get_buffer_data(ctx, 0, &len_tmp);
 	DUK_ASSERT(input != NULL || len == 0);

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -627,8 +627,9 @@ DUK_LOCAL void duk__dec_buffer(duk_json_dec_ctx *js_ctx) {
 		p++;
 	}
 
+	/* XXX: this is not very nice; unnecessary copy is made. */
 	src_len = (duk_size_t) (p - js_ctx->p);
-	buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, src_len);
+	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, src_len);
 	DUK_ASSERT(buf != NULL);
 	DUK_MEMCPY((void *) buf, (const void *) js_ctx->p, src_len);
 	duk_hex_decode(ctx, -1);

--- a/src-input/duk_dblunion.h.in
+++ b/src-input/duk_dblunion.h.in
@@ -76,7 +76,7 @@ typedef union duk_double_union duk_double_union;
  */
 
 #if defined(DUK_USE_DOUBLE_LE)
-#ifdef DUK_USE_64BIT_OPS
+#if defined(DUK_USE_64BIT_OPS)
 #define DUK_DBL_IDX_ULL0   0
 #endif
 #define DUK_DBL_IDX_UI0    1
@@ -96,7 +96,7 @@ typedef union duk_double_union duk_double_union;
 #define DUK_DBL_IDX_VP0    DUK_DBL_IDX_UI0  /* packed tval */
 #define DUK_DBL_IDX_VP1    DUK_DBL_IDX_UI1  /* packed tval */
 #elif defined(DUK_USE_DOUBLE_BE)
-#ifdef DUK_USE_64BIT_OPS
+#if defined(DUK_USE_64BIT_OPS)
 #define DUK_DBL_IDX_ULL0   0
 #endif
 #define DUK_DBL_IDX_UI0    0
@@ -116,7 +116,7 @@ typedef union duk_double_union duk_double_union;
 #define DUK_DBL_IDX_VP0    DUK_DBL_IDX_UI0  /* packed tval */
 #define DUK_DBL_IDX_VP1    DUK_DBL_IDX_UI1  /* packed tval */
 #elif defined(DUK_USE_DOUBLE_ME)
-#ifdef DUK_USE_64BIT_OPS
+#if defined(DUK_USE_64BIT_OPS)
 #define DUK_DBL_IDX_ULL0   0  /* not directly applicable, byte order differs from a double */
 #endif
 #define DUK_DBL_IDX_UI0    0
@@ -152,8 +152,8 @@ typedef union duk_double_union duk_double_union;
 		(u)->ui[DUK_DBL_IDX_UI0] = (duk_uint32_t) (v); \
 	} while (0)
 
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_64BIT_OPS)
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK_DBLUNION_SET_HIGH32_ZERO_LOW32(u,v)  do { \
 		(u)->ull[DUK_DBL_IDX_ULL0] = (duk_uint64_t) (v); \
 	} while (0)
@@ -177,8 +177,8 @@ typedef union duk_double_union duk_double_union;
 #define DUK_DBLUNION_GET_HIGH32(u)  ((u)->ui[DUK_DBL_IDX_UI0])
 #define DUK_DBLUNION_GET_LOW32(u)   ((u)->ui[DUK_DBL_IDX_UI1])
 
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_64BIT_OPS)
+#if defined(DUK_USE_DOUBLE_ME)
 #define DUK_DBLUNION_SET_UINT64(u,v)  do { \
 		(u)->ui[DUK_DBL_IDX_UI0] = (duk_uint32_t) ((v) >> 32); \
 		(u)->ui[DUK_DBL_IDX_UI1] = (duk_uint32_t) (v); \
@@ -222,65 +222,72 @@ typedef union duk_double_union duk_double_union;
  *  This is not full ARM support but suffices for some environments.
  */
 
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
+#if defined(DUK_USE_64BIT_OPS)
+#if defined(DUK_USE_DOUBLE_ME)
+/* Macros for 64-bit ops + mixed endian doubles. */
 #define DUK__DBLUNION_SET_NAN_FULL(u)  do { \
 		(u)->ull[DUK_DBL_IDX_ULL0] = 0x000000007ff80000ULL; \
 	} while (0)
+#define DUK__DBLUNION_IS_NAN_FULL(u) \
+	((((u)->ull[DUK_DBL_IDX_ULL0] & 0x000000007ff00000ULL) == 0x000000007ff00000ULL) && \
+	 ((((u)->ull[DUK_DBL_IDX_ULL0]) & 0xffffffff000fffffULL) != 0))
+#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x000000007ff80000ULL)
+#define DUK__DBLUNION_IS_ANYINF(u) \
+	(((u)->ull[DUK_DBL_IDX_ULL0] & 0xffffffff7fffffffULL) == 0x000000007ff00000ULL)
+#define DUK__DBLUNION_IS_POSINF(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x000000007ff00000ULL)
+#define DUK__DBLUNION_IS_NEGINF(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x00000000fff00000ULL)
 #else
+/* Macros for 64-bit ops + big/little endian doubles. */
 #define DUK__DBLUNION_SET_NAN_FULL(u)  do { \
 		(u)->ull[DUK_DBL_IDX_ULL0] = 0x7ff8000000000000ULL; \
 	} while (0)
+#define DUK__DBLUNION_IS_NAN_FULL(u) \
+	((((u)->ull[DUK_DBL_IDX_ULL0] & 0x7ff0000000000000ULL) == 0x7ff0000000000000UL) && \
+	 ((((u)->ull[DUK_DBL_IDX_ULL0]) & 0x000fffffffffffffULL) != 0))
+#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x7ff8000000000000ULL)
+#define DUK__DBLUNION_IS_ANYINF(u) \
+	(((u)->ull[DUK_DBL_IDX_ULL0] & 0x7fffffffffffffffULL) == 0x7ff0000000000000ULL)
+#define DUK__DBLUNION_IS_POSINF(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x7ff0000000000000ULL)
+#define DUK__DBLUNION_IS_NEGINF(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0xfff0000000000000ULL)
 #endif
 #else  /* DUK_USE_64BIT_OPS */
+/* Macros for no 64-bit ops, any endianness. */
 #define DUK__DBLUNION_SET_NAN_FULL(u)  do { \
 		(u)->ui[DUK_DBL_IDX_UI0] = (duk_uint32_t) 0x7ff80000UL; \
 		(u)->ui[DUK_DBL_IDX_UI1] = (duk_uint32_t) 0x00000000UL; \
 	} while (0)
+#define DUK__DBLUNION_IS_NAN_FULL(u) \
+	((((u)->ui[DUK_DBL_IDX_UI0] & 0x7ff00000UL) == 0x7ff00000UL) && \
+	 (((u)->ui[DUK_DBL_IDX_UI0] & 0x000fffffUL) != 0 || \
+          (u)->ui[DUK_DBL_IDX_UI1] != 0))
+#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
+	(((u)->ui[DUK_DBL_IDX_UI0] == 0x7ff80000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_ANYINF(u) \
+	((((u)->ui[DUK_DBL_IDX_UI0] & 0x7fffffffUL) == 0x7ff00000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_POSINF(u) \
+	(((u)->ui[DUK_DBL_IDX_UI0] == 0x7ff00000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_NEGINF(u) \
+	(((u)->ui[DUK_DBL_IDX_UI0] == 0xfff00000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
 #endif  /* DUK_USE_64BIT_OPS */
 
 #define DUK__DBLUNION_SET_NAN_NOTFULL(u)  do { \
 		(u)->us[DUK_DBL_IDX_US0] = 0x7ff8UL; \
 	} while (0)
 
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
-#define DUK__DBLUNION_IS_NAN_FULL(u) \
-	/* E == 0x7ff, F != 0 => NaN */ \
-	((((u)->us[DUK_DBL_IDX_US0] & 0x7ff0UL) == 0x7ff0UL) && \
-	 ((((u)->ull[DUK_DBL_IDX_ULL0]) & 0xffffffff000fffffULL) != 0))
-#else
-#define DUK__DBLUNION_IS_NAN_FULL(u) \
-	/* E == 0x7ff, F != 0 => NaN */ \
-	((((u)->us[DUK_DBL_IDX_US0] & 0x7ff0UL) == 0x7ff0UL) && \
-	 ((((u)->ull[DUK_DBL_IDX_ULL0]) & 0x000fffffffffffffULL) != 0))
-#endif
-#else  /* DUK_USE_64BIT_OPS */
-#define DUK__DBLUNION_IS_NAN_FULL(u) \
-	/* E == 0x7ff, F != 0 => NaN */ \
-	((((u)->ui[DUK_DBL_IDX_UI0] & 0x7ff00000UL) == 0x7ff00000UL) && \
-	 (((u)->ui[DUK_DBL_IDX_UI0] & 0x000fffffUL) != 0 || \
-          (u)->ui[DUK_DBL_IDX_UI1] != 0))
-#endif  /* DUK_USE_64BIT_OPS */
-
 #define DUK__DBLUNION_IS_NAN_NOTFULL(u) \
 	/* E == 0x7ff, topmost four bits of F != 0 => assume NaN */ \
 	((((u)->us[DUK_DBL_IDX_US0] & 0x7ff0UL) == 0x7ff0UL) && \
 	 (((u)->us[DUK_DBL_IDX_US0] & 0x000fUL) != 0x0000UL))
-
-#ifdef DUK_USE_64BIT_OPS
-#ifdef DUK_USE_DOUBLE_ME
-#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
-	((u)->ull[DUK_DBL_IDX_ULL0] == 0x000000007ff80000ULL)
-#else
-#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
-	((u)->ull[DUK_DBL_IDX_ULL0] == 0x7ff8000000000000ULL)
-#endif
-#else  /* DUK_USE_64BIT_OPS */
-#define DUK__DBLUNION_IS_NORMALIZED_NAN_FULL(u) \
-	(((u)->ui[DUK_DBL_IDX_UI0] == 0x7ff80000UL) && \
-	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
-#endif  /* DUK_USE_64BIT_OPS */
 
 #define DUK__DBLUNION_IS_NORMALIZED_NAN_NOTFULL(u) \
 	/* E == 0x7ff, F == 8 => normalized NaN */ \
@@ -330,6 +337,10 @@ typedef union duk_double_union duk_double_union;
 	} while (0)
 #endif  /* DUK_USE_PACKED_TVAL */
 
+#define DUK_DBLUNION_IS_ANYINF(u) DUK__DBLUNION_IS_ANYINF((u))
+#define DUK_DBLUNION_IS_POSINF(u) DUK__DBLUNION_IS_POSINF((u))
+#define DUK_DBLUNION_IS_NEGINF(u) DUK__DBLUNION_IS_NEGINF((u))
+
 /* XXX: native 64-bit byteswaps when available */
 
 /* 64-bit byteswap, same operation independent of target endianness. */
@@ -375,10 +386,13 @@ typedef union duk_double_union duk_double_union;
 /* Reverse operation is the same. */
 #define DUK_DBLUNION_DOUBLE_NTOH(u) DUK_DBLUNION_DOUBLE_HTON((u))
 
-/* Sign check. */
-#define DUK_DBLUNION_HAS_SIGNBIT(u) (((u)->ui[DUK_DBL_IDX_UI0] & 0x80000000UL))
-
-/* Sign bit as 1 (negative) or 0 (positive). */
+/* Some sign bit helpers. */
+#if defined(DUK_USE_64BIT_OPS)
+#define DUK_DBLUNION_HAS_SIGNBIT(u) (((u)->ull[DUK_DBL_IDX_ULL0] & 0x8000000000000000ULL) != 0)
+#define DUK_DBLUNION_GET_SIGNBIT(u) (((u)->ull[DUK_DBL_IDX_ULL0] >> 63U))
+#else
+#define DUK_DBLUNION_HAS_SIGNBIT(u) (((u)->ui[DUK_DBL_IDX_UI0] & 0x80000000UL) != 0)
 #define DUK_DBLUNION_GET_SIGNBIT(u) (((u)->ui[DUK_DBL_IDX_UI0] >> 31U))
+#endif
 
 #endif  /* DUK_DBLUNION_H_INCLUDED */

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -352,7 +352,7 @@ DUK_LOCAL duk_hstring *duk__debug_read_hstring_raw(duk_hthread *thr, duk_uint32_
 		duk_debug_read_bytes(thr, buf, (duk_size_t) len);
 		duk_push_lstring(ctx, (const char *) buf, (duk_size_t) len);
 	} else {
-		p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);
+		p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);  /* zero for paranoia */
 		DUK_ASSERT(p != NULL);
 		duk_debug_read_bytes(thr, p, (duk_size_t) len);
 		(void) duk_buffer_to_string(ctx, -1);
@@ -393,7 +393,7 @@ DUK_LOCAL duk_hbuffer *duk__debug_read_hbuffer_raw(duk_hthread *thr, duk_uint32_
 	duk_context *ctx = (duk_context *) thr;
 	duk_uint8_t *p;
 
-	p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);
+	p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);  /* zero for paranoia */
 	DUK_ASSERT(p != NULL);
 	duk_debug_read_bytes(thr, p, (duk_size_t) len);
 

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -181,7 +181,7 @@ DUK_LOCAL void duk__push_string(duk_context *ctx, duk_bitdecoder_ctx *bd) {
 	duk_uint8_t *p;
 
 	n = (duk_small_uint_t) duk_bd_decode(bd, DUK__STRING_LENGTH_BITS);
-	p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, n);
+	p = (duk_uint8_t *) duk_push_fixed_buffer_nozero(ctx, n);
 	for (i = 0; i < n; i++) {
 		*p++ = (duk_uint8_t) duk_bd_decode(bd, DUK__STRING_CHAR_BITS);
 	}

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -742,7 +742,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 	                     (long) funcs_count, (long) sizeof(duk_hobject *),
 	                     (long) code_size, (long) data_size));
 
-	duk_push_fixed_buffer(ctx, data_size);
+	duk_push_fixed_buffer_nozero(ctx, data_size);
 	h_data = (duk_hbuffer_fixed *) duk_get_hbuffer(ctx, -1);
 	DUK_ASSERT(h_data != NULL);
 

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -498,8 +498,8 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 			DUK_ASSERT(idx_count > 0);
 
 			duk_require_stack((duk_context *) re_ctx->thr, 1);
-			range_save = (duk_uint8_t **) duk_push_fixed_buffer((duk_context *) re_ctx->thr,
-			                                                    sizeof(duk_uint8_t *) * idx_count);
+			range_save = (duk_uint8_t **) duk_push_fixed_buffer_nozero((duk_context *) re_ctx->thr,
+			                                                           sizeof(duk_uint8_t *) * idx_count);
 			DUK_ASSERT(range_save != NULL);
 			DUK_MEMCPY(range_save, re_ctx->saved + idx_start, sizeof(duk_uint8_t *) * idx_count);
 #ifdef DUK_USE_EXPLICIT_NULL_INIT
@@ -555,8 +555,8 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 			DUK_ASSERT(re_ctx->nsaved > 0);
 
 			duk_require_stack((duk_context *) re_ctx->thr, 1);
-			full_save = (duk_uint8_t **) duk_push_fixed_buffer((duk_context *) re_ctx->thr,
-			                                                   sizeof(duk_uint8_t *) * re_ctx->nsaved);
+			full_save = (duk_uint8_t **) duk_push_fixed_buffer_nozero((duk_context *) re_ctx->thr,
+			                                                          sizeof(duk_uint8_t *) * re_ctx->nsaved);
 			DUK_ASSERT(full_save != NULL);
 			DUK_MEMCPY(full_save, re_ctx->saved, sizeof(duk_uint8_t *) * re_ctx->nsaved);
 
@@ -757,7 +757,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	DUK_ASSERT(re_ctx.nsaved >= 2);
 	DUK_ASSERT((re_ctx.nsaved % 2) == 0);
 
-	p_buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, sizeof(duk_uint8_t *) * re_ctx.nsaved);
+	p_buf = (duk_uint8_t *) duk_push_fixed_buffer(ctx, sizeof(duk_uint8_t *) * re_ctx.nsaved);  /* rely on zeroing */
 	DUK_UNREF(p_buf);
 	re_ctx.saved = (const duk_uint8_t **) duk_get_buffer(ctx, -1, NULL);
 	DUK_ASSERT(re_ctx.saved != NULL);

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -250,8 +250,17 @@ DUK_INTERNAL duk_small_int_t duk_unicode_decode_xutf8(duk_hthread *thr, const du
 
 	while (n > 0) {
 		DUK_ASSERT(p >= ptr_start && p < ptr_end);
-		res = res << 6;
-		res += (duk_uint32_t) ((*p++) & 0x3f);
+		ch = (duk_uint_fast8_t) (*p++);
+#if 0
+		if (ch & 0xc0 != 0x80) {
+			/* not a continuation byte */
+			p--;
+			*ptr = p;
+			*out_cp = DUK_UNICODE_CP_REPLACEMENT_CHARACTER;
+			return 1;
+		}
+#endif
+		res = (res << 6) + (duk_uint32_t) (ch & 0x3f);
 		n--;
 	}
 

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -537,5 +537,8 @@ DUK_INTERNAL_DECL void duk_byteswap_bytes(duk_uint8_t *p, duk_small_uint_t len);
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32_nonegzero(duk_double_t x, duk_int32_t *ival);
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32(duk_double_t x, duk_int32_t *ival);
+DUK_INTERNAL_DECL duk_bool_t duk_is_anyinf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_is_posinf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_is_neginf(duk_double_t x);
 
 #endif  /* DUK_UTIL_H_INCLUDED */

--- a/src-input/duk_util_misc.c
+++ b/src-input/duk_util_misc.c
@@ -261,3 +261,21 @@ DUK_INTERNAL duk_bool_t duk_is_whole_get_int32(duk_double_t x, duk_int32_t *ival
 	*ival = t;
 	return 1;
 }
+
+DUK_INTERNAL duk_bool_t duk_is_anyinf(duk_double_t x) {
+	duk_double_union du;
+	du.d = x;
+	return DUK_DBLUNION_IS_ANYINF(&du);
+}
+
+DUK_INTERNAL duk_bool_t duk_is_posinf(duk_double_t x) {
+	duk_double_union du;
+	du.d = x;
+	return DUK_DBLUNION_IS_POSINF(&du);
+}
+
+DUK_INTERNAL duk_bool_t duk_is_neginf(duk_double_t x) {
+	duk_double_union du;
+	du.d = x;
+	return DUK_DBLUNION_IS_NEGINF(&du);
+}

--- a/tests/ecmascript/test-bi-string-proto-repeat-internalstring.js
+++ b/tests/ecmascript/test-bi-string-proto-repeat-internalstring.js
@@ -1,0 +1,73 @@
+/*
+ *  String.prototype.repeat() for an internal string just concatenates the
+ *  internal representations.  At the join point between segments this may
+ *  generate valid codepoints.  This is not a compliance issue because all
+ *  compliant strings are CESU-8 encoded and have no such isses; it's also
+ *  not a sandboxing issue because the concatenation process can't create
+ *  internal keys unless you already have one at hand.  The prefix of the
+ *  result is also from the repeated string so you also can't create a new
+ *  prefix byte by repeating something.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+4
+65533 65 66 67
+12
+|ff414243ff414243ff414243|
+65533 65 66 67 65533 65 66 67 65533 65 66 67
+4
+65533 65 66 65533
+undefined
+12
+|abbe414243ecabbe414243ecabbe414243ec|
+65533
+65533 65 66 67 51966 65 66 51966 65 66 67 65533
+===*/
+
+function test() {
+    var str, res;
+
+    function dump(x) {
+        var res = [];
+        for (var i = 0; i < x.length; i++) {
+            res.push(x.charCodeAt(i));
+        }
+        print(res.join(' '));
+    }
+
+    // Internal prefix 0xFF is just repeated, unaffected.
+    str = String.fromBuffer(new Uint8Array([ 0xff, 0x41, 0x42, 0x43 ]));
+    print(str.length);
+    dump(str);
+    res = str.repeat(3);
+    print(res.length);
+    print(Duktape.enc('jx', ArrayBuffer.allocPlain(res)));
+    dump(res);
+
+    // Here the string begins and ends with a broken codepoint, but
+    // repeating the string joins the broken pieces into a valid
+    // codepoint; U+CAFE encodes to EC AB BE.
+    // This comes out very oddly when iterated using x.charCodeAt()
+    // but there are no guarantees for invalid UTF-8 strings so that's
+    // OK for this test.
+    str = String.fromBuffer(new Uint8Array([ 0xab, 0xbe, 0x41, 0x42, 0x43, 0xec ]));
+    print(str.length);
+    print(dump(str));
+    res = str.repeat(3);
+    print(res.length);
+    print(Duktape.enc('jx', ArrayBuffer.allocPlain(res)));
+    print(res.charCodeAt(0));
+    dump(res);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-string-proto-repeat.js
+++ b/tests/ecmascript/test-bi-string-proto-repeat.js
@@ -1,0 +1,156 @@
+/*
+ *  String.prototype.repeat()
+ */
+
+print=console.log
+
+/*===
+xxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+50
+51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047 51966 97 98 99 2047
+0
+0
+0
+0
+0
+5
+RangeError
+0
+RangeError
+RangeError
+0
+246
+0
+3000000
+0
+100
+200
+300
+400
+500
+600
+700
+800
+900
+RangeError
+all done
+===*/
+
+function test() {
+    var res;
+    var i, j, k, n;
+
+    // basic usage
+    res = 'x'.repeat(10);
+    print(res);
+
+    // chaining
+    res = 'x'.repeat(2).repeat(5).repeat(10);
+    print(res);
+
+    // unicode
+    res = '\ucafeabc\u07ff'.repeat(10);
+    print(res.length);
+    print(Array.prototype.map.call(res, function (v) { return v.charCodeAt(0); }).join(' '));
+
+    res = ''.repeat(1e9);
+    print(res.length);
+    try {
+        res = ''.repeat(1e15);  // allowed: as long as ToInteger() coerce check succeeds and result is small enough
+        print(res.length);
+    } catch (e) {
+        print(e.name);
+    }
+    res = 'xxxx'.repeat(0);
+    print(res.length);
+    res = 'x'.repeat(1e6).repeat(0);
+    print(res.length);
+    res = ''.repeat(0);
+    print(res.length);
+
+    // ToInteger coercions fractions towards zero.
+    res = 'x'.repeat(5.9);  // allowed
+    print(res.length);
+
+    // ToInteger(+inf) is +inf, but E6 Section 21.1.3.13 step 7 rejects it
+    // even when the input size is zero.
+    try {
+        res = ''.repeat(1/0);
+        print(res.length);
+    } catch (e) {
+        print(e.name);
+    }
+
+    // negative counts are always rejected, but the value is truncated towards
+    // zero and negative zero is allowed
+    res = ''.repeat(-0.9);  // allowed
+    print(res.length);
+    try {
+        res = ''.repeat(-1);  // not allowed
+        print(res.length);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        res = ''.repeat(-1/0);  // not allowed
+        print(res.length);
+    } catch (e) {
+        print(e.name);
+    }
+
+    // NaN coerces to +0 in ToInteger() so allowed
+    res = 'xxx'.repeat(0/0);
+    print(res.length);
+
+    // Repeat count is ToNumber() coerced, so e.g. '123' works.
+    res = 'xy'.repeat('123.1');
+    print(res.length);
+
+    // And anything that doesn't parse as a number is equivalent to 0.
+    res = 'xy'.repeat('dummy');
+    print(res.length);
+
+    // large input, small repeat count
+    res = 'x'.repeat(1e6).repeat(3);
+    print(res.length);
+
+    // brute force some counts and lengths
+    var inputs = [
+        'x',
+        'xy',
+        'xyz',
+        'xyzz',
+        'xyzzy\ucafe\u1234\u07ffabcdefghijklmnopqrstuvwxyz'
+    ];
+    for (i = 0; i < 1e3; i++) {
+        if ((i % 100) == 0) { print(i); }
+        for (j = 0; j < 5; j++) {
+            res = inputs[j].repeat(i);
+            n = inputs[j].length;
+            if (res.length !== n * i) {
+                throw new Error('length mismatch: ' + i + ',' + j);
+            }
+            for (k = 0; k < res.length; k++) {
+                if (res.charCodeAt(k) !== inputs[j].charCodeAt(k % n)) {
+                    throw new Error('charcode mismatch: ' + k + ',' + i + ',' + j);
+                }
+            }
+        }
+    }
+
+    // string length overflow, assume for now it happens at least around 1024G
+    try {
+        res = 'x'.repeat(256).repeat(256).repeat(256).repeat(256).repeat(256);
+    } catch (e) {
+        print(e.name);
+    }
+
+    print('all done');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
- [x] Rebase once #1049 is merged
- [x] Basic implementation
- [x] Small footprint variant
- [x] Internal fixed buffer zeroing optimization (very often zeroing not needed)
- [x] Note on UTF-8 safety: if input is UTF-8, output is also UTF-8; if input is not UTF-8 it's possible for initial and last bytes of the repeated string to combine in the repetition => noted in test case
- [x] Testcase
- [x] Releases entry
