### PR TITLE
Fix delprop and Object.defineProperty() bugs triggered by value deletion finalizer side effect

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1966,6 +1966,11 @@ Planned
 
 * Add a fastint check for duk_put_number_list() values (GH-1086)
 
+* Fix a few bugs in object property handling (delete property and
+  Object.defineProperty()) where an object property table resize triggered
+  by a finalizer of a previous value could cause memory unsafe behavior
+  (GH-1096)
+
 * Fix Object.prototype.__proto__ handling to use ToObject() coercion rather
   than requiring an object; this matches ES6 requirements and allows e.g.
   the expression (123).__proto__ to work (GH-1080)

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -456,7 +456,7 @@ DUK_EXTERNAL void duk_set_top(duk_context *ctx, duk_idx_t idx) {
 			DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, tv);
 		} while (tv != tv_end);
 		thr->valstack_top = tv_end;
-		DUK_REFZERO_CHECK(thr);
+		DUK_REFZERO_CHECK_FAST(thr);
 #else  /* DUK_USE_REFERENCE_COUNTING */
 		duk_uidx_t count;
 		duk_tval *tv_end;
@@ -4448,7 +4448,7 @@ DUK_EXTERNAL void duk_pop_n(duk_context *ctx, duk_idx_t count) {
 		DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, tv);
 	}
 	thr->valstack_top = tv;
-	DUK_REFZERO_CHECK(thr);
+	DUK_REFZERO_CHECK_FAST(thr);
 #else
 	tv = thr->valstack_top;
 	while (count > 0) {

--- a/src-input/duk_error_longjmp.c
+++ b/src-input/duk_error_longjmp.c
@@ -43,6 +43,14 @@ DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 	                   (int) thr->heap->lj.type, (int) thr->heap->lj.iserror,
 	                   &thr->heap->lj.value1, &thr->heap->lj.value2));
 
+	/* Perform a refzero check before throwing: this catches cases where
+	 * some internal code uses no-refzero (NORZ) macro variants but an
+	 * error occurs before it has the chance to DUK_REFZERO_CHECK_xxx()
+	 * explicitly.  Refzero'ed objects would otherwise remain pending
+	 * until the next refzero (which is not a big issue but still).
+	 */
+	DUK_REFZERO_CHECK_SLOW(thr);
+
 #if !defined(DUK_USE_CPP_EXCEPTIONS)
 	/* If we don't have a jmpbuf_ptr, there is little we can do except
 	 * cause a fatal error.  The caller's expectation is that we never

--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -518,10 +518,13 @@ struct duk_heaphdr_string {
 /* Free pending refzero entries; quick check to avoid call because often
  * the queue is empty.
  */
-#define DUK_REFZERO_CHECK(thr) do { \
+#define DUK_REFZERO_CHECK_FAST(thr) do { \
 		if ((thr)->heap->refzero_list != NULL) { \
 			duk_refzero_free_pending((thr)); \
 		} \
+	} while (0)
+#define DUK_REFZERO_CHECK_SLOW(thr) do { \
+		duk_refzero_free_pending((thr)); \
 	} while (0)
 
 /*
@@ -767,7 +770,8 @@ struct duk_heaphdr_string {
 #define DUK_HOBJECT_INCREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr,h)  do {} while (0) /* nop */
-#define DUK_REFZERO_CHECK(thr)                 do {} while (0) /* nop */
+#define DUK_REFZERO_CHECK_FAST(thr)            do {} while (0) /* nop */
+#define DUK_REFZERO_CHECK_SLOW(thr)            do {} while (0) /* nop */
 
 #define DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0(thr,tvptr_dst) do { \
 		duk_tval *tv__dst; tv__dst = (tvptr_dst); \
@@ -872,6 +876,7 @@ struct duk_heaphdr_string {
 	} while (0)
 
 #define DUK_TVAL_SET_UNDEFINED_UPDREF         DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0
+#define DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ    DUK_TVAL_SET_UNDEFINED_UPDREF_ALT0
 #define DUK_TVAL_SET_UNUSED_UPDREF            DUK_TVAL_SET_UNUSED_UPDREF_ALT0
 #define DUK_TVAL_SET_NULL_UPDREF              DUK_TVAL_SET_NULL_UPDREF_ALT0
 #define DUK_TVAL_SET_BOOLEAN_UPDREF           DUK_TVAL_SET_BOOLEAN_UPDREF_ALT0

