### PR TITLE
Use a bare object for module loader caches

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1926,10 +1926,12 @@ Planned
   (GH-767)
 
 * Add an extra module (extras/module-duktape) providing a Duktape 1.x
-  compatible module loading framework (Duktape.modSearch etc) (GH-821)
+  compatible module loading framework (Duktape.modSearch etc) (GH-821,
+  GH-1127)
 
 * Add an extra module (extras/module-node) providing a Node.js-like module
-  loading framework supporting require.cache, module.loaded, etc. (GH-796)
+  loading framework supporting require.cache, module.loaded, etc. (GH-796,
+  GH-1127)
 
 * Add an extra module (extras/minimal-printf) providing minimal,
   Duktape-optimized sprintf(), snprintf(), vsnprintf(), and sscanf()

--- a/extras/module-duktape/duk_module_duktape.c
+++ b/extras/module-duktape/duk_module_duktape.c
@@ -441,7 +441,7 @@ void duk_module_duktape_init(duk_context *ctx) {
 		"var D=Object.defineProperty;"
 		"D(req,'name',{value:'require'});"
 		"D(this,'require',{value:req,writable:true,configurable:true});"
-		"D(Duktape,'modLoaded',{value:{},writable:true,configurable:true});"
+		"D(Duktape,'modLoaded',{value:Object.create(null),writable:true,configurable:true});"
 		"})");
 	duk_push_c_function(ctx, duk__require, 1 /*nargs*/);
 	duk_call(ctx, 1);

--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -288,7 +288,7 @@ void duk_module_node_init(duk_context *ctx) {
 
 	/* Initialize the require cache to a fresh object. */
 	duk_push_global_stash(ctx);
-	duk_push_object(ctx);
+	duk_push_bare_object(ctx);
 	duk_put_prop_string(ctx, -2, "\xff" "requireCache");
 	duk_pop(ctx);
 

--- a/tests/ecmascript/test-bug-modloaded-cache-inherit.js
+++ b/tests/ecmascript/test-bug-modloaded-cache-inherit.js
@@ -1,0 +1,17 @@
+/*
+ *  In Duktape 1.5.1 Duktape.modLoaded[] inherited from Object.prototype
+ *  which caused e.g. require('toString') to return undefined without
+ *  trying to load a module.
+ */
+
+/*===
+TypeError
+===*/
+
+// Without a module loader, expected result is TypeError.
+try {
+    require('toString');
+    print('never here');
+} catch (e) {
+    print(e.name);
+}


### PR DESCRIPTION
Use a bare object for module loader caches. Without the change, e.g. `require('toString')` would find the `toString` key from `Object.prototype` and figure the module was loaded.

This is also present in the 1.x module loader so I'll backport a fix. But this is not a bug in 2.0 because the external module loaders haven't been released yet (thus no "bug" tag).