### PR TITLE
Revise enumeration order to match common ES6 engine behavior

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1843,6 +1843,11 @@ Planned
   Ecmascript code to read and write text stored in an ArrayBuffer or a plain
   buffer (GH-975)
 
+* Respect ES6 enumeration order (array index keys, other keys in insertion
+  order) for Object.getOwnPropertyNames(), also use the same order in
+  for-in, Object.keys(), and duk_enum() even though that's not strictly
+  required by ES6 or ES7 (GH-1054)
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -976,6 +976,31 @@ To upgrade:
 * If you're using the user InitJS option, call sites need to be modified to
   run the init code explicitly on heap/thread creation.
 
+Enumeration order changes
+-------------------------
+
+Enumeration order for ``Object.getOwnPropertyNames()`` has been changed to
+match ES6/ES7 ``[[OwnPropertyKeys]]`` enumeration order, which is:
+
+* Array indices in ascending order
+
+* Normal (non-array-index) property keys in insertion order
+
+* Symbols in insertion order
+
+While not required by ES6/ES7, the same enumeration order is also used in
+Duktape 2.x for ``for-in``, ``Object.keys()``, and ``duk_enum()``.  A related
+change is that ``duk_enum()`` flags ``DUK_ENUM_ARRAY_INDICES_ONLY`` and
+``DUK_ENUM_SORT_ARRAY_INDICES`` can now be used independently.
+
+The revised enumeration order makes enumeration behavior more predictable
+and matches other modern engines.  In particular, sparse arrays (arrays
+without an internal array part) now enumerate identically to dense arrays.
+
+To upgrade:
+
+* Check application code for enumeration assumptions.
+
 Other incompatible changes
 --------------------------
 

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -177,10 +177,10 @@ struct duk_time_components {
 
 /* Enumeration flags for duk_enum() */
 #define DUK_ENUM_INCLUDE_NONENUMERABLE    (1 << 0)    /* enumerate non-numerable properties in addition to enumerable */
-#define DUK_ENUM_INCLUDE_INTERNAL         (1 << 1)    /* enumerate internal properties (regardless of enumerability) */
+#define DUK_ENUM_INCLUDE_INTERNAL         (1 << 1)    /* enumerate internal properties */
 #define DUK_ENUM_OWN_PROPERTIES_ONLY      (1 << 2)    /* don't walk prototype chain, only check own properties */
 #define DUK_ENUM_ARRAY_INDICES_ONLY       (1 << 3)    /* only enumerate array indices */
-#define DUK_ENUM_SORT_ARRAY_INDICES       (1 << 4)    /* sort array indices, use with DUK_ENUM_ARRAY_INDICES_ONLY */
+#define DUK_ENUM_SORT_ARRAY_INDICES       (1 << 4)    /* sort array indices (applied to full enumeration result, including inherited array indices) */
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 << 5)    /* enumerate a proxy object itself without invoking proxy behavior */
 
 /* Compilation flags for duk_compile() and duk_eval() */

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -575,7 +575,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_extensible(duk_context *ctx)
 
 #if defined(DUK_USE_OBJECT_BUILTIN) || defined(DUK_USE_REFLECT_BUILTIN)
 /* Shared helper for Object.getOwnPropertyNames() and Object.keys().
- * Magic: 0=getOwnPropertyNames, 1=Object.keys.
+ * Magic: 0=Object.getOwnPropertyNames() or Reflect.ownKeys(), 1=Object.keys().
  */
 DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;

--- a/tests/api/test-def-prop.c
+++ b/tests/api/test-def-prop.c
@@ -162,38 +162,38 @@ final top: 1
 final top: 1
 ==> rc=0, result='undefined'
 *** test_fail_array_smaller (duk_safe_call)
