### PR TITLE
Add support for ToNumber() octal and binary conversion

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1836,7 +1836,8 @@ Planned
   and identifiers, no RegExp support yet (requires RegExp /u Unicode mode)
   (GH-1001)
 
-* Add support for ES6 octal (0o123) and binary (0b100001) literals (GH-1057)
+* Add support for ES6 octal (0o123) and binary (0b100001) in source code
+  literals and ToNumber() coercion (e.g. "+'0o123'") (GH-1057, GH-1084)
 
 * Add support for ES6 String.prototype.codePointAt(), String.fromCodePoint(),
   and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -601,6 +601,9 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_int(duk_context *ctx) {
 
 	radix = duk_to_int32(ctx, 1);
 
+	/* While parseInt() recognizes 0xdeadbeef, it doesn't recognize
+	 * ES6 0o123 or 0b10001.
+	 */
 	s2n_flags = DUK_S2N_FLAG_TRIM_WHITE |
 	            DUK_S2N_FLAG_ALLOW_GARBAGE |
 	            DUK_S2N_FLAG_ALLOW_PLUS |

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -151,6 +151,8 @@ DUK_LOCAL duk_double_t duk__tonumber_string_raw(duk_hthread *thr) {
 	duk_small_uint_t s2n_flags;
 	duk_double_t d;
 
+	DUK_ASSERT(duk_is_string(ctx, -1));
+
 	/* Quite lenient, e.g. allow empty as zero, but don't allow trailing
 	 * garbage.
 	 */
@@ -164,9 +166,12 @@ DUK_LOCAL duk_double_t duk__tonumber_string_raw(duk_hthread *thr) {
 	            DUK_S2N_FLAG_ALLOW_EMPTY_FRAC |
 	            DUK_S2N_FLAG_ALLOW_EMPTY_AS_ZERO |
 	            DUK_S2N_FLAG_ALLOW_LEADING_ZERO |
-	            DUK_S2N_FLAG_ALLOW_AUTO_HEX_INT;
+	            DUK_S2N_FLAG_ALLOW_AUTO_HEX_INT |
+	            DUK_S2N_FLAG_ALLOW_AUTO_OCT_INT |
+	            DUK_S2N_FLAG_ALLOW_AUTO_BIN_INT;
 
 	duk_numconv_parse(ctx, 10 /*radix*/, s2n_flags);
+
 #if defined(DUK_USE_PREFER_SIZE)
 	d = duk_get_number(ctx, -1);
 	duk_pop(ctx);

--- a/src-input/duk_numconv.h
+++ b/src-input/duk_numconv.h
@@ -75,10 +75,20 @@
  */
 #define DUK_S2N_FLAG_ALLOW_AUTO_HEX_INT   (1 << 11)
 
-/* Allow automatic detection of octal base, overrides radix
- * argument and forces integer mode.
+/* Allow automatic detection of legacy octal base ("0n"),
+ * overrides radix argument and forces integer mode.
  */
-#define DUK_S2N_FLAG_ALLOW_AUTO_OCT_INT   (1 << 12)
+#define DUK_S2N_FLAG_ALLOW_AUTO_LEGACY_OCT_INT   (1 << 12)
+
+/* Allow automatic detection of ES6 octal base ("0o123"),
+ * overrides radix argument and forces integer mode.
+ */
+#define DUK_S2N_FLAG_ALLOW_AUTO_OCT_INT   (1 << 13)
+
+/* Allow automatic detection of ES6 binary base ("0b10001"),
+ * overrides radix argument and forces integer mode.
+ */
+#define DUK_S2N_FLAG_ALLOW_AUTO_BIN_INT   (1 << 14)
 
 /*
  *  Prototypes

--- a/tests/ecmascript/test-conv-tonumber.js
+++ b/tests/ecmascript/test-conv-tonumber.js
@@ -54,30 +54,69 @@ test(Number.NEGATIVE_INFINITY);
 
 /*===
 -1 nz
+-1 nz
 0 neg
 0 pos
 0 pos
 1 nz
+17 nz
+19 nz
 -Infinity nz
 Infinity nz
 Infinity nz
 3735928559 nz
+3735928559 nz
+3735928559 nz
+NaN nz
 ===*/
 
 /* String to number */
 
-test("-1");
-test("-0");
-test("+0");
-test("0");
-test("1");
+test('-1');
+test('   -1    ');  // whitespace is trimmed
+test('-0');
+test('+0');
+test('0');
+test('1');
+test('000017');  // lead zeroes allowed, not interpreted as octal!
+test('000019');
 
-test("-Infinity");
-test("+Infinity");
-test("Infinity");
+test('  -Infinity');
+test(' +Infinity');
+test('   Infinity');
 
-test("0xdeadbeef");
+test('0xdeadbeef');
+test('0Xdeadbeef');
+test('    \n0xdeadbeef\n');
+test('    \n0xdeadbeefg\n');  // trailing garbage not allowed -> NaN
 
-/* XXX: octal */
+/*===
+83 nz
+83 nz
+83 nz
+83 nz
+NaN nz
+17 nz
+17 nz
+17 nz
+17 nz
+NaN nz
+===*/
+
+/* In ES6 0o123, and 0b10001 are recognized.  Whitespace is also allowed.
+ * Note that whitespace is trimmed so these forms cannot be recognized
+ * by just peeking at the first few characters.
+ */
+
+test('0o123');
+test('0O123');
+test('\n0o123  \t');
+test('\n0o000000123  \t');
+test('\n0o000000123  x\t');
+test('0b10001');
+test('0B10001');
+test('\t0b10001  \r\n');
+test('\t0b0000010001  \r\n');
+test('\t0b00000000000100012  \r\n');  // '2' is garbage to binary
 
 /* XXX: object coercion */


### PR DESCRIPTION
See https://github.com/svaarala/duktape/pull/1028#issuecomment-260497240.

- [x] Change ToNumber() to support ES6 octal and binary (still no legacy octal)
- [x] Testcase coverage
- [x] Releases entry