### PR TITLE
Use same bitpacked format for heap strings and thread property string data

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2106,7 +2106,8 @@ Planned
   built-ins for low memory builds (GH-989); remove internal accessor setup
   helper and use duk_def_prop() instead (GH-1010); minor IEEE double handling
   optimizations (GH-1051); precomputed duk_hstring array index (GH-1056);
-  internal value stack access improvements (GH-1058)
+  internal value stack access improvements (GH-1058); shared bitpacked string
+  format for heap and thread initialization data (GH-1119)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -54,6 +54,8 @@ struct duk_bitdecoder_ctx {
 	duk_small_int_t currbits;
 };
 
+#define DUK_BD_BITPACKED_STRING_MAXLEN 256
+
 /*
  *  Bitstream encoder
  */
@@ -509,6 +511,7 @@ DUK_INTERNAL_DECL duk_uint32_t duk_util_get_hash_prime(duk_uint32_t size);
 DUK_INTERNAL_DECL duk_int32_t duk_bd_decode(duk_bitdecoder_ctx *ctx, duk_small_int_t bits);
 DUK_INTERNAL_DECL duk_small_int_t duk_bd_decode_flag(duk_bitdecoder_ctx *ctx);
 DUK_INTERNAL_DECL duk_int32_t duk_bd_decode_flagged(duk_bitdecoder_ctx *ctx, duk_small_int_t bits, duk_int32_t def_value);
+DUK_INTERNAL_DECL duk_small_uint_t duk_bd_decode_bitpacked_string(duk_bitdecoder_ctx *bd, duk_uint8_t *out);
 
 DUK_INTERNAL_DECL void duk_be_encode(duk_bitencoder_ctx *ctx, duk_uint32_t data, duk_small_int_t bits);
 DUK_INTERNAL_DECL void duk_be_finish(duk_bitencoder_ctx *ctx);


### PR DESCRIPTION
This reduces footprint, and is also required later on by the ES6 Symbol pull; the current string data has limitations for full 8-bit data which are removed here.