### PR TITLE
Change for-in on Proxy to use 'ownKeys' trap for ES7 compliance

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1865,6 +1865,14 @@ Planned
   for-in, Object.keys(), and duk_enum() even though that's not strictly
   required by ES6 or ES7 (GH-1054)
 
+* Follow ES7 behavior when a Proxy instance is used as a for-in target:
+  the "ownKeys" trap is invoked instead of the "enumerate" trap, and the
+  "enumerate" trap is thus obsoleted entirely (GH-1115)
+
+* Add enumerability check for properties enumerated using Proxy "ownKeys"
+  trap; because "getOwnPropertyDescriptor" trap is not yet supported, the
+  check is always made against the target object (GH-1115)
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -1045,6 +1045,11 @@ Other incompatible changes
 * The NetBSD pow() workaround option ``DUK_USE_POW_NETBSD_WORKAROUND`` has been
   generalized and renamed to ``DUK_USE_POW_WORKAROUNDS``.
 
+* When using a Proxy as a for-in target the "ownKeys" trap is invoked instead
+  of the "enumerate" trap in ES7.  Duktape now follows this behavior.  The
+  "enumerate" trap has been obsoleted.  Key enumerability is also now checked
+  when "ownKeys" trap is used in Object.keys() and for-in.
+
 Known issues
 ============
 

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -61,4 +61,8 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 
 DUK_INTERNAL_DECL duk_ret_t duk_textdecoder_decode_utf8_nodejs(duk_context *ctx);
 
+#if defined(DUK_USE_ES6_PROXY)
+DUK_INTERNAL_DECL void duk_proxy_ownkeys_postprocess(duk_context *ctx, duk_hobject *h_proxy_target, duk_bool_t enumerable_only);
+#endif
+
 #endif  /* DUK_BUILTIN_PROTOS_H_INCLUDED */

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -5,6 +5,68 @@
 #include "duk_internal.h"
 
 #if defined(DUK_USE_ES6_PROXY)
+/* Post-process a Proxy ownKeys() result at stack top.  Push a cleaned up
+ * array of valid result keys (strings or symbols).  TypeError for invalid
+ * values.
+ */
+DUK_INTERNAL void duk_proxy_ownkeys_postprocess(duk_context *ctx, duk_hobject *h_proxy_target, duk_bool_t enumerable_only) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_uarridx_t i, len, idx;
+	duk_propdesc desc;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(h_proxy_target != NULL);
+
+	len = (duk_uarridx_t) duk_get_length(ctx, -1);
+	idx = 0;
+	duk_push_array(ctx);
+	for (i = 0; i < len; i++) {
+		/* [ obj trap_result res_arr ] */
+		(void) duk_get_prop_index(ctx, -2, i);
+		if (duk_is_string(ctx, -1)) {
+			if (enumerable_only) {
+				/* No support for 'getOwnPropertyDescriptor' trap yet,
+				 * so check enumerability always from target object
+				 * descriptor.
+				 */
+				if (duk_hobject_get_own_propdesc(thr, h_proxy_target, duk_known_hstring(ctx, -1), &desc, 0 /*flags*/)) {
+					if ((desc.flags & DUK_PROPDESC_FLAG_ENUMERABLE) == 0) {
+						DUK_DDD(DUK_DDDPRINT("ignore non-enumerable property: %!T", duk_get_tval(ctx, -1)));
+						goto skip_key;
+					}
+				} else {
+					DUK_DDD(DUK_DDDPRINT("ignore non-existent property: %!T", duk_get_tval(ctx, -1)));
+					goto skip_key;
+				}
+			}
+
+			/* [ obj trap_result res_arr propname ] */
+			duk_put_prop_index(ctx, -2, idx++);
+			continue;
+
+		 skip_key:
+			duk_pop(ctx);
+			continue;
+		} else {
+			DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr);
+		}
+	}
+
+	/* XXX: Missing trap result validation for non-configurable target keys
+	 * (must be present), for non-extensible target all target keys must be
+	 * present and no extra keys can be present.
+	 * http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+	 */
+
+	/* XXX: The key enumerability check should trigger the "getOwnPropertyDescriptor"
+	 * trap which has not yet been implemented.  In the absence of such a trap,
+	 * the enumerability should be checked from the target object; this is
+	 * handled above.
+	 */
+}
+#endif  /* DUK_USE_ES6_PROXY */
+
+#if defined(DUK_USE_ES6_PROXY)
 DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
 	duk_hobject *h_target;
 	duk_hobject *h_handler;

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -222,6 +222,9 @@
 		DUK_ERROR_TYPE_INVALID_ARGS((thr)); \
 		return 0; \
 	} while (0)
