### PR TITLE
Add explicit lexenv/varenv fields to duk_hcompfunc

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2008,6 +2008,11 @@ Planned
 
 * Add an fmod() self test (GH-1108)
 
+* Fix duk_hcompfunc 'data' field != NULL assumptions which might lead to
+  memory unsafe behavior if Duktape ran out of memory when creating a
+  duk_hcompfunc during compilation or function instantiation (GH-1144,
+  GH-1132)
+
 * Fix a few bugs in object property handling (delete property and
   Object.defineProperty()) where an object property table resize triggered
   by a finalizer of a previous value could cause memory unsafe behavior
@@ -2117,7 +2122,7 @@ Planned
   GH-973, GH-1042); minor RegExp compile/execute optimizations (GH-974,
   GH-1033); minor IEEE double handling optimizations (GH-1051); precomputed
   duk_hstring array index (GH-1056); duk_get_{type,type_mask}() optimization
-  (GH-1077)
+  (GH-1077); explicit lexenv/varenv fields in duk_hcompfunc struct (GH-1132)
 
 * Miscellaneous footprint improvements: RegExp compiler/executor (GH-977);
   internal duk_dup() variants (GH-990); allow stripping of (almost) all
@@ -2125,7 +2130,8 @@ Planned
   helper and use duk_def_prop() instead (GH-1010); minor IEEE double handling
   optimizations (GH-1051); precomputed duk_hstring array index (GH-1056);
   internal value stack access improvements (GH-1058); shared bitpacked string
-  format for heap and thread initialization data (GH-1119)
+  format for heap and thread initialization data (GH-1119); explicit
+  lexenv/varenv fields in duk_hcompfunc struct (GH-1132)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/debugger/duk_debug_proxy.js
+++ b/debugger/duk_debug_proxy.js
@@ -937,7 +937,7 @@ TargetConnHandler.prototype.trialParseDvalue = function trialParseDvalue() {
                 if (avail >= 2 + len) {
                     v = new Uint8Array(len);
                     v.set(buf.subarray(2, 2 + len));
-                    v = { type: 'heapptr', pointer: Duktape.enc('hex', plainof(v)) };
+                    v = { type: 'heapptr', pointer: Duktape.enc('hex', plainOf(v)) };
                     consume(2 + len);
                 }
             }

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -2433,6 +2433,10 @@ The following list describes artificial keys included in Duktape 1.5.0, see
 +---------------------------------+---------------------------+---------------------------------------------------------+
 | (not present yet)               | ``duk_hcompfunc``         | Ecmascript function data area, including bytecode.      |
 +---------------------------------+---------------------------+---------------------------------------------------------+
+| ``lex_env``                     | ``duk_hcompfunc``         | Function lexical environment.                           |
++---------------------------------+---------------------------+---------------------------------------------------------+
+| ``var_env``                     | ``duk_hcompfunc``         | Function variable environment.                          |
++---------------------------------+---------------------------+---------------------------------------------------------+
 | ``nregs``                       | ``duk_hcompfunc``         | Number of bytecode executor registers.                  |
 +---------------------------------+---------------------------+---------------------------------------------------------+
 | ``nargs``                       | ``duk_hcompfunc``         | Number of stack arguments.                              |

--- a/doc/function-objects.rst
+++ b/doc/function-objects.rst
@@ -251,21 +251,6 @@ user documentation for the exposed parts):
 +---------------+---------------------------------------------------------+
 | ``fileName``  | See function templates.                                 |
 +---------------+---------------------------------------------------------+
-| ``_Lexenv``   | Together with DUK_HOBJECT_FLAG_NEWENV, controls the     |
-|               | initialization of variable/lexical environment when a   |
-|               | function call occurs.                                   |
-|               |                                                         |
-|               | The DUK_HOBJECT_FLAG_NEWENV is set for ordinary         |
-|               | functions, which always get a new environment record    |
-|               | when they are called.  The flag is cleared for global   |
-|               | code and eval code, which "share" an existing           |
-|               | environment record.                                     |
-|               |                                                         |
-|               | If _Varenv is missing, it defaults to _Lexenv (which is |
-|               | very often the case).                                   |
-+---------------+---------------------------------------------------------+
-| ``_Varenv``   | See ``_Lexenv``.                                        |
-+---------------+---------------------------------------------------------+
 | ``_Varmap``   | See function templates.                                 |
 +---------------+---------------------------------------------------------+
 | ``_Formals``  | See function templates.                                 |

--- a/doc/hobject-design.rst
+++ b/doc/hobject-design.rst
@@ -1643,9 +1643,10 @@ double brackets are omitted from the specification property names
 | HasInstance       | Not stored, implicit in algorithms.                  |
 |                   |                                                      |
 +-------------------+------------------------------------------------------+
-| Scope             | Internal properties ``_Lexenv`` and ``_Varenv``.     |
-|                   | (Unlike E5, global and eval code are also compiled   |
-|                   | into functions, hence two scope fields are needed.)  |
+| Scope             | Internal ``duk_hcompfunc`` fields ``lex_env`` and    |
+|                   | ``var_env``.  Unlike E5, global and eval code are    |
+|                   | also compiled into functions, hence two scope fields |
+|                   | are needed.)                                         |
 +-------------------+------------------------------------------------------+
 | FormalParameters  | Internal property ``_Formals``.                      |
 |                   |                                                      |

