### PR TITLE
Fix a few broken asserts in refcount code

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2034,6 +2034,10 @@ Planned
 
 * Fix incorrect duk_hbufferobject size in Duktape.info() (GH-804)
 
+* Fix a few incorrect asserts in refcount code; the asserts didn't check for
+  NULL and cause memory unsafe behavior, but the code itself is correct
+  (GH-1090)
+
 * Miscellaneous portability improvements: remove dependency on fmin() and
   fmax() (GH-1072)
 

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -85,10 +85,10 @@ DUK_LOCAL void duk__refcount_finalize_hobject(duk_hthread *thr, duk_hobject *h) 
 		if (p_flag[n] & DUK_PROPDESC_FLAG_ACCESSOR) {
 			duk_hobject *h_getset;
 			h_getset = p_val[n].a.get;
-			DUK_ASSERT(DUK_HEAPHDR_IS_OBJECT((duk_heaphdr *) h_getset));
+			DUK_ASSERT(h_getset == NULL || DUK_HEAPHDR_IS_OBJECT((duk_heaphdr *) h_getset));
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, h_getset);
 			h_getset = p_val[n].a.set;
-			DUK_ASSERT(DUK_HEAPHDR_IS_OBJECT((duk_heaphdr *) h_getset));
+			DUK_ASSERT(h_getset == NULL || DUK_HEAPHDR_IS_OBJECT((duk_heaphdr *) h_getset));
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, h_getset);
 		} else {
 			duk_tval *tv_val;


### PR DESCRIPTION
The asserts didn't check for NULL properly.  The code itself is OK, and handles NULL correctly.