### PR TITLE
Allow dropping of _Varmap when only safe slow path variable reads are present

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2146,7 +2146,9 @@ Planned
   internal value stack access improvements (GH-1058); shared bitpacked string
   format for heap and thread initialization data (GH-1119); explicit
   lexenv/varenv fields in duk_hcompfunc struct (GH-1132); omit duk_hcompfunc
-  _Formals array when it is safe to do so (GH-1141)
+  _Formals array when it is safe to do so (GH-1141); omit duk_hcompfunc
+  _Varmap in more cases when it is safe to do so (GH-1146); reduce initial
+  bytecode allocation in Ecmascript compiler for low memory targets (GH-1146)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/doc/testcase-known-issues.yaml
+++ b/doc/testcase-known-issues.yaml
@@ -163,6 +163,10 @@
   test: "test-bi-typedarray-nan-handling.js"
   specialoptions: "NaN sign is platform dependent"
   # No longer relevant (at least with current test runs)
+-
+  test: "test-dev-func-varmap-drop.js"
+  specialoptions: "debugger support must be disabled"
+  # Moved
 
 # API testcase (tests/api/) known issues
 

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -130,7 +130,7 @@ struct duk_compiler_func {
 	duk_hobject *h_argnames;            /* array of formal argument names (-> _Formals) */
 	duk_hobject *h_varmap;              /* variable map for pass 2 (identifier -> register number or null (unmapped)) */
 
-	/* value stack indices for tracking objects */
+	/* Value stack indices for tracking objects. */
 	/* code_idx: not needed */
 	duk_idx_t consts_idx;
 	duk_idx_t funcs_idx;
@@ -140,24 +140,24 @@ struct duk_compiler_func {
 	duk_idx_t argnames_idx;
 	duk_idx_t varmap_idx;
 
-	/* temp reg handling */
+	/* Temp reg handling. */
 	duk_reg_t temp_first;               /* first register that is a temporary (below: variables) */
 	duk_reg_t temp_next;                /* next temporary register to allocate */
 	duk_reg_t temp_max;                 /* highest value of temp_reg (temp_max - 1 is highest used reg) */
 
-	/* shuffle registers if large number of regs/consts */
+	/* Shuffle registers if large number of regs/consts. */
 	duk_reg_t shuffle1;
 	duk_reg_t shuffle2;
 	duk_reg_t shuffle3;
 
-	/* stats for current expression being parsed */
+	/* Stats for current expression being parsed. */
 	duk_int_t nud_count;
 	duk_int_t led_count;
 	duk_int_t paren_level;              /* parenthesis count, 0 = top level */
 	duk_bool_t expr_lhs;                /* expression is left-hand-side compatible */
 	duk_bool_t allow_in;                /* current paren level allows 'in' token */
 
-	/* misc */
+	/* Misc. */
 	duk_int_t stmt_next;                /* statement id allocation (running counter) */
 	duk_int_t label_next;               /* label id allocation (running counter) */
 	duk_int_t catch_depth;              /* catch stack depth */
@@ -170,22 +170,23 @@ struct duk_compiler_func {
 	duk_int_t max_line;
 #endif
 
-	/* status booleans */
-	duk_bool_t is_function;             /* is an actual function (not global/eval code) */
-	duk_bool_t is_eval;                 /* is eval code */
-	duk_bool_t is_global;               /* is global code */
-	duk_bool_t is_setget;               /* is a setter/getter */
-	duk_bool_t is_decl;                 /* is a function declaration (as opposed to function expression) */
-	duk_bool_t is_strict;               /* function is strict */
-	duk_bool_t is_notail;               /* function must not be tail called */
-	duk_bool_t in_directive_prologue;   /* parsing in "directive prologue", recognize directives */
-	duk_bool_t in_scanning;             /* parsing in "scanning" phase (first pass) */
-	duk_bool_t may_direct_eval;         /* function may call direct eval */
-	duk_bool_t id_access_arguments;     /* function refers to 'arguments' identifier */
-	duk_bool_t id_access_slow;          /* function makes one or more slow path accesses */
-	duk_bool_t is_arguments_shadowed;   /* argument/function declaration shadows 'arguments' */
-	duk_bool_t needs_shuffle;           /* function needs shuffle registers */
-	duk_bool_t reject_regexp_in_adv;    /* reject RegExp literal on next advance() call; needed for handling IdentifierName productions */
+	/* Status booleans. */
+	duk_uint8_t is_function;             /* is an actual function (not global/eval code) */
+	duk_uint8_t is_eval;                 /* is eval code */
+	duk_uint8_t is_global;               /* is global code */
+	duk_uint8_t is_setget;               /* is a setter/getter */
+	duk_uint8_t is_decl;                 /* is a function declaration (as opposed to function expression) */
+	duk_uint8_t is_strict;               /* function is strict */
+	duk_uint8_t is_notail;               /* function must not be tail called */
+	duk_uint8_t in_directive_prologue;   /* parsing in "directive prologue", recognize directives */
+	duk_uint8_t in_scanning;             /* parsing in "scanning" phase (first pass) */
+	duk_uint8_t may_direct_eval;         /* function may call direct eval */
+	duk_uint8_t id_access_arguments;     /* function refers to 'arguments' identifier */
+	duk_uint8_t id_access_slow;          /* function makes one or more slow path accesses that won't match own static variables */
+	duk_uint8_t id_access_slow_own;      /* function makes one or more slow path accesses that may match own static variables */
+	duk_uint8_t is_arguments_shadowed;   /* argument/function declaration shadows 'arguments' */
+	duk_uint8_t needs_shuffle;           /* function needs shuffle registers */
+	duk_uint8_t reject_regexp_in_adv;    /* reject RegExp literal on next advance() call; needed for handling IdentifierName productions */
 };
 
 struct duk_compiler_ctx {

--- a/tests/ecmascript/test-arguments-magic-sync.js
+++ b/tests/ecmascript/test-arguments-magic-sync.js
@@ -57,5 +57,5 @@ function f(x) {
 try {
     f(1);
 } catch (e) {
-    print(e);
+    print(e.stack || e);
 }

--- a/tests/ecmascript/test-dev-func-formals-drop.js
+++ b/tests/ecmascript/test-dev-func-formals-drop.js
@@ -5,6 +5,12 @@
  *  is always kept.
  */
 
+/*---
+{
+    "custom": true
+}
+---*/
+
 /*===
 3
 foo bar quux

--- a/tests/ecmascript/test-dev-func-varmap-drop.js
+++ b/tests/ecmascript/test-dev-func-varmap-drop.js
@@ -1,0 +1,222 @@
+/*
+ *  Function _Varmap can be dropped when there can be no runtime need for it.
+ *  Exercise current conditions.  Needs to be executed with debugger support
+ *  disabled (otherwise _Varmap will always be present).
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*@include util-object.js@*/
+
+/*===
+- pr(arg)
+hello
+prop count diff: 0
+- Math.PI
+3.141592653589793
+prop count diff: 0
+3.141592653589793
+prop count diff: 0
+- direct eval
+3.141592653589793
+prop count diff: 2
+3.141592653589793
+prop count diff: 0
+- inner function
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 1
+- try-catch without a slow path access in catch clause
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- try-catch with a slow path access in catch clause
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- with statement without a slow path access
+3.141592653589793
+prop count diff: 0
+3.141592653589793
+prop count diff: 0
+- with statement with a slow path access
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- arguments object access
+3.141592653589793
+object
+prop count diff: 2
+3.141592653589793
+object
+prop count diff: 0
+- test eval creating a local variable for a function without _Varmap
+123
+prop count diff: 2
+123
+prop count diff: 0
+- inner function without varmap, access outer function variables
+123
+prop count diff: 1
+123
+prop count diff: 1
+===*/
+
+function test() {
+    var func;
+    var propsBaseline;
+
+    // Baseline case.
+    func = function foo() {};
+    func();
+    propsBase = getObjectPropertyCount(func);
+    function printPropDiff() {
+        print('prop count diff: ' + (getObjectPropertyCount(func) - propsBase));
+    }
+
+    // Basic case: all identifier accesses are to register variables
+    // and no slow path accesses are made.
+    print('- pr(arg)');
+    func = function foo(pr, arg) { pr(arg); };
+    func(print, 'hello');
+    printPropDiff();
+
+    // Quite basic case: print and Math are slow path accesses that cannot
+    // match statically declared locals.
+    print('- Math.PI');
+    func = function foo(a,b) { print(Math.PI); };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); };
+    func();
+    printPropDiff();
+
+    // Eval in the function might introduce new variable declarations at
+    // run time, so presence of a (direct) eval requires _Varmap.
+    // If there are no register-bound variables in the _Varmap,
+    // it can still be omitted.
+    //
+    // Note that eval() here also causes _Formals to be kept, unless there
+    // are no formal arguments at all.
+    print('- direct eval');
+    func = function foo(a,b) { print(Math.PI); eval(1); };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); eval(1); };
+    func();
+    printPropDiff();
+
+    // Inner functions could potentially need the _Varmap so any inner
+    // function declarations (even if not invoked) cause _Varmap to be
+    // kept at present.  It would be possible to detect if the inner
+    // function(s) actually make any dangerous slow path accesses, and
+    // only keep the outer function's _Varmap if really necessary.
+    // However, the compiler doesn't have enough state right now to do
+    // this.
+    //
+    // Note that an inner function always creates a register based local
+    // variable, so that _Varmap is never empty even if there are no formal
+    // arguments or variable declarations/consts.
+    print('- inner function');
+    func = function foo(a,b) { print(Math.PI); function inner() {}; };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); function inner() {}; };
+    func();
+    printPropDiff();
+
+    // Try-catch statement's catch variable is handled using a dynamic
+    // scope object.  Identifier accesses within the catch block use slow
+    // path access, and for simplicity the _Varmap is kept if any slow
+    // path accesses are made there.  _Varmap could be omitted if the catch
+    // clause doesn't perform a slow path access in practice -- but this
+    // won't happen now because the automatic catch clause prologue will
+    // perform a slow path access to load the catch variable into a register.
+    //
+    // When there are no register-based declarations (no formals, no variables,
+    // no inner functions) _Varmap is still omitted because it is empty.
+    print('- try-catch without a slow path access in catch clause');
+    func = function foo(a,b) { print(Math.PI); try { throw new Error('aiee'); } catch (e) {} };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); try { throw new Error('aiee'); } catch (e) {} };
+    func();
+    printPropDiff();
+
+    // But with a slow path access in the catch clause the _Varmap is
+    // kept, even if there's no way for the catch clause to run.
+    print('- try-catch with a slow path access in catch clause');
+    func = function foo(a,b) { print(Math.PI); try {} catch (e) { print(Math); } };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); try {} catch (e) { print(Math); } };
+    func();
+    printPropDiff();
+
+    // Presence of a with statement alone is not enough to cause _Varmap to be
+    // kept.
+    print('- with statement without a slow path access');
+    func = function foo(a,b) { print(Math.PI); with({}) {} };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); with({}) {} };
+    func();
+    printPropDiff();
+
+    // But any variable access inside the with statement causes _Varmap to
+    // be kept, unless there are no register-bound variables at all.
+    print('- with statement with a slow path access');
+    func = function foo(a,b) { print(Math.PI); with({}) { Math; } };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); with({}) { Math; } };
+    func();
+    printPropDiff();
+
+    // Access to 'arguments' specifically causes _Varmap to be kept.  It's
+    // handled as a special case in the compiler, so also worth testing
+    // separately.
+    print('- arguments object access');
+    func = function foo(a,b) { print(Math.PI); print(typeof arguments); };
+    func();
+    printPropDiff();
+    func = function foo() { print(Math.PI); print(typeof arguments); };
+    func();
+    printPropDiff();
+
+    // Regardless of the optimizations above, eval must be able to create
+    // local variables (even if _Varmap is dropped).  This happens in the
+    // latter case without formals (so that _Formals.length is 0 and there
+    // are no register bound variables).
+    print('- test eval creating a local variable for a function without _Varmap');
+    func = function foo(a,b) { eval('var z = 123;'); print(z); };
+    func();
+    printPropDiff();
+    func = function foo() { eval('var z = 123;'); print(z); };
+    func();
+    printPropDiff();
+
+    // Test that if an inner function has no _Varmap, it can still access
+    // the outer function's varmap.
+    print('- inner function without varmap, access outer function variables');
+    func = function foo(a,b) { var z = 123; function inner() { print(z); } inner(); };
+    func();
+    printPropDiff();
+    func = function foo() { var z = 123; function inner() { print(z); } inner(); };
+    func();
+    printPropDiff();
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/util-object.js
+++ b/tests/ecmascript/util-object.js
@@ -1,0 +1,10 @@
+/* Get object property count using Duktape.info(). */
+function getObjectPropertyCount(obj) {
+    var i = Duktape.info(obj);
+    if (typeof i === 'object' && 6 in i) {
+        return i[6];
+    } else if (typeof i === 'object' && 'enext' in i) {
+        return i.enext;
+    }
+    throw new Error('getObjectPropertyCount() relies on Duktape.info(), cannot parse result');
+}

