### PR TITLE
Fix JX/JC handling of array gaps in JSON stringify fast path

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2012,6 +2012,10 @@ Planned
 
 * Add an fmod() self test (GH-1108)
 
+* Fix JSON stringify fastpath handling of array gaps in JX and JC; they
+  incorrectly stringified as 'null' (like in JSON) instead of 'undefined'
+  and '{"_undef":true}' as intended (GH-859, GH-1149)
+
 * Fix duk_hcompfunc 'data' field != NULL assumptions which might lead to
   memory unsafe behavior if Duktape ran out of memory when creating a
   duk_hcompfunc during compilation or function instantiation (GH-1144,

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2503,10 +2503,15 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 				}
 
 				/* Ordinary gap, undefined encodes to 'null' in
-				 * standard JSON (and no JX/JC support here now).
+				 * standard JSON, but JX/JC use their form for
+				 * undefined to better preserve the typing.
 				 */
 				DUK_D(DUK_DPRINT("gap in array, no conflicting inherited property, remain on fast path"));
+#if defined(DUK_USE_JX)
+				DUK__EMIT_STRIDX(js_ctx, js_ctx->stridx_custom_undefined);
+#else
 				DUK__EMIT_STRIDX(js_ctx, DUK_STRIDX_LC_NULL);
+#endif
 				/* fall through */
 
 			 elem_done:
@@ -2861,6 +2866,7 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 	 * combinations properly.
 	 */
 #if defined(DUK_USE_JX) || defined(DUK_USE_JC)