--- a/doc/identifier-handling.rst
+++ b/doc/identifier-handling.rst
@@ -590,8 +590,8 @@ detailed properties vary a bit between the two.
 
 More concretely:
 
-* The ``DUK_HOBJECT_FLAG_NEWENV`` object level flag, and the internal
-  properties ``_Lexenv`` and ``_Varenv`` control activation record
+* The ``DUK_HOBJECT_FLAG_NEWENV`` object level flag, and the ``lex_env``
+  and ``var_env`` fields of ``duk_hcompfunc`` control activation record
   lexical and variable environment initialization as described below.
 
 * The internal property ``_Varmap`` contains a mapping from an
@@ -606,35 +606,6 @@ More concretely:
   represents a named function expression.  For such functions, the function
   name (stored in ``name``) needs to be bound in an environment record just
   outside a function activation's environment record.
-
-To minimize book-keeping in common cases, the following short cuts
-are supported:
-
-* If both scope references are missing:
-
-  + Assume that the function has an empty declarative environment record,
-    whose parent is the global environment record.
-
-  + For variable lookups this means that we proceed directly to the global
-    environment record.
-
-  + For variable declarations this means that a declarative environment
-    record needs to be created on demand.
-
-* If ``_Varenv`` is missing:
-
-  + Assume that ``_Varenv`` has the same value as ``_Lexenv``.
-
-  + This is very common, and saves one (unnecessary) reference.
-
-  + Note: it would be more logical to allow ``_Lexenv`` to be missing
-    and default it to ``_Varenv``; however, dynamic variable
-    declarations are comparatively rare so the defaulting is more
-    useful this way around
-
-* If ``_Varmap`` is missing:
-
-  + Assume that the function has no register-mapped variables.
 
 * The compiler attempts to drop any fields not required from compiled
   objects.  In many common cases (even when dynamic variables accesses
@@ -651,11 +622,6 @@ Notes:
 * Environment record initialization is done only when (if) it is actually
   needed (e.g. for a function declaration).  It is not created
   unnecessarily when a function is called.
-
-* The default behavior for ``_Lexenv`` and ``_Varenv`` allows them to
-  be omitted in a large number of cases (for instance, many functions
-  are declared in the global scope, and for many compiled eval
-  functions the values are the same).
 
 * The ``DUK_HOBJECT_FLAG_NEWENV`` is set for ordinary functions, which
   always get a new environment record for variable declaration and

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -161,22 +161,18 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 	 *  same (initial) built-ins.
 	 */
 
-	(void) duk_push_object_helper(ctx,
-	                              DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
-	                              -1);  /* no prototype, updated below */
+	h_env = duk_push_object_helper(ctx,
+	                               DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                               DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
+	                               -1);  /* no prototype, updated below */
+	DUK_ASSERT(h_env != NULL);
 
 	duk_dup_m2(ctx);
 	duk_dup_m3(ctx);
-
-	/* [ ... new_glob new_env new_glob new_glob ] */
-
 	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 	duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
 
 	/* [ ... new_glob new_env ] */
-
-	h_env = duk_known_hobject(ctx, -1);
 
 	h_prev_env = thr->builtins[DUK_BIDX_GLOBAL_ENV];
 	thr->builtins[DUK_BIDX_GLOBAL_ENV] = h_env;

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -152,9 +152,9 @@ DUK_INTERNAL_DECL void duk_push_hbuffer(duk_context *ctx, duk_hbuffer *h);
 #define duk_push_hnatfunc(ctx,h) \
 	duk_push_hobject((ctx), (duk_hobject *) (h))
 DUK_INTERNAL_DECL void duk_push_hobject_bidx(duk_context *ctx, duk_small_int_t builtin_idx);
-DUK_INTERNAL_DECL duk_idx_t duk_push_object_helper(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
-DUK_INTERNAL_DECL duk_idx_t duk_push_object_helper_proto(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_hobject *proto);
-DUK_INTERNAL_DECL duk_idx_t duk_push_compiledfunction(duk_context *ctx);
+DUK_INTERNAL_DECL duk_hobject *duk_push_object_helper(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
+DUK_INTERNAL_DECL duk_hobject *duk_push_object_helper_proto(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_hobject *proto);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_push_compiledfunction(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_push_c_function_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);
 DUK_INTERNAL_DECL void duk_push_c_function_noconstruct_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);
 
@@ -210,6 +210,8 @@ DUK_INTERNAL_DECL void duk_unpack(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_require_constructor_call(duk_context *ctx);
 
 DUK_INTERNAL_DECL void duk_require_constructable(duk_context *ctx, duk_idx_t idx);
+
+DUK_INTERNAL_DECL duk_idx_t duk_get_top_index_unsafe(duk_context *ctx);
 
 /* Raw internal valstack access macros: access is unsafe so call site
  * must have a guarantee that the index is valid.  When that is the case,

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -1419,10 +1419,10 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor(duk_context *ctx) {
 
 	DUK_DDD(DUK_DDDPRINT("Date constructor, nargs=%ld, is_cons=%ld", (long) nargs, (long) is_cons));
 
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DATE),
-	                       DUK_BIDX_DATE_PROTOTYPE);
+	(void) duk_push_object_helper(ctx,
+	                              DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DATE),
+	                              DUK_BIDX_DATE_PROTOTYPE);
 
 	/* Unlike most built-ins, the internal [[PrimitiveValue]] of a Date
 	 * is mutable.

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -21,7 +21,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_constructor_shared(duk_context *ctx) {
 
 	DUK_UNREF(thr);
 
-	duk_push_object_helper(ctx, flags_and_class, bidx_prototype);
+	(void) duk_push_object_helper(ctx, flags_and_class, bidx_prototype);
 
 	/* If message is undefined, the own property 'message' is not set at
 	 * all to save property space.  An empty message is inherited anyway.

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -323,13 +323,13 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, nargs + 1);
 
 	/* create bound function object */
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_FLAG_BOUNDFUNC |
-	                       DUK_HOBJECT_FLAG_CONSTRUCTABLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION),
-	                       DUK_BIDX_FUNCTION_PROTOTYPE);
-	h_bound = duk_known_hobject(ctx, -1);
+	h_bound = duk_push_object_helper(ctx,
+	                                 DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                                 DUK_HOBJECT_FLAG_BOUNDFUNC |
+	                                 DUK_HOBJECT_FLAG_CONSTRUCTABLE |
+	                                 DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION),
+	                                 DUK_BIDX_FUNCTION_PROTOTYPE);
+	DUK_ASSERT(h_bound != NULL);
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
 	duk_dup_m2(ctx);  /* func */

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -521,13 +521,12 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			act_lex_env = act->lex_env;
 			act = NULL;  /* invalidated */
 
