### PR TITLE
Implement Math.cbrt(), Math.log{2,10}(), Math.trunc()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1846,7 +1846,8 @@ Planned
 * Add support for ES6 String.prototype.codePointAt(), String.fromCodePoint(),
   and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)
 
-* Add support for ES6 Math.hypot() (GH-1069)
+* Add support for ES6 Math.hypot(), Math.cbrt(), Math.log2(), Math.log10(),
+  Math.trunc() (GH-1069, GH-1093)
 
 * Add support for ES6 Object.assign() (GH-1064)
 

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -265,6 +265,17 @@
 #define DUK_SQRT             sqrt
 #endif
 
+/* The functions below exist only in C99/C++11 or later and need a workaround
+ * for platforms that don't include them.  MSVC isn't detected as C99, but
+ * these functions also exist in MSVC 2013 and later so include a clause for
+ * that too.
+ */
+#if defined(DUK_F_C99) || defined(DUK_F_CPP11) || (defined(_MSC_VER) && (_MSC_VER >= 1800))
+#if !defined(DUK_CBRT)
+#define DUK_CBRT             cbrt
+#endif  /* DUK_CBRT */
+#endif  /* DUK_F_C99 */
+
 /* NetBSD 6.0 x86 (at least) has a few problems with pow() semantics,
  * see test-bug-netbsd-math-pow.js.  Use NetBSD specific workaround.
  * (This might be a wider problem; if so, generalize the define name.)

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -280,6 +280,9 @@
 #if !defined(DUK_LOG10)
 #define DUK_LOG10            log10
 #endif
+#if !defined(DUK_TRUNC)
+#define DUK_TRUNC            trunc
+#endif
 #endif  /* DUK_F_C99 */
 
 /* NetBSD 6.0 x86 (at least) has a few problems with pow() semantics,

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -273,7 +273,13 @@
 #if defined(DUK_F_C99) || defined(DUK_F_CPP11) || (defined(_MSC_VER) && (_MSC_VER >= 1800))
 #if !defined(DUK_CBRT)
 #define DUK_CBRT             cbrt
-#endif  /* DUK_CBRT */
+#endif
+#if !defined(DUK_LOG2)
+#define DUK_LOG2             log2
+#endif
+#if !defined(DUK_LOG10)
+#define DUK_LOG10            log10
+#endif
 #endif  /* DUK_F_C99 */
 
 /* NetBSD 6.0 x86 (at least) has a few problems with pow() semantics,

--- a/config/other-defines/platform_functions.yaml
+++ b/config/other-defines/platform_functions.yaml
@@ -24,6 +24,7 @@
 - define: DUK_CBRT
 - define: DUK_LOG2
 - define: DUK_LOG10
+- define: DUK_TRUNC
 
 # Memory allocation
 - define: DUK_ANSI_MALLOC

--- a/config/other-defines/platform_functions.yaml
+++ b/config/other-defines/platform_functions.yaml
@@ -22,6 +22,8 @@
 - define: DUK_LOG
 - define: DUK_SQRT
 - define: DUK_CBRT
+- define: DUK_LOG2
+- define: DUK_LOG10
 
 # Memory allocation
 - define: DUK_ANSI_MALLOC

--- a/config/other-defines/platform_functions.yaml
+++ b/config/other-defines/platform_functions.yaml
@@ -21,6 +21,7 @@
 - define: DUK_EXP
 - define: DUK_LOG
 - define: DUK_SQRT
+- define: DUK_CBRT
 
 # Memory allocation
 - define: DUK_ANSI_MALLOC

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2285,6 +2285,8 @@ objects:
           magic:
             type: math_onearg
             funcname: "cbrt"  # BI_MATH_CBRT_IDX
+        es6: true
+        present_if: DUK_USE_ES6
       - key: "ceil"
         value:
           type: function
@@ -2333,6 +2335,26 @@ objects:
           magic:
             type: math_onearg
             funcname: "log"  # BI_MATH_LOG_IDX
+      - key: "log2"
+        value:
+          type: function
+          native: duk_bi_math_object_onearg_shared
+          length: 1
+          magic:
+            type: math_onearg
+            funcname: "log2"  # BI_MATH_LOG2_IDX
+        es6: true
+        present_if: DUK_USE_ES6
+      - key: "log10"
+        value:
+          type: function
+          native: duk_bi_math_object_onearg_shared
+          length: 1
+          magic:
+            type: math_onearg
+            funcname: "log10"  # BI_MATH_LOG10_IDX
+        es6: true
+        present_if: DUK_USE_ES6
       - key: "max"
         value:
           type: function

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2412,6 +2412,16 @@ objects:
           magic:
             type: math_onearg
             funcname: "tan"  # BI_MATH_TAN_IDX
+      - key: "trunc"
+        value:
+          type: function
+          native: duk_bi_math_object_onearg_shared
+          length: 1
+          magic:
+            type: math_onearg
+            funcname: "trunc"  # BI_MATH_TRUNC_IDX
+        es6: true
+        present_if: DUK_USE_ES6
 
   - id: bi_json
     class: JSON

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2277,6 +2277,14 @@ objects:
           magic:
             type: math_twoarg
             funcname: "atan2"  # BI_MATH_ATAN2_IDX
+      - key: "cbrt"
+        value:
+          type: function
+          native: duk_bi_math_object_onearg_shared
+          length: 1
+          magic:
+            type: math_onearg
+            funcname: "cbrt"  # BI_MATH_CBRT_IDX
       - key: "ceil"
         value:
           type: function

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -90,18 +90,18 @@ DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 	return duk_double_fmax(x, y);
 }
 
-DUK_LOCAL double duk__cbrt_fixed(double x) {
+DUK_LOCAL double duk__cbrt(double x) {
 	/* cbrt() is C99.  To avoid hassling embedders with the need to provide a
 	 * cube root function, we can get by with pow().  The result is not
 	 * identical, but that's OK: ES6 says it's implementation-dependent.
 	 */
 
