### PR TITLE
Small IEEE double handling improvements

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2021,12 +2021,13 @@ Planned
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
   opcode handler optimizations (GH-903); refcount optimizations (GH-443,
   GH-973, GH-1042); minor RegExp compile/execute optimizations (GH-974,
-  GH-1033)
+  GH-1033); minor IEEE double handling optimizations (GH-1051)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977);
   internal duk_dup() variants (GH-990); allow stripping of (almost) all
   built-ins for low memory builds (GH-989); remove internal accessor setup
-  helper and use duk_def_prop() instead (GH-1010)
+  helper and use duk_def_prop() instead (GH-1010); minor IEEE double handling
+  optimizations (GH-1051)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -2885,6 +2885,8 @@ DUK_EXTERNAL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx) {
 
 	tv = duk_get_tval_or_unused(ctx, idx);
 	DUK_ASSERT(tv != NULL);
+
+	/* XXX: for packed duk_tval an explicit "is number" check is unnecessary */
 	if (!DUK_TVAL_IS_NUMBER(tv)) {
 		return 0;
 	}

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -54,8 +54,20 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 	 * -0 as Ecmascript requires.
 	 */
 	if (x == 0 && y == 0) {
+		duk_double_union du1, du2;
+		du1.d = x;
+		du2.d = y;
+
+		/* Already checked to be zero so these must hold, and allow us
+		 * to check for "x is -0 or y is -0" by ORing the high parts
+		 * for comparison.
+		 */
+		DUK_ASSERT(du1.ui[DUK_DBL_IDX_UI0] == 0 || du1.ui[DUK_DBL_IDX_UI0] == 0x80000000UL);
+		DUK_ASSERT(du2.ui[DUK_DBL_IDX_UI0] == 0 || du2.ui[DUK_DBL_IDX_UI0] == 0x80000000UL);
+
 		/* XXX: what's the safest way of creating a negative zero? */
-		if (DUK_SIGNBIT(x) != 0 || DUK_SIGNBIT(y) != 0) {
+		if ((du1.ui[DUK_DBL_IDX_UI0] | du2.ui[DUK_DBL_IDX_UI0]) != 0) {
+			/* Enter here if either x or y (or both) is -0. */
 			return -0.0;
 		} else {
 			return +0.0;

--- a/src-input/duk_dblunion.h.in
+++ b/src-input/duk_dblunion.h.in
@@ -239,6 +239,12 @@ typedef union duk_double_union duk_double_union;
 	((u)->ull[DUK_DBL_IDX_ULL0] == 0x000000007ff00000ULL)
 #define DUK__DBLUNION_IS_NEGINF(u) \
 	((u)->ull[DUK_DBL_IDX_ULL0] == 0x00000000fff00000ULL)
+#define DUK__DBLUNION_IS_ANYZERO(u) \
+	(((u)->ull[DUK_DBL_IDX_ULL0] & 0xffffffff7fffffffULL) == 0x0000000000000000ULL)
+#define DUK__DBLUNION_IS_POSZERO(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x0000000000000000ULL)
+#define DUK__DBLUNION_IS_NEGZERO(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x0000000080000000ULL)
 #else
 /* Macros for 64-bit ops + big/little endian doubles. */
 #define DUK__DBLUNION_SET_NAN_FULL(u)  do { \
@@ -255,6 +261,12 @@ typedef union duk_double_union duk_double_union;
 	((u)->ull[DUK_DBL_IDX_ULL0] == 0x7ff0000000000000ULL)
 #define DUK__DBLUNION_IS_NEGINF(u) \
 	((u)->ull[DUK_DBL_IDX_ULL0] == 0xfff0000000000000ULL)
+#define DUK__DBLUNION_IS_ANYZERO(u) \
+	(((u)->ull[DUK_DBL_IDX_ULL0] & 0x7fffffffffffffffULL) == 0x0000000000000000ULL)
+#define DUK__DBLUNION_IS_POSZERO(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x0000000000000000ULL)
+#define DUK__DBLUNION_IS_NEGZERO(u) \
+	((u)->ull[DUK_DBL_IDX_ULL0] == 0x8000000000000000ULL)
 #endif
 #else  /* DUK_USE_64BIT_OPS */
 /* Macros for no 64-bit ops, any endianness. */
@@ -277,6 +289,15 @@ typedef union duk_double_union duk_double_union;
 	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
 #define DUK__DBLUNION_IS_NEGINF(u) \
 	(((u)->ui[DUK_DBL_IDX_UI0] == 0xfff00000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_ANYZERO(u) \
+	((((u)->ui[DUK_DBL_IDX_UI0] & 0x7fffffffUL) == 0x00000000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_POSZERO(u) \
+	(((u)->ui[DUK_DBL_IDX_UI0] == 0x00000000UL) && \
+	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
+#define DUK__DBLUNION_IS_NEGZERO(u) \
+	(((u)->ui[DUK_DBL_IDX_UI0] == 0x80000000UL) && \
 	 ((u)->ui[DUK_DBL_IDX_UI1] == 0x00000000UL))
 #endif  /* DUK_USE_64BIT_OPS */
 
@@ -328,8 +349,8 @@ typedef union duk_double_union duk_double_union;
 	 DUK_DBLUNION_IS_NORMALIZED_NAN((u)))  /* or is a normalized NaN */
 #else  /* DUK_USE_PACKED_TVAL */
 #define DUK_DBLUNION_NORMALIZE_NAN_CHECK(u)  /* nop: no need to normalize */
-#define DUK_DBLUNION_IS_NAN(u)               (DUK_ISNAN((u)->d))
-#define DUK_DBLUNION_IS_NORMALIZED_NAN(u)    (DUK_ISNAN((u)->d))
+#define DUK_DBLUNION_IS_NAN(u)               DUK__DBLUNION_IS_NAN_FULL((u))  /* (DUK_ISNAN((u)->d)) */
+#define DUK_DBLUNION_IS_NORMALIZED_NAN(u)    DUK__DBLUNION_IS_NAN_FULL((u))  /* (DUK_ISNAN((u)->d)) */
 #define DUK_DBLUNION_IS_NORMALIZED(u)        1  /* all doubles are considered normalized */
 #define DUK_DBLUNION_SET_NAN(u)  do { \
 		/* in non-packed representation we don't care about which NaN is used */ \
@@ -340,6 +361,10 @@ typedef union duk_double_union duk_double_union;
 #define DUK_DBLUNION_IS_ANYINF(u) DUK__DBLUNION_IS_ANYINF((u))
 #define DUK_DBLUNION_IS_POSINF(u) DUK__DBLUNION_IS_POSINF((u))
 #define DUK_DBLUNION_IS_NEGINF(u) DUK__DBLUNION_IS_NEGINF((u))
+
+#define DUK_DBLUNION_IS_ANYZERO(u) DUK__DBLUNION_IS_ANYZERO((u))
+#define DUK_DBLUNION_IS_POSZERO(u) DUK__DBLUNION_IS_POSZERO((u))
+#define DUK_DBLUNION_IS_NEGZERO(u) DUK__DBLUNION_IS_NEGZERO((u))
 
 /* XXX: native 64-bit byteswaps when available */
 

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -17,8 +17,8 @@
 #define DUK_EQUALS_FLAG_STRICT               (1 << 1)  /* use strict equality instead of non-strict equality */
 
 /* Flags for duk_js_compare_helper(). */
-#define DUK_COMPARE_FLAG_EVAL_LEFT_FIRST     (1 << 0)  /* eval left argument first */
-#define DUK_COMPARE_FLAG_NEGATE              (1 << 1)  /* negate result */
+#define DUK_COMPARE_FLAG_NEGATE              (1 << 0)  /* negate result */
+#define DUK_COMPARE_FLAG_EVAL_LEFT_FIRST     (1 << 1)  /* eval left argument first */
 
 /* conversions, coercions, comparison, etc */
 DUK_INTERNAL_DECL duk_bool_t duk_js_toboolean(duk_tval *tv);

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -2239,6 +2239,10 @@ DUK_INTERNAL void duk_numconv_parse(duk_context *ctx, duk_small_int_t radix, duk
 	/*
 	 *  Convert binary digits into an IEEE double.  Need to handle
 	 *  denormals and rounding correctly.
+	 *
+	 *  Some call sites currently assume the result is always a
+	 *  non-fastint double.  If this is changed, check all call
+	 *  sites.
 	 */
 
 	duk__dragon4_ctx_to_double(nc_ctx, &res);

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -537,8 +537,15 @@ DUK_INTERNAL_DECL void duk_byteswap_bytes(duk_uint8_t *p, duk_small_uint_t len);
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32_nonegzero(duk_double_t x, duk_int32_t *ival);
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32(duk_double_t x, duk_int32_t *ival);
-DUK_INTERNAL_DECL duk_bool_t duk_is_anyinf(duk_double_t x);
-DUK_INTERNAL_DECL duk_bool_t duk_is_posinf(duk_double_t x);
-DUK_INTERNAL_DECL duk_bool_t duk_is_neginf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_anyinf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_posinf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_neginf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_nan(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_nan_or_zero(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_nan_or_inf(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_is_nan_zero_inf(duk_double_t x);
+DUK_INTERNAL_DECL duk_small_uint_t duk_double_signbit(duk_double_t x);
+DUK_INTERNAL_DECL duk_double_t duk_double_trunc_towards_zero(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_same_sign(duk_double_t x, duk_double_t y);
 
 #endif  /* DUK_UTIL_H_INCLUDED */


### PR DESCRIPTION
Minor footprint and performance improvements for IEEE double handling:
- Avoid explicit `signbit()` calls here and there where it benefits both footprint and performance.
- Rework some `duk_js_ops.c` algorithms like comparison for better footprint and performance.
- Other odds and ends

Dropping dependency entirely to e.g. `signbit()` and `fpclassify()` would simplify porting and avoid pulling them in from a libc provider on bare metal targets.