### PR TITLE
Add duk_push_bare_object() API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1882,6 +1882,9 @@ Planned
   duk_components_to_time()) to allow C code to conveniently work with the
   same time provider as seen by Ecmascript code (GH-771)
 
+* Add duk_push_bare_object() API call which pushes an object without an
+  internal prototype, equivalent to Object.create(null) (GH-1126)
+
 * Add ability to perform an indirect debugger Eval with non-empty callstack by
   sending null for the callstack level (GH-747)
 

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -154,7 +154,6 @@ DUK_INTERNAL_DECL void duk_push_hbuffer(duk_context *ctx, duk_hbuffer *h);
 DUK_INTERNAL_DECL void duk_push_hobject_bidx(duk_context *ctx, duk_small_int_t builtin_idx);
 DUK_INTERNAL_DECL duk_idx_t duk_push_object_helper(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
 DUK_INTERNAL_DECL duk_idx_t duk_push_object_helper_proto(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_hobject *proto);
-DUK_INTERNAL_DECL duk_idx_t duk_push_object_internal(duk_context *ctx);
 DUK_INTERNAL_DECL duk_idx_t duk_push_compiledfunction(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_push_c_function_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);
 DUK_INTERNAL_DECL void duk_push_c_function_noconstruct_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -470,6 +470,7 @@ DUK_EXTERNAL_DECL void duk_push_global_stash(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_thread_stash(duk_context *ctx, duk_context *target_ctx);
 
 DUK_EXTERNAL_DECL duk_idx_t duk_push_object(duk_context *ctx);
+DUK_EXTERNAL_DECL duk_idx_t duk_push_bare_object(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_array(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_c_function(duk_context *ctx, duk_c_function func, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_c_lightfunc(duk_context *ctx, duk_c_function func, duk_idx_t nargs, duk_idx_t length, duk_int_t magic);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3529,7 +3529,7 @@ DUK_LOCAL void duk__push_stash(duk_context *ctx) {
 	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE)) {
 		DUK_DDD(DUK_DDDPRINT("creating heap/global/thread stash on first use"));
 		duk_pop(ctx);
-		duk_push_object_internal(ctx);
+		duk_push_bare_object(ctx);
 		duk_dup_top(ctx);
 		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_C);  /* [ ... parent stash stash ] -> [ ... parent stash ] */
 	}
@@ -4357,7 +4357,8 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 	return ret;
 }
 
-DUK_INTERNAL duk_idx_t duk_push_object_internal(duk_context *ctx) {
+/* Push object with no prototype, i.e. a "bare" object. */
+DUK_EXTERNAL duk_idx_t duk_push_bare_object(duk_context *ctx) {
 	return duk_push_object_helper(ctx,
 	                              DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT),

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2907,7 +2907,7 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 
 	DUK_BW_INIT_PUSHBUF(thr, &js_ctx->bw, DUK__JSON_STRINGIFY_BUFSIZE);
 
-	js_ctx->idx_loop = duk_push_object_internal(ctx);
+	js_ctx->idx_loop = duk_push_bare_object(ctx);
 	DUK_ASSERT(js_ctx->idx_loop >= 0);
 
 	/* [ ... buf loop ] */

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -276,7 +276,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	enum_target = duk_require_hobject(ctx, -1);
 	DUK_ASSERT(enum_target != NULL);
 
-	duk_push_object_internal(ctx);
+	duk_push_bare_object(ctx);
 	res = duk_known_hobject(ctx, -1);
 
 	/* [enum_target res] */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -555,7 +555,7 @@ DUK_LOCAL void duk__init_func_valstack_slots(duk_compiler_ctx *comp_ctx) {
 	func->h_argnames = DUK_GET_HOBJECT_POSIDX(ctx, entry_top + 6);
 	DUK_ASSERT(func->h_argnames != NULL);
 
-	duk_push_object_internal(ctx);
+	duk_push_bare_object(ctx);
 	func->varmap_idx = entry_top + 7;
 	func->h_varmap = DUK_GET_HOBJECT_POSIDX(ctx, entry_top + 7);
 	DUK_ASSERT(func->h_varmap != NULL);
@@ -581,7 +581,7 @@ DUK_LOCAL void duk__reset_func_for_pass2(duk_compiler_ctx *comp_ctx) {
 	/* keep func->h_argnames; it is fixed for all passes */
 
 	/* truncated in case pass 3 needed */
-	duk_push_object_internal(ctx);
+	duk_push_bare_object(ctx);
 	duk_replace(ctx, func->varmap_idx);
 	func->h_varmap = DUK_GET_HOBJECT_POSIDX(ctx, func->varmap_idx);
 	DUK_ASSERT(func->h_varmap != NULL);

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -177,6 +177,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_pop_n(ctx, 0);
 	(void) duk_pop(ctx);
 	(void) duk_push_array(ctx);
+	(void) duk_push_bare_object(ctx);
 	(void) duk_push_boolean(ctx, 0);
 	(void) duk_push_buffer_object(ctx, 0, 0, 0, 0);
 	(void) duk_push_buffer(ctx, 0, 0);

--- a/tests/api/test-push-bare-object.c
+++ b/tests/api/test-push-bare-object.c
@@ -1,6 +1,6 @@
 /*===
 duk_is_object(1) = 1
-.toString rc=1 -> function toString() {"native"}
+.toString rc=0 -> undefined
 json encoded: {"meaningOfLife":42}
 top=2
 ===*/
@@ -11,11 +11,9 @@ void test(duk_context *ctx) {
 
 	duk_push_int(ctx, 123);  /* dummy */
 
-	obj_idx = duk_push_object(ctx);
+	obj_idx = duk_push_bare_object(ctx);
 	duk_push_int(ctx, 42);
 	duk_put_prop_string(ctx, obj_idx, "meaningOfLife");
-
-	/* object is now: { "meaningOfLife": 42 } */
 
 	printf("duk_is_object(%ld) = %d\n", (long) obj_idx, (int) duk_is_object(ctx, obj_idx));
 

--- a/website/api/duk_push_bare_object.yaml
+++ b/website/api/duk_push_bare_object.yaml
@@ -1,0 +1,28 @@
+name: duk_push_bare_object
+
+proto: |
+  duk_idx_t duk_push_bare_object(duk_context *ctx);
+
+stack: |
+  [ ... ] -> [ ... obj! ]
+
+summary: |
+  <p>Similar to <code><a href="#duk_push_object">duk_push_object()</a></code>
+  but the pushed object doesn't inherit from any other object, i.e. its internal
+  prototype is <code>null</code>.  This call is equivalent to
+  <code>Object.create(null)</code>.  Returns non-negative index (relative to
+  stack bottom) of the pushed object.</p>
+
+example: |
+  duk_idx_t obj_idx;
+
+  obj_idx = duk_push_bare_object(ctx);
+
+tags:
+  - stack
+  - object
+
+seealso:
+  - duk_push_object
+
+introduced: 2.0.0

--- a/website/api/duk_push_object.yaml
+++ b/website/api/duk_push_object.yaml
@@ -28,4 +28,7 @@ tags:
   - stack
   - object
 
+seealso:
+  - duk_push_bare_object
+
 introduced: 1.0.0


### PR DESCRIPTION
Add a convenience API call `duk_push_bare_object()` which pushes an object without an internal prototype, same as `Object.create(null)`. Bare objects are useful for various tracking hashmap purposes.

Previously one would have to `duk_push_object()` and then `duk_set_prototype()`. This pull exposes an internal helper which pushed a bare object already.

- [x] Expose new API call
- [x] Testcases
- [x] API documentation
- [x] Releases entry