### PR TITLE
Add tooling to validate DUK_USE_xxx options in source code

### DIFF
--- a/config/config-options/DUK_USE_DATE_TZO_GMTIME_S.yaml
+++ b/config/config-options/DUK_USE_DATE_TZO_GMTIME_S.yaml
@@ -1,0 +1,8 @@
+define: DUK_USE_DATE_TZO_GMTIME_S
+introduced: 2.0.0
+default: false
+tags:
+  - date
+  - portability
+description: >
+  Use gmtime_s() to get local time offset at a certain time.

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -520,6 +520,18 @@ def main():
     copy_and_cquote(license_file, os.path.join(tempdir, 'LICENSE.txt.tmp'))
     copy_and_cquote(authors_file, os.path.join(tempdir, 'AUTHORS.rst.tmp'))
 
+    # Scan used stridx, bidx, config options, etc.
+
+    res = exec_get_stdout([
+        sys.executable,
+        os.path.join(script_path, 'scan_used_stridx_bidx.py')
+    ] + glob.glob(os.path.join(srcdir, '*.c')) \
+      + glob.glob(os.path.join(srcdir, '*.h')) \
+      + glob.glob(os.path.join(srcdir, '*.h.in'))
+    )
+    with open(os.path.join(tempdir, 'duk_used_stridx_bidx_defs.json.tmp'), 'wb') as f:
+        f.write(res)
+
     # Create a duk_config.h.
     # XXX: might be easier to invoke genconfig directly, but there are a few
     # options which currently conflict (output file, git commit info, etc).
@@ -572,7 +584,8 @@ def main():
         sys.executable, os.path.join(script_path, 'genconfig.py'),
         '--output', os.path.join(tempdir, 'duk_config.h.tmp'),
         '--output-active-options', os.path.join(tempdir, 'duk_config_active_options.json'),
-        '--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch
+        '--git-commit', git_commit, '--git-describe', git_describe, '--git-branch', git_branch,
+        '--used-stridx-metadata', os.path.join(tempdir, 'duk_used_stridx_bidx_defs.json.tmp')
     ]
     cmd += forward_genconfig_options()
     cmd += [
@@ -616,16 +629,6 @@ def main():
     #
     # There are currently no profile specific variants of strings/builtins, but
     # this will probably change when functions are added/removed based on profile.
-
-    res = exec_get_stdout([
-        sys.executable,
-        os.path.join(script_path, 'scan_used_stridx_bidx.py')
-    ] + glob.glob(os.path.join(srcdir, '*.c')) \
-      + glob.glob(os.path.join(srcdir, '*.h')) \
-      + glob.glob(os.path.join(srcdir, '*.h.in'))
-    )
-    with open(os.path.join(tempdir, 'duk_used_stridx_bidx_defs.json.tmp'), 'wb') as f:
-        f.write(res)
 
     cmd = [
         sys.executable,

--- a/tools/scan_used_stridx_bidx.py
+++ b/tools/scan_used_stridx_bidx.py
@@ -19,10 +19,12 @@ re_str_stridx = re.compile(r'DUK_STRIDX_(\w+)', re.MULTILINE)
 re_str_heap = re.compile(r'DUK_HEAP_STRING_(\w+)', re.MULTILINE)
 re_str_hthread = re.compile(r'DUK_HTHREAD_STRING_(\w+)', re.MULTILINE)
 re_obj_bidx = re.compile(r'DUK_BIDX_(\w+)', re.MULTILINE)
+re_duk_use = re.compile(r'DUK_USE_(\w+)', re.MULTILINE)
 
 def main():
     str_defs = {}
     obj_defs = {}
+    opt_defs = {}
 
     for fn in sys.argv[1:]:
         with open(fn, 'rb') as f:
@@ -35,20 +37,20 @@ def main():
                 str_defs[m.group(1)] = True
             for m in re.finditer(re_obj_bidx, d):
                 obj_defs[m.group(1)] = True
+            for m in re.finditer(re_duk_use, d):
+                opt_defs[m.group(1)] = True
 
-    str_used = []
-    for k in sorted(str_defs.keys()):
-        str_used.append('DUK_STRIDX_' + k)
-
-    obj_used = []
-    for k in sorted(obj_defs.keys()):
-        obj_used.append('DUK_BIDX_' + k)
+    str_used = ['DUK_STRIDX_' + x for x in sorted(str_defs.keys())]
+    obj_used = ['DUK_BIDX_' + x for x in sorted(obj_defs.keys())]
+    opt_used = ['DUK_USE_' + x for x in sorted(opt_defs.keys())]
 
     doc = {
         'used_stridx_defines': str_used,
         'used_bidx_defines': obj_used,
+        'used_duk_use_options': opt_used,
         'count_used_stridx_defines': len(str_used),
-        'count_used_bidx_defines': len(obj_used)
+        'count_used_bidx_defines': len(obj_used),
+        'count_duk_use_options': len(opt_used),
     }
     print(json.dumps(doc, indent=4))
 


### PR DESCRIPTION
Fail if source code uses a `DUK_USE_xxx` define without a metadata file. This protects against typos in config option names which are otherwise very hard to find (some #ifdef will simply never be activated). Also info log about config options still active in metadata (= not removed) but which don't appear in source code at all.

Fix missing metadata file for `DUK_USE_DATE_TZO_GMTIME_S`.