### PR TITLE
Add duk_def_prop() ToString() key coercion

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1803,6 +1803,9 @@ Planned
   duk_del_prop_lstring(), duk_has_prop_lstring(), duk_get_global_lstring(),
   duk_put_global_lstring() (GH-946, GH-953)
 
+* Add a ToString (later, ToPropertyKey) coercion to duk_def_prop() key
+  argument to allow e.g. numbers to be used in the key slot (GH-836, GH-1130)
+
 * Add duk_get_prop_desc() API call which pushes a property descriptor object
   for a target object and key, similar to Object.getOwnPropertyDescriptor()
   (GH-1087)

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -1032,6 +1032,10 @@ Other incompatible changes
   other API calls.  A NULL pointer not causes memory unsafe behavior, as with
   all other API calls.
 
+* ``duk_def_prop()`` now ToString() coerces its argument rather than requiring
+  the key to be a string.  This allows e.g. numbers to be used as property
+  keys.
+
 * ``duk_char_code_at()`` and ``String.charCodeAt()`` now return 0xFFFD (Unicode
   replacement character) if the string cannot be decoded as extended UTF-8,
   previously an error was thrown.  This situation never occurs for standard

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -438,7 +438,8 @@ DUK_EXTERNAL void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uint_t f
 	} else {
 		idx_value = (duk_idx_t) -1;
 	}
-	key = duk_require_hstring(ctx, idx_base);
+	key = duk_to_hstring(ctx, idx_base);  /* XXX: later should accept symbols */
+	DUK_ASSERT(key != NULL);
 
 	duk_require_valid_index(ctx, idx_base);
 


### PR DESCRIPTION
Add a ToString() coercion for duk_def_prop() key. Previously the key was required to be a string and e.g. a number wasn't accepted. Fixes #836.

- [x] Change coercion (note that will need to be ToPropertyKey() in the future)
- [x] Testcase update
- [x] Migration notes
- [x] Releases entry