### PR TITLE
Add some new Array methods from ES6+

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1910,6 +1910,8 @@ Planned
 * Add support for ES6 octal (0o123) and binary (0b100001) in source code
   literals and ToNumber() coercion (e.g. "+'0o123'") (GH-1057, GH-1084)
 
+* Add support for ES6 Array.prototype.includes() (GH-1114)
+
 * Add support for ES6 String.prototype.codePointAt(), String.fromCodePoint(),
   and String.prototype.repeat() (GH-1043, GH-1049, GH-1050)
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -878,6 +878,17 @@ objects:
           length: 1
           varargs: true
         present_if: DUK_USE_ARRAY_BUILTIN
+      - key: "includes"
+        value:
+          type: function
+          native: duk_bi_array_prototype_indexof_shared
+          length: 1
+          varargs: true
+          magic: 2  # magic: includes()
+        es6: true
+        present_if:
+          - DUK_USE_ARRAY_BUILTIN
+          - DUK_USE_ES6
       - key: "indexOf"
         value:
           type: function

--- a/tests/ecmascript/test-bi-array-proto-includes.js
+++ b/tests/ecmascript/test-bi-array-proto-includes.js
@@ -1,0 +1,70 @@
+/*===
+basic tests
+true
+true
+true
+true
+true
+true
+false
+true
+false
+true
+true
+false
+true
+false
+false
+false
+false
+false
+false
+false
+true
+===*/
+
+function basicTest() {
+    var arr;
+
+    // includes() uses SameValue algorithm, so it sees zero sign as well
+    // as being able to find NaNs, unlike indexOf().
+    arr = [ 0, 1, 2, 3, 4, 5, 0/0, "foo" ];
+    print(arr.includes(0));
+    print(arr.includes(1));
+    print(arr.includes(2));
+    print(arr.includes(3));
+    print(arr.includes(4));
+    print(arr.includes(5));
+    print(arr.includes(6));
+    print(arr.includes("foo"));
+    print(arr.includes(-0));   // SameValue(0, -0) is false
+    print(arr.includes(0/0));  // SameValue(NaN, NaN) is true
+
+    // Gaps in sparse arrays are searched; nonpresent = undefined.
+    arr = [];
+    arr[0] = "foo";
+    arr[2] = "baz";
+    print(arr.includes(void 0));  // true
+    arr[1] = "bar";
+    print(arr.includes(void 0));  // now false
+
+    // Like indexOf(), fromIndex is effectively clamped to (-len,len).  If
+    // fromIndex === len, nothing is searched.
+    arr = [ "pig", "cow", "ape" ];
+    print(arr.includes("pig", 0));
+    print(arr.includes("pig", 1));
+    print(arr.includes("pig", 2));
+    print(arr.includes("pig", 3));
+    print(arr.includes("cow", 3));
+    print(arr.includes("ape", 3));
+    print(arr.includes("pig", -1));
+    print(arr.includes("cow", -1));
+    print(arr.includes("ape", -1));
+}
+
+try {
+    print('basic tests');
+    basicTest();
+} catch (e) {
+    print(e);
+}


### PR DESCRIPTION
This is a work-in-progress pull to implement `Array.prototype.includes()` and any other easy-to-implement `Array` built-ins.  Not yet merge ready.

- [x] Implement `Array.prototype.includes()` built-in
- [ ] Review ES6 for other low-hanging fruit w.r.t. `Array` builtins
- [x] Basic testcase
- [ ] Improve coverage in testcase
- [x] Releases entry