### PR TITLE
Use duk_known_{hstring,hbuffer,hobject}() helpers

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2028,7 +2028,8 @@ Planned
   internal duk_dup() variants (GH-990); allow stripping of (almost) all
   built-ins for low memory builds (GH-989); remove internal accessor setup
   helper and use duk_def_prop() instead (GH-1010); minor IEEE double handling
-  optimizations (GH-1051); precomputed duk_hstring array index (GH-1056)
+  optimizations (GH-1051); precomputed duk_hstring array index (GH-1056);
+  internal value stack access improvements (GH-1058)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -417,8 +417,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	 * duk_js_push_closure() quite carefully.
 	 */
 	duk_push_compiledfunction(ctx);
-	h_fun = duk_get_hcompfunc(ctx, -1);
-	DUK_ASSERT(h_fun != NULL);
+	h_fun = duk_known_hcompfunc(ctx, -1);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) h_fun));
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_DATA(thr->heap, h_fun) == NULL);
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_FUNCS(thr->heap, h_fun) == NULL);
@@ -515,8 +514,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	 * them afterwards.
 	 */
 
-	h_data = (duk_hbuffer *) duk_get_hbuffer(ctx, idx_base + 1);
-	DUK_ASSERT(h_data != NULL);
+	h_data = (duk_hbuffer *) duk_known_hbuffer(ctx, idx_base + 1);
 	DUK_ASSERT(!DUK_HBUFFER_HAS_DYNAMIC(h_data));
 	DUK_HCOMPFUNC_SET_DATA(thr->heap, h_fun, h_data);
 	DUK_HBUFFER_INCREF(thr, h_data);

--- a/src-input/duk_api_compile.c
+++ b/src-input/duk_api_compile.c
@@ -128,8 +128,7 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx, void *udata) {
 
 	/* [ ... func_template ] */
 
-	h_templ = (duk_hcompfunc *) duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h_templ != NULL);
+	h_templ = (duk_hcompfunc *) duk_known_hobject(ctx, -1);
 	duk_js_push_closure(thr,
 	                   h_templ,
 	                   thr->builtins[DUK_BIDX_GLOBAL_ENV],

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -176,8 +176,7 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 
 	/* [ ... new_glob new_env ] */
 
-	h_env = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h_env != NULL);
+	h_env = duk_known_hobject(ctx, -1);
 
 	h_prev_env = thr->builtins[DUK_BIDX_GLOBAL_ENV];
 	thr->builtins[DUK_BIDX_GLOBAL_ENV] = h_env;

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -108,6 +108,12 @@ DUK_INTERNAL_DECL duk_hobject *duk_require_hobject_accept_mask(duk_context *ctx,
 DUK_INTERNAL_DECL void *duk_get_voidptr(duk_context *ctx, duk_idx_t idx);
 #endif
 
+DUK_INTERNAL_DECL duk_hstring *duk_known_hstring(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hobject *duk_known_hobject(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hbuffer *duk_known_hbuffer(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_known_hcompfunc(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL duk_hnatfunc *duk_known_hnatfunc(duk_context *ctx, duk_idx_t idx);
+
 DUK_INTERNAL_DECL duk_hstring *duk_to_hstring(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL duk_hobject *duk_to_hobject(duk_context *ctx, duk_idx_t idx);
 

--- a/src-input/duk_bi_boolean.c
+++ b/src-input/duk_bi_boolean.c
@@ -57,8 +57,7 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_constructor(duk_context *ctx) {
 	if (duk_is_constructor_call(ctx)) {
 		/* XXX: helper; rely on Boolean.prototype as being non-writable, non-configurable */
 		duk_push_this(ctx);
-		h_this = duk_get_hobject(ctx, -1);
-		DUK_ASSERT(h_this != NULL);
+		h_this = duk_known_hobject(ctx, -1);
 		DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h_this) == thr->builtins[DUK_BIDX_BOOLEAN_PROTOTYPE]);
 
 		DUK_HOBJECT_SET_CLASS_NUMBER(h_this, DUK_HOBJECT_CLASS_BOOLEAN);

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -241,8 +241,7 @@ DUK_LOCAL duk_hbufobj *duk__push_arraybuffer_with_length(duk_context *ctx, duk_u
 	duk_hbufobj *h_bufobj;
 
 	(void) duk_push_fixed_buffer(ctx, (duk_size_t) len);
-	h_val = (duk_hbuffer *) duk_get_hbuffer(ctx, -1);
-	DUK_ASSERT(h_val != NULL);
+	h_val = (duk_hbuffer *) duk_known_hbuffer(ctx, -1);
 
 	h_bufobj = duk_push_bufobj_raw(ctx,
 	                               DUK_HOBJECT_FLAG_EXTENSIBLE |
@@ -568,7 +567,7 @@ DUK_LOCAL duk_hbuffer *duk__hbufobj_fixed_from_argvalue(duk_context *ctx) {
 		DUK_ERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
 	}
 	DUK_ASSERT(duk_is_buffer(ctx, -1));
-	return duk_get_hbuffer(ctx, -1);
+	return duk_known_hbuffer(ctx, -1);
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -623,8 +622,7 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_constructor(duk_context *ctx) {
 		goto fail_length;
 	}
 	(void) duk_push_fixed_buffer(ctx, (duk_size_t) len);
-	h_val = (duk_hbuffer *) duk_get_hbuffer(ctx, -1);
-	DUK_ASSERT(h_val != NULL);
+	h_val = (duk_hbuffer *) duk_known_hbuffer(ctx, -1);
 
 #if !defined(DUK_USE_ZERO_BUFFER_DATA)
 	/* Khronos/ES6 requires zeroing even when DUK_USE_ZERO_BUFFER_DATA
@@ -1600,8 +1598,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_context *ctx) {
 	}
 
 	duk_hbufobj_promote_plain(ctx, 0);
-	h_obj = duk_require_hobject(ctx, 0);
-	DUK_ASSERT(h_obj != NULL);
+	h_obj = duk_known_hobject(ctx, 0);
 
 	/* XXX: V8 throws a TypeError for negative values.  Would it
 	 * be more useful to interpret negative offsets here from the
@@ -2018,8 +2015,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 		           (const void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + start_offset),
 		           copy_length);
 
-		h_val = duk_get_hbuffer(ctx, -1);
-		DUK_ASSERT(h_val != NULL);
+		h_val = duk_known_hbuffer(ctx, -1);
 
 		h_bufobj->buf = h_val;
 		DUK_HBUFFER_INCREF(thr, h_val);
@@ -2225,8 +2221,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_context *ctx) {
 		duk_pop(ctx);
 	}
 
-	h_val = duk_get_hbuffer(ctx, -1);
-	DUK_ASSERT(h_val != NULL);
+	h_val = duk_known_hbuffer(ctx, -1);
 
 	duk__set_bufobj_buffer(ctx, h_bufres, h_val);
 	DUK_ASSERT_HBUFOBJ_VALID(h_bufres);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -69,8 +69,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	               (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_sourcecode),
 	               (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sourcecode),
 	               comp_flags);
-	func = (duk_hcompfunc *) duk_get_hobject(ctx, -1);
-	DUK_ASSERT(func != NULL);
+	func = (duk_hcompfunc *) duk_known_hobject(ctx, -1);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) func));
 
 	/* [ body formals source template ] */
@@ -329,8 +328,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 	                       DUK_HOBJECT_FLAG_CONSTRUCTABLE |
 	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION),
 	                       DUK_BIDX_FUNCTION_PROTOTYPE);
-	h_bound = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h_bound != NULL);
+	h_bound = duk_known_hobject(ctx, -1);
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
 	duk_dup_m2(ctx);  /* func */

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -485,8 +485,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 	               (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h),
 	               (duk_size_t) DUK_HSTRING_GET_BYTELEN(h),
 	               comp_flags);
-	func = (duk_hcompfunc *) duk_get_hobject(ctx, -1);
-	DUK_ASSERT(func != NULL);
+	func = (duk_hcompfunc *) duk_known_hobject(ctx, -1);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) func));
 
 	/* [ source template ] */
@@ -526,8 +525,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			                                    DUK_HOBJECT_FLAG_EXTENSIBLE |
 			                                    DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
 			                                    act_lex_env);