-	duk_small_int_t c = (duk_small_int_t) DUK_FPCLASSIFY(x);
-
 #if defined(DUK_CBRT)
 	/* cbrt() matches ES6 requirements. */
 	return DUK_CBRT(x);
 #else
+	duk_small_int_t c = (duk_small_int_t) DUK_FPCLASSIFY(x);
+
 	/* pow() does not, however. */
 	if (c == DUK_FP_NAN || c == DUK_FP_INFINITE || c == DUK_FP_ZERO) {
 		return x;
@@ -114,7 +114,7 @@ DUK_LOCAL double duk__cbrt_fixed(double x) {
 #endif
 }
 
-DUK_LOCAL double duk__log2_fixed(double x) {
+DUK_LOCAL double duk__log2(double x) {
 #if defined(DUK_LOG2)
 	return DUK_LOG2(x);
 #else
@@ -122,11 +122,19 @@ DUK_LOCAL double duk__log2_fixed(double x) {
 #endif
 }
 
-DUK_LOCAL double duk__log10_fixed(double x) {
+DUK_LOCAL double duk__log10(double x) {
 #if defined(DUK_LOG10)
 	return DUK_LOG10(x);
 #else
 	return DUK_LOG(x) / DUK_LOG(10.0);
+#endif
+}
+
+DUK_LOCAL double duk__trunc(double x) {
+#if defined(DUK_TRUNC)
+	return DUK_TRUNC(x);
+#else
+	return x >= 0.0 ? DUK_FLOOR(x) : DUK_CEIL(x);
 #endif
 }
 
@@ -233,9 +241,10 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	duk__sin,
 	duk__sqrt,
 	duk__tan,
-	duk__cbrt_fixed,
-	duk__log2_fixed,
-	duk__log10_fixed
+	duk__cbrt,
+	duk__log2,
+	duk__log10,
+	duk__trunc
 #else
 	DUK_FABS,
 	DUK_ACOS,
@@ -250,9 +259,10 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	DUK_SIN,
 	DUK_SQRT,
 	DUK_TAN,
-	duk__cbrt_fixed,
-	duk__log2_fixed,
-	duk__log10_fixed
+	duk__cbrt,
+	duk__log2,
+	duk__log10,
+	duk__trunc
 #endif
 };
 

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -114,6 +114,22 @@ DUK_LOCAL double duk__cbrt_fixed(double x) {
 #endif
 }
 
+DUK_LOCAL double duk__log2_fixed(double x) {
+#if defined(DUK_LOG2)
+	return DUK_LOG2(x);
+#else
+	return DUK_LOG(x) / DUK_LOG(2.0);
+#endif
+}
+
+DUK_LOCAL double duk__log10_fixed(double x) {
+#if defined(DUK_LOG10)
+	return DUK_LOG10(x);
+#else
+	return DUK_LOG(x) / DUK_LOG(10.0);
+#endif
+}
+
 DUK_LOCAL double duk__round_fixed(double x) {
 	/* Numbers half-way between integers must be rounded towards +Infinity,
 	 * e.g. -3.5 must be rounded to -3 (not -4).  When rounded to zero, zero
@@ -218,6 +234,8 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	duk__sqrt,
 	duk__tan,
 	duk__cbrt_fixed,
+	duk__log2_fixed,
+	duk__log10_fixed
 #else
 	DUK_FABS,
 	DUK_ACOS,
@@ -231,8 +249,10 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	duk__round_fixed,
 	DUK_SIN,
 	DUK_SQRT,
-	DUK_TAN
+	DUK_TAN,
 	duk__cbrt_fixed,
+	duk__log2_fixed,
+	duk__log10_fixed
 #endif
 };
 

--- a/tests/ecmascript/test-bi-math-cbrt.js
+++ b/tests/ecmascript/test-bi-math-cbrt.js
@@ -1,0 +1,47 @@
+/*
+ *  Math.cbrt()
+ */
+
+/*@include util-number.js@*/
+
+/*===
+function true false true
+1
+0
+-0
+Infinity
+-Infinity
+NaN
+2
+4
+10
+-2
+2.5
+-2.5
+812
+===*/
+
+function test() {
+    var pd = Object.getOwnPropertyDescriptor(Math, 'cbrt');
+    print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
+    print(Math.cbrt.length);
+
+    printExact(Math.cbrt(0));
+    printExact(Math.cbrt(-0));
+    printExact(Math.cbrt(Infinity));
+    printExact(Math.cbrt(-Infinity));
+    printExact(Math.cbrt(NaN));
+    printExact(Math.cbrt(8));
+    printExact(Math.cbrt(64));
+    printExact(Math.cbrt(1000));
+    printExact(Math.cbrt(-8));
+    printExact(Math.cbrt(15.625));
+    printExact(Math.cbrt(-15.625));
+    printExact(Math.cbrt(535387328));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-math-cbrt.js
+++ b/tests/ecmascript/test-bi-math-cbrt.js
@@ -28,9 +28,10 @@ function test() {
 
     printExact(Math.cbrt(0));
     printExact(Math.cbrt(-0));
-    printExact(Math.cbrt(Infinity));
-    printExact(Math.cbrt(-Infinity));
-    printExact(Math.cbrt(NaN));
+    printExact(Math.cbrt(1 / 0));
+    printExact(Math.cbrt(-1 / 0));
+    printExact(Math.cbrt(0 / 0));
+
     printExact(Math.cbrt(8));
     printExact(Math.cbrt(64));
     printExact(Math.cbrt(1000));

--- a/tests/ecmascript/test-bi-math-log10.js
+++ b/tests/ecmascript/test-bi-math-log10.js
@@ -24,12 +24,12 @@ function test() {
     print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
     print(Math.log10.length);
 
-    printExact(Math.log10(NaN));
+    printExact(Math.log10(0 / 0));
     printExact(Math.log10(-1));
     printExact(Math.log10(0));
     printExact(Math.log10(-0));
     printExact(Math.log10(1));
-    printExact(Math.log10(Infinity));
+    printExact(Math.log10(1 / 0));
 
     printExact(Math.log10(10));
     printExact(Math.log10(1000));

--- a/tests/ecmascript/test-bi-math-log10.js
+++ b/tests/ecmascript/test-bi-math-log10.js
@@ -1,0 +1,44 @@
+/*
+ *  Math.log10()
+ */
+
+/*@include util-number.js@*/
+
+/*===
+function true false true
+1
+NaN
+NaN
+-Infinity
+-Infinity
+0
+Infinity
+1
+3
+88
+3010300
+===*/
+
+function test() {
+    var pd = Object.getOwnPropertyDescriptor(Math, 'log10');
+    print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
+    print(Math.log10.length);
+
+    printExact(Math.log10(NaN));
+    printExact(Math.log10(-1));
+    printExact(Math.log10(0));
+    printExact(Math.log10(-0));
+    printExact(Math.log10(1));
+    printExact(Math.log10(Infinity));
+
+    printExact(Math.log10(10));
+    printExact(Math.log10(1000));
+    printExact(Math.log10(1e+88));
+    printRounded6(Math.log10(1024));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-math-log2.js
+++ b/tests/ecmascript/test-bi-math-log2.js
@@ -1,0 +1,44 @@
+/*
+ *  Math.log2()
+ */
+
+/*@include util-number.js@*/
+
+/*===
+function true false true
+1
+NaN
+NaN
+-Infinity
+-Infinity
+0
+Infinity
+1
+10
+812
+9965784
+===*/
+
+function test() {
+    var pd = Object.getOwnPropertyDescriptor(Math, 'log2');
+    print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
+    print(Math.log2.length);
+
+    printExact(Math.log2(NaN));
+    printExact(Math.log2(-1));
+    printExact(Math.log2(0));
+    printExact(Math.log2(-0));
+    printExact(Math.log2(1));
+    printExact(Math.log2(Infinity));
+
+    printExact(Math.log2(2));
+    printExact(Math.log2(1024));
+    printExact(Math.log2(2.73121871170759e+244));
+    printRounded6(Math.log2(1000));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-math-log2.js
+++ b/tests/ecmascript/test-bi-math-log2.js
@@ -17,6 +17,60 @@ Infinity
 10
 812
 9965784
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
 ===*/
 
 function test() {
@@ -24,17 +78,21 @@ function test() {
     print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
     print(Math.log2.length);
 
-    printExact(Math.log2(NaN));
+    printExact(Math.log2(0 / 0));
     printExact(Math.log2(-1));
     printExact(Math.log2(0));
     printExact(Math.log2(-0));
     printExact(Math.log2(1));
-    printExact(Math.log2(Infinity));
+    printExact(Math.log2(1 / 0));
 
     printExact(Math.log2(2));
     printExact(Math.log2(1024));
     printExact(Math.log2(2.73121871170759e+244));
     printRounded6(Math.log2(1000));
+
+    for (var n = 0; n <= 53; ++n) {
+        printExact(Math.log2(2 ** n));
+    }
 }
 
 try {

--- a/tests/ecmascript/test-bi-math-trunc.js
+++ b/tests/ecmascript/test-bi-math-trunc.js
@@ -1,0 +1,48 @@
+/*
+ *  Math.trunc()
+ */
+
+/*@include util-number.js@*/
+
+/*===
+function true false true
+1
+NaN
+-0
+0
+Infinity
+-Infinity
+0
+-0
+10
+9000
+-1
+-812
+812
+===*/
+
+function test() {
+    var pd = Object.getOwnPropertyDescriptor(Math, 'trunc');
+    print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
+    print(Math.trunc.length);
+
+    printExact(Math.trunc(0 / 0));
+    printExact(Math.trunc(-0));
+    printExact(Math.trunc(0));
+    printExact(Math.trunc(1 / 0));
+    printExact(Math.trunc(-1 / 0));
+    printExact(Math.trunc(0.5));
+    printExact(Math.trunc(-0.5));
+
+    printExact(Math.trunc(10.5));
+    printExact(Math.trunc(9000.5));
+    printExact(Math.trunc(-1.5));
+    printExact(Math.trunc(-812.88));
+    printExact(Math.trunc(812.88));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1189,20 +1189,22 @@ def load_metadata(opts, rom=False, build_info=None, active_opts=None):
 
 # Magic values for Math built-in.
 math_onearg_magic = {
-    'fabs': 0,   # BI_MATH_FABS_IDX
-    'acos': 1,   # BI_MATH_ACOS_IDX
-    'asin': 2,   # BI_MATH_ASIN_IDX
-    'atan': 3,   # BI_MATH_ATAN_IDX
-    'ceil': 4,   # BI_MATH_CEIL_IDX
-    'cos': 5,    # BI_MATH_COS_IDX
-    'exp': 6,    # BI_MATH_EXP_IDX
-    'floor': 7,  # BI_MATH_FLOOR_IDX
-    'log': 8,    # BI_MATH_LOG_IDX
-    'round': 9,  # BI_MATH_ROUND_IDX
-    'sin': 10,   # BI_MATH_SIN_IDX
-    'sqrt': 11,  # BI_MATH_SQRT_IDX
-    'tan': 12,   # BI_MATH_TAN_IDX
-    'cbrt': 13   # BI_MATH_CBRT_IDX
+    'fabs': 0,    # BI_MATH_FABS_IDX
+    'acos': 1,    # BI_MATH_ACOS_IDX
+    'asin': 2,    # BI_MATH_ASIN_IDX
+    'atan': 3,    # BI_MATH_ATAN_IDX
+    'ceil': 4,    # BI_MATH_CEIL_IDX
+    'cos': 5,     # BI_MATH_COS_IDX
+    'exp': 6,     # BI_MATH_EXP_IDX
+    'floor': 7,   # BI_MATH_FLOOR_IDX
+    'log': 8,     # BI_MATH_LOG_IDX
+    'round': 9,   # BI_MATH_ROUND_IDX
+    'sin': 10,    # BI_MATH_SIN_IDX
+    'sqrt': 11,   # BI_MATH_SQRT_IDX
+    'tan': 12,    # BI_MATH_TAN_IDX
+    'cbrt': 13,   # BI_MATH_CBRT_IDX
+    'log2': 14,   # BI_MATH_LOG2_IDX
+    'log10': 15,  # BI_MATH_LOG10_IDX
 }
 math_twoarg_magic = {
     'atan2': 0,  # BI_MATH_ATAN2_IDX

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1205,6 +1205,7 @@ math_onearg_magic = {
     'cbrt': 13,   # BI_MATH_CBRT_IDX
     'log2': 14,   # BI_MATH_LOG2_IDX
     'log10': 15,  # BI_MATH_LOG10_IDX
+    'trunc': 16,  # BI_MATH_TRUNC_IDX
 }
 math_twoarg_magic = {
     'atan2': 0,  # BI_MATH_ATAN2_IDX

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1201,7 +1201,8 @@ math_onearg_magic = {
     'round': 9,  # BI_MATH_ROUND_IDX
     'sin': 10,   # BI_MATH_SIN_IDX
     'sqrt': 11,  # BI_MATH_SQRT_IDX
-    'tan': 12    # BI_MATH_TAN_IDX
+    'tan': 12,   # BI_MATH_TAN_IDX
+    'cbrt': 13   # BI_MATH_CBRT_IDX
 }
 math_twoarg_magic = {
     'atan2': 0,  # BI_MATH_ATAN2_IDX

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -68,6 +68,7 @@ rejected_plain_identifiers_list = [
     'exp',
     'log',
     'sqrt',
+    'cbrt',
 
     # memory functions
     'malloc',


### PR DESCRIPTION
This pull adds support for ES6 `Math.cbrt()`, which calculates the cubic root of a number, as well as `Math.log2()` and `Math.log10()` (base 2 and base 10 logarithm).  The C99 standard functions are used if available (i.e. for C99/C++11, MSVC 2013+), otherwise a workaround is used instead.

Checklist:
- [x] Implement support for `Math.cbrt()`
- [x] Implement support for `Math.log2()`, `Math.log10()`
- [x] Implement support for `Math.trunc()`
- [x] Testcases
- [x] Releases entry