### PR TITLE
Add precomputed arridx to duk_hstring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,11 @@ CONFIGOPTS_NONDEBUG_SCANBUILD=--option-file util/makeduk_base.yaml --option-file
 CONFIGOPTS_NONDEBUG_PERF=--option-file config/examples/performance_sensitive.yaml
 CONFIGOPTS_NONDEBUG_SIZE=--option-file config/examples/low_memory.yaml
 CONFIGOPTS_NONDEBUG_AJDUK=--option-file util/makeduk_base.yaml --option-file util/makeduk_ajduk.yaml --fixup-file util/makeduk_ajduk_fixup.h
-CONFIGOPTS_NONDEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT
-CONFIGOPTS_NONDEBUG_AJDUK_ROM=--rom-support --rom-auto-lightfunc --builtin-file util/example_user_builtins1.yaml --builtin-file util/example_user_builtins2.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -DDUK_USE_ASSERTIONS -UDUK_USE_DEBUG
+CONFIGOPTS_NONDEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
+CONFIGOPTS_NONDEBUG_AJDUK_ROM=--rom-support --rom-auto-lightfunc --builtin-file util/example_user_builtins1.yaml --builtin-file util/example_user_builtins2.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX -DDUK_USE_ASSERTIONS -UDUK_USE_DEBUG
 CONFIGOPTS_DEBUG=--option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml
 CONFIGOPTS_DEBUG_SCANBUILD=--option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml --option-file util/makeduk_scanbuild.yaml
-CONFIGOPTS_DEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT
+CONFIGOPTS_DEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
 CONFIGOPTS_EMDUK=-UDUK_USE_FASTINT -UDUK_USE_PACKED_TVAL
 CONFIGOPTS_DUKWEB=--option-file util/dukweb_base.yaml --fixup-file util/dukweb_fixup.h
 

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2021,13 +2021,14 @@ Planned
   (GH-891); call related bytecode simplification (GH-896); minor bytecode
   opcode handler optimizations (GH-903); refcount optimizations (GH-443,
   GH-973, GH-1042); minor RegExp compile/execute optimizations (GH-974,
-  GH-1033); minor IEEE double handling optimizations (GH-1051)
+  GH-1033); minor IEEE double handling optimizations (GH-1051); precomputed
+  duk_hstring array index (GH-1056)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977);
   internal duk_dup() variants (GH-990); allow stripping of (almost) all
   built-ins for low memory builds (GH-989); remove internal accessor setup
   helper and use duk_def_prop() instead (GH-1010); minor IEEE double handling