-			new_env = duk_require_hobject(ctx, -1);
-			DUK_ASSERT(new_env != NULL);
+			new_env = duk_known_hobject(ctx, -1);
 			DUK_DDD(DUK_DDDPRINT("new_env allocated: %!iO",
 			                     (duk_heaphdr *) new_env));
 

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1380,8 +1380,7 @@ DUK_LOCAL void duk__enc_double(duk_json_enc_ctx *js_ctx) {
 			/* [ ... number ] -> [ ... string ] */
 			duk_numconv_stringify(ctx, 10 /*radix*/, 0 /*digits*/, n2s_flags);
 		}
-		h_str = duk_get_hstring(ctx, -1);
-		DUK_ASSERT(h_str != NULL);
+		h_str = duk_known_hstring(ctx, -1);
 		DUK__EMIT_HSTR(js_ctx, h_str);
 		return;
 	}
@@ -1702,8 +1701,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 	 * with overflow in a loop check object.
 	 */
 
-	h_target = duk_get_hobject(ctx, -1);  /* object or array */
-	DUK_ASSERT(h_target != NULL);
+	h_target = duk_known_hobject(ctx, -1);  /* object or array */
 
 	n = js_ctx->recursion_depth;
 	if (DUK_UNLIKELY(n > DUK_JSON_ENC_LOOPARRAY)) {
@@ -1753,8 +1751,7 @@ DUK_LOCAL void duk__enc_objarr_exit(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_t
 
 	/* Loop check. */
 
-	h_target = duk_get_hobject(ctx, *entry_top - 1);  /* original target at entry_top - 1 */
-	DUK_ASSERT(h_target != NULL);
+	h_target = duk_known_hobject(ctx, *entry_top - 1);  /* original target at entry_top - 1 */
 
 	if (js_ctx->recursion_depth < DUK_JSON_ENC_LOOPARRAY) {
 		/* Previous entry was inside visited[], nothing to do. */
@@ -1822,8 +1819,7 @@ DUK_LOCAL void duk__enc_object(duk_json_enc_ctx *js_ctx) {
 		                     (duk_tval *) duk_get_tval(ctx, idx_obj),
 		                     (duk_tval *) duk_get_tval(ctx, -1)));
 
-		h_key = duk_get_hstring(ctx, -1);
-		DUK_ASSERT(h_key != NULL);
+		h_key = duk_known_hstring(ctx, -1);
 
 		prev_size = DUK_BW_GET_SIZE(js_ctx->thr, &js_ctx->bw);
 		if (DUK_UNLIKELY(js_ctx->h_gap != NULL)) {
@@ -2995,14 +2991,12 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 		DUK_ASSERT(nspace >= 0 && nspace <= 10);
 
 		duk_push_lstring(ctx, spaces, (duk_size_t) nspace);
-		js_ctx->h_gap = duk_get_hstring(ctx, -1);
-		DUK_ASSERT(js_ctx->h_gap != NULL);
+		js_ctx->h_gap = duk_known_hstring(ctx, -1);
 	} else if (duk_is_string(ctx, idx_space)) {
 		/* XXX: substring in-place at idx_place? */
 		duk_dup(ctx, idx_space);
 		duk_substring(ctx, -1, 0, 10);  /* clamp to 10 chars */
-		js_ctx->h_gap = duk_get_hstring(ctx, -1);
-		DUK_ASSERT(js_ctx->h_gap != NULL);
+		js_ctx->h_gap = duk_known_hstring(ctx, -1);
 	} else {
 		/* nop */
 	}

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -75,8 +75,7 @@ DUK_INTERNAL duk_ret_t duk_bi_number_constructor(duk_context *ctx) {
 
 	/* XXX: helper */
 	duk_push_this(ctx);
-	h_this = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h_this != NULL);
+	h_this = duk_known_hobject(ctx, -1);
 	DUK_HOBJECT_SET_CLASS_NUMBER(h_this, DUK_HOBJECT_CLASS_NUMBER);
 
 	DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h_this) == thr->builtins[DUK_BIDX_NUMBER_PROTOTYPE]);

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -161,8 +161,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_context *
 				continue;
 			}
 
