### PR TITLE
Add DUK_GC_COMPACT flag to duk_gc()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1782,6 +1782,9 @@ Planned
   [[DefaultValue]] specification algorithm removed in ES6 (it was folded
   to ToPrimitive()), use duk_to_primitive() instead (GH-984)
 
+* Incompatible change: duk_gc() no longer allows a NULL context pointer
+  for consistency with other API calls (GH-1129)
+
 * Add support for dropping built-in bindings entirely when they are disabled
   in configuration, e.g. the Proxy and buffer object bindings will be absent
   instead of being replaced by functions throwing an error; this is more
@@ -1884,6 +1887,9 @@ Planned
 
 * Add duk_push_bare_object() API call which pushes an object without an
   internal prototype, equivalent to Object.create(null) (GH-1126)
+
+* Add DUK_GC_COMPACT flag to duk_gc() to force object property table
+  compaction (GH-778, GH-1129)
 
 * Add ability to perform an indirect debugger Eval with non-empty callstack by
   sending null for the callstack level (GH-747)

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -1028,6 +1028,10 @@ Other incompatible changes
 * If a user function is called using the identifier 'eval', such a call won't
   get tailcall optimized even if otherwise possible.
 
+* ``duk_gc()`` no longer accepts a NULL context pointer for consistence with
+  other API calls.  A NULL pointer not causes memory unsafe behavior, as with
+  all other API calls.
+
 * ``duk_char_code_at()`` and ``String.charCodeAt()`` now return 0xFFFD (Unicode
   replacement character) if the string cannot be decoded as extended UTF-8,
   previously an error was thrown.  This situation never occurs for standard

--- a/src-input/duk_api_memory.c
+++ b/src-input/duk_api_memory.c
@@ -79,22 +79,19 @@ DUK_EXTERNAL void duk_get_memory_functions(duk_context *ctx, duk_memory_function
 }
 
 DUK_EXTERNAL void duk_gc(duk_context *ctx, duk_uint_t flags) {
-#ifdef DUK_USE_MARK_AND_SWEEP
+#if defined(DUK_USE_MARK_AND_SWEEP)
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_heap *heap;
+	duk_small_uint_t ms_flags;
 
-	DUK_UNREF(flags);
-
-	/* NULL accepted */
-	if (!ctx) {
-		return;
-	}
 	DUK_ASSERT_CTX_VALID(ctx);
 	heap = thr->heap;
 	DUK_ASSERT(heap != NULL);
 
 	DUK_D(DUK_DPRINT("mark-and-sweep requested by application"));
-	duk_heap_mark_and_sweep(heap, 0);
+	DUK_ASSERT(DUK_GC_COMPACT == DUK_MS_FLAG_EMERGENCY);  /* Compact flag is 1:1 with emergency flag which forces compaction. */
+	ms_flags = (duk_small_uint_t) flags;
+	duk_heap_mark_and_sweep(heap, ms_flags);
 #else
 	DUK_D(DUK_DPRINT("mark-and-sweep requested by application but mark-and-sweep not enabled, ignoring"));
 	DUK_UNREF(ctx);

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -216,6 +216,9 @@ struct duk_time_components {
 /* Flags for duk_push_thread_raw() */
 #define DUK_THREAD_NEW_GLOBAL_ENV         (1 << 0)    /* create a new global environment */
 
+/* Flags for duk_gc() */
+#define DUK_GC_COMPACT                    (1 << 0)    /* compact heap objects */
+
 /* Error codes (must be 8 bits at most, see duk_error.h) */
 #define DUK_ERR_NONE                      0    /* no error (e.g. from duk_get_error_code()) */
 #define DUK_ERR_ERROR                     1    /* Error */

--- a/tests/api/test-gc.c
+++ b/tests/api/test-gc.c
@@ -1,10 +1,77 @@
 /*===
-still here
+*** test_basic (duk_safe_call)
+final top: 0
+==> rc=0, result='undefined'
+*** test_compaction (duk_safe_call)
+true true
+true true
+final top: 1
+==> rc=0, result='undefined'
 ===*/
 
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_compaction(duk_context *ctx, void *udata) {
+	/* Force GC a few times to ensure voluntary GC won't surprise us. */
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+
+	/* Create a non-compact object. */
+	duk_eval_string(ctx,
+		"(function () {\n"
+		"    var obj = { foo: 123, bar: 234, quux: 345 };\n"
+		"    delete obj.foo;  // now has an empty slot\n"
+		"    delete obj.bar;  // and another\n"
+		"    return obj;\n"
+		"})()\n");
+
+	/* Before compaction, esize and enext will be > 1.  Don't test
+	 * for specific values because they'll depend on resizing parameters.
+	 */
+
+	duk_eval_string(ctx,
+		"(function (obj) {\n"
+		"    var info, esize, enext;\n"
+		"    info = Duktape.info(obj);\n"
+		"    esize = ('esize' in info ? info.esize : info[5]);\n"
+		"    enext = ('enext' in info ? info.enext : info[6]);\n"
+		"    print(esize > 1, enext > 1);\n"
+		"})\n");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	duk_gc(ctx, DUK_GC_COMPACT);
+
+	/* After compaction esize == enext == 1 because the object has only
+	 * a single property.
+	 */
+	duk_eval_string(ctx,
+		"(function (obj) {\n"
+		"    var info, esize, enext;\n"
+		"    info = Duktape.info(obj);\n"
+		"    esize = ('esize' in info ? info.esize : info[5]);\n"
+		"    enext = ('enext' in info ? info.enext : info[6]);\n"
+		"    print(esize == 1, enext == 1);\n"
+		"})\n");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
 void test(duk_context *ctx) {
-	duk_gc(ctx, 0);
-	duk_gc(ctx, 0);
-	duk_gc(ctx, 0);
-	printf("still here\n");
+	TEST_SAFE_CALL(test_basic);
+	TEST_SAFE_CALL(test_compaction);
 }

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -155,6 +155,12 @@ typedef struct duk_number_list_entry duk_number_list_entry;
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 &lt;&lt; 5)    /* enumerate a proxy object itself without invoking proxy behavior */
 </pre>
 
+<h2>Garbage collection flags for duk_gc()</h2>
+<pre class="c-code">
+/* Flags for duk_gc() */
+#define DUK_GC_COMPACT                    (1 &lt;&lt; 0)    /* compact heap objects */
+</pre>
+
 <h2>Coercion hints</h2>
 <pre class="c-code">
 /* Coercion hints */

--- a/website/api/duk_gc.yaml
+++ b/website/api/duk_gc.yaml
@@ -5,8 +5,13 @@ proto: |
 
 summary: |
   <p>Force a mark-and-sweep garbage collection round.  If mark-and-sweep is
-  disabled in the Duktape build, the call is a no-op.  The flags field is a
-  placeholder; no flags are defined at the moment.</p>
+  disabled in the Duktape build, the call is a no-op.</p>
+
+  <p>The following flags are defined:</p>
+  <table>
+  <tr><th>Define</th><th>Description</th></tr>
+  <tr><td>DUK_GC_COMPACT</td><td>Force object property table compaction</td></tr>
+  </table>
 
   <p>You may want to call this function twice to ensure even objects with
   finalizers are collected.  Currently it takes two mark-and-sweep rounds


### PR DESCRIPTION
Add `DUK_GC_COMPACT` flag to `duk_gc()` which causes all object property tables to be compacted. Fixes #778.

- [x] Add public API flag
- [x] Testcase coverage
- [x] API documentation
- [x] Migration notes: duk_gc() no longer accepts a NULL ctx (consistency)
- [x] Releases entry