### PR TITLE
Minor cleanups to Math.cbrt() etc

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1847,7 +1847,7 @@ Planned
   and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)
 
 * Add support for ES6 Math.hypot(), Math.cbrt(), Math.log2(), Math.log10(),
-  Math.trunc() (GH-1069, GH-1093)
+  Math.trunc() (GH-1069, GH-1093, GH-1095)
 
 * Add support for ES6 Object.assign() (GH-1064)
 

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -101,13 +101,6 @@
 #define DUK_MEMZERO(p,n) DUK_MEMSET((p), 0, (n))
 #endif
 
-#if !defined(DUK_DOUBLE_2TO32)
-#define DUK_DOUBLE_2TO32     4294967296.0
-#endif
-#if !defined(DUK_DOUBLE_2TO31)
-#define DUK_DOUBLE_2TO31     2147483648.0
-#endif
-
 #if !defined(DUK_DOUBLE_INFINITY)
 #undef DUK_USE_COMPUTED_INFINITY
 #if defined(DUK_F_GCC_VERSION) && (DUK_F_GCC_VERSION < 40600)

--- a/config/other-defines/c_types.yaml
+++ b/config/other-defines/c_types.yaml
@@ -173,5 +173,3 @@
 # Double constants
 - define: DUK_DOUBLE_NAN  # FIXME: document DUK_USE_COMPUTED_NAN
 - define: DUK_DOUBLE_INFINITY  # FIXME: document DUK_USE_COMPUTED_INFINITY
-- define: DUK_DOUBLE_2TO32     # FIXME: make internal, no portability issue
-- define: DUK_DOUBLE_2TO31     # FIXME: make internal, no portability issue

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -90,6 +90,7 @@ DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 	return duk_double_fmax(x, y);
 }
 
+#if defined(DUK_USE_ES6)
 DUK_LOCAL double duk__cbrt(double x) {
 	/* cbrt() is C99.  To avoid hassling embedders with the need to provide a
 	 * cube root function, we can get by with pow().  The result is not
@@ -118,7 +119,7 @@ DUK_LOCAL double duk__log2(double x) {
 #if defined(DUK_LOG2)
 	return DUK_LOG2(x);
 #else
-	return DUK_LOG(x) / DUK_LOG(2.0);
+	return DUK_LOG(x) * DUK_DOUBLE_LOG2E;
 #endif
 }
 
@@ -126,7 +127,7 @@ DUK_LOCAL double duk__log10(double x) {
 #if defined(DUK_LOG10)
 	return DUK_LOG10(x);
 #else
-	return DUK_LOG(x) / DUK_LOG(10.0);
+	return DUK_LOG(x) * DUK_DOUBLE_LOG10E;
 #endif
 }
 
@@ -134,9 +135,13 @@ DUK_LOCAL double duk__trunc(double x) {
 #if defined(DUK_TRUNC)
 	return DUK_TRUNC(x);
 #else
+	/* Handles -0 correctly: -0.0 matches 'x >= 0.0' but floor()
+	 * is required to return -0 when the argument is -0.
+	 */
 	return x >= 0.0 ? DUK_FLOOR(x) : DUK_CEIL(x);
 #endif
 }
+#endif  /* DUK_USE_ES6 */
 
 DUK_LOCAL double duk__round_fixed(double x) {
 	/* Numbers half-way between integers must be rounded towards +Infinity,
@@ -241,11 +246,13 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	duk__sin,
 	duk__sqrt,
 	duk__tan,
+#if defined(DUK_USE_ES6)
 	duk__cbrt,
 	duk__log2,
 	duk__log10,
 	duk__trunc
-#else
+#endif
+#else  /* DUK_USE_AVOID_PLATFORM_FUNCPTRS */
 	DUK_FABS,
 	DUK_ACOS,
 	DUK_ASIN,
@@ -259,11 +266,13 @@ DUK_LOCAL const duk__one_arg_func duk__one_arg_funcs[] = {
 	DUK_SIN,
 	DUK_SQRT,
 	DUK_TAN,
+#if defined(DUK_USE_ES6)
 	duk__cbrt,
 	duk__log2,
 	duk__log10,
 	duk__trunc
 #endif
+#endif  /* DUK_USE_AVOID_PLATFORM_FUNCPTRS */
 };
 
 /* order must match constants in genbuiltins.py */

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -16,6 +16,15 @@
 #endif
 
 /*
+ *  Some useful constants
+ */
+
+#define DUK_DOUBLE_2TO32     4294967296.0
+#define DUK_DOUBLE_2TO31     2147483648.0
+#define DUK_DOUBLE_LOG2E     1.4426950408889634
+#define DUK_DOUBLE_LOG10E    0.4342944819032518
+
+/*
  *  Endian conversion
  */
 

--- a/tests/ecmascript/test-bi-math-log2-2n.js
+++ b/tests/ecmascript/test-bi-math-log2-2n.js
@@ -1,0 +1,33 @@
+/*
+ *  While not required by ES6, Math.log2(2^N) should return exactly N, at least
+ *  with common C99 log2() implementations.
+ */
+
+/*===
+positive exponents done
+negative exponents done
+===*/
+
+function test() {
+    var expect, x;
+
+    for (expect = 0, x = 1; x !== 1/0; x *= 2, expect++) {
+        if (Math.log2(x) != expect) {
+            console.log('FAIL', x, Math.log2(x));
+        }
+    }
+    console.log('positive exponents done');
+
+    for (expect = 0, x = 1; x !== 0; x /= 2, expect--) {
+        if (Math.log2(x) != expect) {
+            console.log('FAIL', x, Math.log2(x));
+        }
+    }
+    console.log('negative exponents done');
+}
+
+try {
+    test();
+} catch (e) {
+    console.log(e.stack || e);
+}


### PR DESCRIPTION
- [x] Make function pointers in math table conditional to `DUK_USE_ES6` or replace them with `duk__math_nop()` when ES6 not enabled (footprint)
- [x] Extend Math.log2() 2^N testcase for all IEEE double exponents (separate testcase)
- [x] Precomputation for `/ DUK_LOG(2)` and `/ DUK_LOG(10)` in fallback path