--- a/tests/knownissues/test-dev-func-varmap-drop-1.txt
+++ b/tests/knownissues/test-dev-func-varmap-drop-1.txt
@@ -1,0 +1,57 @@
+summary: debugger support enabled; affects _Varmap behavior
+---
+- pr(arg)
+hello
+prop count diff: 1
+- Math.PI
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- direct eval
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- inner function
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 1
+- try-catch without a slow path access in catch clause
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- try-catch with a slow path access in catch clause
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- with statement without a slow path access
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- with statement with a slow path access
+3.141592653589793
+prop count diff: 1
+3.141592653589793
+prop count diff: 0
+- arguments object access
+3.141592653589793
+object
+prop count diff: 1
+3.141592653589793
+object
+prop count diff: 0
+- test eval creating a local variable for a function without _Varmap
+123
+prop count diff: 1
+123
+prop count diff: 0
+- inner function without varmap, access outer function variables
+123
+prop count diff: 1
+123
+prop count diff: 1


### PR DESCRIPTION
Currently any slow path variable read in a function (among with other conditions) causes a function's `_Varmap` to be kept. This is necessary in general so that a slow path variable access matches variables declared in a function; in the worst case the declared variables set is dynamic because eval() may introduce new variables.

This can be relaxed so that the _Varmap can be dropped even when there are slow path accesses, provided that the accesses are guaranteed not to match the function's statically declared variables (provided that there are no inner functions or eval()).

For example, if a function accesses `Math.PI` but: (1) doesn't declare `Math`, (2) doesn't call direct eval, and (3) doesn't have inner functions, it's safe to drop _Varmap.

- [x] Add separate compiler tracking state for "slow path, not own static variable" and "slow path, maybe own static variable"
- [x] Add compiler tracking state for "contains one or more try-catch statements" => Existing "catch_depth" is enough.
- [x] Change _Varmap condition
- [x] Change _Formals condition to allow dropping of formals when _Formals.length is zero, as long as _Formals.length == nargs
- [x] Use `duk_uint8_t`s for compiler status flags, reduces code and RAM footprint slightly
- [x] Reduce bytecode buffer preallocation for targets that prefer size (unrelated but implemented at the same time)
- [x] Testcase coverage
- [x] Add test for inner/outer function, with inner function dropping _Varmap but accessing outer function variables
- [x] Releases entry