+#define DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr) do { \
+		duk_err_type_invalid_trap_result((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO); \
+	} while (0)
 #define DUK_ERROR_TYPE(thr,msg) do { \
 		DUK_ERROR((thr), DUK_ERR_TYPE_ERROR, (msg)); \
 	} while (0)
@@ -283,6 +286,9 @@
 		duk_err_syntax((thr)); \
 	} while (0)
 #define DUK_ERROR_TYPE_INVALID_ARGS(thr) do { \
+		duk_err_type((thr)); \
+	} while (0)
+#define DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr) do { \
 		duk_err_type((thr)); \
 	} while (0)
 #define DUK_DCERROR_TYPE_INVALID_ARGS(thr) do { \
@@ -430,6 +436,7 @@ DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_range_index(duk_hthread *thr, const 
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_range_push_beyond(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_args(duk_hthread *thr, const char *filename, duk_int_t linenumber));
+DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 #else  /* DUK_VERBOSE_ERRORS */
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_error(duk_hthread *thr));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_range(duk_hthread *thr));

--- a/src-input/duk_error_macros.c
+++ b/src-input/duk_error_macros.c
@@ -67,6 +67,9 @@ DUK_INTERNAL void duk_err_range_push_beyond(duk_hthread *thr, const char *filena
 DUK_INTERNAL void duk_err_type_invalid_args(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_ARGS);
 }
+DUK_INTERNAL void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_TRAP_RESULT);
+}
 #else
 /* The file/line arguments are NULL and 0, they're ignored by DUK_ERROR_RAW()
  * when non-verbose errors are used.

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -308,15 +308,20 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 		goto skip_proxy;
 	}
 
+	/* XXX: share code with Object.keys() Proxy handling */
+
+	/* In ES6 for-in invoked the "enumerate" trap; in ES7 "enumerate"
+	 * has been obsoleted and "ownKeys" is used instead.
+	 */
 	DUK_DDD(DUK_DDDPRINT("proxy enumeration"));
 	duk_push_hobject(ctx, h_proxy_handler);