-			(void) duk_push_object_helper_proto(ctx,
-			                                    DUK_HOBJECT_FLAG_EXTENSIBLE |
-			                                    DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
-			                                    act_lex_env);
-			new_env = duk_known_hobject(ctx, -1);
-			DUK_DDD(DUK_DDDPRINT("new_env allocated: %!iO",
-			                     (duk_heaphdr *) new_env));
+			new_env = duk_push_object_helper_proto(ctx,
+			                                       DUK_HOBJECT_FLAG_EXTENSIBLE |
+			                                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
+			                                       act_lex_env);
+			DUK_ASSERT(new_env != NULL);
+			DUK_DDD(DUK_DDDPRINT("new_env allocated: %!iO", (duk_heaphdr *) new_env));
 
 			outer_lex_env = new_env;
 			outer_var_env = new_env;

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -44,10 +44,10 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor(duk_context *ctx) {
 		return 1;
 	}
 
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT),
-	                       DUK_BIDX_OBJECT_PROTOTYPE);
+	(void) duk_push_object_helper(ctx,
+	                              DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT),
+	                              DUK_BIDX_OBJECT_PROTOTYPE);
 	return 1;
 }
 #endif  /* DUK_USE_OBJECT_BUILTIN */

--- a/src-input/duk_bi_pointer.c
+++ b/src-input/duk_bi_pointer.c
@@ -22,10 +22,10 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_constructor(duk_context *ctx) {
 	duk_set_top(ctx, 1);
 
 	if (duk_is_constructor_call(ctx)) {
-		duk_push_object_helper(ctx,
-		                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-		                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_POINTER),
-		                       DUK_BIDX_POINTER_PROTOTYPE);
+		(void) duk_push_object_helper(ctx,
+		                              DUK_HOBJECT_FLAG_EXTENSIBLE |
+		                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_POINTER),
+		                              DUK_BIDX_POINTER_PROTOTYPE);
 
 		/* Pointer object internal value is immutable */
 		duk_dup_0(ctx);

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -33,11 +33,11 @@ DUK_INTERNAL duk_ret_t duk_bi_string_constructor(duk_context *ctx) {
 	duk_set_top(ctx, 1);
 
 	if (duk_is_constructor_call(ctx)) {
-		duk_push_object_helper(ctx,
-		                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-		                       DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ |
-		                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_STRING),
-		                       DUK_BIDX_STRING_PROTOTYPE);
+		(void) duk_push_object_helper(ctx,
+		                              DUK_HOBJECT_FLAG_EXTENSIBLE |
+		                              DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ |
+		                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_STRING),
+		                              DUK_BIDX_STRING_PROTOTYPE);
 
 		/* String object internal value is immutable */
 		duk_dup_0(ctx);

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -344,9 +344,8 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 			subtype = "thread";
 		} else if (DUK_HOBJECT_IS_BUFOBJ(h)) {
 			subtype = "bufobj";
-			/* XXX: add duk_harray here */
-		} else {
-			duk_fb_sprintf(fb, "%sobject %p%s", (const char *) brace1, (void *) h, (const char *) brace2);  /* may be NULL */
+		} else if (DUK_HOBJECT_IS_ARRAY(h)) {
+			subtype = "array";
 		}
 		duk_fb_sprintf(fb, "%sobject/%s %p%s", (const char *) brace1, subtype, (void *) h, (const char *) brace2);
 		return;