-  optimizations (GH-1051)
+  optimizations (GH-1051); precomputed duk_hstring array index (GH-1056)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/config/config-options/DUK_USE_HSTRING_ARRIDX.yaml
+++ b/config/config-options/DUK_USE_HSTRING_ARRIDX.yaml
@@ -1,0 +1,12 @@
+define: DUK_USE_HSTRING_ARRIDX
+introduced: 2.0.0
+default: true
+tags:
+  - lowmemory
+description: >
+  When enabled, duk_hstring stores a precomputed array index (or "not an array
+  index") value related to the string.  This reduces code footprint and
+  improves performance a littl ebit.
+
+  When disabled, duk_hstring has a flag indicating whether it is an array
+  index or not, but the actual value is computed on-the-fly.

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -45,6 +45,8 @@ DUK_USE_STRTAB_CHAIN: true
 DUK_USE_STRTAB_PROBE: false
 DUK_USE_STRTAB_CHAIN_SIZE: 128
 
+DUK_USE_HSTRING_ARRIDX: false
+
 # Consider using pointer compression, see doc/low-memory.rst.
 #DUK_USE_REFCOUNT16: true
 #DUK_USE_STRHASH16: true

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -1295,7 +1295,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_context *ctx) {
 	duk_uint8_t *p;
 	duk_double_t d;
 #if !defined(DUK_USE_PREFER_SIZE)
-	duk_uint_t copy_size;
+	duk_size_t copy_size;
 	duk_uint8_t *p_end;
 #endif
 

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -37,7 +37,9 @@ duk_hstring *duk__alloc_init_hstring(duk_heap *heap,
 	duk_hstring *res = NULL;
 	duk_uint8_t *data;
 	duk_size_t alloc_size;
+#if !defined(DUK_USE_HSTRING_ARRIDX)
 	duk_uarridx_t dummy;
+#endif
 	duk_uint32_t clen;
 
 #if defined(DUK_USE_STRLEN16)
@@ -80,7 +82,11 @@ duk_hstring *duk__alloc_init_hstring(duk_heap *heap,
 	}
 
 	DUK_ASSERT(!DUK_HSTRING_HAS_ARRIDX(res));
+#if defined(DUK_USE_HSTRING_ARRIDX)
+	if (duk_js_to_arrayindex_raw_string(str, blen, &res->arridx)) {
+#else
 	if (duk_js_to_arrayindex_raw_string(str, blen, &dummy)) {
+#endif
 		DUK_HSTRING_SET_ARRIDX(res);
 	}
 

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -134,15 +134,20 @@
 /* marker value; in E5 2^32-1 is not a valid array index (2^32-2 is highest valid) */
 #define DUK_HSTRING_NO_ARRAY_INDEX  (0xffffffffUL)
 
-/* get array index related to string (or return DUK_HSTRING_NO_ARRAY_INDEX);
+#if defined(DUK_USE_HSTRING_ARRIDX)
+#define DUK_HSTRING_GET_ARRIDX_FAST(h)  ((h)->arridx)
+#define DUK_HSTRING_GET_ARRIDX_SLOW(h)  ((h)->arridx)
+#else
+/* Get array index related to string (or return DUK_HSTRING_NO_ARRAY_INDEX);
  * avoids helper call if string has no array index value.
  */
 #define DUK_HSTRING_GET_ARRIDX_FAST(h)  \
 	(DUK_HSTRING_HAS_ARRIDX((h)) ? duk_js_to_arrayindex_string_helper((h)) : DUK_HSTRING_NO_ARRAY_INDEX)
 
-/* slower but more compact variant */
+/* Slower but more compact variant. */
 #define DUK_HSTRING_GET_ARRIDX_SLOW(h)  \
 	(duk_js_to_arrayindex_string_helper((h)))
+#endif
 
 /*
  *  Misc
@@ -165,6 +170,11 @@ struct duk_hstring {
 	/* If 16-bit hash is in use, stuff it into duk_heaphdr_string flags. */
 #else
 	duk_uint32_t hash;
+#endif
+
+	/* precomputed array index (or DUK_HSTRING_NO_ARRAY_INDEX) */
+#if defined(DUK_USE_HSTRING_ARRIDX)
+	duk_uarridx_t arridx;
 #endif
 
 	/* length in bytes (not counting NUL term) */

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1277,8 +1277,10 @@ DUK_INTERNAL duk_small_uint_t duk_js_typeof_stridx(duk_tval *tv_x) {
  *  Array index: E5 Section 15.4
  *  Array length: E5 Section 15.4.5.1 steps 3.c - 3.d (array length write)
  *
- *  The DUK_HSTRING_GET_ARRIDX_SLOW() and DUK_HSTRING_GET_ARRIDX_FAST() macros
- *  call duk_js_to_arrayindex_string_helper().
+ *  duk_js_to_arrayindex_string_helper() computes the array index from
+ *  string contents alone.  Depending on options it's only called during
+ *  string intern (and value stored to duk_hstring) or it's called also
+ *  at runtime.
  */
 
 DUK_INTERNAL duk_small_int_t duk_js_to_arrayindex_raw_string(const duk_uint8_t *str, duk_uint32_t blen, duk_uarridx_t *out_idx) {

--- a/testrunner/client-simple-node/run_commit_test.py
+++ b/testrunner/client-simple-node/run_commit_test.py
@@ -741,7 +741,8 @@ def context_helper_hello_ram(archopt):
     kb_rom = test([
         '-DDUK_USE_ROM_OBJECTS',
         '-DDUK_USE_ROM_STRINGS',
-        '-DDUK_USE_ROM_GLOBAL_INHERIT'
+        '-DDUK_USE_ROM_GLOBAL_INHERIT',
+        '-UDUK_USE_HSTRING_ARRIDX'
     ])
 
     set_output_description('%s %s %s (kB)' % (kb_default, kb_nobufobj, kb_rom))

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -2979,6 +2979,9 @@ def main():
         gc_src.emitLine('#if !defined(DUK_USE_ROM_STRINGS)')
         gc_src.emitLine('#error DUK_USE_ROM_OBJECTS requires DUK_USE_ROM_STRINGS')
         gc_src.emitLine('#endif')
+        gc_src.emitLine('#if defined(DUK_USE_HSTRING_ARRIDX)')
+        gc_src.emitLine('#error DUK_USE_HSTRING_ARRIDX is currently incompatible with ROM built-ins')
+        gc_src.emitLine('#endif')
     else:
         gc_src.emitLine('#error ROM support not enabled, rerun configure.py with --rom-support')
     gc_src.emitLine('#else  /* DUK_USE_ROM_OBJECTS */')


### PR DESCRIPTION
Add back a precomputed `arridx` field to `duk_hstring`. This may be preferable if flash is critical but RAM isn't, or when (small) performance improvements matter. The arridx is computed during interning in any case to properly set the `DUK_HSTRING_HAS_ARRIDX()` flag. With a precomputed arridx RAM usage is higher but footprint for call sites is smaller.

- [x] Add config option, default true (low memory default false, because RAM is usually more restricting)
- [x] Releases entry