-			key = duk_get_hstring(ctx, 3);
-			DUK_ASSERT(key != NULL);
+			key = duk_known_hstring(ctx, 3);
 
 			duk_hobject_define_property_helper(ctx,
 			                                   defprop_flags,

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -150,7 +150,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_to_string(duk_context *ctx) {
 
 	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_SOURCE);
 	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_INT_BYTECODE);
-	h_bc = duk_get_hstring(ctx, -1);
+	h_bc = duk_require_hstring(ctx, -1);
 	DUK_ASSERT(h_bc != NULL);
 	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(h_bc) >= 1);
 	DUK_ASSERT(DUK_HSTRING_GET_CHARLEN(h_bc) >= 1);

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -579,8 +579,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 
 			duk_get_prop_index(ctx, -1, 0);
 			DUK_ASSERT(duk_is_string(ctx, -1));
-			h_match = duk_get_hstring(ctx, -1);
-			DUK_ASSERT(h_match != NULL);
+			h_match = duk_known_hstring(ctx, -1);
 			duk_pop(ctx);  /* h_match is borrowed, remains reachable through match_obj */
 
 			if (DUK_HSTRING_GET_BYTELEN(h_match) == 0) {
@@ -616,8 +615,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 			p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_input);
 			p = p_start;
 
-			h_search = duk_get_hstring(ctx, 0);
-			DUK_ASSERT(h_search != NULL);
+			h_search = duk_known_hstring(ctx, 0);
 			q_start = DUK_HSTRING_GET_DATA(h_search);
 			q_blen = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_search);
 
