### PR TITLE
Implement support for ES6 Math.hypot()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1841,6 +1841,8 @@ Planned
 * Add support for ES6 String.prototype.codePointAt(), String.fromCodePoint(),
   and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)
 
+* Add support for ES6 Math.hypot() (GH-1069)
+
 * Add support for ES6 Object.assign() (GH-1064)
 
 * Add support for ES6 Object.is() and duk_samevalue() API call (GH-1068)

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2309,6 +2309,14 @@ objects:
           magic:
             type: math_onearg
             funcname: "floor"  # BI_MATH_FLOOR_IDX
+      - key: "hypot"
+        value:
+          type: function
+          native: duk_bi_math_object_hypot
+          length: 2
+          varargs: true
+        es6: true
+        present_if: DUK_USE_ES6
       - key: "log"
         value:
           type: function

--- a/tests/ecmascript/test-bi-math.js
+++ b/tests/ecmascript/test-bi-math.js
@@ -354,6 +354,48 @@ prE(Math.floor(0.5)); print(zeroSign(Math.floor(0.5)));
 prE(Math.floor(1));
 
 /*===
+hypot
+0
+NaN
+NaN
+NaN
+Infinity
+Infinity
+NaN
+Infinity
+NaN
+NaN
+NaN
+0
+5
+5
+7.0710678118654755
+7.0710678118654755
+812
+===*/
+
+print('hypot');
+
+prE(Math.hypot());
+prE(Math.hypot(NaN, 1));
+prE(Math.hypot(1, NaN));
+prE(Math.hypot(NaN, NaN));
+prE(Math.hypot(Infinity, NaN));
+prE(Math.hypot(NaN, -Infinity));
+prE(Math.hypot(1, 2, NaN));
+prE(Math.hypot(1, 2, NaN, Infinity));
+prE(Math.hypot(1, 2, 'pig'));
+prE(Math.hypot('pig', 'cow'));
+prE(Math.hypot('pig', 'cow', 'ape'));
+prE(Math.hypot(-0));
+
+prE(Math.hypot(3, 4));
+prE(Math.hypot('3', '4'));
+prE(Math.hypot(3, 4, 5));
+prE(Math.hypot('3', '4', '5'));
+prE(Math.hypot(-812));
+
+/*===
 log
 4812184
 NaN


### PR DESCRIPTION
This is an implementation of `Math.hypot()` using an algorithm based on V8 (without sharing code) that avoids overflow and minimizes floating point rounding error.  The algorithm first finds the largest (absolute) value, normalizes all arguments against it, and uses Kahan summation followed by a `sqrt()` to arrive at the result.

All arguments are ToNumber coerced, per ES6 spec, as part of the "find the largest value" step.

Checklist:
- [x] Implement `Math.hypot()` from ES6
- [x] Testcase
- [x] RELEASES entry