### PR TITLE
Ensure DUK_FMIN() and DUK_FMAX() are always available

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2025,6 +2025,9 @@ Planned
 
 * Fix incorrect duk_hbufferobject size in Duktape.info() (GH-804)
 
+* Miscellaneous portability improvements: simplified DUK_FMIN() and DUK_FMAX()
+  handling (GH-1071)
+
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch
   by around 20-25% and avoid a two-level dispatch for EXTRA opcodes; the

--- a/config/config-options/DUK_USE_MATH_FMAX.yaml
+++ b/config/config-options/DUK_USE_MATH_FMAX.yaml
@@ -1,11 +1,14 @@
 define: DUK_USE_MATH_FMAX
 introduced: 1.0.0
+removed: 2.0.0
 default: true
 tags:
   - portability
 description: >
   Assume platform function fmax() is available and works correctly.
-
   Some platforms don't have fmax() (it is defined in C99) and on some
   platforms (e.g. some uclibc environments) it may not be provided even
   though the compilation environment is nominally C99.
+
+  Removed in Duktape 2.0.0: if the platform doesn't have fmax(), simply
+  define a replacement for DUK_FMAX().

--- a/config/config-options/DUK_USE_MATH_FMIN.yaml
+++ b/config/config-options/DUK_USE_MATH_FMIN.yaml
@@ -1,11 +1,14 @@
 define: DUK_USE_MATH_FMIN
 introduced: 1.0.0
+removed: 2.0.0
 default: true
 tags:
   - portability
 description: >
   Assume platform function fmin() is available and works correctly.
-
   Some platforms don't have fmin() (it is defined in C99) and on some
   platforms (e.g. some uclibc environments) it may not be provided even
   though the compilation environment is nominally C99.
+
+  Removed in Duktape 2.0.0: if the platform doesn't have fmin(), simply
+  define a replacement for DUK_FMIN().

--- a/config/config-options/DUK_USE_MATH_ROUND.yaml
+++ b/config/config-options/DUK_USE_MATH_ROUND.yaml
@@ -1,11 +1,15 @@
 define: DUK_USE_MATH_ROUND
 introduced: 1.0.0
+removed: 2.0.0
 default: true
 tags:
   - portability
 description: >
   Assume platform function round() is available and works correctly.
-
   Some platforms don't have round() (it is defined in C99) and on some
   platforms (e.g. some uclibc environments) it may not be provided even
   though the compilation environment is nominally C99.
+
+  Removed in Duktape 2.0.0: if the platform doesn't have round(), simply
+  define a replacement for DUK_ROUND().  Currently DUK_ROUND() isn't used
+  at all however.

--- a/config/config-options/DUK_USE_REPL_FMAX.yaml
+++ b/config/config-options/DUK_USE_REPL_FMAX.yaml
@@ -1,0 +1,9 @@
+define: DUK_USE_REPL_FMAX
+introduced: 2.0.0
+default: false
+tags:
+  - portability
+description: >
+  Provide a built-in replacement for fmax(), duk_repl_fmax.
+
+  When enabled, define DUK_FMAX as duk_repl_fmax.

--- a/config/config-options/DUK_USE_REPL_FMIN.yaml
+++ b/config/config-options/DUK_USE_REPL_FMIN.yaml
@@ -1,0 +1,9 @@
+define: DUK_USE_REPL_FMIN
+introduced: 2.0.0
+default: false
+tags:
+  - portability
+description: >
+  Provide a built-in replacement for fmin(), duk_repl_fmin.
+
+  When enabled, define DUK_FMIN as duk_repl_fmin.

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -215,14 +215,12 @@
 #undef DUK_F_USE_REPL_ALL
 #endif
 
-/* Some math functions are C99 only.  This is also an issue with some
- * embedded environments using uclibc where uclibc has been configured
- * not to provide some functions.  For now, use replacements whenever
- * using uclibc.
+/* Some math functions are C99 only: fmin(), fmax(), round() at least.
+ * This is also an issue with some embedded environments using uclibc
+ * where uclibc has been configured not to provide some functions.
+ * For now, use replacements whenever using uclibc.
  */
-#undef DUK_USE_MATH_FMIN
-#undef DUK_USE_MATH_FMAX
-#undef DUK_USE_MATH_ROUND
+#define DUK_F_MISSING_FMIN_FMAX
 #if defined(DUK_F_UCLIBC)
 /* uclibc may be missing these */
 #elif defined(DUK_F_AMIGAOS) && defined(DUK_F_VBCC)
@@ -233,9 +231,25 @@
 /* build is not C99 or C++11, play it safe */
 #else
 /* C99 or C++11, no known issues */
