### PR TITLE
Implement ES6 bound function .name handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1970,6 +1970,10 @@ Planned
   ES6 and other engines; "\078" is now accepted and is the same as
   "\u00078", "\8" and "\9" are accepted as literal "8" and "9"  (GH-1057)
 
+* Change bound function .name property handling to match ES6 requirements;
+  for a target function with name "foo", bound function name is "bound foo"
+  (GH-1113)
+
 * Add a fastint check for duk_put_number_list() values (GH-1086)
 
 * Remove an unintended fastint downgrade check for unary minus executor

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -370,7 +370,17 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 
 	/* these non-standard properties are copied for convenience */
 	/* XXX: 'copy properties' API call? */
-	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_NAME);
+	duk_push_string(ctx, "bound ");  /* ES6 19.2.3.2. */
+	duk_get_prop_stridx(ctx, -3, DUK_STRIDX_NAME);
+	if (!duk_is_string(ctx, -1)) {
+		/* ES6 has requirement to check that .name of target is a string
+		 * (also must check for Symbol); if not, targetName should be the
+		 * empty string.  ES6 19.2.3.2.
+		 */
+		duk_pop(ctx);
+		duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);
+	}
+	duk_concat(ctx, 2);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_WC);
 	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME);
 	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);

--- a/tests/api/test-dev-func-bind-name-notstring.c
+++ b/tests/api/test-dev-func-bind-name-notstring.c
@@ -1,0 +1,45 @@
+/*
+ *  Function.prototype.bind() must set the bound function .name as
+ *  'bound ' + target .name.  However, if target .name does not exist
+ *  or isn't a string, empty string is used instead.
+ */
+
+/*===
+*** test_basic (duk_safe_call)
+123
+"bound "
+final top: 2
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Create a function; the .name property is usually non-writable
+	 * and non-configurable.  Then force the name to 123.
+	 */
+	duk_eval_string(ctx, "(function foo() {})");
+	duk_push_string(ctx, "name");
+	duk_push_int(ctx, 123);
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_FORCE);
+
+	/* ES6 19.2.3.2 requires that a non-string .name is ignored and
+	 * treated like an empty string.  The bound function .name is
+	 * then required to be 'bound ' + .name.
+	 */
+	duk_eval_string(ctx,
+		"(function (v) {\n"
+		"    print(JSON.stringify(v.name));\n"
+		"    var f = v.bind();\n"
+		"    print(JSON.stringify(f.name));\n"
+		"})\n");
+	duk_dup(ctx, 0);
+	duk_call(ctx, 1);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/ecmascript/test-bi-function-bind-name.js
+++ b/tests/ecmascript/test-bi-function-bind-name.js
@@ -1,0 +1,33 @@
+/*
+ *  ES6 19.2.3.2 specifies how a bound function .name is set.
+ */
+
+/*===
+"bound myFunc"
+"bound "
+"bound bound bound cos"
+===*/
+
+function test() {
+    var f = function myFunc() {};
+    var g = (1, 2, function () {});  // anonymous
+
+    // Name becomes 'bound ' + name property.
+    var bound_f = f.bind();
+    print(JSON.stringify(bound_f.name));
+
+    // If name property is missing or not a string, empty string is
+    // used and the result is 'bound '.  A non-string name is covered
+    // by an API testcase which can force the name using duk_def_prop().
+    var bound_g = g.bind();
+    print(JSON.stringify(bound_g.name));
+
+    // The bound prefix multiplies.
+    print(JSON.stringify(Math.cos.bind().bind().bind().name));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Bound function name is `bound <targetName>`. If target has no `.name` or it isn't a string, the result is `bound ` (with a trailing space).