### PR TITLE
Add a few fmod() self tests

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1970,6 +1970,8 @@ Planned
   opcode (fastint downgrade check is intended to be applied to unary plus
   only) (GH-903)
 
+* Add an fmod() self test (GH-1108)
+
 * Fix a few bugs in object property handling (delete property and
   Object.defineProperty()) where an object property table resize triggered
   by a finalizer of a previous value could cause memory unsafe behavior


### PR DESCRIPTION
Fmod() issues are sometimes encountered in porting (for some reason it's more often an issue than other math functions). It's the likely cause of #1107 for example.

Add a few self tests to detect e.g. a stubbed out or obviously broken `fmod()`.