--- a/tests/ecmascript/test-bug-object-defprop-eidx-1.js
+++ b/tests/ecmascript/test-bug-object-defprop-eidx-1.js
@@ -1,0 +1,55 @@
+/*
+ *  Demonstrate a bug in Object.defineProperty() accessor-to-data-property
+ *  convertion when a previous value has a finalizer which modifies the object
+ *  which is going through Object.defineProperty().
+ *
+ *  See comments in test-bug-object-delprop-eidx-1.js.
+ *
+ *  https://github.com/svaarala/duktape/pull/1096
+ */
+
+/*===
+Object.defineProperty() to convert .prop to a data property
+finalizer, modify object
+finalizer done
+Object.defineProperty() done
+{prop:"replaced",oops:345,"dummy-0":"foo","dummy-1":"foo","dummy-2":"foo","dummy-3":"foo","dummy-4":"foo","dummy-5":"foo","dummy-6":"foo","dummy-7":"foo","dummy-8":"foo","dummy-9":"foo"}
+===*/
+
+var obj = {};
+
+function myFinalizer() {
+    var i;
+
+    print('finalizer, modify object');
+
+    delete obj.first;
+    for (i = 0; i < 10; i++) {
+        // i limit 2 is enough to trigger the bug now, overshoot a bit.
+        obj['dummy-' + i] = 'foo';
+    }
+
+    print('finalizer done');
+}
+
+function accessorToDataTest() {
+    obj.first = 123;
+
+    Object.defineProperty(obj, 'prop', { get: new Function(''), configurable: true, enumerable: true });
+    Object.getOwnPropertyDescriptor(obj, 'prop').get.prototype = null;  // break circular ref
+    Duktape.fin(Object.getOwnPropertyDescriptor(obj, 'prop').get, myFinalizer);
+
+    obj.oops = 345;
+
+    print('Object.defineProperty() to convert .prop to a data property');
+    Object.defineProperty(obj, 'prop', { value: 'replaced' });
+    print('Object.defineProperty() done');
+
+    print(Duktape.enc('jx', obj));
+}
+
+try {
+    accessorToDataTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bug-object-defprop-eidx-2.js
+++ b/tests/ecmascript/test-bug-object-defprop-eidx-2.js
@@ -1,0 +1,56 @@
+/*
+ *  Demonstrate a bug in Object.defineProperty() data-to-accessor-property
+ *  convertion when a previous value has a finalizer which modifies the object
+ *  which is going through Object.defineProperty().
+ *
+ *  For some reason this test doesn't trigger the bug in practice.
+ *
+ *  See comments in test-bug-object-delprop-eidx-1.js.
+ *
+ *  https://github.com/svaarala/duktape/pull/1096
+ */
+
+/*===
+Object.defineProperty() to convert .prop to an accessor property
+finalizer, modify object
+finalizer done
+Object.defineProperty() done
+{prop:"getter",oops:"keep","dummy-0":"foo","dummy-1":"foo","dummy-2":"foo","dummy-3":"foo","dummy-4":"foo","dummy-5":"foo","dummy-6":"foo","dummy-7":"foo","dummy-8":"foo","dummy-9":"foo"}
+===*/
+
+var obj = {};
+
+function myFinalizer() {
+    var i;
+
+    print('finalizer, modify object');
+
+    delete obj.first;
+    for (i = 0; i < 10; i++) {
+        // i limit 2 is enough to trigger the bug now, overshoot a bit.
+        obj['dummy-' + i] = 'foo';
+    }
+
+    print('finalizer done');
+}
+
+function accessorToDataTest() {
+    obj.first = 123;
+
+    Object.defineProperty(obj, 'prop', { value: {}, configurable: true, enumerable: true });
+    Duktape.fin(Object.getOwnPropertyDescriptor(obj, 'prop').value, myFinalizer);
+
+    obj.oops = 'keep';
+
+    print('Object.defineProperty() to convert .prop to an accessor property');
+    Object.defineProperty(obj, 'prop', { get: new Function('return "getter";'), set: new Function() });
+    print('Object.defineProperty() done');
+
+    print(Duktape.enc('jx', obj));
+}
+
+try {
+    accessorToDataTest();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bug-object-delprop-eidx-1.js
+++ b/tests/ecmascript/test-bug-object-delprop-eidx-1.js
@@ -1,0 +1,57 @@
+/*
+ *  Demonstrate bug in internal delprop helper when previous value has a
+ *  finalizer which modifies the same object which is going through a delprop.
+ *  https://github.com/svaarala/duktape/pull/1096
+ */
+
+/*===
+deleting obj.prop
+finalizer, modify object
+finalizer done
+deleted obj.prop
+{oops:345,"dummy-0":"foo","dummy-1":"foo","dummy-2":"foo","dummy-3":"foo","dummy-4":"foo","dummy-5":"foo","dummy-6":"foo","dummy-7":"foo","dummy-8":"foo","dummy-9":"foo"}
+===*/
+
+var obj = {};
+
+function myFinalizer() {
+    var i;
+
+    print('finalizer, modify object');
+
+    // To cause the runtime e_idx to change, delete the 'first' property which
+    // leaves an entry part gap.  Then insert enough properties to cause a
+    // property table resize, so that 'prop' moves into the gap.  Delprop
+    // continues updating the slot before this move, i.e. the property
+    // which follows 'prop'.
+
+    delete obj.first;
+    for (i = 0; i < 10; i++) {
+        // i limit 2 is enough to trigger the bug now, overshoot a bit.
+        obj['dummy-' + i] = 'foo';
+    }
+
+    print('finalizer done');
+}
+
+function test() {
+    obj.first = 123;  // gets deleted
+    obj.prop = {};    // gets deleted
+    obj.oops = 345;
+    Duktape.fin(obj.prop, myFinalizer);
+
+    print('deleting obj.prop');
+    delete obj.prop;
+    print('deleted obj.prop');
+
+    // When the bug triggers, 'oops' get deleted while 'prop' remains,
+    // but 'prop' value is undefined.  The delprop update has updated
+    // two unrelated slots due to the finalizer activity.
+    print(Duktape.enc('jx', obj));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Side effects may include finalizers which operate on the object and may thus invalidate the 'e_idx' we've looked up.  Fix by operating with NORZ macros and using a single refzero check. Reported by @oleavr via IRC.

- [x] Fix issue with delprop
- [x] Fix issue with Object.defineProperty() when property is converted from data to accessor
- [x] Fix issue with Object.defineProperty() when property is converted from accessor to data
- [x] Add forced refzero to error throwing to ensure refzero gets executed even when an error happens in the "atomic" part of an update (unlikely but still worth doing)
- [x] Bug testcase
- [x] Check for other similar issues in e_idx stability assumptions
- [x] Releases entry
- [x] 1.x backport => bullet added to 1.5.2 release

Tagged security because the invalid e_idx might introduce memory unsafe behavior.