-#define DUK_USE_MATH_FMIN
-#define DUK_USE_MATH_FMAX
-#define DUK_USE_MATH_ROUND
+#undef DUK_F_MISSING_FMIN_FMAX
+#endif
+
+#if !defined(DUK_FMIN)
+#if defined(DUK_F_MISSING_FMIN_FMAX)
+#define DUK_USE_REPL_FMIN
+#define DUK_FMIN             duk_repl_fmin
+#else
+#define DUK_FMIN             fmin
+#endif
+#endif
+
+#if !defined(DUK_FMAX)
+#if defined(DUK_F_MISSING_FMIN_FMAX)
+#define DUK_USE_REPL_FMAX
+#define DUK_FMAX             duk_repl_fmax
+#else
+#define DUK_FMAX             fmax
+#endif
 #endif
 
 /* These functions don't currently need replacement but are wrapped for
@@ -244,12 +258,6 @@
  */
 #if !defined(DUK_FABS)
 #define DUK_FABS             fabs
-#endif
-#if !defined(DUK_FMIN)
-#define DUK_FMIN             fmin
-#endif
-#if !defined(DUK_FMAX)
-#define DUK_FMAX             fmax
 #endif
 #if !defined(DUK_FLOOR)
 #define DUK_FLOOR            floor

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -109,6 +109,12 @@ To upgrade:
   - Finally, you can remove your custom header and add the equivalent options
     to ``tools/configure.py`` when possible.
 
+Config option changes
+---------------------
+
+There are several new config options and some existing config options have
+been removed.
+
 Built-ins disabled in configuration are now absent
 --------------------------------------------------
 

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -73,11 +73,7 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 			return +0.0;
 		}
 	}
-#ifdef DUK_USE_MATH_FMIN
 	return DUK_FMIN(x, y);
-#else
-	return (x < y ? x : y);
-#endif
 }
 
 DUK_LOCAL double duk__fmax_fixed(double x, double y) {
@@ -91,11 +87,7 @@ DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 			return -0.0;
 		}
 	}
-#ifdef DUK_USE_MATH_FMAX
 	return DUK_FMAX(x, y);
-#else
-	return (x > y ? x : y);
-#endif
 }
 
 DUK_LOCAL double duk__round_fixed(double x) {

--- a/src-input/duk_replacements.c
+++ b/src-input/duk_replacements.c
@@ -80,3 +80,25 @@ DUK_INTERNAL int duk_repl_isinf(double x) {
 	return (c == DUK_FP_INFINITE);
 }
 #endif
+
+#if defined(DUK_USE_REPL_FMIN)
+DUK_INTERNAL double duk_repl_fmin(double x, double y) {
+	/* Doesn't replicate fmin() behavior exactly: for fmin() if one
+	 * argument is a NaN, the other argument should be returned.
+	 * Duktape doesn't rely on this behavior so the replacement can
+	 * be simplified.
+	 */
+	return (x < y ? x : y);
+}
+#endif
+
+#if defined(DUK_USE_REPL_FMAX)
+DUK_INTERNAL double duk_repl_fmax(double x, double y) {
+	/* Doesn't replicate fmax() behavior exactly: for fmax() if one
+	 * argument is a NaN, the other argument should be returned.
+	 * Duktape doesn't rely on this behavior so the replacement can
+	 * be simplified.
+	 */
+	return (x > y ? x : y);
+}
+#endif

--- a/src-input/duk_replacements.h
+++ b/src-input/duk_replacements.h
@@ -8,6 +8,8 @@ DUK_INTERNAL_DECL double duk_computed_infinity;
 #if defined(DUK_USE_COMPUTED_NAN)
 DUK_INTERNAL_DECL double duk_computed_nan;
 #endif
+#endif  /* !DUK_SINGLE_FILE */
+
 #if defined(DUK_USE_REPL_FPCLASSIFY)
 DUK_INTERNAL_DECL int duk_repl_fpclassify(double x);
 #endif
@@ -23,6 +25,11 @@ DUK_INTERNAL_DECL int duk_repl_isnan(double x);
 #if defined(DUK_USE_REPL_ISINF)
 DUK_INTERNAL_DECL int duk_repl_isinf(double x);
 #endif
-#endif  /* !DUK_SINGLE_FILE */
+#if defined(DUK_USE_REPL_FMIN)
+DUK_INTERNAL_DECL double duk_repl_fmin(double x, double y);
+#endif
+#if defined(DUK_USE_REPL_FMAX)
+DUK_INTERNAL_DECL double duk_repl_fmax(double x, double y);
+#endif
 
 #endif  /* DUK_REPLACEMENTS_H_INCLUDED */


### PR DESCRIPTION
`fmin()` and `fmax()` are not available in all environments so replacements are needed. However, previous approach required calling code inside Duktape to `#if defined(DUK_USE_MATH_FMIN)` before using `DUK_FMIN()` and also to provide an inline replacement.

This pull simplifies the handling so that internal code can always call `DUK_FMIN()` and it is either provided by the platform or a built-in replacement.

- [x] Change config handling and call sites
- [x] Check MSVC build
- [x] 2.0 migration notes
- [x] Releases entry