@@ -629,8 +627,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
 				if (DUK_MEMCMP((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 					duk_dup_0(ctx);
-					h_match = duk_get_hstring(ctx, -1);
-					DUK_ASSERT(h_match != NULL);
+					h_match = duk_known_hstring(ctx, -1);
 #ifdef DUK_USE_REGEXP_SUPPORT
 					match_caps = 0;
 #endif
@@ -788,8 +785,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 						if (duk_is_string(ctx, -1)) {
 							duk_hstring *h_tmp_str;
 
-							h_tmp_str = duk_get_hstring(ctx, -1);
-							DUK_ASSERT(h_tmp_str != NULL);
+							h_tmp_str = duk_known_hstring(ctx, -1);
 
 							DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_tmp_str);
 						} else {
@@ -976,8 +972,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 			p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_input);
 			p = p_start + prev_match_end_boff;
 
-			h_sep = duk_get_hstring(ctx, 0);
-			DUK_ASSERT(h_sep != NULL);
+			h_sep = duk_known_hstring(ctx, 0);
 			q_start = DUK_HSTRING_GET_DATA(h_sep);
 			q_blen = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sep);
 			q_clen = (duk_size_t) DUK_HSTRING_GET_CHARLEN(h_sep);

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -19,8 +19,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_context *ctx) {
 	duk_require_callable(ctx, 0);
 
 	duk_push_thread(ctx);
-	new_thr = (duk_hthread *) duk_get_hobject(ctx, -1);
-	DUK_ASSERT(new_thr != NULL);
+	new_thr = (duk_hthread *) duk_known_hobject(ctx, -1);
 	new_thr->state = DUK_HTHREAD_STATE_INACTIVE;
 
 	/* push initial function call to new thread stack; this is

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1463,8 +1463,7 @@ DUK_LOCAL void duk__debug_handle_get_locals(duk_hthread *thr, duk_heap *heap) {
 	if (duk_is_object(ctx, -1)) {
 		duk_enum(ctx, -1, 0 /*enum_flags*/);
 		while (duk_next(ctx, -1 /*enum_index*/, 0 /*get_value*/)) {
-			varname = duk_get_hstring(ctx, -1);
-			DUK_ASSERT(varname != NULL);
+			varname = duk_known_hstring(ctx, -1);
 
 			duk_js_getvar_activation(thr, curr_act, varname, 0 /*throw_flag*/);
 			/* [ ... func varmap enum key value this ] */

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -947,8 +947,7 @@ DUK_LOCAL int duk__protected_compact_object(duk_context *ctx, void *udata) {
 	/* XXX: for threads, compact value stack, call stack, catch stack? */
 
 	DUK_UNREF(udata);
-	obj = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(obj != NULL);
+	obj = duk_known_hobject(ctx, -1);
 	duk_hobject_compact_props((duk_hthread *) ctx, obj);
 	return 0;
 }

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -187,7 +187,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	DUK_ASSERT(enum_target != NULL);
 
 	duk_push_object_internal(ctx);
-	res = duk_require_hobject(ctx, -1);
+	res = duk_known_hobject(ctx, -1);
 
 	DUK_DDD(DUK_DDDPRINT("created internal object"));
 
@@ -624,8 +624,7 @@ DUK_INTERNAL duk_ret_t duk_hobject_get_enumerated_keys(duk_context *ctx, duk_sma
 
 	/* [enum_target enum res] */
 
-	e = duk_require_hobject(ctx, -2);
-	DUK_ASSERT(e != NULL);
+	e = duk_known_hobject(ctx, -2);
 
 	idx = 0;
 	for (i = DUK__ENUM_START_INDEX; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(e); i++) {

--- a/src-input/duk_hobject_pc2line.c
+++ b/src-input/duk_hobject_pc2line.c
@@ -35,8 +35,7 @@ DUK_INTERNAL void duk_hobject_pc2line_pack(duk_hthread *thr, duk_compiler_instr 
 	curr_offset = (duk_uint_fast32_t) (sizeof(duk_uint32_t) + num_header_entries * sizeof(duk_uint32_t) * 2);
 
 	duk_push_dynamic_buffer(ctx, (duk_size_t) curr_offset);
-	h_buf = (duk_hbuffer_dynamic *) duk_get_hbuffer(ctx, -1);
-	DUK_ASSERT(h_buf != NULL);
+	h_buf = (duk_hbuffer_dynamic *) duk_known_hbuffer(ctx, -1);
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(h_buf) && !DUK_HBUFFER_HAS_EXTERNAL(h_buf));
 
 	hdr = (duk_uint32_t *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR(thr->heap, h_buf);

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -148,8 +148,7 @@ DUK_LOCAL duk_uint32_t duk__push_tval_to_hstring_arr_idx(duk_context *ctx, duk_t
 	DUK_ASSERT(out_h != NULL);
 
 	duk_push_tval(ctx, tv);
-	duk_to_string(ctx, -1);
-	h = duk_get_hstring(ctx, -1);
+	h = duk_to_hstring(ctx, -1);
 	DUK_ASSERT(h != NULL);
 	*out_h = h;
 
@@ -4450,8 +4449,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 #endif  /* DUK_USE_ES6_PROXY */
 
-		duk_to_string(ctx, -1);
-		key = duk_get_hstring(ctx, -1);
+		key = duk_to_hstring(ctx, -1);
 		DUK_ASSERT(key != NULL);
 
 		rc = duk_hobject_delprop_raw(thr, obj, key, throw_flag ? DUK_DELPROP_FLAG_THROW : 0);
@@ -4463,8 +4461,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv_obj);
 		DUK_ASSERT(h != NULL);
 
-		duk_to_string(ctx, -1);
-		key = duk_get_hstring(ctx, -1);
+		key = duk_to_hstring(ctx, -1);
 		DUK_ASSERT(key != NULL);
 
 		if (key == DUK_HTHREAD_STRING_LENGTH(thr)) {
@@ -4485,8 +4482,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 		duk_hbuffer *h = DUK_TVAL_GET_BUFFER(tv_obj);
 		DUK_ASSERT(h != NULL);
 
-		duk_to_string(ctx, -1);
-		key = duk_get_hstring(ctx, -1);
+		key = duk_to_hstring(ctx, -1);
 		DUK_ASSERT(key != NULL);
 
 		if (key == DUK_HTHREAD_STRING_LENGTH(thr)) {
@@ -4504,8 +4500,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 		 * reject if match any of them.
 		 */
 
-		duk_to_string(ctx, -1);
-		key = duk_get_hstring(ctx, -1);
+		key = duk_to_hstring(ctx, -1);
 		DUK_ASSERT(key != NULL);
 
 		if (duk__key_is_lightfunc_ownprop(thr, key)) {
@@ -4810,8 +4805,7 @@ DUK_INTERNAL duk_ret_t duk_hobject_object_get_own_property_descriptor(duk_contex
 	DUK_ASSERT(thr->heap != NULL);
 
 	obj = duk_require_hobject_promote_mask(ctx, 0, DUK_TYPE_MASK_LIGHTFUNC | DUK_TYPE_MASK_BUFFER);
-	(void) duk_to_string(ctx, 1);
-	key = duk_require_hstring(ctx, 1);
+	key = duk_to_hstring(ctx, 1);
 
 	DUK_ASSERT(obj != NULL);
 	DUK_ASSERT(key != NULL);

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -65,8 +65,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
 	                       DUK_BIDX_GLOBAL);
-	h1 = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h1 != NULL);
+	h1 = duk_known_hobject(ctx, -1);
 #elif defined(DUK_USE_ROM_GLOBAL_CLONE)
 	/* Clone the properties of the ROM-based global object to create a
 	 * fully RAM-based global object.  Uses more memory than the inherit
@@ -76,8 +75,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
 	                       DUK_BIDX_OBJECT_PROTOTYPE);
-	h1 = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h1 != NULL);
+	h1 = duk_known_hobject(ctx, -1);
 	h2 = thr->builtins[DUK_BIDX_GLOBAL];
 	DUK_ASSERT(h2 != NULL);
 
@@ -126,8 +124,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
 	                       -1);  /* no prototype */
-	h1 = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h1 != NULL);
+	h1 = duk_known_hobject(ctx, -1);
 	duk_dup_m2(ctx);
 	duk_dup_top(ctx);  /* -> [ ... new_global new_globalenv new_global new_global ] */
 	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
@@ -267,8 +264,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			/* XXX: set magic directly here? (it could share the c_nargs arg) */
 			duk_push_c_function_noexotic(ctx, c_func, c_nargs);
 
-			h = duk_require_hobject(ctx, -1);
-			DUK_ASSERT(h != NULL);
+			h = duk_known_hobject(ctx, -1);
 
 			/* Currently all built-in native functions are strict.
 			 * duk_push_c_function() now sets strict flag, so
@@ -311,8 +307,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 		}
 
-		h = duk_require_hobject(ctx, -1);
-		DUK_ASSERT(h != NULL);
+		h = duk_known_hobject(ctx, -1);
 		DUK_HOBJECT_SET_CLASS_NUMBER(h, class_num);
 
 		if (i < DUK_NUM_BUILTINS) {
@@ -384,13 +379,12 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 		duk_small_uint_t num;
 
 		DUK_DDD(DUK_DDDPRINT("initializing built-in object at index %ld", (long) i));
-		h = duk_require_hobject(ctx, i);
-		DUK_ASSERT(h != NULL);
+		h = duk_known_hobject(ctx, i);
 
 		t = (duk_small_uint_t) duk_bd_decode(bd, DUK__BIDX_BITS);
 		if (t != DUK__NO_BIDX_MARKER) {
 			DUK_DDD(DUK_DDDPRINT("set internal prototype: built-in %ld", (long) t));
-			DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, h, duk_require_hobject(ctx, t));
+			DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, h, duk_known_hobject(ctx, t));
 		}
 
 		t = (duk_small_uint_t) duk_bd_decode(bd, DUK__BIDX_BITS);
@@ -542,8 +536,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 #endif
 
 			duk__push_stridx_or_string(ctx, bd);
-			h_key = duk_get_hstring(ctx, -1);
-			DUK_ASSERT(h_key != NULL);
+			h_key = duk_known_hstring(ctx, -1);
 			DUK_UNREF(h_key);
 			natidx = (duk_small_uint_t) duk_bd_decode(bd, DUK__NATIDX_BITS);
 
@@ -595,7 +588,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			/* [ (builtin objects) name ] */
 
 			duk_push_c_function_noconstruct_noexotic(ctx, c_func, c_nargs);
-			h_func = duk_require_hnatfunc(ctx, -1);
+			h_func = duk_known_hnatfunc(ctx, -1);
 			DUK_UNREF(h_func);
 
 			/* Currently all built-in native functions are strict.
@@ -668,8 +661,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 	duk_xdef_prop_stridx(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_GMT_STRING, DUK_PROPDESC_FLAGS_WC);
 #endif
 
-	h = duk_require_hobject(ctx, DUK_BIDX_DOUBLE_ERROR);
-	DUK_ASSERT(h != NULL);
+	h = duk_known_hobject(ctx, DUK_BIDX_DOUBLE_ERROR);
 	DUK_HOBJECT_CLEAR_EXTENSIBLE(h);
 
 #if !defined(DUK_USE_ES6_OBJECT_PROTO_PROPERTY)
@@ -796,7 +788,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 	DUK_DD(DUK_DDPRINT("compact built-ins"));
 	for (i = 0; i < DUK_NUM_ALL_BUILTINS; i++) {
-		duk_hobject_compact_props(thr, duk_require_hobject(ctx, i));
+		duk_hobject_compact_props(thr, duk_known_hobject(ctx, i));
 	}
 
 	DUK_D(DUK_DPRINT("INITBUILTINS END"));

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -175,8 +175,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	                               DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_ARGUMENTS),
 	                               DUK_BIDX_OBJECT_PROTOTYPE);
 	DUK_ASSERT(i_arg >= 0);
-	arg = duk_require_hobject(ctx, -1);
-	DUK_ASSERT(arg != NULL);
+	arg = duk_known_hobject(ctx, -1);
 
 	i_map = duk_push_object_helper(ctx,
 	                               DUK_HOBJECT_FLAG_EXTENSIBLE |

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -546,7 +546,7 @@ DUK_LOCAL void duk__init_func_valstack_slots(duk_compiler_ctx *comp_ctx) {
 
 	duk_push_dynamic_buffer(ctx, 0);
 	func->labelinfos_idx = entry_top + 5;
-	func->h_labelinfos = (duk_hbuffer_dynamic *) duk_get_hbuffer(ctx, entry_top + 5);
+	func->h_labelinfos = (duk_hbuffer_dynamic *) duk_known_hbuffer(ctx, entry_top + 5);
 	DUK_ASSERT(func->h_labelinfos != NULL);
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(func->h_labelinfos) && !DUK_HBUFFER_HAS_EXTERNAL(func->h_labelinfos));
 
@@ -743,8 +743,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 	                     (long) code_size, (long) data_size));
 
 	duk_push_fixed_buffer_nozero(ctx, data_size);
-	h_data = (duk_hbuffer_fixed *) duk_get_hbuffer(ctx, -1);
-	DUK_ASSERT(h_data != NULL);
+	h_data = (duk_hbuffer_fixed *) duk_known_hbuffer(ctx, -1);
 
 	DUK_HCOMPFUNC_SET_DATA(thr->heap, h_res, (duk_hbuffer *) h_data);
 	DUK_HEAPHDR_INCREF(thr, h_data);
@@ -2395,8 +2394,7 @@ DUK_LOCAL duk_reg_t duk__lookup_active_register_binding(duk_compiler_ctx *comp_c
 	 *  Special name handling
 	 */
 
-	h_varname = duk_get_hstring(ctx, -1);
-	DUK_ASSERT(h_varname != NULL);
+	h_varname = duk_known_hstring(ctx, -1);
 
 	if (h_varname == DUK_HTHREAD_STRING_LC_ARGUMENTS(thr)) {
 		DUK_DDD(DUK_DDDPRINT("flagging function as accessing 'arguments'"));
@@ -3656,8 +3654,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 			duk_reg_t reg_varbind;
 			duk_regconst_t rc_varname;
 
-			h_varname = duk_get_hstring(ctx, res->x1.valstack_idx);
-			DUK_ASSERT(h_varname != NULL);
+			h_varname = duk_known_hstring(ctx, res->x1.valstack_idx);
 
 			if (duk__hstring_is_eval_or_arguments_in_strict_mode(comp_ctx, h_varname)) {
 				goto syntax_error;
@@ -3846,8 +3843,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 			DUK_DDD(DUK_DDDPRINT("function call with identifier base"));
 
-			h_varname = duk_get_hstring(ctx, left->x1.valstack_idx);
-			DUK_ASSERT(h_varname != NULL);
+			h_varname = duk_known_hstring(ctx, left->x1.valstack_idx);
 			if (h_varname == DUK_HTHREAD_STRING_EVAL(thr)) {
 				/* Potential direct eval call detected, flag the CALL
 				 * so that a run-time "direct eval" check is made and
@@ -4332,8 +4328,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 			DUK_ASSERT(left->x1.t == DUK_ISPEC_VALUE);  /* LHS is already side effect free */
 
-			h_varname = duk_get_hstring(ctx, left->x1.valstack_idx);
-			DUK_ASSERT(h_varname != NULL);
+			h_varname = duk_known_hstring(ctx, left->x1.valstack_idx);
 			if (duk__hstring_is_eval_or_arguments_in_strict_mode(comp_ctx, h_varname)) {
 				/* E5 Section 11.13.1 (and others for other assignments), step 4. */
 				goto syntax_error_lvalue;
@@ -4627,8 +4622,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 			duk_reg_t reg_varbind;
 			duk_regconst_t rc_varname;
 
-			h_varname = duk_get_hstring(ctx, left->x1.valstack_idx);
-			DUK_ASSERT(h_varname != NULL);
+			h_varname = duk_known_hstring(ctx, left->x1.valstack_idx);
 
 			if (duk__hstring_is_eval_or_arguments_in_strict_mode(comp_ctx, h_varname)) {
 				goto syntax_error;
@@ -6266,8 +6260,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 
 				duk_get_prop_index(ctx, comp_ctx->curr_func.funcs_idx, fnum * 3);
 				duk_get_prop_stridx(ctx, -1, DUK_STRIDX_NAME);  /* -> [ ... func name ] */
-				h_funcname = duk_get_hstring(ctx, -1);
-				DUK_ASSERT(h_funcname != NULL);
+				h_funcname = duk_known_hstring(ctx, -1);
 
 				DUK_DDD(DUK_DDDPRINT("register function declaration %!O in pass 1, fnum %ld",
 				                     (duk_heaphdr *) h_funcname, (long) fnum));
@@ -6796,8 +6789,7 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 
 	for (i = 0; i < num_args; i++) {
 		duk_get_prop_index(ctx, comp_ctx->curr_func.argnames_idx, i);
-		h_name = duk_get_hstring(ctx, -1);
-		DUK_ASSERT(h_name != NULL);
+		h_name = duk_known_hstring(ctx, -1);
 
 		if (comp_ctx->curr_func.is_strict) {
 			if (duk__hstring_is_eval_or_arguments(comp_ctx, h_name)) {
@@ -6989,8 +6981,7 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 			/* shadowed, ignore */
 		} else {
 			duk_get_prop_index(ctx, comp_ctx->curr_func.decls_idx, i);  /* decl name */
-			h_name = duk_get_hstring(ctx, -1);
-			DUK_ASSERT(h_name != NULL);
+			h_name = duk_known_hstring(ctx, -1);
 
 			if (h_name == DUK_HTHREAD_STRING_LC_ARGUMENTS(thr) &&
 			    !comp_ctx->curr_func.is_arguments_shadowed) {
@@ -7445,8 +7436,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_bool_t i
 		} else {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_GETSET_NAME);
 		}
-		comp_ctx->curr_func.h_name = duk_get_hstring(ctx, -1);  /* borrowed reference */
-		DUK_ASSERT(comp_ctx->curr_func.h_name != NULL);
+		comp_ctx->curr_func.h_name = duk_known_hstring(ctx, -1);  /* borrowed reference */
 		duk__advance(comp_ctx);
 	} else {
 		/* Function name is an Identifier (not IdentifierName), but we get
@@ -7455,8 +7445,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_bool_t i
 		 */
 		if (comp_ctx->curr_token.t_nores == DUK_TOK_IDENTIFIER) {
 			duk_push_hstring(ctx, comp_ctx->curr_token.str1);       /* keep in valstack */
-			comp_ctx->curr_func.h_name = duk_get_hstring(ctx, -1);  /* borrowed reference */
-			DUK_ASSERT(comp_ctx->curr_func.h_name != NULL);
+			comp_ctx->curr_func.h_name = duk_known_hstring(ctx, -1);  /* borrowed reference */
 			duk__advance(comp_ctx);
 		} else {
 			/* valstack will be unbalanced, which is OK */
@@ -7704,8 +7693,7 @@ DUK_LOCAL duk_ret_t duk__js_compile_raw(duk_context *ctx, void *udata) {
 	comp_ctx->lex.slot1_idx = comp_ctx->tok11_idx;
 	comp_ctx->lex.slot2_idx = comp_ctx->tok12_idx;
 	comp_ctx->lex.buf_idx = entry_top + 0;
-	comp_ctx->lex.buf = (duk_hbuffer_dynamic *) duk_get_hbuffer(ctx, entry_top + 0);
-	DUK_ASSERT(comp_ctx->lex.buf != NULL);
+	comp_ctx->lex.buf = (duk_hbuffer_dynamic *) duk_known_hbuffer(ctx, entry_top + 0);
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(comp_ctx->lex.buf) && !DUK_HBUFFER_HAS_EXTERNAL(comp_ctx->lex.buf));
 	comp_ctx->lex.token_limit = DUK_COMPILER_TOKEN_LIMIT;
 

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4796,7 +4796,7 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 			 * ToUint32() which is odd but happens now as a side effect of
 			 * 'arr_idx' type.
 			 */
-			duk_hobject_set_length(thr, duk_get_hobject(ctx, obj_idx), (duk_uint32_t) arr_idx);
+			duk_hobject_set_length(thr, duk_known_hobject(ctx, obj_idx), (duk_uint32_t) arr_idx);
 			break;
 		}
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -131,8 +131,7 @@ void duk_js_push_closure(duk_hthread *thr,
 	duk_push_compiledfunction(ctx);
 	duk_push_hobject(ctx, &fun_temp->obj);  /* -> [ ... closure template ] */
 
-	fun_clos = (duk_hcompfunc *) duk_get_hcompfunc(ctx, -2);
-	DUK_ASSERT(fun_clos != NULL);
+	fun_clos = (duk_hcompfunc *) duk_known_hcompfunc(ctx, -2);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) fun_clos));
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_DATA(thr->heap, fun_clos) == NULL);
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_FUNCS(thr->heap, fun_clos) == NULL);
@@ -502,8 +501,7 @@ duk_hobject *duk_create_activation_environment_record(duk_hthread *thr,
 	                              DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
 	                              -1);  /* no prototype, updated below */
-	env = duk_require_hobject(ctx, -1);
-	DUK_ASSERT(env != NULL);
+	env = duk_known_hobject(ctx, -1);
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, env, parent);  /* parent env is the prototype */
 
 	/* open scope information, for compiled functions only */

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -567,6 +567,7 @@ DUK_LOCAL void duk__internbuffer(duk_lexer_ctx *lex_ctx, duk_idx_t valstack_idx)
 
 	DUK_BW_PUSH_AS_STRING(lex_ctx->thr, &lex_ctx->bw);
 	duk_replace(ctx, valstack_idx);
+	/* XXX: return hstring *? */
 }
 
 /*
@@ -1179,7 +1180,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 				DUK__APPENDBUFFER(lex_ctx, x);
 			}
 			duk__internbuffer(lex_ctx, lex_ctx->slot1_idx);
-			out_token->str1 = duk_get_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
+			out_token->str1 = duk_known_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
 
 			/* second, parse flags */
 
@@ -1194,7 +1195,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 				DUK__ADVANCECHARS(lex_ctx, 1);
 			}
 			duk__internbuffer(lex_ctx, lex_ctx->slot2_idx);
-			out_token->str2 = duk_get_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot2_idx);
+			out_token->str2 = duk_known_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot2_idx);
 
 			DUK__INITBUFFER(lex_ctx);  /* free some memory */
 
@@ -1369,7 +1370,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		DUK__INITBUFFER(lex_ctx);
 		duk__lexer_parse_string_literal(lex_ctx, out_token, x /*quote*/, strict_mode);
 		duk__internbuffer(lex_ctx, lex_ctx->slot1_idx);
-		out_token->str1 = duk_get_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
+		out_token->str1 = duk_known_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
 
 		DUK__INITBUFFER(lex_ctx);  /* free some memory */
 
@@ -1470,9 +1471,8 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		}
 
 		duk__internbuffer(lex_ctx, lex_ctx->slot1_idx);
-		out_token->str1 = duk_get_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
+		out_token->str1 = duk_known_hstring((duk_context *) lex_ctx->thr, lex_ctx->slot1_idx);
 		str = out_token->str1;
-		DUK_ASSERT(str != NULL);
 		out_token->t_nores = DUK_TOK_IDENTIFIER;
 
 		DUK__INITBUFFER(lex_ctx);  /* free some memory */

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -926,8 +926,7 @@ DUK_LOCAL void duk__create_escaped_source(duk_hthread *thr, int idx_pattern) {
 	duk_size_t i, n;
 	duk_uint_fast8_t c_prev, c;
 
-	h = duk_get_hstring(ctx, idx_pattern);
-	DUK_ASSERT(h != NULL);
+	h = duk_known_hstring(ctx, idx_pattern);
 	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h);
 	n = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h);
 
@@ -1106,7 +1105,7 @@ DUK_INTERNAL void duk_regexp_create_instance(duk_hthread *thr) {
 
 	/* [ ... escape_source bytecode ] */
 
-	h_bc = duk_get_hstring(ctx, -1);
+	h_bc = duk_require_hstring(ctx, -1);
 	DUK_ASSERT(h_bc != NULL);
 	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(h_bc) >= 1);          /* always at least the header */
 	DUK_ASSERT(DUK_HSTRING_GET_CHARLEN(h_bc) >= 1);
@@ -1116,8 +1115,7 @@ DUK_INTERNAL void duk_regexp_create_instance(duk_hthread *thr) {
 	/* [ ... escaped_source bytecode ] */
 
 	duk_push_object(ctx);
-	h = duk_get_hobject(ctx, -1);
-	DUK_ASSERT(h != NULL);
+	h = duk_known_hobject(ctx, -1);
 	duk_insert(ctx, -3);
 
 	/* [ ... regexp_object escaped_source bytecode ] */

--- a/src-input/duk_util_bufwriter.c
+++ b/src-input/duk_util_bufwriter.c
@@ -41,7 +41,7 @@ DUK_INTERNAL void duk_bw_init_pushbuf(duk_hthread *thr, duk_bufwriter_ctx *bw_ct
 	ctx = (duk_context *) thr;
 
 	(void) duk_push_dynamic_buffer(ctx, buf_size);
-	bw_ctx->buf = (duk_hbuffer_dynamic *) duk_get_hbuffer(ctx, -1);
+	bw_ctx->buf = (duk_hbuffer_dynamic *) duk_known_hbuffer(ctx, -1);
 	duk__bw_update_ptrs(thr, bw_ctx, 0, buf_size);
 }
 


### PR DESCRIPTION
These can be used whenever we're 100% certain that the value stack index exists and the type matches expected type.  When these are true, a duk_hstring, duk_hbuffer, or duk_hobject pointer fetch can be inlined to small code.

- [x] Internal helpers and call site fixes
- [x] Releases entry