-	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_ENUMERATE)) {
+	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_OWN_KEYS)) {
 		/* No need to replace the 'enum_target' value in stack, only the
 		 * enum_target reference.  This also ensures that the original
 		 * enum target is reachable, which keeps the proxy and the proxy
 		 * target reachable.  We do need to replace the internal _Target.
 		 */
-		DUK_DDD(DUK_DDDPRINT("no enumerate trap, enumerate proxy target instead"));
+		DUK_DDD(DUK_DDDPRINT("no ownKeys trap, enumerate proxy target instead"));
 		DUK_DDD(DUK_DDDPRINT("h_proxy_target=%!O", (duk_heaphdr *) h_proxy_target));
 		enum_target = h_proxy_target;
 
@@ -334,28 +339,24 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	h_trap_result = duk_require_hobject(ctx, -1);
 	DUK_UNREF(h_trap_result);
 
-	/* Copy trap result keys into the enumerator object. */
+	/* XXX: more filter flags? */
+	duk_proxy_ownkeys_postprocess(ctx, h_proxy_target, (enum_flags & DUK_ENUM_INCLUDE_NONENUMERABLE) ? 0 : 1 /*enumerable_only*/);
+	/* -> [ ... enum_target res trap_result keys_array ] */
+
+	/* Copy cleaned up trap result keys into the enumerator object. */
+	/* XXX: result is a dense array; could make use of that. */
+	DUK_ASSERT(duk_is_array(ctx, -1));
 	len = (duk_uint_fast32_t) duk_get_length(ctx, -1);
 	for (i = 0; i < len; i++) {
-		/* XXX: not sure what the correct semantic details are here,
-		 * e.g. handling of missing values (gaps), handling of non-array
-		 * trap results, etc.
-		 *
-		 * For keys, we simply skip non-string keys which seems to be
-		 * consistent with how e.g. Object.keys() will process proxy trap
-		 * results (ES6, Section 19.1.2.14).
-		 */
-		if (duk_get_prop_index(ctx, -1, i) && duk_is_string(ctx, -1)) {
-			/* [ ... enum_target res trap_result val ] */
-			duk_push_true(ctx);
-			/* [ ... enum_target res trap_result val true ] */
-			duk_put_prop(ctx, -4);
-		} else {
-			duk_pop(ctx);
-		}
+		(void) duk_get_prop_index(ctx, -1, i);
+		DUK_ASSERT(duk_is_string(ctx, -1));  /* postprocess cleaned up */
+		/* [ ... enum_target res trap_result keys_array val ] */
+		duk_push_true(ctx);
+		/* [ ... enum_target res trap_result keys_array val true ] */
+		duk_put_prop(ctx, -5);
 	}
-	/* [ ... enum_target res trap_result ] */
-	duk_pop(ctx);
+	/* [ ... enum_target res trap_result keys_array ] */
+	duk_pop_2(ctx);
 	duk_remove(ctx, -2);
 
 	/* [ ... res ] */

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -80,6 +80,9 @@
 #define DUK_STR_SETTER_UNDEFINED                 "setter undefined"
 #define DUK_STR_INVALID_DESCRIPTOR               "invalid descriptor"
 
+/* Proxy */
+#define DUK_STR_INVALID_TRAP_RESULT              "invalid trap result"
+
 /* Variables */
 
 /* Lexer */

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -431,8 +431,8 @@ strings:
     es6: true
   #- str: "defineProperty"
   #  es6: true
-  - str: "enumerate"
-    es6: true
+  #- str: "enumerate"   # obsoleted in ES7
+  #  es6: true
   - str: "ownKeys"
     es6: true
   #- str: "apply"

--- a/tests/ecmascript/test-bi-json-enc-proxy.js
+++ b/tests/ecmascript/test-bi-json-enc-proxy.js
@@ -46,9 +46,7 @@ getOwnPropertyDescriptor for nonEnumerable
 {"foo":"key-foo","quux":"key-quux","baz":"key-baz"}
 ===*/
 
-/* Proxy 'ownKeys' trap is consulted, 'enumerate' trap is NOT consulted.
- * This has been verified to match Firefox behavior.
- */
+/* Proxy 'ownKeys' trap is consulted. */
 
 function jsonStringifyOwnKeysProxyTest() {
     var target, proxy, obj;
@@ -86,6 +84,7 @@ function jsonStringifyOwnKeysProxyTest() {
     // out what 'ownKeys' result keys are enumerable.
 
     target = { foo: 123, bar: 234, quux: 345, nonEnumerable: 456 };
+    Object.defineProperty(target, 'nonEnumerable', { enumerable: false });
     proxy = new Proxy(target, {
         getOwnPropertyDescriptor: function (targ, key) {
             print('getOwnPropertyDescriptor for ' + key);

--- a/tests/ecmascript/test-bi-proxy-enumerate-es7-obsolete.js
+++ b/tests/ecmascript/test-bi-proxy-enumerate-es7-obsolete.js
@@ -1,0 +1,44 @@
+/*
+ *  In ES7 the 'enumerate' trap is obsolete and is not called in any situation.
+ *  For-in enumeration uses the 'ownKeys' trap.
+ *
+ *  for-in uses EnumerateObjectProperties:
+ *      - http://www.ecma-international.org/ecma-262/7.0/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind
+ *
+ *  EnumerateObjectProperties is pretty vague on how the keys are obtained:
+ *      - http://www.ecma-international.org/ecma-262/7.0/#sec-enumerate-object-properties
+ *      - "EnumerateObjectProperties must obtain the own property keys of the
+ *        target object by calling its [[OwnPropertyKeys]] internal method."
+ *
+ *  Proxy [[OwnPropertyKeys]] calls the 'ownKeys' rather than 'enumerate' trap:
+ *      - http://www.ecma-international.org/ecma-262/7.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+ *
+ *  There's no reference to a "enumerate" trap anywhere in ES7 specification.
+ *  MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate.
+ */
+
+/*===
+ownKeys trap
+string bar
+===*/
+
+function test() {
+    var P;
+    var P = new Proxy({ foo: 123, bar: 234 }, {
+        enumerate: function () {
+            print('enumerate trap'); return [ 'foo' ];
+        },
+        ownKeys: function () {
+            print('ownKeys trap'); return [ 'bar' ];
+        }
+    });
+    for (k in P) {
+        print(typeof k, String(k));
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/knownissues/test-bi-json-enc-proxy-2.txt
+++ b/tests/knownissues/test-bi-json-enc-proxy-2.txt
@@ -1,0 +1,8 @@
+summary: Proxy getOwnPropertyDescriptor trap is unimplemented
+---
+{"foo":234}
+{"foo":345}
+ownKeys should be called
+{"foo":"key-foo","quux":"key-quux"}
+ownKeys should be called
+{"foo":"key-foo","quux":"key-quux"}

--- a/website/guide/es6features.html
+++ b/website/guide/es6features.html
@@ -84,12 +84,12 @@ ES6.  The following traps are implemented:</p>
 <tr><td class="propname">preventExtension</td><td>no</td><td></td></tr>
 <tr><td class="propname">getOwnPropertyDescriptor</td><td>no</td><td></td></tr>
 <tr><td class="propname">defineProperty</td><td>no</td><td></td></tr>
-<tr><td class="propname">has</td><td>yes</td><td><code>Object.hasOwnProperty()</code> does not invoke the trap at the moment, <code>key in obj</code> does</td></tr>
+<tr><td class="propname">has</td><td>yes</td><td><code>Object.hasOwnProperty()</code> does not invoke the trap at the moment, <code>key in obj</code> does.</td></tr>
 <tr><td class="propname">get</td><td>yes</td><td></td></tr>
 <tr><td class="propname">set</td><td>yes</td><td></td></tr>
 <tr><td class="propname">deleteProperty</td><td>yes</td><td></td></tr>
-<tr><td class="propname">enumerate</td><td>yes</td><td></td></tr>
-<tr><td class="propname">ownKeys</td><td>yes</td><td><code>Object.keys()</code> enumerability check limitation, trap result validation (non-configurable properties, non-extensible target) not done</td></tr>
+<tr><td class="propname">enumerate</td><td>no (*)</td><td>The "enumerate" trap was removed in ES7 and for-in uses "ownKeys" trap; Duktape 1.x supports "enumerate" trap in for-in.</td></tr>
+<tr><td class="propname">ownKeys</td><td>yes</td><td>Some trap result validation (non-configurable properties, non-extensible target) not yet implemented.</td></tr>
 <tr><td class="propname">apply</td><td>no</td><td></td></tr>
 <tr><td class="propname">construct</td><td>no</td><td></td></tr>
 </tbody>
@@ -99,11 +99,6 @@ ES6.  The following traps are implemented:</p>
 <ul>
 <li>Only about half of the ES6 traps have been implemented.  This causes odd behavior
     if you e.g. call <code>Object.defineProperty()</code> on a proxy object.</li>
-<li><code>Object.keys()</code> invokes the <code>ownKeys</code> trap, cleans up the trap
-    result to a gap-free string list, but does not check that the property names returned
-    by the trap are enumerable.  <code>Object.keys()</code> and <code>Object.getOwnPropertyNames()</code>
-    thus currently return the same value for a proxy object implementing the <code>ownKeys</code>
-    trap.</li>
 <li>Proxy trap results are not validated, e.g. <code>ownKeys</code> trap result validation
     steps described in <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">[[OwnPropertyKeys]] ()</a>
     for non-configurable target properties and/or non-extensible target object are not


### PR DESCRIPTION
In ES6 `for-in` on a Proxy would invoke the `enumerate` trap. In ES7 `enumerate` is obsoleted and `for-in` should use `ownKeys` trap instead.

- [x] Change for-in handling
- [x] Fix enumerability check for 'ownKeys' result for both `for-in` and `Object.keys()`
- [x] Testcase updates
- [x] Test coverage for for-in trap change
- [ ] Test coverage for Object.keys() target property enumerability check
- [x] Test coverage for for-in target property enumerability check
- [x] Website trap list update
- [x] 2.0 migration note
- [x] Releases entry