### PR TITLE
Support ARM64 platform detection on Android.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,6 +38,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Harold Brenes (https://github.com/harold-b)
 * Oliver Crow (https://github.com/ocrow)
 * Jakub Chłapiński (https://github.com/jchlapinski)
+* Brett Vickers (https://github.com/beevik)
 
 Other contributions
 ===================

--- a/config/helper-snippets/DUK_F_ARM.h.in
+++ b/config/helper-snippets/DUK_F_ARM.h.in
@@ -1,7 +1,7 @@
 /* ARM */
-#if defined(__arm__) || defined(__thumb__) || defined(_ARM) || defined(_M_ARM)
+#if defined(__arm__) || defined(__thumb__) || defined(_ARM) || defined(_M_ARM) || defined(__aarch64__)
 #define DUK_F_ARM
-#if defined(__LP64__) || defined(_LP64) || defined(__arm64) || defined(__arm64__)
+#if defined(__LP64__) || defined(_LP64) || defined(__arm64) || defined(__arm64__) || defined(__aarch64__)
 #define DUK_F_ARM64
 #else
 #define DUK_F_ARM32


### PR DESCRIPTION
Use the Android __aarch64__ #define as a valid ARM64 signifier when detecting the compiler platform.

Rationale: the library currently fails to configure correctly for some Android ARM64 platforms.  See [here](http://www.phoronix.com/scan.php?page=news_item&px=MTY5ODk) for a longer explanation.