### PR TITLE
Fix Array .push() fast path return value

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2126,7 +2126,7 @@ Planned
   build is slightly smaller (GH-903)
 
 * Internal performance improvement: add optional fast path for dense arrays in
-  Array.prototype operations like push() and pop() (GH-584)
+  Array.prototype operations like push() and pop() (GH-584, GH-1154)
 
 * Miscellaneous performance improvements: avoid one extra shift when computing
   reg/const pointers in the bytecode executor (GH-674); avoid value stack for

--- a/doc/test262-known-issues.yaml
+++ b/doc/test262-known-issues.yaml
@@ -83,6 +83,9 @@
   test: "ch15/15.4/15.4.4/15.4.4.15/15.4.4.15-8-9"
   diagnosed: "probably Duktape bug: long array corner cases (C typing?)"
 -
+  test: "ch15/15.4/15.4.4/15.4.4.6/S15.4.4.6_A4_T1"
+  diagnosed: "Array .pop() fast path (can be disabled) ignores inherited array index properties"
+-
   test: "ch15/15.5/15.5.4/15.5.4.7/S15.5.4.7_A1_T11"
   knownissue: "test case relies on locale specific Date format, Duktape uses ISO 8601 for Date toString()"
 -

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -523,6 +523,8 @@ DUK_LOCAL duk_ret_t duk__array_push_fastpath(duk_context *ctx, duk_harray *h_arr
 	len += n;
 	h_arr->length = len;
 
+	DUK_ASSERT((duk_uint_t) len == len);
+	duk_push_uint(ctx, (duk_uint_t) len);
 	return 1;
 }
 #endif  /* DUK_USE_ARRAY_FASTPATH */

--- a/tests/ecmascript/test-bug-array-fastpath-push-retval.js
+++ b/tests/ecmascript/test-bug-array-fastpath-push-retval.js
@@ -1,0 +1,19 @@
+/*
+ *  https://github.com/svaarala/duktape/pull/1154
+ */
+
+/*===
+number 5
+===*/
+
+function test() {
+    var arr = [ 1, 2, 3 ];
+    var ret = arr.push('foo', 'bar');
+    print(typeof ret, ret);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
When Array .push() fastpath was enabled, .push() return value was incorrect (should be new length). This bug was in master but not in Duktape 1.x so no need to backport the fix.