### PR TITLE
Remove external fmin() and fmax() dependency

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2029,8 +2029,8 @@ Planned
 
 * Fix incorrect duk_hbufferobject size in Duktape.info() (GH-804)
 
-* Miscellaneous portability improvements: simplified DUK_FMIN() and DUK_FMAX()
-  handling (GH-1071)
+* Miscellaneous portability improvements: remove dependency on fmin() and
+  fmax() (GH-1072)
 
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch

--- a/config/config-options/DUK_USE_REPL_FMAX.yaml
+++ b/config/config-options/DUK_USE_REPL_FMAX.yaml
@@ -1,9 +1,0 @@
-define: DUK_USE_REPL_FMAX
-introduced: 2.0.0
-default: false
-tags:
-  - portability
-description: >
-  Provide a built-in replacement for fmax(), duk_repl_fmax.
-
-  When enabled, define DUK_FMAX as duk_repl_fmax.

--- a/config/config-options/DUK_USE_REPL_FMIN.yaml
+++ b/config/config-options/DUK_USE_REPL_FMIN.yaml
@@ -1,9 +1,0 @@
-define: DUK_USE_REPL_FMIN
-introduced: 2.0.0
-default: false
-tags:
-  - portability
-description: >
-  Provide a built-in replacement for fmin(), duk_repl_fmin.
-
-  When enabled, define DUK_FMIN as duk_repl_fmin.

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -215,43 +215,6 @@
 #undef DUK_F_USE_REPL_ALL
 #endif
 
-/* Some math functions are C99 only: fmin(), fmax(), round() at least.
- * This is also an issue with some embedded environments using uclibc
- * where uclibc has been configured not to provide some functions.
- * For now, use replacements whenever using uclibc.
- */
-#define DUK_F_MISSING_FMIN_FMAX
-#if defined(DUK_F_UCLIBC)
-/* uclibc may be missing these */
-#elif defined(DUK_F_AMIGAOS) && defined(DUK_F_VBCC)
-/* vbcc + AmigaOS may be missing these */
-#elif defined(DUK_F_MINT)
-/* mint clib is missing these */
-#elif !defined(DUK_F_C99) && !defined(DUK_F_CPP11)
-/* build is not C99 or C++11, play it safe */
-#else
-/* C99 or C++11, no known issues */
-#undef DUK_F_MISSING_FMIN_FMAX
-#endif
-
-#if !defined(DUK_FMIN)
-#if defined(DUK_F_MISSING_FMIN_FMAX)
-#define DUK_USE_REPL_FMIN
-#define DUK_FMIN             duk_repl_fmin
-#else
-#define DUK_FMIN             fmin
-#endif
-#endif
-
-#if !defined(DUK_FMAX)
-#if defined(DUK_F_MISSING_FMIN_FMAX)
-#define DUK_USE_REPL_FMAX
-#define DUK_FMAX             duk_repl_fmax
-#else
-#define DUK_FMAX             fmax
-#endif
-#endif
-
 /* These functions don't currently need replacement but are wrapped for
  * completeness.  Because these are used as function pointers, they need
  * to be defined as concrete C functions (not macros).

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -73,7 +73,7 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 			return +0.0;
 		}
 	}
-	return DUK_FMIN(x, y);
+	return duk_double_fmin(x, y);
 }
 
 DUK_LOCAL double duk__fmax_fixed(double x, double y) {
@@ -87,7 +87,7 @@ DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 			return -0.0;
 		}
 	}
-	return DUK_FMAX(x, y);
+	return duk_double_fmax(x, y);
 }
 
 DUK_LOCAL double duk__round_fixed(double x) {
@@ -280,7 +280,7 @@ DUK_INTERNAL duk_ret_t duk_bi_math_object_hypot(duk_context *ctx) {
 		if (DUK_FPCLASSIFY(t) == DUK_FP_NAN) {
 			found_nan = 1;
 		} else {
-			max = DUK_FMAX(max, t);
+			max = duk_double_fmax(max, t);
 		}
 	}
 

--- a/src-input/duk_replacements.c
+++ b/src-input/duk_replacements.c
@@ -80,25 +80,3 @@ DUK_INTERNAL int duk_repl_isinf(double x) {
 	return (c == DUK_FP_INFINITE);
 }
 #endif
-
-#if defined(DUK_USE_REPL_FMIN)
-DUK_INTERNAL double duk_repl_fmin(double x, double y) {
-	/* Doesn't replicate fmin() behavior exactly: for fmin() if one
-	 * argument is a NaN, the other argument should be returned.
-	 * Duktape doesn't rely on this behavior so the replacement can
-	 * be simplified.
-	 */
-	return (x < y ? x : y);
-}
-#endif
-
-#if defined(DUK_USE_REPL_FMAX)
-DUK_INTERNAL double duk_repl_fmax(double x, double y) {
-	/* Doesn't replicate fmax() behavior exactly: for fmax() if one
-	 * argument is a NaN, the other argument should be returned.
-	 * Duktape doesn't rely on this behavior so the replacement can
-	 * be simplified.
-	 */
-	return (x > y ? x : y);
-}
-#endif

