### PR TITLE
Faster duk_get_type() and duk_get_type_mask()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2048,7 +2048,8 @@ Planned
   opcode handler optimizations (GH-903); refcount optimizations (GH-443,
   GH-973, GH-1042); minor RegExp compile/execute optimizations (GH-974,
   GH-1033); minor IEEE double handling optimizations (GH-1051); precomputed
-  duk_hstring array index (GH-1056)
+  duk_hstring array index (GH-1056); duk_get_{type,type_mask}() optimization
+  (GH-1077)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977);
   internal duk_dup() variants (GH-990); allow stripping of (almost) all

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -36,6 +36,9 @@ DUK_INTERNAL_DECL void duk_dup_m2(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_dup_m3(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_dup_m4(duk_context *ctx);
 
+DUK_INTERNAL_DECL duk_int_t duk_get_type_tval(duk_tval *tv);
+DUK_INTERNAL_DECL duk_uint_t duk_get_type_mask_tval(duk_tval *tv);
+
 #if defined(DUK_USE_VERBOSE_ERRORS) && defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL const char *duk_get_type_name(duk_context *ctx, duk_idx_t idx);
 #endif

--- a/src-input/duk_tval.c
+++ b/src-input/duk_tval.c
@@ -97,7 +97,7 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_double_t duk_tval_get_number_unpacked(duk_tva
 	duk_double_union du;
 	duk_uint64_t t;
 
-	DUK_ASSERT(tv->t == DUK__TAG_NUMBER || tv->t == DUK_TAG_FASTINT);
+	DUK_ASSERT(tv->t == DUK_TAG_NUMBER || tv->t == DUK_TAG_FASTINT);
 
 	if (tv->t == DUK_TAG_FASTINT) {
 		if (tv->v.fi >= 0) {

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -43,6 +43,7 @@ typedef struct {
 /* tags */
 #define DUK_TAG_NORMALIZED_NAN    0x7ff8UL   /* the NaN variant we use */
 /* avoid tag 0xfff0, no risk of confusion with negative infinity */
+#define DUK_TAG_MIN               0xfff1UL
 #if defined(DUK_USE_FASTINT)
 #define DUK_TAG_FASTINT           0xfff1UL   /* embed: integer value */
 #endif
@@ -56,6 +57,7 @@ typedef struct {
 #define DUK_TAG_STRING            0xfff8UL   /* embed: duk_hstring ptr */
 #define DUK_TAG_OBJECT            0xfff9UL   /* embed: duk_hobject ptr */
 #define DUK_TAG_BUFFER            0xfffaUL   /* embed: duk_hbuffer ptr */
+#define DUK_TAG_MAX               0xfffaUL
 
 /* for convenience */
 #define DUK_XTAG_BOOLEAN_FALSE    0xfff50000UL
@@ -317,7 +319,8 @@ typedef struct {
 #define DUK_TVAL_UNUSED_INITIALIZER() \
 	{ DUK_TAG_UNUSED, 0, 0.0 }
 
-#define DUK__TAG_NUMBER               0  /* not exposed */
+#define DUK_TAG_MIN                   0
+#define DUK_TAG_NUMBER                0  /* DUK_TAG_NUMBER only defined for non-packed duk_tval */
 #if defined(DUK_USE_FASTINT)
 #define DUK_TAG_FASTINT               1
 #endif
@@ -330,8 +333,9 @@ typedef struct {
 #define DUK_TAG_STRING                8  /* first heap allocated, match bit boundary */
 #define DUK_TAG_OBJECT                9
 #define DUK_TAG_BUFFER                10
+#define DUK_TAG_MAX                   10
 
-/* DUK__TAG_NUMBER is intentionally first, as it is the default clause in code
+/* DUK_TAG_NUMBER is intentionally first, as it is the default clause in code
  * to support the 8-byte representation.  Further, it is a non-heap-allocated
  * type so it should come before DUK_TAG_STRING.  Finally, it should not break
  * the tag value ranges covered by case-clauses in a switch-case.
@@ -370,7 +374,7 @@ typedef struct {
 		duk__dblval = (val); \
 		DUK_ASSERT_DOUBLE_IS_NORMALIZED(duk__dblval); /* nop for unpacked duk_tval */ \
 		duk__tv = (tv); \
-		duk__tv->t = DUK__TAG_NUMBER; \
+		duk__tv->t = DUK_TAG_NUMBER; \
 		duk__tv->v.d = duk__dblval; \
 	} while (0)
 #define DUK_TVAL_SET_I48(tv,val)  do { \
@@ -419,7 +423,7 @@ typedef struct {
 		duk__dblval = (val); \
 		DUK_ASSERT_DOUBLE_IS_NORMALIZED(duk__dblval); /* nop for unpacked duk_tval */ \
 		duk__tv = (tv); \
-		duk__tv->t = DUK__TAG_NUMBER; \
+		duk__tv->t = DUK_TAG_NUMBER; \
 		duk__tv->v.d = duk__dblval; \
 	} while (0)
 #define DUK_TVAL_SET_NUMBER_CHKFAST(tv,d) \
@@ -470,7 +474,7 @@ typedef struct {
 		/* in non-packed representation we don't care about which NaN is used */ \
 		duk_tval *duk__tv; \
 		duk__tv = (tv); \
-		duk__tv->t = DUK__TAG_NUMBER; \
+		duk__tv->t = DUK_TAG_NUMBER; \
 		duk__tv->v.d = DUK_DOUBLE_NAN; \
 	} while (0)
 
@@ -519,12 +523,12 @@ typedef struct {
 #define DUK_TVAL_IS_BOOLEAN_TRUE(tv)       (((tv)->t == DUK_TAG_BOOLEAN) && ((tv)->v.i != 0))
 #define DUK_TVAL_IS_BOOLEAN_FALSE(tv)      (((tv)->t == DUK_TAG_BOOLEAN) && ((tv)->v.i == 0))
 #if defined(DUK_USE_FASTINT)
-#define DUK_TVAL_IS_DOUBLE(tv)             ((tv)->t == DUK__TAG_NUMBER)
+#define DUK_TVAL_IS_DOUBLE(tv)             ((tv)->t == DUK_TAG_NUMBER)
 #define DUK_TVAL_IS_FASTINT(tv)            ((tv)->t == DUK_TAG_FASTINT)
-#define DUK_TVAL_IS_NUMBER(tv)             ((tv)->t == DUK__TAG_NUMBER || \
+#define DUK_TVAL_IS_NUMBER(tv)             ((tv)->t == DUK_TAG_NUMBER || \
                                             (tv)->t == DUK_TAG_FASTINT)
 #else
-#define DUK_TVAL_IS_NUMBER(tv)             ((tv)->t == DUK__TAG_NUMBER)
+#define DUK_TVAL_IS_NUMBER(tv)             ((tv)->t == DUK_TAG_NUMBER)
 #define DUK_TVAL_IS_DOUBLE(tv)             DUK_TVAL_IS_NUMBER((tv))
 #endif  /* DUK_USE_FASTINT */
 #define DUK_TVAL_IS_POINTER(tv)            ((tv)->t == DUK_TAG_POINTER)

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -2474,7 +2474,7 @@ def rom_emit_object_initializer_types_and_macros(genc):
     genc.emitLine('#error invalid endianness defines')
     genc.emitLine('#endif')
     genc.emitLine('#else  /* DUK_USE_PACKED_TVAL */')
-    genc.emitLine('#define DUK__TVAL_NUMBER(hostbytes) { DUK__TAG_NUMBER, 0, hostbytes }')  # bytes already in host order
+    genc.emitLine('#define DUK__TVAL_NUMBER(hostbytes) { DUK_TAG_NUMBER, 0, hostbytes }')  # bytes already in host order
     genc.emitLine('#define DUK__TVAL_UNDEFINED() { DUK_TAG_UNDEFINED, 0, {0,0,0,0,0,0,0,0} }')
     genc.emitLine('#define DUK__TVAL_NULL() { DUK_TAG_NULL, 0, {0,0,0,0,0,0,0,0} }')
     genc.emitLine('#define DUK__TVAL_BOOLEAN(bval) { DUK_TAG_BOOLEAN, 0, (bval), 0 }')


### PR DESCRIPTION
For unpacked duk_tval, do a straight lookup with no tag type range check.