@@ -456,6 +455,9 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 		if (DUK_HOBJECT_HAS_STRICT(h)) {
 			DUK__COMMA(); duk_fb_sprintf(fb, "__strict:true");
 		}
+		if (DUK_HOBJECT_HAS_NOTAIL(h)) {
+			DUK__COMMA(); duk_fb_sprintf(fb, "__notail:true");
+		}
 		if (DUK_HOBJECT_HAS_NEWENV(h)) {
 			DUK__COMMA(); duk_fb_sprintf(fb, "__newenv:true");
 		}
@@ -496,6 +498,8 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 		duk_hcompfunc *f = (duk_hcompfunc *) h;
 		DUK__COMMA(); duk_fb_put_cstring(fb, "__data:");
 		duk__print_hbuffer(st, (duk_hbuffer *) DUK_HCOMPFUNC_GET_DATA(NULL, f));
+		DUK__COMMA(); duk_fb_put_cstring(fb, "__lexenv:"); duk__print_hobject(st, DUK_HCOMPFUNC_GET_LEXENV(NULL, f));
+		DUK__COMMA(); duk_fb_put_cstring(fb, "__varenv:"); duk__print_hobject(st, DUK_HCOMPFUNC_GET_VARENV(NULL, f));
 		DUK__COMMA(); duk_fb_sprintf(fb, "__nregs:%ld", (long) f->nregs);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__nargs:%ld", (long) f->nargs);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -2201,10 +2201,28 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 		if (DUK_HOBJECT_IS_COMPFUNC(h_obj)) {
 			duk_hcompfunc *h_fun;
 			duk_hbuffer *h_buf;
+			duk_hobject *h_lexenv;
+			duk_hobject *h_varenv;
 			h_fun = (duk_hcompfunc *) h_obj;
 
 			duk__debug_getinfo_prop_int(thr, "nregs", h_fun->nregs);
 			duk__debug_getinfo_prop_int(thr, "nargs", h_fun->nargs);
+
+			duk__debug_getinfo_flags_key(thr, "lex_env");
+			h_lexenv = DUK_HCOMPFUNC_GET_LEXENV(thr->heap, h_fun);
+			if (h_lexenv != NULL) {
+				duk_debug_write_hobject(thr, h_lexenv);
+			} else {
+				duk_debug_write_null(thr);
+			}
+			duk__debug_getinfo_flags_key(thr, "var_env");
+			h_varenv = DUK_HCOMPFUNC_GET_VARENV(thr->heap, h_fun);
+			if (h_varenv != NULL) {
+				duk_debug_write_hobject(thr, h_varenv);
+			} else {
+				duk_debug_write_null(thr);
+			}
+
 			duk__debug_getinfo_prop_uint(thr, "start_line", h_fun->start_line);
 			duk__debug_getinfo_prop_uint(thr, "end_line", h_fun->end_line);
 			h_buf = (duk_hbuffer *) DUK_HCOMPFUNC_GET_DATA(thr->heap, h_fun);

--- a/src-input/duk_hcompfunc.h
+++ b/src-input/duk_hcompfunc.h
@@ -30,21 +30,36 @@
 #define DUK_HCOMPFUNC_SET_BYTECODE(heap,h,v)  do { \
 		(h)->bytecode16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (v)); \
 	} while (0)
+#define DUK_HCOMPFUNC_GET_LEXENV(heap,h)  \
+	((duk_hobject *) (void *) (DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, (h)->lex_env16)))
+#define DUK_HCOMPFUNC_SET_LEXENV(heap,h,v)  do { \
+		(h)->lex_env16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (v)); \
+	} while (0)
+#define DUK_HCOMPFUNC_GET_VARENV(heap,h)  \
+	((duk_hobject *) (void *) (DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, (h)->var_env16)))
+#define DUK_HCOMPFUNC_SET_VARENV(heap,h,v)  do { \
+		(h)->var_env16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (v)); \
+	} while (0)
 #else
-#define DUK_HCOMPFUNC_GET_DATA(heap,h) \
-	((duk_hbuffer_fixed *) (void *) (h)->data)
+#define DUK_HCOMPFUNC_GET_DATA(heap,h)  ((duk_hbuffer_fixed *) (void *) (h)->data)
 #define DUK_HCOMPFUNC_SET_DATA(heap,h,v) do { \
 		(h)->data = (duk_hbuffer *) (v); \
 	} while (0)
-#define DUK_HCOMPFUNC_GET_FUNCS(heap,h)  \
-	((h)->funcs)
+#define DUK_HCOMPFUNC_GET_FUNCS(heap,h)  ((h)->funcs)
 #define DUK_HCOMPFUNC_SET_FUNCS(heap,h,v)  do { \
 		(h)->funcs = (v); \
 	} while (0)
-#define DUK_HCOMPFUNC_GET_BYTECODE(heap,h)  \
-	((h)->bytecode)
+#define DUK_HCOMPFUNC_GET_BYTECODE(heap,h)  ((h)->bytecode)
 #define DUK_HCOMPFUNC_SET_BYTECODE(heap,h,v)  do { \
 		(h)->bytecode = (v); \