--- a/src-input/duk_replacements.h
+++ b/src-input/duk_replacements.h
@@ -25,11 +25,5 @@ DUK_INTERNAL_DECL int duk_repl_isnan(double x);
 #if defined(DUK_USE_REPL_ISINF)
 DUK_INTERNAL_DECL int duk_repl_isinf(double x);
 #endif
-#if defined(DUK_USE_REPL_FMIN)
-DUK_INTERNAL_DECL double duk_repl_fmin(double x, double y);
-#endif
-#if defined(DUK_USE_REPL_FMAX)
-DUK_INTERNAL_DECL double duk_repl_fmax(double x, double y);
-#endif
 
 #endif  /* DUK_REPLACEMENTS_H_INCLUDED */

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -547,5 +547,7 @@ DUK_INTERNAL_DECL duk_bool_t duk_double_is_nan_zero_inf(duk_double_t x);
 DUK_INTERNAL_DECL duk_small_uint_t duk_double_signbit(duk_double_t x);
 DUK_INTERNAL_DECL duk_double_t duk_double_trunc_towards_zero(duk_double_t x);
 DUK_INTERNAL_DECL duk_bool_t duk_double_same_sign(duk_double_t x, duk_double_t y);
+DUK_INTERNAL_DECL duk_double_t duk_double_fmin(duk_double_t x, duk_double_t y);
+DUK_INTERNAL_DECL duk_double_t duk_double_fmax(duk_double_t x, duk_double_t y);
 
 #endif  /* DUK_UTIL_H_INCLUDED */

--- a/src-input/duk_util_misc.c
+++ b/src-input/duk_util_misc.c
@@ -385,3 +385,21 @@ DUK_INTERNAL duk_bool_t duk_double_same_sign(duk_double_t x, duk_double_t y) {
 
 	return (((du1.ui[DUK_DBL_IDX_UI0] ^ du2.ui[DUK_DBL_IDX_UI0]) & 0x80000000UL) == 0);
 }
+
+DUK_INTERNAL duk_double_t duk_double_fmin(duk_double_t x, duk_double_t y) {
+	/* Doesn't replicate fmin() behavior exactly: for fmin() if one
+	 * argument is a NaN, the other argument should be returned.
+	 * Duktape doesn't rely on this behavior so the replacement can
+	 * be simplified.
+	 */
+	return (x < y ? x : y);
+}
+
+DUK_INTERNAL duk_double_t duk_double_fmax(duk_double_t x, duk_double_t y) {
+	/* Doesn't replicate fmax() behavior exactly: for fmax() if one
+	 * argument is a NaN, the other argument should be returned.
+	 * Duktape doesn't rely on this behavior so the replacement can
+	 * be simplified.
+	 */
+	return (x > y ? x : y);
+}


### PR DESCRIPTION
The `fmin()` and `fmax()` functions are C99 only and thus require some portability wrapping. They also don't inline as intrinsics (at least on GCC x64) and because Duktape doesn'y rely on their NaN semantics a simple `x < y ? x : y` expression works instead.