-"length" {value:4,writable:true,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "1" {value:"bar",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "2" {value:"quux",writable:true,enumerable:true,configurable:false} no-getter no-setter
 "3" {value:"baz",writable:true,enumerable:true,configurable:true} no-getter no-setter
+"length" {value:4,writable:true,enumerable:false,configurable:false} no-getter no-setter
 ==> rc=1, result='TypeError: not configurable'
 *** test_force_array_smaller (duk_safe_call)
-"length" {value:4,writable:true,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "1" {value:"bar",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "2" {value:"quux",writable:true,enumerable:true,configurable:false} no-getter no-setter
 "3" {value:"baz",writable:true,enumerable:true,configurable:true} no-getter no-setter
-"length" {value:1,writable:true,enumerable:false,configurable:false} no-getter no-setter
+"length" {value:4,writable:true,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
+"length" {value:1,writable:true,enumerable:false,configurable:false} no-getter no-setter
 json: ["foo"]
 final top: 1
 ==> rc=0, result='undefined'
 *** test_fail_array_smaller_nonwritablelength (duk_safe_call)
-"length" {value:4,writable:false,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "1" {value:"bar",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "2" {value:"quux",writable:true,enumerable:true,configurable:false} no-getter no-setter
 "3" {value:"baz",writable:true,enumerable:true,configurable:true} no-getter no-setter
+"length" {value:4,writable:false,enumerable:false,configurable:false} no-getter no-setter
 ==> rc=1, result='TypeError: not configurable'
 *** test_force_array_smaller_nonwritablelength (duk_safe_call)
-"length" {value:4,writable:false,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "1" {value:"bar",writable:true,enumerable:true,configurable:true} no-getter no-setter
 "2" {value:"quux",writable:true,enumerable:true,configurable:false} no-getter no-setter
 "3" {value:"baz",writable:true,enumerable:true,configurable:true} no-getter no-setter
-"length" {value:1,writable:false,enumerable:false,configurable:false} no-getter no-setter
+"length" {value:4,writable:false,enumerable:false,configurable:false} no-getter no-setter
 "0" {value:"foo",writable:true,enumerable:true,configurable:true} no-getter no-setter
+"length" {value:1,writable:false,enumerable:false,configurable:false} no-getter no-setter
 json: ["foo"]
 final top: 1
 ==> rc=0, result='undefined'

--- a/tests/api/test-enum.c
+++ b/tests/api/test-enum.c
@@ -2,16 +2,16 @@
 *** test_1 (duk_safe_call)
 object with own properties only, enum with get_value=0
 key: '1'
+key: '2'
 key: 'foo'
 key: 'bar'
 key: 'quux'
-key: '2'
 object with own properties only, enum with get_value=1
 key: '1', value: '1'
+key: '2', value: '5'
 key: 'foo', value: '2'
 key: 'bar', value: '3'
 key: 'quux', value: '4'
-key: '2', value: '5'
 object with inherited, enumerable properties, enum with get_value=1
 key: 'foo', value: 'bar'
 key: 'parent', value: 'inherited'
@@ -23,11 +23,11 @@ key: 'enumerable_prop', value: '123'
 key: 'nonenumerable_prop', value: '234'
 object with string and array index keys, enum with get_value=1
 - enum array indices only, not sorted
-key: '999', value: 'val2'
 key: '1', value: 'val3'
+key: '2', value: 'val6'
 key: '123', value: 'val4'
 key: '234', value: 'val5'
-key: '2', value: 'val6'
+key: '999', value: 'val2'
 - enum array indices only, sorted
 key: '1', value: 'val3'
 key: '2', value: 'val6'
@@ -94,6 +94,12 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_pop(ctx);
 	duk_pop(ctx);
 
+	/* Duktape 2.x ES6-based enumeration order ensures array indices are
+	 * sorted even when not explicitly requested.  This only applies to
+	 * each inheritance level (e.g. own properties) separately.  In
+	 * practice array indices will be sorted because array indices are
+	 * very rarely inherited.
+	 */
 	printf("object with string and array index keys, enum with get_value=1\n");
 	duk_eval_string(ctx, "({ foo: 'val1', 999: 'val2', 1: 'val3', 123: 'val4', 234: 'val5', 2: 'val6', bar: 'val7' })");
 	printf("- enum array indices only, not sorted\n");

--- a/tests/ecmascript/test-bi-json-enc-arr-length-sparse.js
+++ b/tests/ecmascript/test-bi-json-enc-arr-length-sparse.js
@@ -1,16 +1,16 @@
+/*===
+0
+1
+3
+100
+[1,2,null,4,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,"foo"]
+===*/
+
 /*---
 {
     "custom": true
 }
 ---*/
-
-/*===
-0
-1
-100
-3
-[1,2,null,4,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,"foo"]
-===*/
 
 function sparseArrayLengthTest() {
     var arr, k;
@@ -18,7 +18,10 @@ function sparseArrayLengthTest() {
     // sparse array test
     arr = [1, 2];
     arr[100] = 'foo';  // becomes sparse
-    arr[3] = 4;        // will enumerate "incorrectly"
+    arr[3] = 4;        // in Duktape 1.x would enumerate "incorrectly",
+                       // Duktape 2.x adheres to ES6 [[OwnPropertyKeys]]
+                       // enum order (even when ES6 doesn't require it
+                       // for the for-in statement)
 
     // custom behavior here
     for (k in arr) {

--- a/tests/ecmascript/test-dev-duk-harray.js
+++ b/tests/ecmascript/test-dev-duk-harray.js
@@ -322,9 +322,9 @@ enumeration order for sparse arrays
 0,1,2
 0,1,2,length,foo
 0,1,2,foo
-length,0,1,2,foo
+0,1,2,length,foo
 0,1,2,foo
-length,0,1,2,foo,bar
+0,1,2,length,foo,bar
 0,1,2,foo,bar
 ===*/
 
@@ -338,19 +338,14 @@ length,0,1,2,foo,bar
  * 0,1,2,length.  When that array becomes sparse, Duktape 1.x would still
  * enumerate it as 0,1,2,length because .length was stored explicitly and
  * could thus be moved to the entry part.  Duktape 2.x has a virtual Array
- * .length and the sparse array will thus enumerate as length,0,1,2.
+ * .length and, without any changes, the sparse array would thus enumerate
+ * as length,0,1,2.
  *
- *     ((o) Duktape 1.5.0 (v1.4.0-421-g8e90d3d-dirty)
- *     duk> a = [1,2,3]; a[100] = 1; a.length = 3;
- *     = 3
- *     duk> Object.getOwnPropertyNames(a)
- *     = 0,1,2,length
- *
- *     ((o) Duktape [linenoise] 1.99.99 (v1.5.0-168-g86373ab-dirty)
- *     duk> a = [1,2,3]; a[100] = 1; a.length = 3;
- *     = 3
- *     duk> Object.getOwnPropertyNames(a)
- *     = length,0,1,2
+ * However, Duktape 2.x has an explicit post-enumeration sorting step to
+ * achieve ES6 [[OwnPropertyKeys]] key order which fixes this internal order.
+ * The end result is: array index keys first, then keys in insertion order;
+ * .length is "inserted" during duk_harray creation so it first in the
+ * key part but follows array indices.
  */
 
 function sparseArrayEnumTest() {

--- a/tests/ecmascript/test-dev-es6-enum-order.js
+++ b/tests/ecmascript/test-dev-es6-enum-order.js
@@ -1,0 +1,168 @@
+/*
+ *  Some ES6 (and ES7) enumeration order tests
+ *
+ *  https://github.com/svaarala/duktape/pull/1054
+ *
+ *  Duktape 2.x applies the ES6 [[OwnPropertyKeys]] enumeration order also
+ *  in for-in, Object.keys(), and duk.enum(), even though neither ES6 nor
+ *  ES7 requires it.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+2
+3
+foo
+bar
+quux
+2
+foo
+bar
+4
+0 yes
+2 yes
+3 yes
+4294967292 yes
+4294967293 yes
+4294967294 yes
+0.0 no
+-0 no
+0.1 no
+4294967297 no
+4294967296 no
+4294967295 no
+0
+4
+3
+2
+1
+3
+0
+1
+2
+4
+0
+3
+1
+2
+4
+0
+3
+1
+2
+4
+["a","b","foo","d","e"]
+0 a
+1 b
+3 d
+4 e
+2 foo
+a
+b
+foo
+d
+e
+===*/
+
+function test() {
+    var a, b, c, d, e;
+    var k;
+
+    // Basic case: for own properties array indices come first, followed by
+    // keys in insert order.
+    a = { foo: 1, 2: 'bar', 3: 'quux', bar: 4, quux: 5 };
+    for (k in a) { print(k); }
+
+    // When properties are inherited, the sorting rule is applied to each
+    // inheritance level in turn (eliminating duplicates).
+    a = { 4: 'foo', foo: 'shadowed', 2: 'shadowed' };
+    b = { foo: 1, 2: 'bar', bar: 'quux' };
+    b.__proto__ = a;
+    for (k in b) { print(k); }
+
+    // Array indices are recognized specially as canonical strings for
+    // integers [0,2**32-2].
+    a = { 0: 'yes', '0.0': 'no', '-0': 'no', '0.1': 'no', 3: 'yes', 2: 'yes',
+          4294967297: 'no', 4294967296: 'no', 4294967295: 'no',
+          4294967294: 'yes', 4294967293: 'yes', 4294967292: 'yes' };
+    for (k in a) { print(k, a[k]); }
+
+    // Another example, multiple inheritance levels.
+    a = { 1: 'foo' }; b = { 2: 'foo' }; c = { 3: 'foo' }; d = { 4: 'foo' }; e = [ 'foo' ];
+    e.__proto__ = d; d.__proto__ = c; c.__proto__ = b; b.__proto__ = a;
+    for (k in e) { print(k); }
+
+    // Array inheritance.
+    a = [ 1,1,1,1,1 ]; b = { 3: 'foo' };
+    b.__proto__ = a;
+    for (k in b) { print(k); }
+
+    // Array gaps.
+    a = [ 1,1,1,1,1 ]; b = [1,,,1];
+    b.__proto__ = a;
+    for (k in b) { print(k); }
+
+    // Parent properties are array-like and get sorted.
+    a = { 4: true, 0: true, 3: true, 1: true, 2: true }; b = [1,,,1];
+    b.__proto__ = a;
+    for (k in b) { print(k); }
+
+    // Array with gap; JSON.stringify() must include inherited properties
+    // (this differs from how objects are handled, as they only serialize
+    // own properties).
+    a = { 2: 'foo' }; b = ['a','b',,'d','e']; b.__proto__ = a;
+    print(JSON.stringify(b));
+
+    // For same Array with gap case, Array.prototype.forEach() must see
+    // the keys in sorted order regardless of whether keys are inherited.
+    // So this order differs from for-in!
+    a = { 2: 'foo' }; b = ['a','b',,'d','e']; b.__proto__ = a;
+    for (k in b) { print(k, b[k]); }
+    Array.prototype.forEach.call(b, function (v) { print(v); });
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+all done
+===*/
+
+function randomOrderTest() {
+    var i;
+    var vals;
+    var obj;
+    var t;
+
+    for (i = 0; i < 1e4; i++) {
+        obj = {};
+        vals = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ];
+        obj.foo = 1;
+        while (vals.length > 0) {
+            t = vals.splice(Math.floor(Math.random() * vals.length), 1);
+            obj[t[0]] = 'foo';
+        }
+        obj.bar = 1;
+        vals = [];
+        for (var k in obj) { vals.push(k); }
+        if (JSON.stringify(vals) !== '["0","1","2","3","4","5","6","7","8","9","foo","bar"]') {
+            throw new Error('failed: ' + JSON.stringify(vals));
+        }
+    }
+
+    print('all done');
+}
+
+try {
+    randomOrderTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-sparse-array-enum.js
+++ b/tests/ecmascript/test-dev-sparse-array-enum.js
@@ -1,13 +1,8 @@
 /*
- *  Array enumeration order is not strictly specified.  This test case
- *  compares behavior against the currently desired semantics:
- *
- *    - If dense, enumerate array keys first, then other keys
- *
- *    - When converting to sparse, re-add keys so that array keys
- *      are first (i.e. preserve order when abandoning array part)
- *
- *    - If sparse, maintain key insertion order only
+ *  Array for-in enumeration order is not strictly specified in ES5.
+ *  That is also the case for ES6 and ES7.  However, Duktape 2.x follows
+ *  ES6 [[OwnPropertyKeys]] order also in for-in and Object.keys() so
+ *  test for the custom behavior.
  */
 
 /*---
@@ -42,17 +37,17 @@ array keys
 2
 3
 4
-foo
 10000
+foo
 array keys
 0
 1
 2
 3
 4
-foo
-10000
 10
+10000
+foo
 ===*/
 
 var a;

--- a/tests/perf/test-enum-basic.js
+++ b/tests/perf/test-enum-basic.js
@@ -1,0 +1,32 @@
+/*
+ *  Basic enumeration performance
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var obj = { foo: 1, bar: 2, quux: 3, baz: 4, quuux: 5, 5: 'number key', 1: 'number key', 999: 'number key' };
+    var arr = [ 1, 2, 3, 4, 5, 6, 7, 8 ];
+    var i;
+    var ign;
+
+    for (i = 0; i < 1e5; i++) {
+        for (ign in obj) {}
+        for (ign in arr) {}
+        for (ign in obj) {}
+        for (ign in arr) {}
+        for (ign in obj) {}
+        for (ign in arr) {}
+        for (ign in obj) {}
+        for (ign in arr) {}
+        for (ign in obj) {}
+        for (ign in arr) {}
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -146,10 +146,10 @@ typedef struct duk_number_list_entry duk_number_list_entry;
 <pre class="c-code">
 /* Enumeration flags for duk_enum() */
 #define DUK_ENUM_INCLUDE_NONENUMERABLE    (1 &lt;&lt; 0)    /* enumerate non-numerable properties in addition to enumerable */
-#define DUK_ENUM_INCLUDE_INTERNAL         (1 &lt;&lt; 1)    /* enumerate internal properties (regardless of enumerability) */
+#define DUK_ENUM_INCLUDE_INTERNAL         (1 &lt;&lt; 1)    /* enumerate internal properties */
 #define DUK_ENUM_OWN_PROPERTIES_ONLY      (1 &lt;&lt; 2)    /* don't walk prototype chain, only check own properties */
 #define DUK_ENUM_ARRAY_INDICES_ONLY       (1 &lt;&lt; 3)    /* only enumerate array indices */
-#define DUK_ENUM_SORT_ARRAY_INDICES       (1 &lt;&lt; 4)    /* sort array indices, use with DUK_ENUM_ARRAY_INDICES_ONLY */
+#define DUK_ENUM_SORT_ARRAY_INDICES       (1 &lt;&lt; 4)    /* sort array indices (applied to full enumeration result, including inherited array indices) */
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 &lt;&lt; 5)    /* enumerate a proxy object itself without invoking proxy behavior */
 </pre>
 

--- a/website/api/duk_enum.yaml
+++ b/website/api/duk_enum.yaml
@@ -12,42 +12,54 @@ summary: |
   is not an object, throws an error.</p>
 
   <p>Enumeration flags:</p>
-  <ul>
-  <li><code>DUK_ENUM_INCLUDE_NONENUMERABLE</code>: enumerate also non-enumerable
-      properties (by default only enumerable properties are enumerated)</li>
-  <li><code>DUK_ENUM_INCLUDE_INTERNAL</code>: enumerate also internal properties
-      (by default internal properties are not enumerated)</li>
-  <li><code>DUK_ENUM_OWN_PROPERTIES_ONLY</code>: enumerate only an object's "own"
-      properties (by default also inherited properties are enumerated) </li>
-  <li><code>DUK_ENUM_ARRAY_INDICES_ONLY</code>: enumerate only array indices,
-      i.e. property names of the form "0", "1", "2", etc.</li>
-  <li><code>DUK_ENUM_SORT_ARRAY_INDICES</code>: guarantee that array indices are
-      sorted by their numeric value, only use with <code>DUK_ENUM_ARRAY_INDICES_ONLY</code>;
-      this is quite slow</li>
-  </ul>
+  <table>
+  <tr>
+  <td>DUK_ENUM_INCLUDE_NONENUMERABLE</td>
+  <td>Enumerate also non-enumerable properties, by default only enumerable
+      properties are enumerated</td>
+  </tr>
+  <tr>
+  <td>DUK_ENUM_INCLUDE_INTERNAL</td>
+  <td>Enumerate also internal properties, by default internal properties
+      are not enumerated</td>
+  </tr>
+  <tr>
+  <td>DUK_ENUM_OWN_PROPERTIES_ONLY</td>
+  <td>Enumerate only an object's "own" properties, by default also inherited
+      properties are enumerated</td>
+  </tr>
+  <tr>
+  <td>DUK_ENUM_ARRAY_INDICES_ONLY</td>
+  <td>Enumerate only array indices, i.e. property names of the form "0", "1",
+      "2", etc</td>
+  </tr>
+  <tr>
+  <td>DUK_ENUM_SORT_ARRAY_INDICES</td>
+  <td>Apply the ES6 [[OwnPropertyKeys]] enumeration order over the whole
+      enumeration result rather than per inheritance level, this has the
+      effect of sorting array indices (even when inherited)</td>
+  </tr>
+  </table>
 
-  <p>Without any flags, enumeration follows the Ecmascript default enumeration
-  semantics, as in the expression:</p>
-  <pre class="ecmascript-code">
-  for (key in obj) {
-      print(key, obj[i]);
-  }
-  </pre>
+  <p>Without any flags the enumeration behaves like <code>for-in</code>:
+  own and inherited enumerable properties are included, and enumeration
+  order follows the
+  <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">Ecmascript ES6 [[OwnPropertyKeys]]</a>
+  enumeration order, applied for each inheritance level.</p>
 
   <p>Once the enumerator has been created, use
   <code><a href="#duk_next">duk_next()</a></code> to extract keys (or key/value
   pairs) from the enumerator.</p>
 
   <div class="note">
-  Array indices are usually enumerated in a sorted order even without the
-  <code>DUK_ENUM_SORT_ARRAY_INDICES</code> flag.  This is not the case
-  for "sparse arrays" which contain a lot of gaps (unused indices).
-  Duktape represents such arrays internally using a key-value representation
-  instead of a plain array, which affects key enumeration order.
-  The criteria for switching from a dense to a sparse array are internal details
-  and potentially version dependent.  With the <code>DUK_ENUM_SORT_ARRAY_INDICES</code>
-  flag the array indices will be sorted even for sparse arrays, at the
-  cost of an explicit key sorting pass.
+  The ES6 [[OwnPropertyKeys]] enumeration order is:
+  (1) array indices in ascending order, (2) non-array-index keys in their
+  insertion order, and (3) symbols in their insertion order.  This rule
+  is applied separately for each inheritance level, so that if array index
+  keys are inherited, they will appear out-of-order in the result.  For
+  most practical code this is not an issue because array indices are very
+  rarely inherited.  You can force the whole enumeration sequence to be
+  sorted using <code>DUK_ENUM_SORT_ARRAY_INDICES</code>.
   </div>
 
 example: |

--- a/website/guide/es6features.html
+++ b/website/guide/es6features.html
@@ -112,3 +112,14 @@ ES6.  The following traps are implemented:</p>
 
 <p>Duktape implements Khronos typed array support which is a subset of ES6
 typed arrays.</p>
+
+<h2 id="es6-enum-order">Enumeration order</h2>
+
+<p><code>Object.getOwnPropertyNames()</code> follows the
+<a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">ES6 [[OwnPropertyKeys]]</a>
+enumeration order: (1) array indices in ascending order, (2) other properties
+in insertion order, (3) symbols in insertion order.  While ES6 or ES7 doesn't
+require it, Duktape follows this same order also for <code>for-in</code>,
+<code>Object.keys()</code>, and <code>duk_enum()</code> in general.  As in V8,
+the rule is applied for every "inheritance level" in turn, i.e. inherited
+non-duplicate properties always follow child properties.</p>


### PR DESCRIPTION
- [x] Add support for ES6 enumeration order as a sorting post-step (similarly to existing array index sort)
- [x] Performance optimization for "get enumerated keys", write keys directly into dense array part
- [x] Check if duk__sort_array_indices() actually works for ES6 for now (without symbols!)
- [x] Check duk_enum() flags, can some flags be removed?
- [x] Avoid explicit sorting when not needed
- [x] Config option, low memory ES5 build won't need it => Not necessary, footprint impact is < 100 bytes and existing sort algorithms works for now (at least without symbols)
- [x] Website note on enumeration order
- [x] Clarify on website that `for-in` etc are not guaranteed by ES6 or ES7 but Duktape follows the order like most other engines
- [x] Clarify code and comments that enumeration order matches ES6/ES7 (not just ES6)
- [x] Internal document fixes
- [x] Testcases and testcase fixes
- [x] Testcase coverage: random orders and sorting
- [x] Performance test: enumeration
- [x] JSON enumeration order (own properties for object, inherited properties for array!)
- [x] 2.0 migration notes
- [x] Releases entry
- [x] Future work issue for `duk_enum()` flag cleanup, `DUK_ENUM_SORT_ARRAY_INDICES` is not very descriptive now => #1060