### PR TITLE
Debugger callstack index change cleanups

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1721,7 +1721,7 @@ Planned
   version incompatible protocol changes in the 2.0.0 release (GH-756)
 
 * Incompatible change: make callstack level mandatory for most debugger
-  commands which accept one (GH-747)
+  commands which accept one (GH-747, GH-1109)
 
 * Incompatible change: require a DUK_USE_DEBUG_WRITE() macro for handling
   debug writes when DUK_USE_DEBUG is enabled; this avoids a platform I/O

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -819,6 +819,17 @@ types in the text)::
     <obj: field name>      e.g. <obj: target>
     <heapptr: field name>  e.g. <heapptr: target>
 
+These additional notations are used::
+
+    # Alternatives, e.g. one integer or two strings:
+    (<int: foo> | <str: bar> <str: quux>)
+
+    # Repetition, e.g. 0-N integers:
+    [<int: foo>]*
+
+    # Repetition, e.g. 1-N values, each string or integer:
+    [<str: foo> | <int: bar>]+
+
 When a field does not relate to an Ecmascript value exactly, e.g. the field
 is a debugger control field, typing can be loose.  For example, a boolean
 field can be represented sometimes as integer dvalue and an arbitrary binary
@@ -1764,7 +1775,7 @@ Eval request (0x1e)
 
 Format::
 
-    REQ <int: 0x1e> <int: level | null> <str: expression> EOM
+    REQ <int: 0x1e> (<int: level> | <null>) <str: expression> EOM
     REP <int: 0=success, 1=error> <tval: value> EOM
 
 Example::
@@ -1876,7 +1887,7 @@ GetBytecode request (0x21)
 
 Format::
 
-    REQ <int: 0x21> [<int: level | obj: target | heapptr: target>] EOM
+    REQ <int: 0x21> (<int: level> | <obj: target> | <heapptr: target>) EOM
     REP <int: numconsts> (<tval: const>){numconsts}
         <int: numfuncs> (<tval: func>){numfuncs}
         <str: bytecode> EOM
@@ -1955,7 +1966,7 @@ GetHeapObjInfo (0x23)
 
 Format::
 
-    REQ <int: 0x23> <tval: heapptr|object|pointer> EOM
+    REQ <int: 0x23> (<heapptr: target> | <object: target> | <pointer: target>) EOM
     REP [<int: flags> <str/int: key> [<tval: value> | <obj: getter> <obj: setter>]]* EOM
 
 Example::
@@ -2001,7 +2012,7 @@ GetObjPropDesc (0x24)
 Format::
 
     REQ <int: 0x24> <obj: target> <str: key> EOM
-    REP <int: flags> <str/int: key> [<tval: value> | <obj: getter> <obj: setter>] EOM
+    REP <int: flags> (<str: key> | <int: key>) (<tval: value> | <obj: getter> <obj: setter>) EOM
 
 Example::
 
@@ -2080,7 +2091,7 @@ GetObjPropDescRange (0x25)
 Format::
 
     REQ <int: 0x25> <obj: target> <int: idx_start> <int: idx_end> EOM
-    REP [<int: flags> <str/int: key> [<tval: value> | <obj: getter> <obj: setter>]]* EOM
+    REP [<int: flags> (<str: key> | <int: key>) (<tval: value> | <obj: getter> <obj: setter>)]* EOM
 
 Example::
 

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -807,6 +807,18 @@ To upgrade:
           /* ... */
       }
 
+Debugger command callstack index changes
+----------------------------------------
+
+Debug command callstack indexes have been made mandatory where appropriate to
+simplify the protocol.  Affected commands are: GetVar, PutVar, GetLocals, and
+Eval.
+
+To upgrade:
+
+* Review debug client handling of callstack indices when sending affected
+  commands.
+
 Debugger print/alert and logger forwarding removed
 --------------------------------------------------
 


### PR DESCRIPTION
- [x] Fix Eval segfault
- [x] Fix compile warning for unused variable
- [x] Shared helper to read and validate callstack index
- [x] 2.0 migration notes on affected commands
- [x] Debugger documentation X or Y argument notation consistency
- [x] Test affected commands using JSON proxy