### PR TITLE
Fix bound coroutine resume assert

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1906,7 +1906,7 @@ Planned
   fully implemented and not part of the documented public API (GH-762)
 
 * Allow a bound Ecmascript function as an argument to new Duktape.Thread()
-  (GH-1134)
+  (GH-1134, GH-1157)
 
 * Minor changes to error messages for errors thrown by Duktape internals
   (GH-827, GH-839, GH-840, GH-1016)

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1117,10 +1117,6 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 		           (resumee->callstack + resumee->callstack_top - 2)->idx_retval >= 0);                              /* idx_retval unsigned */
 		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_INACTIVE ||
 		           resumee->callstack_top == 0);                                                                     /* INACTIVE: no activation, single function value on valstack */
-		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_INACTIVE ||
-		           (resumee->valstack_top == resumee->valstack + 1 &&
-		            DUK_TVAL_IS_OBJECT(resumee->valstack_top - 1) &&
-		            DUK_HOBJECT_IS_COMPFUNC(DUK_TVAL_GET_OBJECT(resumee->valstack_top - 1))));
 
 		if (thr->heap->lj.iserror) {
 			/*


### PR DESCRIPTION
Fix a leftover assert from a previous change; resumee can now be a BOUNDFUNC too.