+	} while (0)
+#define DUK_HCOMPFUNC_GET_LEXENV(heap,h)  ((h)->lex_env)
+#define DUK_HCOMPFUNC_SET_LEXENV(heap,h,v)  do { \
+		(h)->lex_env = (v); \
+	} while (0)
+#define DUK_HCOMPFUNC_GET_VARENV(heap,h)  ((h)->var_env)
+#define DUK_HCOMPFUNC_SET_VARENV(heap,h,v)  do { \
+		(h)->var_env = (v); \
 	} while (0)
 #endif
 
@@ -164,6 +179,17 @@ struct duk_hcompfunc {
 	duk_instr_t *bytecode;
 #endif
 
+	/* Lexenv: lexical environment of closure, NULL for templates.
+	 * Varenv: variable environment of closure, NULL for templates.
+	 */
+#if defined(DUK_USE_HEAPPTR16)
+	duk_uint16_t lex_env16;
+	duk_uint16_t var_env16;
+#else
+	duk_hobject *lex_env;
+	duk_hobject *var_env;
+#endif
+
 	/*
 	 *  'nregs' registers are allocated on function entry, at most 'nargs'
 	 *  are initialized to arguments, and the rest to undefined.  Arguments
@@ -219,8 +245,6 @@ struct duk_hcompfunc {
 	 *      _Formals: [ "arg1", "arg2" ],
 	 *      _Source: "function func(arg1, arg2) { ... }",
 	 *      _Pc2line: <debug info for pc-to-line mapping>,
-	 *      _Varenv: <variable environment of closure>,
-	 *      _Lexenv: <lexical environment of closure (if differs from _Varenv)>
 	 *    }
 	 *
 	 *  More detailed description of these properties can be found

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -84,6 +84,8 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 		 */
 
 		duk__mark_heaphdr(heap, (duk_heaphdr *) DUK_HCOMPFUNC_GET_DATA(heap, f));
+		duk__mark_heaphdr(heap, (duk_heaphdr *) DUK_HCOMPFUNC_GET_LEXENV(heap, f));
+		duk__mark_heaphdr(heap, (duk_heaphdr *) DUK_HCOMPFUNC_GET_VARENV(heap, f));
 
 		tv = DUK_HCOMPFUNC_GET_CONSTS_BASE(heap, f);
 		tv_end = DUK_HCOMPFUNC_GET_CONSTS_END(heap, f);

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -87,18 +87,23 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 		duk__mark_heaphdr(heap, (duk_heaphdr *) DUK_HCOMPFUNC_GET_LEXENV(heap, f));
 		duk__mark_heaphdr(heap, (duk_heaphdr *) DUK_HCOMPFUNC_GET_VARENV(heap, f));
 
-		tv = DUK_HCOMPFUNC_GET_CONSTS_BASE(heap, f);
-		tv_end = DUK_HCOMPFUNC_GET_CONSTS_END(heap, f);
-		while (tv < tv_end) {
-			duk__mark_tval(heap, tv);
-			tv++;
-		}
+		if (DUK_HCOMPFUNC_GET_DATA(heap, f) != NULL) {
+			tv = DUK_HCOMPFUNC_GET_CONSTS_BASE(heap, f);
+			tv_end = DUK_HCOMPFUNC_GET_CONSTS_END(heap, f);
+			while (tv < tv_end) {
+				duk__mark_tval(heap, tv);
+				tv++;
+			}
 
-		fn = DUK_HCOMPFUNC_GET_FUNCS_BASE(heap, f);
-		fn_end = DUK_HCOMPFUNC_GET_FUNCS_END(heap, f);
-		while (fn < fn_end) {
-			duk__mark_heaphdr(heap, (duk_heaphdr *) *fn);
-			fn++;
+			fn = DUK_HCOMPFUNC_GET_FUNCS_BASE(heap, f);
+			fn_end = DUK_HCOMPFUNC_GET_FUNCS_END(heap, f);
+			while (fn < fn_end) {
+				duk__mark_heaphdr(heap, (duk_heaphdr *) *fn);
+				fn++;
+			}
+		} else {
+			/* May happen in some out-of-memory corner cases. */
+			DUK_D(DUK_DPRINT("duk_hcompfunc 'data' is NULL, skipping marking"));
 		}
 	} else if (DUK_HOBJECT_IS_NATFUNC(h)) {
 		duk_hnatfunc *f = (duk_hnatfunc *) h;

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -144,7 +144,9 @@ DUK_LOCAL void duk__refcount_finalize_hobject(duk_hthread *thr, duk_hobject *h) 
 			funcs++;
 		}
 
-		DUK_HBUFFER_DECREF(thr, (duk_hbuffer *) DUK_HCOMPFUNC_GET_DATA(thr->heap, f));
+		DUK_HEAPHDR_DECREF_ALLOWNULL(thr, (duk_heaphdr *) DUK_HCOMPFUNC_GET_LEXENV(thr->heap, f));
+		DUK_HEAPHDR_DECREF_ALLOWNULL(thr, (duk_heaphdr *) DUK_HCOMPFUNC_GET_VARENV(thr->heap, f));
+		DUK_HEAPHDR_DECREF_ALLOWNULL(thr, (duk_hbuffer *) DUK_HCOMPFUNC_GET_DATA(thr->heap, f));
 	} else if (DUK_HOBJECT_IS_NATFUNC(h)) {
 		duk_hnatfunc *f = (duk_hnatfunc *) h;
 		DUK_UNREF(f);

--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -366,36 +366,21 @@ struct duk_heaphdr_string {
 /* Slow variants, call to a helper to reduce code size.
  * Can be used explicitly when size is always more important than speed.
  */
-#define DUK_TVAL_INCREF_SLOW(thr,tv) do { \
-		duk_tval_incref((tv)); \
-	} while (0)
-#define DUK_TVAL_DECREF_SLOW(thr,tv) do { \
-		duk_tval_decref((thr), (tv)); \
-	} while (0)
-#define DUK_TVAL_DECREF_NORZ_SLOW(thr,tv) do { \
-		duk_tval_decref_norz((thr), (tv)); \
-	} while (0)
-#define DUK_HEAPHDR_INCREF_SLOW(thr,h) do { \
-		duk_heaphdr_incref((duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HSTRING_DECREF_SLOW(thr,h) do { \
-		duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HSTRING_DECREF_NORZ_SLOW(thr,h) do { \
-		duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HBUFFER_DECREF_SLOW(thr,h) do { \
-		duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HBUFFER_DECREF_NORZ_SLOW(thr,h) do { \
-		duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HOBJECT_DECREF_SLOW(thr,h) do { \
-		duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); \
-	} while (0)
-#define DUK_HOBJECT_DECREF_NORZ_SLOW(thr,h) do { \
-		duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); \
-	} while (0)
+#define DUK_TVAL_INCREF_SLOW(thr,tv)         do { duk_tval_incref((tv)); } while (0)
+#define DUK_TVAL_DECREF_SLOW(thr,tv)         do { duk_tval_decref((thr), (tv)); } while (0)
+#define DUK_TVAL_DECREF_NORZ_SLOW(thr,tv)    do { duk_tval_decref_norz((thr), (tv)); } while (0)
+#define DUK_HEAPHDR_INCREF_SLOW(thr,h)       do { duk_heaphdr_incref((duk_heaphdr *) (h)); } while (0)
+#define DUK_HEAPHDR_DECREF_SLOW(thr,h)       do { duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HEAPHDR_DECREF_NORZ_SLOW(thr,h)  do { duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HSTRING_INCREF_SLOW(thr,h)       do { duk_heaphdr_incref((duk_heaphdr *) (h)); } while (0)
+#define DUK_HSTRING_DECREF_SLOW(thr,h)       do { duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HSTRING_DECREF_NORZ_SLOW(thr,h)  do { duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HBUFFER_INCREF_SLOW(thr,h)       do { duk_heaphdr_incref((duk_heaphdr *) (h)); } while (0)
+#define DUK_HBUFFER_DECREF_SLOW(thr,h)       do { duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HBUFFER_DECREF_NORZ_SLOW(thr,h)  do { duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HOBJECT_INCREF_SLOW(thr,h)       do { duk_heaphdr_incref((duk_heaphdr *) (h)); } while (0)
+#define DUK_HOBJECT_DECREF_SLOW(thr,h)       do { duk_heaphdr_decref((thr), (duk_heaphdr *) (h)); } while (0)
+#define DUK_HOBJECT_DECREF_NORZ_SLOW(thr,h)  do { duk_heaphdr_decref_norz((thr), (duk_heaphdr *) (h)); } while (0)
 
 /* Default variants.  Selection depends on speed/size preference.
  * Concretely: with gcc 4.8.1 -Os x64 the difference in final binary
@@ -409,10 +394,8 @@ struct duk_heaphdr_string {
 #define DUK_TVAL_DECREF(thr,tv)                DUK_TVAL_DECREF_FAST((thr),(tv))
 #define DUK_TVAL_DECREF_NORZ(thr,tv)           DUK_TVAL_DECREF_NORZ_FAST((thr),(tv))
 #define DUK_HEAPHDR_INCREF(thr,h)              DUK_HEAPHDR_INCREF_FAST((thr),(h))
-#if 0  /* DUK_HEAPHDR_INCREF() is needed (it's generic) but generic DECREF is not. */
 #define DUK_HEAPHDR_DECREF(thr,h)              DUK_HEAPHDR_DECREF_FAST_RAW((thr),(h),duk_heaphdr_refzero,duk_heaphdr *)
 #define DUK_HEAPHDR_DECREF_NORZ(thr,h)         DUK_HEAPHDR_DECREF_FAST_RAW((thr),(h),duk_heaphdr_refzero_norz,duk_heaphdr *)
-#endif
 #define DUK_HSTRING_INCREF(thr,h)              DUK_HEAPHDR_INCREF((thr),(duk_heaphdr *) (h))
 #define DUK_HSTRING_DECREF(thr,h)              DUK_HEAPHDR_DECREF_FAST_RAW((thr),(h),duk_hstring_refzero,duk_hstring *)
 #define DUK_HSTRING_DECREF_NORZ(thr,h)         DUK_HEAPHDR_DECREF_FAST_RAW((thr),(h),duk_hstring_refzero,duk_hstring *)  /* no 'norz' variant */
@@ -439,10 +422,8 @@ struct duk_heaphdr_string {
 #define DUK_TVAL_DECREF(thr,tv)                DUK_TVAL_DECREF_SLOW((thr),(tv))
 #define DUK_TVAL_DECREF_NORZ(thr,tv)           DUK_TVAL_DECREF_NORZ_SLOW((thr),(tv))
 #define DUK_HEAPHDR_INCREF(thr,h)              DUK_HEAPHDR_INCREF_SLOW((thr),(h))
-#if 0
 #define DUK_HEAPHDR_DECREF(thr,h)              DUK_HEAPHDR_DECREF_SLOW((thr),(h))
 #define DUK_HEAPHDR_DECREF_NORZ(thr,h)         DUK_HEAPHDR_DECREF_NORZ_SLOW((thr),(h))
-#endif
 #define DUK_HSTRING_INCREF(thr,h)              DUK_HEAPHDR_INCREF((thr),(duk_heaphdr *) (h))
 #define DUK_HSTRING_DECREF(thr,h)              DUK_HSTRING_DECREF_SLOW((thr),(h))
 #define DUK_HSTRING_DECREF_NORZ(thr,h)         DUK_HSTRING_DECREF_NORZ_SLOW((thr),(h))
@@ -746,15 +727,34 @@ struct duk_heaphdr_string {
 #define DUK_HEAPHDR_INCREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HEAPHDR_DECREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HEAPHDR_DECREF_NORZ(thr,h)         do {} while (0) /* nop */
+#define DUK_HSTRING_INCREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HSTRING_DECREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HSTRING_DECREF_NORZ_FAST(thr,h)    do {} while (0) /* nop */
+#define DUK_HSTRING_INCREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HSTRING_DECREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HSTRING_DECREF_NORZ_SLOW(thr,h)    do {} while (0) /* nop */
 #define DUK_HSTRING_INCREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HSTRING_DECREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HSTRING_DECREF_NORZ(thr,h)         do {} while (0) /* nop */
+#define DUK_HOBJECT_INCREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HOBJECT_DECREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HOBJECT_DECREF_NORZ_FAST(thr,h)    do {} while (0) /* nop */
+#define DUK_HOBJECT_INCREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HOBJECT_DECREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HOBJECT_DECREF_NORZ_SLOW(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_INCREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_NORZ(thr,h)         do {} while (0) /* nop */
+#define DUK_HBUFFER_INCREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HBUFFER_DECREF_FAST(thr,h)         do {} while (0) /* nop */
+#define DUK_HBUFFER_DECREF_NORZ_FAST(thr,h)    do {} while (0) /* nop */
+#define DUK_HBUFFER_INCREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HBUFFER_DECREF_SLOW(thr,h)         do {} while (0) /* nop */
+#define DUK_HBUFFER_DECREF_NORZ_SLOW(thr,h)    do {} while (0) /* nop */
 #define DUK_HBUFFER_INCREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HBUFFER_DECREF(thr,h)              do {} while (0) /* nop */
 #define DUK_HBUFFER_DECREF_NORZ(thr,h)         do {} while (0) /* nop */
+
 #define DUK_HCOMPFUNC_INCREF(thr,h)            do {} while (0) /* nop */
 #define DUK_HCOMPFUNC_DECREF(thr,h)            do {} while (0) /* nop */
 #define DUK_HCOMPFUNC_DECREF_NORZ(thr,h)       do {} while (0) /* nop */
@@ -770,6 +770,7 @@ struct duk_heaphdr_string {
 #define DUK_HOBJECT_INCREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_ALLOWNULL(thr,h)    do {} while (0) /* nop */
 #define DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr,h)  do {} while (0) /* nop */
+
 #define DUK_REFZERO_CHECK_FAST(thr)            do {} while (0) /* nop */
 #define DUK_REFZERO_CHECK_SLOW(thr)            do {} while (0) /* nop */
 

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -86,6 +86,8 @@ DUK_INTERNAL duk_hcompfunc *duk_hcompfunc_alloc(duk_heap *heap, duk_uint_t hobje
 	res->funcs = NULL;
 	res->bytecode = NULL;
 #endif
+	res->lex_env = NULL;
+	res->var_env = NULL;
 #endif
 
 	return res;

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -59,21 +59,21 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 
 #if defined(DUK_USE_ROM_GLOBAL_INHERIT)
 	/* Inherit from ROM-based global object: less RAM usage, less transparent. */
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
-	                       DUK_BIDX_GLOBAL);
-	h1 = duk_known_hobject(ctx, -1);
+	h1 = duk_push_object_helper(ctx,
+	                            DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
+	                            DUK_BIDX_GLOBAL);
+	DUK_ASSERT(h1 != NULL);
 #elif defined(DUK_USE_ROM_GLOBAL_CLONE)
 	/* Clone the properties of the ROM-based global object to create a
 	 * fully RAM-based global object.  Uses more memory than the inherit
 	 * model but more compliant.
 	 */
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
-	                       DUK_BIDX_OBJECT_PROTOTYPE);
-	h1 = duk_known_hobject(ctx, -1);
+	h1 = duk_push_object_helper(ctx,
+	                            DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_GLOBAL),
+	                            DUK_BIDX_OBJECT_PROTOTYPE);
+	DUK_ASSERT(h1 != NULL);
 	h2 = thr->builtins[DUK_BIDX_GLOBAL];
 	DUK_ASSERT(h2 != NULL);
 
@@ -118,11 +118,11 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	 * needed so that the global scope points to the newly created RAM-based
 	 * global object.
 	 */
-	duk_push_object_helper(ctx,
-	                       DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
-	                       -1);  /* no prototype */
-	h1 = duk_known_hobject(ctx, -1);
+	h1 = duk_push_object_helper(ctx,
+	                            DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV),
+	                            -1);  /* no prototype */
+	DUK_ASSERT(h1 != NULL);
 	duk_dup_m2(ctx);
 	duk_dup_top(ctx);  /* -> [ ... new_global new_globalenv new_global new_global ] */
 	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
@@ -297,9 +297,9 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 		} else if (class_num == DUK_HOBJECT_CLASS_ARRAY) {
 			duk_push_array(ctx);
 		} else {
-			duk_push_object_helper(ctx,
-			                       DUK_HOBJECT_FLAG_EXTENSIBLE,
-			                       -1);  /* no prototype or class yet */
+			(void) duk_push_object_helper(ctx,
+			                              DUK_HOBJECT_FLAG_EXTENSIBLE,
+			                              -1);  /* no prototype or class yet */
 
 		}
 

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -667,8 +667,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 
 	/* Valstack should suffice here, required on function valstack init */
 
-	(void) duk_push_compiledfunction(ctx);
-	h_res = (duk_hcompfunc *) DUK_GET_HOBJECT_NEGIDX(ctx, -1);  /* XXX: specific getter */
+	h_res = duk_push_compiledfunction(ctx);
 	DUK_ASSERT(h_res != NULL);
 
 	if (func->is_function) {

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -929,11 +929,10 @@ DUK_LOCAL void duk__handle_catch(duk_hthread *thr, duk_size_t cat_idx, duk_tval 
 		act_lex_env = act->lex_env;
 		act = NULL;  /* invalidated */
 
-		(void) duk_push_object_helper_proto(ctx,
-		                                    DUK_HOBJECT_FLAG_EXTENSIBLE |
-		                                    DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
-		                                    act_lex_env);
-		new_env = DUK_GET_HOBJECT_NEGIDX(ctx, -1);
+		new_env = duk_push_object_helper_proto(ctx,
+		                                       DUK_HOBJECT_FLAG_EXTENSIBLE |
+		                                       DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV),
+		                                       act_lex_env);
 		DUK_ASSERT(new_env != NULL);
 		DUK_DDD(DUK_DDDPRINT("new_env allocated: %!iO", (duk_heaphdr *) new_env));
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -74,8 +74,14 @@ DUK_LOCAL void duk__inc_data_inner_refcounts(duk_hthread *thr, duk_hcompfunc *f)
 	duk_tval *tv, *tv_end;
 	duk_hobject **funcs, **funcs_end;
 
-	DUK_ASSERT(DUK_HCOMPFUNC_GET_DATA(thr->heap, f) != NULL);  /* compiled functions must be created 'atomically' */
 	DUK_UNREF(thr);
+
+	/* If function creation fails due to out-of-memory, the data buffer
+	 * pointer may be NULL in some cases.  That's actually possible for
+	 * GC code, but shouldn't be possible here because the incomplete
+	 * function will be unwound from the value stack and never instantiated.
+	 */
+	DUK_ASSERT(DUK_HCOMPFUNC_GET_DATA(thr->heap, f) != NULL);
 
 	tv = DUK_HCOMPFUNC_GET_CONSTS_BASE(thr->heap, f);
 	tv_end = DUK_HCOMPFUNC_GET_CONSTS_END(thr->heap, f);

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -767,12 +767,6 @@ strings:
   - str: "\u00ffVarmap"
     duktape: true
     internal: true
-  - str: "\u00ffLexenv"
-    duktape: true
-    internal: true
-  - str: "\u00ffVarenv"
-    duktape: true
-    internal: true
   - str: "\u00ffSource"
     duktape: true
     internal: true
@@ -798,6 +792,9 @@ strings:
     duktape: true
     internal: true
   - str: "\u00ffCallee"
+    duktape: true
+    internal: true
+  - str: "\u00ffVarenv"
     duktape: true
     internal: true
 


### PR DESCRIPTION
Scope pointers are currently internal properties of Ecmascript functions. Because they're nearly always needed, being explicit properties has unnecessary property overhead for both reading and writing them, and for RAM footprint. Add explicit lexenv/varenv fields into `duk_hcompfunc`.

- [x] Add the fields and make related call handling etc changes
- [x] Debugger changes (artificial properties)
- [x] Test artificial properties manually
- [x] Internal debug print macro fixes
- [x] Compress pointers
- [x] Fix duk_hcompfunc data != NULL assumptions #1144
- [x] Performance test => negligible change
- [x] Releases entry

Fixes #1144.