+	js_ctx->stridx_custom_undefined = DUK_STRIDX_LC_NULL;  /* standard JSON; array gaps */
 #if defined(DUK_USE_JX)
 	if (flags & DUK_JSON_FLAG_EXT_CUSTOM) {
 		js_ctx->stridx_custom_undefined = DUK_STRIDX_LC_UNDEFINED;

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2402,6 +2402,15 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 				if (!k) {
 					continue;
 				}
+				if (DUK_HSTRING_HAS_ARRIDX(k)) {
+					/* If an object has array index keys we would need
+					 * to sort them into the ES6 enumeration order to
+					 * be consistent with the slow path.  Abort the fast
+					 * path and handle in the slow path for now.
+					 */
+					DUK_DD(DUK_DDPRINT("property key is an array index, abort fast path"));
+					goto abort_fastpath;
+				}
 				if (!DUK_HOBJECT_E_SLOT_IS_ENUMERABLE(js_ctx->thr->heap, obj, i)) {
 					continue;
 				}

--- a/tests/api/test-def-prop-virtual.c
+++ b/tests/api/test-def-prop-virtual.c
@@ -26,7 +26,7 @@ final top: 0
 *** test_array_length_overwrite_bigger_noforce (duk_safe_call)
 ==> rc=1, result='TypeError: not configurable'
 *** test_array_length_overwrite_bigger_force (duk_safe_call)
-["foo","bar","quux",null,null]
+["foo","bar","quux",undefined,undefined]
 final top: 0
 ==> rc=0, result='undefined'
 *** test_array_length_overwrite_smaller_noforce (duk_safe_call)

--- a/tests/api/test-del-prop.c
+++ b/tests/api/test-del-prop.c
@@ -90,12 +90,12 @@ final top: 3
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
 *** test_delproplstring_a_safecall (duk_safe_call)
 delete obj.nul<NUL>key -> rc=1
-{"foo":"fooval","bar":"barval","123":"123val"}
+{"123":"123val","foo":"fooval","bar":"barval"}
 final top: 3
 ==> rc=0, result='undefined'
 *** test_delproplstring_a (duk_pcall)
 delete obj.nul<NUL>key -> rc=1
-{"foo":"fooval","bar":"barval","123":"123val"}
+{"123":"123val","foo":"fooval","bar":"barval"}
 final top: 3
 ==> rc=0, result='undefined'
 ===*/

--- a/tests/api/test-put-prop.c
+++ b/tests/api/test-put-prop.c
@@ -108,11 +108,11 @@ eval:
 top after eval: 1
 ==> rc=1, result='TypeError: not extensible'
 *** test_putprop_shorthand_a_safecall (duk_safe_call)
-{"foo":123,"bar":123,"2001":234,"nul\u0000key":345}
+{"2001":234,"foo":123,"bar":123,"nul\u0000key":345}
 final top: 1
 ==> rc=0, result='undefined'
 *** test_putprop_shorthand_a (duk_pcall)
-{"foo":123,"bar":123,"2001":234,"nul\u0000key":345}
+{"2001":234,"foo":123,"bar":123,"nul\u0000key":345}
 final top: 1
 ==> rc=0, result='undefined'
 ===*/

--- a/tests/ecmascript/test-bi-duktape-enc-jc.js
+++ b/tests/ecmascript/test-bi-duktape-enc-jc.js
@@ -1,0 +1,18 @@
+/*
+ *  Duktape.enc() JC
+ */
+
+/*===
+[{"_undef":true},null,{"_undef":true},{"_undef":true},{"_undef":true},1,{"_undef":true}]
+===*/
+
+function test() {
+    // Array gaps: '{"_undef":true}'
+    print(Duktape.enc('jc', [ void 0, null,,,, 1,, ]));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-duktape-enc-jx.js
+++ b/tests/ecmascript/test-bi-duktape-enc-jx.js
@@ -1,0 +1,18 @@
+/*
+ *  Duktape.enc() JX
+ */
+
+/*===
+[undefined,null,undefined,undefined,undefined,1,undefined]
+===*/
+
+function test() {
+    // Array gaps: 'undefined'.
+    print(Duktape.enc('jx', [ void 0, null,,,, 1,, ]));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-duktape-json-custom.js
+++ b/tests/ecmascript/test-bi-duktape-json-custom.js
@@ -492,10 +492,10 @@ try {
 
 /*===
 avoid key quotes
-jx {$:true,_:true,a:true,z:true,A:true,Z:true,"0":false,"9":false,"":false}
-jc {"$":true,"_":true,"a":true,"z":true,"A":true,"Z":true,"0":false,"9":false,"":false}
-jx {$$:true,__:true,a$:true,z_:true,A0:true,Z9:true,"0$":false,"1_":false,"2a":false,"3z":false,"4A":false,"5A":false,"60":false,"79":false}
-jc {"$$":true,"__":true,"a$":true,"z_":true,"A0":true,"Z9":true,"0$":false,"1_":false,"2a":false,"3z":false,"4A":false,"5A":false,"60":false,"79":false}
+jx {"0":false,"9":false,$:true,_:true,a:true,z:true,A:true,Z:true,"":false}
+jc {"0":false,"9":false,"$":true,"_":true,"a":true,"z":true,"A":true,"Z":true,"":false}
+jx {"60":false,"79":false,$$:true,__:true,a$:true,z_:true,A0:true,Z9:true,"0$":false,"1_":false,"2a":false,"3z":false,"4A":false,"5A":false}
+jc {"60":false,"79":false,"$$":true,"__":true,"a$":true,"z_":true,"A0":true,"Z9":true,"0$":false,"1_":false,"2a":false,"3z":false,"4A":false,"5A":false}
 jx {test:true,test_key:true,_test_key:true,$test_key:true}
 jc {"test":true,"test_key":true,"_test_key":true,"$test_key":true}
 jx {"%foo":false,"foo%":false,"foo-bar":false,"foo bar":false}


### PR DESCRIPTION
With fast path enabled, array gaps incorrectly serialized as `null` for JX/JC when `undefined` and `{"_undef":true}` should be used (also in Duktape 1.x.).

Also abort JSON fastpath if an object has an array-index key; the fast path doesn't do any property reordering so an array-index key would appear in the internal insertion order rather than the ES6 sorted order. To remain consistent with the slow path, abort the fast path for array-index keys found in non-array objects.

Fixes #859.