### PR TITLE
Fix wrong syntax highlighting in guide

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Oliver Crow (https://github.com/ocrow)
 * Jakub Chłapiński (https://github.com/jchlapinski)
 * Brett Vickers (https://github.com/beevik)
+* Dominik Okwieka (https://github.com/okitec)
 
 Other contributions
 ===================

--- a/website/guide/programming.html
+++ b/website/guide/programming.html
@@ -263,7 +263,7 @@ and then concatenating the result.  This example illustrates how the number
 of value stack entries required may depend on the input (otherwise this is
 not a very good approach for uppercasing a string):</p>
 
-<pre class="ecmascript-code" include="uppercase.c"></pre>
+<pre class="c-code" include="uppercase.c"></pre>
 
 <p>In addition to user reserved elements, Duktape keeps an automatic internal
 value stack reserve to ensure all API calls have enough value stack space to


### PR DESCRIPTION
One of the code blocks was highlighted as Ecmascript instead of C.