### PR TITLE
Use packed args for internal duk_{get,put,del,has,xdef}_prop_stridx() call sites

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2216,7 +2216,8 @@ Planned
   lexenv/varenv fields in duk_hcompfunc struct (GH-1132); omit duk_hcompfunc
   _Formals array when it is safe to do so (GH-1141); omit duk_hcompfunc
   _Varmap in more cases when it is safe to do so (GH-1146); reduce initial
-  bytecode allocation in Ecmascript compiler for low memory targets (GH-1146)
+  bytecode allocation in Ecmascript compiler for low memory targets (GH-1146);
+  packed arguments for some internal helper calls (GH-1158)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -565,7 +565,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	/* Setup function properties. */
 	tmp32 = DUK_RAW_READ_U32_BE(p);
 	duk_push_u32(ctx, tmp32);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
 
 	p = duk__load_string_raw(ctx, p);  /* -> [ func funcname ] */
 	func_env = thr->builtins[DUK_BIDX_GLOBAL_ENV];
@@ -599,19 +599,19 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	if (need_pop) {
 		duk_pop(ctx);
 	}
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
 
 	p = duk__load_string_raw(ctx, p);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);
 
 	duk_push_object(ctx);
 	duk_dup_m2(ctx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* func.prototype.constructor = func */
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* func.prototype.constructor = func */
 	duk_compact(ctx, -1);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);
 
 	p = duk__load_buffer_raw(ctx, p);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_PC2LINE, DUK_PROPDESC_FLAGS_WC);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_PC2LINE, DUK_PROPDESC_FLAGS_WC);
 
 	duk_push_object(ctx);  /* _Varmap */
 	for (;;) {
@@ -626,7 +626,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 		duk_put_prop(ctx, -3);
 	}
 	duk_compact(ctx, -1);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VARMAP, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VARMAP, DUK_PROPDESC_FLAGS_NONE);
 
 	/* If _Formals wasn't present in the original function, the list
 	 * here will be empty.  Same happens if _Formals was present but
@@ -647,7 +647,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 		duk_pop(ctx);
 	} else {
 		duk_compact(ctx, -1);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_FORMALS, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_FORMALS, DUK_PROPDESC_FLAGS_NONE);
 	}
 
 	/* Return with final function pushed on stack top. */

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -322,8 +322,8 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 			/* Anything else is not constructable. */
 			goto not_constructable;
 		}
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TARGET);  /* -> [... cons target] */
-		duk_remove(ctx, -2);                                  /* -> [... target] */
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TARGET);  /* -> [... cons target] */
+		duk_remove(ctx, -2);                                        /* -> [... target] */
 	}
 	DUK_ASSERT(duk_is_callable(ctx, -1));
 	DUK_ASSERT(duk_is_lightfunc(ctx, -1) ||
@@ -342,7 +342,7 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 
 	/* [... constructor arg1 ... argN final_cons fallback] */
 
-	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_PROTOTYPE);
+	duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_PROTOTYPE);
 	proto = duk_get_hobject(ctx, -1);
 	if (!proto) {
 		DUK_DDD(DUK_DDDPRINT("constructor has no 'prototype' property, or value not an object "
@@ -599,7 +599,7 @@ DUK_INTERNAL void duk_resolve_nonbound_function(duk_context *ctx) {
 			if (!DUK_HOBJECT_IS_CALLABLE(func) || !DUK_HOBJECT_HAS_BOUNDFUNC(func)) {
 				break;
 			}
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TARGET);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TARGET);
 			duk_replace(ctx, -2);
 		} else {
 			break;

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -169,8 +169,8 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 
 	duk_dup_m2(ctx);
 	duk_dup_m3(ctx);
-	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
-	duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
 
 	/* [ ... new_glob new_env ] */
 

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -211,7 +211,7 @@ DUK_EXTERNAL void duk_inspect_callstack_entry(duk_context *ctx, duk_int_t level)
 	duk_push_tval(ctx, &act->tv_func);
 
 	duk_push_uint(ctx, (duk_uint_t) pc);
-	duk_put_prop_stridx(ctx, -3, DUK_STRIDX_PC);
+	duk_put_prop_stridx_short(ctx, -3, DUK_STRIDX_PC);
 
 #if defined(DUK_USE_PC2LINE)
 	line = duk_hobject_pc2line_query(ctx, -1, pc);
@@ -219,9 +219,9 @@ DUK_EXTERNAL void duk_inspect_callstack_entry(duk_context *ctx, duk_int_t level)
 	line = 0;
 #endif
 	duk_push_uint(ctx, (duk_uint_t) line);
-	duk_put_prop_stridx(ctx, -3, DUK_STRIDX_LINE_NUMBER);
+	duk_put_prop_stridx_short(ctx, -3, DUK_STRIDX_LINE_NUMBER);
 
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_LC_FUNCTION);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_LC_FUNCTION);
 	/* Providing access to e.g. act->lex_env would be dangerous: these
 	 * internal structures must never be accessible to the application.
 	 * Duktape relies on them having consistent data, and this consistency

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -61,7 +61,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -73,7 +73,11 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_bool_t *out_has_prop) {
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
+	return duk_get_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+}
+
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_bool_t *out_has_prop) {
 	duk_bool_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -155,7 +159,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
-DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -165,6 +169,10 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
 	return duk__put_prop_shared(ctx, obj_idx, -1);
+}
+
+DUK_INTERNAL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
+	return duk_put_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
 }
 
 DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx) {
@@ -217,7 +225,7 @@ DUK_EXTERNAL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 	return duk_del_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -228,6 +236,12 @@ DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
 	return duk_del_prop(ctx, obj_idx);
 }
+
+#if 0
+DUK_INTERNAL duk_bool_t duk_del_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
+	return duk_del_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+}
+#endif
 
 DUK_EXTERNAL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
@@ -277,7 +291,7 @@ DUK_EXTERNAL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 	return duk_has_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
+DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -288,6 +302,12 @@ DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
 	return duk_has_prop(ctx, obj_idx);
 }
+
+#if 0
+DUK_INTERNAL duk_bool_t duk_has_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
+	return duk_has_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+}
+#endif
 
 /* Define own property without inheritance lookups and such.  This differs from
  * [[DefineOwnProperty]] because special behaviors (like Array 'length') are
@@ -325,7 +345,7 @@ DUK_INTERNAL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_u
 	/* value popped by call */
 }
 
-DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hstring *key;
@@ -343,7 +363,11 @@ DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_
 	/* value popped by call */
 }
 
-DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {
+DUK_INTERNAL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
+	duk_xdef_prop_stridx(ctx, packed_args >> 24, (packed_args >> 8) & 0xffffL, packed_args & 0xffL);
+}
+
+DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hobject *obj;
 	duk_hstring *key;
@@ -367,7 +391,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_i
  * object creation code, function instance creation code, and Function.prototype.bind().
  */
 
-DUK_INTERNAL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_idx, duk_small_int_t stridx) {
+DUK_INTERNAL void duk_xdef_prop_stridx_thrower(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx) {
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);
 	duk_push_hstring_stridx(ctx, stridx);
 	duk_push_hobject_bidx(ctx, DUK_BIDX_TYPE_ERROR_THROWER);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -2647,11 +2647,11 @@ DUK_LOCAL void duk__push_func_from_lightfunc(duk_context *ctx, duk_c_function fu
 	if ((duk_idx_t) lf_len != nargs) {
 		/* Explicit length is only needed if it differs from 'nargs'. */
 		duk_push_int(ctx, (duk_int_t) lf_len);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
 	}
 
 	duk_push_lightfunc_name_raw(ctx, func, lf_flags);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
 
 	nf = duk_known_hnatfunc(ctx, -1);
 	nf->magic = (duk_int16_t) DUK_LFUNC_FLAGS_GET_MAGIC(lf_flags);
@@ -2763,7 +2763,7 @@ DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t idx) {
 	 * ideal, but a write to the internal value is not affected by them.
 	 */
 	duk_dup(ctx, idx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 
  replace_value:
 	duk_replace(ctx, idx);
@@ -3555,12 +3555,12 @@ DUK_EXTERNAL void duk_push_global_object(duk_context *ctx) {
 /* XXX: size optimize */
 DUK_LOCAL void duk__push_stash(duk_context *ctx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE)) {
+	if (!duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE)) {
 		DUK_DDD(DUK_DDDPRINT("creating heap/global/thread stash on first use"));
 		duk_pop(ctx);
 		duk_push_bare_object(ctx);
 		duk_dup_top(ctx);
-		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_C);  /* [ ... parent stash stash ] -> [ ... parent stash ] */
+		duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_C);  /* [ ... parent stash stash ] -> [ ... parent stash ] */
 	}
 	duk_remove(ctx, -2);
 }
@@ -4189,7 +4189,7 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_context *ctx, duk_idx_t idx_buffer,
 		DUK_ASSERT(h_bufobj->is_view == 0);
 		DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
 
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 		duk_compact(ctx, -1);
 	}
 
@@ -4241,7 +4241,7 @@ DUK_EXTERNAL duk_idx_t duk_push_error_object_va_raw(duk_context *ctx, duk_errcod
 	/* ... and its 'message' from an instance property */
 	if (fmt) {
 		duk_push_vsprintf(ctx, fmt, ap);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	} else {
 		/* If no explicit message given, put error code into message field
 		 * (as a number).  This is not fully in keeping with the Ecmascript
@@ -4250,7 +4250,7 @@ DUK_EXTERNAL duk_idx_t duk_push_error_object_va_raw(duk_context *ctx, duk_errcod
 		 * probably more useful than having a separate 'code' property.
 		 */
 		duk_push_int(ctx, err_code);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	}
 
 	/* XXX: .code = err_code disabled, not sure if useful */
@@ -4398,7 +4398,7 @@ DUK_INTERNAL void duk_push_hstring(duk_context *ctx, duk_hstring *h) {
 	duk_push_tval(ctx, &tv);
 }
 
-DUK_INTERNAL void duk_push_hstring_stridx(duk_context *ctx, duk_small_int_t stridx) {
+DUK_INTERNAL void duk_push_hstring_stridx(duk_context *ctx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	DUK_UNREF(thr);
 	DUK_ASSERT(stridx >= 0 && stridx < DUK_HEAP_NUM_STRINGS);

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -62,7 +62,7 @@ DUK_LOCAL duk_uint32_t duk__push_this_obj_len_u32(duk_context *ctx) {
 	/* XXX: push more directly? */
 	(void) duk_push_this_coercible_to_object(ctx);
 	DUK_ASSERT_HOBJECT_VALID(duk_get_hobject(ctx, -1));
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_LENGTH);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_LENGTH);
 	len = duk_to_uint32(ctx, -1);
 
 	/* -> [ ... ToObject(this) ToUint32(length) ] */
@@ -192,7 +192,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_constructor_is_array(duk_context *ctx) {
 
 DUK_INTERNAL duk_ret_t duk_bi_array_prototype_to_string(duk_context *ctx) {
 	(void) duk_push_this_coercible_to_object(ctx);
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_JOIN);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_JOIN);
 
 	/* [ ... this func ] */
 	if (!duk_is_callable(ctx, -1)) {
@@ -302,7 +302,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_concat(duk_context *ctx) {
 	 * is known to be an array, this should be equivalent.
 	 */
 	duk_push_uarridx(ctx, idx_last);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
 
 	DUK_ASSERT_TOP(ctx, n + 1);
 	return 1;
@@ -383,7 +383,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_join_shared(duk_context *ctx) {
 		} else {
 			if (to_locale_string) {
 				duk_to_object(ctx, -1);
-				duk_get_prop_stridx(ctx, -1, DUK_STRIDX_TO_LOCALE_STRING);
+				duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_TO_LOCALE_STRING);
 				duk_insert(ctx, -2);  /* -> [ ... toLocaleString ToObject(val) ] */
 				duk_call_method(ctx, 0);
 			}
@@ -468,7 +468,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_pop(duk_context *ctx) {
 	len = duk__push_this_obj_len_u32(ctx);
 	if (len == 0) {
 		duk_push_int(ctx, 0);
-		duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LENGTH);
+		duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LENGTH);
 		return 0;
 	}
 	idx = len - 1;
@@ -476,7 +476,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_pop(duk_context *ctx) {
 	duk_get_prop_index(ctx, 0, (duk_uarridx_t) idx);
 	duk_del_prop_index(ctx, 0, (duk_uarridx_t) idx);
 	duk_push_u32(ctx, idx);
-	duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LENGTH);
+	duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LENGTH);
 	return 1;
 }
 
@@ -582,7 +582,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_push(duk_context *ctx) {
 
 	duk_push_u32(ctx, len);
 	duk_dup_top(ctx);
-	duk_put_prop_stridx(ctx, -4, DUK_STRIDX_LENGTH);
+	duk_put_prop_stridx_short(ctx, -4, DUK_STRIDX_LENGTH);
 
 	/* [ arg1 ... argN obj length new_length ] */
 	return 1;
@@ -989,7 +989,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_splice(duk_context *ctx) {
 		}
 	}
 	duk_push_u32(ctx, (duk_uint32_t) del_count);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
 
 	/* Steps 12 and 13: reorganize elements to make room for itemCount elements */
 
@@ -1062,7 +1062,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_splice(duk_context *ctx) {
 	 */
 
 	duk_push_u32(ctx, len - del_count + item_count);
-	duk_put_prop_stridx(ctx, -4, DUK_STRIDX_LENGTH);
+	duk_put_prop_stridx_short(ctx, -4, DUK_STRIDX_LENGTH);
 
 	/* result array is already at the top of stack */
 	DUK_ASSERT_TOP(ctx, nargs + 3);
@@ -1176,7 +1176,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_slice(duk_context *ctx) {
 	}
 
 	duk_push_u32(ctx, res_length);
-	duk_xdef_prop_stridx(ctx, 4, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
+	duk_xdef_prop_stridx_short(ctx, 4, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
 
 	DUK_ASSERT_TOP(ctx, 5);
 	return 1;
@@ -1193,7 +1193,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_shift(duk_context *ctx) {
 	len = duk__push_this_obj_len_u32(ctx);
 	if (len == 0) {
 		duk_push_int(ctx, 0);
-		duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LENGTH);
+		duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LENGTH);
 		return 0;
 	}
 
@@ -1218,7 +1218,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_shift(duk_context *ctx) {
 	duk_del_prop_index(ctx, 0, (duk_uarridx_t) (len - 1));
 
 	duk_push_u32(ctx, (duk_uint32_t) (len - 1));
-	duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LENGTH);
+	duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LENGTH);
 
 	DUK_ASSERT_TOP(ctx, 3);
 	return 1;
@@ -1282,7 +1282,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_unshift(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, nargs + 2);
 	duk_push_u32(ctx, len + nargs);
 	duk_dup_top(ctx);  /* -> [ ... ToObject(this) ToUint32(length) final_len final_len ] */
-	duk_put_prop_stridx(ctx, -4, DUK_STRIDX_LENGTH);
+	duk_put_prop_stridx_short(ctx, -4, DUK_STRIDX_LENGTH);
 	return 1;
 }
 
@@ -1510,7 +1510,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_iter_shared(duk_context *ctx) {
 		DUK_ASSERT_TOP(ctx, 5);
 		DUK_ASSERT(duk_is_array(ctx, -1));  /* topmost element is the result array already */
 		duk_push_u32(ctx, res_length);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_W);
 		break;
 	default:
 		DUK_UNREACHABLE();

--- a/src-input/duk_bi_boolean.c
+++ b/src-input/duk_bi_boolean.c
@@ -30,7 +30,7 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_prototype_tostring_shared(duk_context *ctx
 		DUK_ASSERT(h != NULL);
 
 		if (DUK_HOBJECT_GET_CLASS_NUMBER(h) == DUK_HOBJECT_CLASS_BOOLEAN) {
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 			DUK_ASSERT(duk_is_boolean(ctx, -1));
 			goto type_ok;
 		}
@@ -63,7 +63,7 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_constructor(duk_context *ctx) {
 		DUK_HOBJECT_SET_CLASS_NUMBER(h_this, DUK_HOBJECT_CLASS_BOOLEAN);
 
 		duk_dup_0(ctx);  /* -> [ val obj val ] */
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);  /* XXX: proper flags? */
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);  /* XXX: proper flags? */
 	}  /* unbalanced stack */
 
 	return 1;

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -800,7 +800,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 
 			/* Set .buffer to the argument ArrayBuffer. */
 			duk_dup_0(ctx);
-			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 			duk_compact(ctx, -1);
 			return 1;
 		} else if (DUK_HOBJECT_IS_BUFOBJ(h_obj)) {
@@ -901,7 +901,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 
 	/* Set .buffer */
 	duk_dup_m2(ctx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 	duk_compact(ctx, -1);
 
 	/* Copy values, the copy method depends on the arguments.
@@ -1069,7 +1069,7 @@ DUK_INTERNAL duk_ret_t duk_bi_dataview_constructor(duk_context *ctx) {
 	 */
 
 	duk_dup_0(ctx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 	duk_compact(ctx, -1);
 
 	DUK_ASSERT_HBUFOBJ_VALID(h_bufobj);
@@ -1227,7 +1227,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tojson(duk_context *ctx) {
 
 	duk_push_object(ctx);
 	duk_push_hstring_stridx(ctx, DUK_STRIDX_UC_BUFFER);
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_TYPE);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_TYPE);
 
 	DUK_ASSERT_DISABLE((duk_size_t) h_this->length <= (duk_size_t) DUK_UINT32_MAX);
 	h_arr = duk_push_harray_with_size(ctx, (duk_uint32_t) h_this->length);  /* XXX: needs revision with >4G buffers */
@@ -1240,7 +1240,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tojson(duk_context *ctx) {
 	for (i = 0, n = h_this->length; i < n; i++) {
 		DUK_TVAL_SET_U32(tv + i, (duk_uint32_t) buf[i]);  /* no need for decref or incref */
 	}
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_DATA);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_DATA);
 
 	return 1;
 }
@@ -2033,8 +2033,8 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 		 */
 
 		duk_push_this(ctx);
-		if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_LC_BUFFER)) {
-			duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
+		if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_LC_BUFFER)) {
+			duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_LC_BUFFER, DUK_PROPDESC_FLAGS_NONE);
 			duk_pop(ctx);
 		} else {
 			duk_pop_2(ctx);

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -899,7 +899,7 @@ DUK_LOCAL duk_double_t duk__push_this_get_timeval_tzoffset(duk_context *ctx, duk
 		DUK_ERROR_TYPE(thr, "expected Date");
 	}
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 	d = duk_to_number(ctx, -1);
 	duk_pop(ctx);
 
@@ -945,7 +945,7 @@ DUK_LOCAL duk_ret_t duk__set_this_timeval_from_dparts(duk_context *ctx, duk_doub
 	d = duk_bi_date_get_timeval_from_dparts(dparts, flags);
 	duk_push_number(ctx, d);  /* -> [ ... this timeval_new ] */
 	duk_dup_top(ctx);         /* -> [ ... this timeval_new timeval_new ] */
-	duk_put_prop_stridx(ctx, -3, DUK_STRIDX_INT_VALUE);
+	duk_put_prop_stridx_short(ctx, -3, DUK_STRIDX_INT_VALUE);
 
 	/* stack top: new time value, return 1 to allow tail calls */
 	return 1;
@@ -1431,7 +1431,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor(duk_context *ctx) {
 	if (nargs == 0 || !is_cons) {
 		d = duk__timeclip(DUK_USE_DATE_GET_NOW(ctx));
 		duk_push_number(ctx, d);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_W);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_W);
 		if (!is_cons) {
 			/* called as a normal function: return new Date().toString() */
 			duk_to_string(ctx, -1);
@@ -1445,7 +1445,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor(duk_context *ctx) {
 		}
 		d = duk__timeclip(duk_to_number(ctx, 0));
 		duk_push_number(ctx, d);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_W);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_W);
 		return 1;
 	}
 
@@ -1559,7 +1559,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_prototype_to_json(duk_context *ctx) {
 	}
 	duk_pop(ctx);
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_TO_ISO_STRING);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_TO_ISO_STRING);
 	duk_dup_m2(ctx);  /* -> [ O toIsoString O ] */
 	duk_call_method(ctx, 0);
 	return 1;
@@ -1703,7 +1703,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_prototype_set_time(duk_context *ctx) {
 	d = duk__timeclip(duk_to_number(ctx, 0));
 	duk_push_number(ctx, d);
 	duk_dup_top(ctx);
-	duk_put_prop_stridx(ctx, -3, DUK_STRIDX_INT_VALUE); /* -> [ timeval this timeval ] */
+	duk_put_prop_stridx_short(ctx, -3, DUK_STRIDX_INT_VALUE); /* -> [ timeval this timeval ] */
 
 	return 1;
 }

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -57,12 +57,12 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
 		 * be deleted.
 		 */
 		duk_set_top(ctx, 2);
-		(void) duk_put_prop_stridx(ctx, 0, DUK_STRIDX_INT_FINALIZER);
+		(void) duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_FINALIZER);
 		return 0;
 	} else {
 		/* Get. */
 		DUK_ASSERT(duk_get_top(ctx) == 1);
-		duk_get_prop_stridx(ctx, 0, DUK_STRIDX_INT_FINALIZER);
+		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_FINALIZER);
 		return 1;
 	}
 }

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -29,7 +29,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_constructor_shared(duk_context *ctx) {
 	if (!duk_is_undefined(ctx, 0)) {
 		duk_to_string(ctx, 0);
 		duk_dup_0(ctx);  /* [ message error message ] */
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	}
 
 	/* Augment the error if called as a normal function.  __FILE__ and __LINE__
@@ -53,7 +53,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx) {
 
 	/* [ ... this ] */
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_NAME);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_NAME);
 	if (duk_is_undefined(ctx, -1)) {
 		duk_pop(ctx);
 		duk_push_string(ctx, "Error");
@@ -67,7 +67,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx) {
 	 * accident or are they actually needed?  The first ToString()
 	 * could conceivably return 'undefined'.
 	 */
-	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE);
+	duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE);
 	if (duk_is_undefined(ctx, -1)) {
 		duk_pop(ctx);
 		duk_push_string(ctx, "");
@@ -131,7 +131,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 	DUK_UNREF(thr);
 
 	duk_push_this(ctx);
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TRACEDATA);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TRACEDATA);
 	idx_td = duk_get_top_index(ctx);
 
 	duk_push_hstring_stridx(ctx, DUK_STRIDX_NEWLINE_4SPACE);
@@ -172,8 +172,8 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_context *ctx, duk_small_int_t o
 
 				h_func = duk_get_hobject(ctx, -2);  /* NULL for lightfunc */
 
-				duk_get_prop_stridx(ctx, -2, DUK_STRIDX_NAME);
-				duk_get_prop_stridx(ctx, -3, DUK_STRIDX_FILE_NAME);
+				duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME);
+				duk_get_prop_stridx_short(ctx, -3, DUK_STRIDX_FILE_NAME);
 
 #if defined(DUK_USE_PC2LINE)
 				line = duk_hobject_pc2line_query(ctx, -4, (duk_uint_fast32_t) pc);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -128,7 +128,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_to_string(duk_context *ctx) {
 		 * if the name contained a suitable prefix followed by '//' it
 		 * might cause the result to parse without error.
 		 */
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_NAME);
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_NAME);
 		if (duk_is_undefined(ctx, -1)) {
 			func_name = "";
 		} else {
@@ -222,6 +222,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 		DUK_DDD(DUK_DDDPRINT("argArray is an object"));
 
 		/* XXX: make this an internal helper */
+		DUK_ASSERT(idx_args >= 0 && idx_args <= 0x7fffL);  /* short variants would work, but avoid shifting */
 		duk_get_prop_stridx(ctx, idx_args, DUK_STRIDX_LENGTH);
 		len = (duk_idx_t) duk_to_uint32(ctx, -1);  /* ToUint32() coercion required */
 		duk_pop(ctx);
@@ -333,10 +334,10 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
 	duk_dup_m2(ctx);  /* func */
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_dup_0(ctx);   /* thisArg */
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_push_array(ctx);
 
@@ -346,7 +347,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 		duk_dup(ctx, 1 + i);
 		duk_put_prop_index(ctx, -2, i);
 	}
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_ARGS, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_ARGS, DUK_PROPDESC_FLAGS_NONE);
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
 
@@ -363,14 +364,14 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 	    DUK_HOBJECT_GET_CLASS_NUMBER(h_target) == DUK_HOBJECT_CLASS_FUNCTION) {
 		/* For lightfuncs, simply read the virtual property. */
 		duk_int_t tmp;
-		duk_get_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH);
+		duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH);
 		tmp = duk_to_int(ctx, -1) - (nargs - 1);  /* step 15.a */
 		duk_pop(ctx);
 		duk_push_int(ctx, (tmp < 0 ? 0 : tmp));
 	} else {
 		duk_push_int(ctx, 0);
 	}
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);  /* attrs in E5 Section 15.3.5.1 */
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);  /* attrs in E5 Section 15.3.5.1 */
 
 	/* caller and arguments must use the same thrower, [[ThrowTypeError]] */
 	duk_xdef_prop_stridx_thrower(ctx, -1, DUK_STRIDX_CALLER);
@@ -379,7 +380,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 	/* these non-standard properties are copied for convenience */
 	/* XXX: 'copy properties' API call? */
 	duk_push_string(ctx, "bound ");  /* ES6 19.2.3.2. */
-	duk_get_prop_stridx(ctx, -3, DUK_STRIDX_NAME);
+	duk_get_prop_stridx_short(ctx, -3, DUK_STRIDX_NAME);
 	if (!duk_is_string(ctx, -1)) {
 		/* ES6 has requirement to check that .name of target is a string
 		 * (also must check for Symbol); if not, targetName should be the
@@ -389,9 +390,9 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_context *ctx) {
 		duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);
 	}
 	duk_concat(ctx, 2);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_WC);
-	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_WC);
+	duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_FILE_NAME);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC);
 
 	/* The 'strict' flag is copied to get the special [[Get]] of E5.1
 	 * Section 15.3.5.4 to apply when a 'caller' value is a strict bound

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1961,7 +1961,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 	if (duk_check_type_mask(ctx, -1, DUK_TYPE_MASK_OBJECT |
 	                                 DUK_TYPE_MASK_LIGHTFUNC |
 	                                 DUK_TYPE_MASK_BUFFER)) {
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_TO_JSON);
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_TO_JSON);
 		if (duk_is_callable(ctx, -1)) {  /* toJSON() can also be a lightfunc */
 			DUK_DDD(DUK_DDDPRINT("value is object, has callable toJSON() -> call it"));
 			/* XXX: duk_dup_unvalidated(ctx, -2) etc. */
@@ -2038,7 +2038,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 #endif
 		case DUK_HOBJECT_CLASS_BOOLEAN: {
 			DUK_DDD(DUK_DDDPRINT("value is a Boolean/Buffer/Pointer object -> get internal value"));
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 			duk_remove(ctx, -2);
 			break;
 		}
@@ -2789,7 +2789,7 @@ void duk_bi_json_parse_helper(duk_context *ctx,
 
 		duk_push_object(ctx);
 		duk_dup_m2(ctx);  /* -> [ ... val root val ] */
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_EMPTY_STRING);  /* default attrs ok */
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_EMPTY_STRING);  /* default attrs ok */
 		duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);  /* -> [ ... val root "" ] */
 
 		DUK_DDD(DUK_DDDPRINT("start reviver walk, root=%!T, name=%!T",
@@ -3091,7 +3091,7 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 
 	idx_holder = duk_push_object(ctx);
 	duk_dup(ctx, idx_value);
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_EMPTY_STRING);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_EMPTY_STRING);
 
 	DUK_DDD(DUK_DDDPRINT("before: flags=0x%08lx, loop=%!T, replacer=%!O, "
 	                     "proplist=%!T, gap=%!O, holder=%!T",

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -24,7 +24,7 @@ DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_context *ctx) {
 		DUK_DDD(DUK_DDDPRINT("unacceptable this value: %!T", (duk_tval *) duk_get_tval(ctx, -1)));
 		DUK_ERROR_TYPE((duk_hthread *) ctx, "number expected");
 	}
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 	DUK_ASSERT(duk_is_number(ctx, -1));
 	DUK_DDD(DUK_DDDPRINT("number object: %!T, internal value: %!T",
 	                     (duk_tval *) duk_get_tval(ctx, -2), (duk_tval *) duk_get_tval(ctx, -1)));
@@ -83,7 +83,7 @@ DUK_INTERNAL duk_ret_t duk_bi_number_constructor(duk_context *ctx) {
 	DUK_ASSERT(DUK_HOBJECT_HAS_EXTENSIBLE(h_this));
 
 	duk_dup_0(ctx);  /* -> [ val obj val ] */
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	return 0;  /* no return value -> don't replace created value */
 }
 

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -302,7 +302,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_sealed_frozen_shared(duk_con
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_locale_string(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 0);
 	(void) duk_push_this_coercible_to_object(ctx);
-	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_TO_STRING);
+	duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_TO_STRING);
 #if 0  /* This is mentioned explicitly in the E5.1 spec, but duk_call_method() checks for it in practice. */
 	duk_require_callable(ctx, 1);
 #endif
@@ -687,7 +687,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 	}
 
 	duk_push_hobject(ctx, h_proxy_handler);
-	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_OWN_KEYS)) {
+	if (!duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_OWN_KEYS)) {
 		/* Careful with reachability here: don't pop 'obj' before pushing
 		 * proxy target.
 		 */

--- a/src-input/duk_bi_pointer.c
+++ b/src-input/duk_bi_pointer.c
@@ -29,7 +29,7 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_constructor(duk_context *ctx) {
 
 		/* Pointer object internal value is immutable */
 		duk_dup_0(ctx);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	}
 	/* Note: unbalanced stack on purpose */
 
@@ -59,7 +59,7 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_prototype_tostring_shared(duk_context *ctx
 			goto type_error;
 		}
 
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 	} else {
 		goto type_error;
 	}

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -116,11 +116,11 @@ DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
 
 	/* Proxy target */
 	duk_dup_0(ctx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
 
 	/* Proxy handler */
 	duk_dup_1(ctx);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_HANDLER, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_HANDLER, DUK_PROPDESC_FLAGS_NONE);
 
 	return 1;  /* replacement handler */
 

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -43,7 +43,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 	    DUK_HOBJECT_GET_CLASS_NUMBER(h_pattern) == DUK_HOBJECT_CLASS_REGEXP) {
 		if (duk_is_undefined(ctx, 1)) {
 			duk_bool_t flag_g, flag_i, flag_m;
-			duk_get_prop_stridx(ctx, 0, DUK_STRIDX_SOURCE);
+			duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_SOURCE);
 			flag_g = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_GLOBAL, NULL);
 			flag_i = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_IGNORE_CASE, NULL);
 			flag_m = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_MULTILINE, NULL);
@@ -148,8 +148,8 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_to_string(duk_context *ctx) {
 
 	/* [ regexp ] */
 
-	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_SOURCE);
-	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_INT_BYTECODE);
+	duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_SOURCE);
+	duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_BYTECODE);
 	h_bc = duk_require_hstring(ctx, -1);
 	DUK_ASSERT(h_bc != NULL);
 	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(h_bc) >= 1);

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -41,7 +41,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_constructor(duk_context *ctx) {
 
 		/* String object internal value is immutable */
 		duk_dup_0(ctx);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	}
 	/* Note: unbalanced stack on purpose */
 
@@ -140,7 +140,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_to_string(duk_context *ctx) {
 			goto type_error;
 		}
 
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VALUE);
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
 		DUK_ASSERT(duk_is_string(ctx, -1));
 
 		return 1;
@@ -507,7 +507,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 		if (is_global) {
 			/* start match from beginning */
 			duk_push_int(ctx, 0);
-			duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+			duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 		}
 #else  /* DUK_USE_REGEXP_SUPPORT */
 		DUK_DCERROR_UNSUPPORTED(thr);
@@ -572,7 +572,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 				break;
 			}
 
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INDEX);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INDEX);
 			DUK_ASSERT(duk_is_number(ctx, -1));
 			match_start_coff = duk_get_int(ctx, -1);
 			duk_pop(ctx);
@@ -588,13 +588,13 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 				 */
 				duk_uint32_t last_index;
 
-				duk_get_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+				duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 				last_index = (duk_uint32_t) duk_get_uint(ctx, -1);
 				DUK_DDD(DUK_DDDPRINT("empty match, bump lastIndex: %ld -> %ld",
 				                     (long) last_index, (long) (last_index + 1)));
 				duk_pop(ctx);
 				duk_push_int(ctx, last_index + 1);
-				duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+				duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 			}
 
 			DUK_ASSERT(duk_get_length(ctx, -1) <= DUK_INT_MAX);  /* string limits */
@@ -935,7 +935,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 			}
 			matched = 1;
 
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INDEX);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INDEX);
 			DUK_ASSERT(duk_is_number(ctx, -1));
 			match_start_coff = duk_get_int(ctx, -1);
 			match_start_boff = duk_heap_strcache_offset_char2byte(thr, h_input, match_start_coff);
@@ -947,7 +947,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 				break;
 			}
 
-			duk_get_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+			duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 			DUK_ASSERT(duk_is_number(ctx, -1));
 			match_end_coff = duk_get_int(ctx, -1);
 			match_end_boff = duk_heap_strcache_offset_char2byte(thr, h_input, match_end_coff);
@@ -956,7 +956,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 			/* empty match -> bump and continue */
 			if (prev_match_end_boff == match_end_boff) {
 				duk_push_int(ctx, match_end_coff + 1);
-				duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+				duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 				duk_pop(ctx);
 				continue;
 			}
@@ -1182,7 +1182,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_search(duk_context *ctx) {
 		return 1;
 	}
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INDEX);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INDEX);
 	DUK_ASSERT(duk_is_number(ctx, -1));
 	return 1;
 }
@@ -1216,7 +1216,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
 	/* [ regexp string ] */
 
 	duk_push_int(ctx, 0);
-	duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+	duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 	duk_push_array(ctx);
 
 	/* [ regexp string res_arr ] */
@@ -1236,7 +1236,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
 			break;
 		}
 
-		duk_get_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 		DUK_ASSERT(duk_is_number(ctx, -1));
 		this_index = duk_get_int(ctx, -1);
 		duk_pop(ctx);
@@ -1244,7 +1244,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_match(duk_context *ctx) {
 		if (this_index == prev_last_index) {
 			this_index++;
 			duk_push_int(ctx, this_index);
-			duk_put_prop_stridx(ctx, 0, DUK_STRIDX_LAST_INDEX);
+			duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_LAST_INDEX);
 		}
 		prev_last_index = this_index;
 

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1047,9 +1047,9 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 
 	if (duk_is_error(ctx, -1)) {
 		/* Error instance, use augmented error data directly */
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_FILE_NAME);
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_FILE_NAME);
 		duk__debug_write_hstring_safe_top(thr);
-		duk_get_prop_stridx(ctx, -2, DUK_STRIDX_LINE_NUMBER);
+		duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_LINE_NUMBER);
 		duk_debug_write_uint(thr, duk_get_uint(ctx, -1));
 	} else {
 		/* For anything other than an Error instance, we calculate the error
@@ -1403,9 +1403,9 @@ DUK_LOCAL void duk__debug_handle_get_call_stack(duk_hthread *thr, duk_heap *heap
 			 * value stack operations.
 			 */
 			duk_push_tval(ctx, &curr_act->tv_func);
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_FILE_NAME);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_FILE_NAME);
 			duk__debug_write_hstring_safe_top(thr);
-			duk_get_prop_stridx(ctx, -2, DUK_STRIDX_NAME);
+			duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME);
 			duk__debug_write_hstring_safe_top(thr);
 			pc = duk_hthread_get_act_curr_pc(thr, curr_act);
 			if (i != curr_thr->callstack_top - 1 && pc > 0) {
@@ -1447,7 +1447,7 @@ DUK_LOCAL void duk__debug_handle_get_locals(duk_hthread *thr, duk_heap *heap) {
 	 */
 
 	duk_push_tval(ctx, &curr_act->tv_func);
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VARMAP);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VARMAP);
 	if (duk_is_object(ctx, -1)) {
 		duk_enum(ctx, -1, 0 /*enum_flags*/);
 		while (duk_next(ctx, -1 /*enum_index*/, 0 /*get_value*/)) {

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -297,7 +297,7 @@ DUK_LOCAL void duk__add_traceback(duk_hthread *thr, duk_hthread *thr_callstack, 
 
 	/* [ ... error arr ] */
 
-	duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INT_TRACEDATA);  /* -> [ ... error ] */
+	duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INT_TRACEDATA);  /* -> [ ... error ] */
 }
 #endif  /* DUK_USE_TRACEBACKS */
 
@@ -378,7 +378,7 @@ DUK_LOCAL void duk__add_fileline(duk_hthread *thr, duk_hthread *thr_callstack, c
 
 			/* [ ... error func ] */
 
-			duk_get_prop_stridx(ctx, -1, DUK_STRIDX_FILE_NAME);
+			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_FILE_NAME);
 			if (!duk_is_string(ctx, -1)) {
 				duk_pop_2(ctx);
 				continue;
@@ -417,8 +417,8 @@ DUK_LOCAL void duk__add_fileline(duk_hthread *thr, duk_hthread *thr_callstack, c
 #if defined(DUK_USE_ASSERTIONS)
 	DUK_ASSERT(duk_get_top(ctx) == entry_top + 2);
 #endif
-	duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC | DUK_PROPDESC_FLAG_NO_OVERWRITE);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LINE_NUMBER, DUK_PROPDESC_FLAGS_WC | DUK_PROPDESC_FLAG_NO_OVERWRITE);
+	duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_WC | DUK_PROPDESC_FLAG_NO_OVERWRITE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LINE_NUMBER, DUK_PROPDESC_FLAGS_WC | DUK_PROPDESC_FLAG_NO_OVERWRITE);
 }
 #endif  /* DUK_USE_AUGMENT_ERROR_CREATE && !DUK_USE_TRACEBACKS */
 
@@ -448,10 +448,10 @@ DUK_LOCAL void duk__add_compiler_error_line(duk_hthread *thr) {
 	DUK_DDD(DUK_DDDPRINT("compile error, before adding line info: %!T",
 	                     (duk_tval *) duk_get_tval(ctx, -1)));
 
-	if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_MESSAGE)) {
+	if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_MESSAGE)) {
 		duk_push_sprintf(ctx, " (line %ld)", (long) thr->compile_ctx->curr_token.start_line);
 		duk_concat(ctx, 2);
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_MESSAGE);
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE);
 	} else {
 		duk_pop(ctx);
 	}

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -111,7 +111,7 @@
 #define DUK_HOBJECT_CLASS_BUFOBJ_MAX           28
 #define DUK_HOBJECT_CLASS_MAX                  28
 
-/* class masks */
+/* Class masks. */
 #define DUK_HOBJECT_CMASK_ALL                  ((1UL << (DUK_HOBJECT_CLASS_MAX + 1)) - 1UL)
 #define DUK_HOBJECT_CMASK_NONE                 (1UL << DUK_HOBJECT_CLASS_NONE)
 #define DUK_HOBJECT_CMASK_ARGUMENTS            (1UL << DUK_HOBJECT_CLASS_ARGUMENTS)
@@ -180,7 +180,7 @@
                                                         DUK_HOBJECT_FLAG_COMPFUNC | \
                                                         DUK_HOBJECT_FLAG_NATFUNC)
 
-/* object has any exotic behavior(s) */
+/* Object has any exotic behavior(s). */
 #define DUK_HOBJECT_EXOTIC_BEHAVIOR_FLAGS      (DUK_HOBJECT_FLAG_EXOTIC_ARRAY | \
                                                 DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS | \
                                                 DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ | \
@@ -189,7 +189,7 @@
                                                 DUK_HOBJECT_FLAG_EXOTIC_PROXYOBJ)
 #define DUK_HOBJECT_HAS_EXOTIC_BEHAVIOR(h)     DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_EXOTIC_BEHAVIOR_FLAGS)
 
-/* object has any virtual properties (not counting Proxy behavior) */
+/* Object has any virtual properties (not counting Proxy behavior). */
 #define DUK_HOBJECT_VIRTUAL_PROPERTY_FLAGS     (DUK_HOBJECT_FLAG_EXOTIC_ARRAY | \
                                                 DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ | \
                                                 DUK_HOBJECT_FLAG_EXOTIC_DUKFUNC | \
@@ -256,7 +256,9 @@
 #define DUK_HOBJECT_CLEAR_EXOTIC_DUKFUNC(h)    DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_DUKFUNC)
 #define DUK_HOBJECT_CLEAR_EXOTIC_PROXYOBJ(h)   DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_PROXYOBJ)
 
-/* flags used for property attributes in duk_propdesc and packed flags */
+/* Flags used for property attributes in duk_propdesc and packed flags.
+ * Must fit into 8 bits.
+ */
 #define DUK_PROPDESC_FLAG_WRITABLE              (1 << 0)    /* E5 Section 8.6.1 */
 #define DUK_PROPDESC_FLAG_ENUMERABLE            (1 << 1)    /* E5 Section 8.6.1 */
 #define DUK_PROPDESC_FLAG_CONFIGURABLE          (1 << 2)    /* E5 Section 8.6.1 */
@@ -269,12 +271,12 @@
                                                  DUK_PROPDESC_FLAG_CONFIGURABLE | \
                                                  DUK_PROPDESC_FLAG_ACCESSOR)
 
-/* additional flags which are passed in the same flags argument as property
+/* Additional flags which are passed in the same flags argument as property
  * flags but are not stored in object properties.
  */
 #define DUK_PROPDESC_FLAG_NO_OVERWRITE          (1 << 4)    /* internal define property: skip write silently if exists */
 
-/* convenience */
+/* Convenience defines for property attributes. */
 #define DUK_PROPDESC_FLAGS_NONE                 0
 #define DUK_PROPDESC_FLAGS_W                    (DUK_PROPDESC_FLAG_WRITABLE)
 #define DUK_PROPDESC_FLAGS_E                    (DUK_PROPDESC_FLAG_ENUMERABLE)
@@ -286,7 +288,7 @@
                                                  DUK_PROPDESC_FLAG_ENUMERABLE | \
                                                  DUK_PROPDESC_FLAG_CONFIGURABLE)
 
-/* flags for duk_hobject_get_own_propdesc() and variants */
+/* Flags for duk_hobject_get_own_propdesc() and variants. */
 #define DUK_GETDESC_FLAG_PUSH_VALUE          (1 << 0)  /* push value to stack */
 #define DUK_GETDESC_FLAG_IGNORE_PROTOLOOP    (1 << 1)  /* don't throw for prototype loop */
 

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -287,11 +287,11 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	 * real object to check against.
 	 */
 	duk_push_hobject(ctx, enum_target);
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_INT_TARGET);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_TARGET);
 
 	/* Initialize index so that we skip internal control keys. */
 	duk_push_int(ctx, DUK__ENUM_START_INDEX);
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_INT_NEXT);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_NEXT);
 
 	/*
 	 *  Proxy object handling
@@ -315,7 +315,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	 */
 	DUK_DDD(DUK_DDDPRINT("proxy enumeration"));
 	duk_push_hobject(ctx, h_proxy_handler);
-	if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_OWN_KEYS)) {
+	if (!duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_OWN_KEYS)) {
 		/* No need to replace the 'enum_target' value in stack, only the
 		 * enum_target reference.  This also ensures that the original
 		 * enum target is reachable, which keeps the proxy and the proxy
@@ -326,7 +326,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 		enum_target = h_proxy_target;
 
 		duk_push_hobject(ctx, enum_target);  /* -> [ ... enum_target res handler undefined target ] */
-		duk_put_prop_stridx(ctx, -4, DUK_STRIDX_INT_TARGET);
+		duk_put_prop_stridx_short(ctx, -4, DUK_STRIDX_INT_TARGET);
 
 		duk_pop_2(ctx);  /* -> [ ... enum_target res ] */
 		goto skip_proxy;
@@ -645,7 +645,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 	e = duk_require_hobject(ctx, -1);
 
 	/* XXX use get tval ptr, more efficient */
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_NEXT);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_NEXT);
 	idx = (duk_uint_fast32_t) duk_require_uint(ctx, -1);
 	duk_pop(ctx);
 	DUK_DDD(DUK_DDDPRINT("enumeration: index is: %ld", (long) idx));
@@ -655,7 +655,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 	 * be the proxy, and checking key existence against the proxy is not
 	 * required (or sensible, as the keys may be fully virtual).
 	 */
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TARGET);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TARGET);
 	enum_target = duk_require_hobject(ctx, -1);
 	DUK_ASSERT(enum_target != NULL);
 #if defined(DUK_USE_ES6_PROXY)
@@ -699,7 +699,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 	DUK_DDD(DUK_DDDPRINT("enumeration: updating next index to %ld", (long) idx));
 
 	duk_push_u32(ctx, (duk_uint32_t) idx);
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_INT_NEXT);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_NEXT);
 
 	/* [... enum] */
 

--- a/src-input/duk_hobject_finalizer.c
+++ b/src-input/duk_hobject_finalizer.c
@@ -36,7 +36,7 @@ DUK_LOCAL duk_ret_t duk__finalize_helper(duk_context *ctx, void *udata) {
 	 * a Proxy.
 	 */
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_FINALIZER);  /* -> [... obj finalizer] */
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_FINALIZER);  /* -> [... obj finalizer] */
 	if (!duk_is_callable(ctx, -1)) {
 		DUK_DDD(DUK_DDDPRINT("-> no finalizer or finalizer not callable"));
 		return 0;

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -459,7 +459,7 @@ DUK_LOCAL duk_bool_t duk__proxy_check_prop(duk_hthread *thr, duk_hobject *obj, d
 
 	duk_require_stack(ctx, DUK__VALSTACK_PROXY_LOOKUP);
 	duk_push_hobject(ctx, h_handler);
-	if (duk_get_prop_stridx(ctx, -1, stridx_trap)) {
+	if (duk_get_prop_stridx_short(ctx, -1, stridx_trap)) {
 		/* -> [ ... handler trap ] */
 		duk_insert(ctx, -2);  /* -> [ ... trap handler ] */
 
@@ -4845,23 +4845,23 @@ DUK_INTERNAL void duk_hobject_object_get_own_property_descriptor(duk_context *ct
 		} else {
 			duk_push_undefined(ctx);
 		}
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_GET);
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_GET);
 		if (pd.set) {
 			duk_push_hobject(ctx, pd.set);
 		} else {
 			duk_push_undefined(ctx);
 		}
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_SET);
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_SET);
 	} else {
 		duk_dup_m2(ctx);
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_VALUE);
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_VALUE);
 		duk_push_boolean(ctx, DUK_PROPDESC_IS_WRITABLE(&pd));
-		duk_put_prop_stridx(ctx, -2, DUK_STRIDX_WRITABLE);
+		duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_WRITABLE);
 	}
 	duk_push_boolean(ctx, DUK_PROPDESC_IS_ENUMERABLE(&pd));
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_ENUMERABLE);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_ENUMERABLE);
 	duk_push_boolean(ctx, DUK_PROPDESC_IS_CONFIGURABLE(&pd));
-	duk_put_prop_stridx(ctx, -2, DUK_STRIDX_CONFIGURABLE);
+	duk_put_prop_stridx_short(ctx, -2, DUK_STRIDX_CONFIGURABLE);
 
 	/* [ ... key value desc ] */
 
@@ -4905,6 +4905,7 @@ void duk_hobject_prepare_property_descriptor(duk_context *ctx,
 	DUK_ASSERT(out_idx_value != NULL);
 	DUK_ASSERT(out_getter != NULL);
 	DUK_ASSERT(out_setter != NULL);
+	DUK_ASSERT(idx_in <= 0x7fffL);  /* short variants would be OK, but not used to avoid shifts */
 
 	/* Must be an object, otherwise TypeError (E5.1 Section 8.10.5, step 1). */
 	idx_in = duk_require_normalize_index(ctx, idx_in);

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -114,8 +114,8 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	DUK_ASSERT(h1 != NULL);
 	duk_dup_m2(ctx);
 	duk_dup_top(ctx);  /* -> [ ... new_global new_globalenv new_global new_global ] */
-	duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
-	duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
+	duk_xdef_prop_stridx_short(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
 
 	duk_hobject_compact_props(thr, h1);
 	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL_ENV] != NULL);
@@ -269,11 +269,11 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 * function.
 			 */
 			duk__push_stridx_or_string(ctx, bd);
-			duk_xdef_prop_stridx(ctx,
-			                     -2,
-			                     DUK_STRIDX_NAME,
-			                     (i == DUK_BIDX_FUNCTION_PROTOTYPE) ?
-			                         DUK_PROPDESC_FLAGS_W : DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx,
+			                           -2,
+			                           DUK_STRIDX_NAME,
+			                           (i == DUK_BIDX_FUNCTION_PROTOTYPE) ?
+			                               DUK_PROPDESC_FLAGS_W : DUK_PROPDESC_FLAGS_NONE);
 
 			/* Almost all global level Function objects are constructable
 			 * but not all: Function.prototype is a non-constructable,
@@ -321,10 +321,10 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 			DUK_ASSERT(class_num != DUK_HOBJECT_CLASS_ARRAY);  /* .length is virtual */
 			duk_push_int(ctx, len);
-			duk_xdef_prop_stridx(ctx,
-			                     -2,
-			                     DUK_STRIDX_LENGTH,
-			                     DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx,
+			                           -2,
+			                           DUK_STRIDX_LENGTH,
+			                           DUK_PROPDESC_FLAGS_NONE);
 		}
 
 		/* enable exotic behaviors last */
@@ -604,10 +604,10 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			/* [ (builtin objects) name func ] */
 
 			duk_push_int(ctx, c_length);
-			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
 
 			duk_dup_m2(ctx);
-			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
 
 			/* XXX: other properties of function instances; 'arguments', 'caller'. */
 
@@ -649,8 +649,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 	 */
 
 #if defined(DUK_USE_DATE_BUILTIN)
-	duk_get_prop_stridx(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_UTC_STRING);
-	duk_xdef_prop_stridx(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_GMT_STRING, DUK_PROPDESC_FLAGS_WC);
+	duk_get_prop_stridx_short(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_UTC_STRING);
+	duk_xdef_prop_stridx_short(ctx, DUK_BIDX_DATE_PROTOTYPE, DUK_STRIDX_TO_GMT_STRING, DUK_PROPDESC_FLAGS_WC);
 #endif
 
 	h = duk_known_hobject(ctx, DUK_BIDX_DOUBLE_ERROR);
@@ -772,7 +772,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 	                DUK_USE_OS_STRING
 			" "
 	                DUK_USE_COMPILER_STRING);
-	duk_xdef_prop_stridx(ctx, DUK_BIDX_DUKTAPE, DUK_STRIDX_ENV, DUK_PROPDESC_FLAGS_WC);
+	duk_xdef_prop_stridx_short(ctx, DUK_BIDX_DUKTAPE, DUK_STRIDX_ENV, DUK_PROPDESC_FLAGS_WC);
 
 	/*
 	 *  Since built-ins are not often extended, compact them.

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -142,7 +142,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	DUK_ASSERT(i_argbase >= 0);
 
 	duk_push_hobject(ctx, func);
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_FORMALS);
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_FORMALS);
 	formals = duk_get_hobject(ctx, -1);
 	if (formals) {
 		n_formals = (duk_idx_t) duk_get_length(ctx, -1);
@@ -383,11 +383,11 @@ DUK_LOCAL void duk__handle_createargs_for_call(duk_hthread *thr,
 
 	/* [ ... arg1 ... argN envobj argobj ] */
 
-	duk_xdef_prop_stridx(ctx,
-	                     -2,
-	                     DUK_STRIDX_LC_ARGUMENTS,
-	                     DUK_HOBJECT_HAS_STRICT(func) ? DUK_PROPDESC_FLAGS_E :   /* strict: non-deletable, non-writable */
-	                                                    DUK_PROPDESC_FLAGS_WE);  /* non-strict: non-deletable, writable */
+	duk_xdef_prop_stridx_short(ctx,
+	                           -2,
+	                           DUK_STRIDX_LC_ARGUMENTS,
+	                           DUK_HOBJECT_HAS_STRICT(func) ? DUK_PROPDESC_FLAGS_E :   /* strict: non-deletable, non-writable */
+	                                                          DUK_PROPDESC_FLAGS_WE);  /* non-strict: non-deletable, writable */
 	/* [ ... arg1 ... argN envobj ] */
 }
 
@@ -470,7 +470,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 
 		/* XXX: duk_get_length? */
 		duk_get_prop_stridx(ctx, idx_func, DUK_STRIDX_INT_ARGS);  /* -> [ ... func this arg1 ... argN _Args ] */
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_LENGTH);          /* -> [ ... func this arg1 ... argN _Args length ] */
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_LENGTH);          /* -> [ ... func this arg1 ... argN _Args length ] */
 		len = (duk_idx_t) duk_require_int(ctx, -1);
 		duk_pop(ctx);
 		for (i = 0; i < len; i++) {

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -861,7 +861,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 		                     (duk_tval *) duk_get_tval(ctx, -1), (long) num_used));
 
 		if (num_used > 0) {
-			duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_VARMAP, DUK_PROPDESC_FLAGS_NONE);
+			duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_VARMAP, DUK_PROPDESC_FLAGS_NONE);
 		} else {
 			DUK_DD(DUK_DDPRINT("varmap is empty after cleanup -> no need to add"));
 			duk_pop(ctx);
@@ -902,13 +902,13 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 
 	if (keep_formals) {
 		duk_dup(ctx, func->argnames_idx);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_FORMALS, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_FORMALS, DUK_PROPDESC_FLAGS_NONE);
 	}
 
 	/* name */
 	if (func->h_name) {
 		duk_push_hstring(ctx, func->h_name);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);
 	}
 
 	/* _Source */
@@ -954,7 +954,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 
 #if 0
 		duk_push_string(ctx, "XXX");
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_SOURCE, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_SOURCE, DUK_PROPDESC_FLAGS_NONE);
 #endif
 	}
 #endif  /* DUK_USE_NONSTD_FUNC_SOURCE_PROPERTY */
@@ -968,7 +968,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 
 		DUK_ASSERT(code_count <= DUK_COMPILER_MAX_BYTECODE_LENGTH);
 		duk_hobject_pc2line_pack(thr, q_instr, (duk_uint_fast32_t) code_count);  /* -> pushes fixed buffer */
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_INT_PC2LINE, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_PC2LINE, DUK_PROPDESC_FLAGS_NONE);
 
 		/* XXX: if assertions enabled, walk through all valid PCs
 		 * and check line mapping.
@@ -983,7 +983,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_boo
 		 */
 
 		duk_push_hstring(ctx, comp_ctx->h_filename);
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_FILE_NAME, DUK_PROPDESC_FLAGS_NONE);
 	}
 
 	DUK_DD(DUK_DDPRINT("converted function: %!ixT",
@@ -6322,7 +6322,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 				duk_hstring *h_funcname;
 
 				duk_get_prop_index(ctx, comp_ctx->curr_func.funcs_idx, fnum * 3);
-				duk_get_prop_stridx(ctx, -1, DUK_STRIDX_NAME);  /* -> [ ... func name ] */
+				duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_NAME);  /* -> [ ... func name ] */
 				h_funcname = duk_known_hstring(ctx, -1);
 
 				DUK_DDD(DUK_DDDPRINT("register function declaration %!O in pass 1, fnum %ld",

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4046,8 +4046,8 @@ DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_th
 				/* [ ... env target ] */
 				/* [ ... env target target ] */
 
-				duk_xdef_prop_stridx(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
-				duk_xdef_prop_stridx(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
+				duk_xdef_prop_stridx_short(thr, -3, DUK_STRIDX_INT_TARGET, DUK_PROPDESC_FLAGS_NONE);
+				duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_THIS, DUK_PROPDESC_FLAGS_NONE);  /* always provideThis=true */
 
 				/* [ ... env ] */
 

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1047,7 +1047,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 
 		/* [ ... lval rval ] */
 
-		duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_TARGET);         /* -> [ ... lval rval new_rval ] */
+		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TARGET);         /* -> [ ... lval rval new_rval ] */
 		duk_replace(ctx, -1);                                        /* -> [ ... lval new_rval ] */
 		func = duk_require_hobject(ctx, -1);
 
@@ -1097,7 +1097,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 	}
 	DUK_ASSERT(val != NULL);  /* Loop doesn't actually rely on this. */
 
-	duk_get_prop_stridx(ctx, -1, DUK_STRIDX_PROTOTYPE);  /* -> [ ... lval rval rval.prototype ] */
+	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_PROTOTYPE);  /* -> [ ... lval rval rval.prototype ] */
 	proto = duk_require_hobject(ctx, -1);
 	duk_pop(ctx);  /* -> [ ... lval rval ] */
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -258,7 +258,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			 * properties in an ancestor are never an issue (they should never be
 			 * e.g. non-writable, but just in case).
 			 */
-			duk_get_prop_stridx(ctx, -2, DUK_STRIDX_NAME);       /* -> [ ... closure template env funcname ] */
+			duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME);       /* -> [ ... closure template env funcname ] */
 			duk_dup_m4(ctx);                                     /* -> [ ... closure template env funcname closure ] */
 			duk_xdef_prop(ctx, -3, DUK_PROPDESC_FLAGS_NONE);     /* -> [ ... closure template env ] */
 			/* env[funcname] = closure */
@@ -324,10 +324,10 @@ void duk_js_push_closure(duk_hthread *thr,
 
 	for (i = 0; i < (duk_small_uint_t) (sizeof(duk__closure_copy_proplist) / sizeof(duk_uint16_t)); i++) {
 		duk_small_int_t stridx = (duk_small_int_t) duk__closure_copy_proplist[i];
-		if (duk_get_prop_stridx(ctx, -1, stridx)) {
+		if (duk_get_prop_stridx_short(ctx, -1, stridx)) {
 			/* [ ... closure template val ] */
 			DUK_DDD(DUK_DDDPRINT("copying property, stridx=%ld -> found", (long) stridx));
-			duk_xdef_prop_stridx(ctx, -3, stridx, DUK_PROPDESC_FLAGS_WC);
+			duk_xdef_prop_stridx_short(ctx, -3, stridx, DUK_PROPDESC_FLAGS_WC);
 		} else {
 			DUK_DDD(DUK_DDDPRINT("copying property, stridx=%ld -> not found", (long) stridx));
 			duk_pop(ctx);
@@ -346,7 +346,7 @@ void duk_js_push_closure(duk_hthread *thr,
 	/* XXX: these lookups should be just own property lookups instead of
 	 * looking up the inheritance chain.
 	 */
-	if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_FORMALS)) {
+	if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_FORMALS)) {
 		/* [ ... closure template formals ] */
 		len_value = (duk_uint_t) duk_get_length(ctx, -1);  /* could access duk_harray directly, not important */
 		DUK_DD(DUK_DDPRINT("closure length from _Formals -> %ld", (long) len_value));
@@ -357,7 +357,7 @@ void duk_js_push_closure(duk_hthread *thr,
 	duk_pop(ctx);
 
 	duk_push_uint(ctx, len_value);  /* [ ... closure template len_value ] */
-	duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_NONE);
 
 	/*
 	 *  "prototype" is, by default, a fresh object with the "constructor"
@@ -378,9 +378,9 @@ void duk_js_push_closure(duk_hthread *thr,
 	if (add_auto_proto) {
 		duk_push_object(ctx);  /* -> [ ... closure template newobj ] */
 		duk_dup_m3(ctx);       /* -> [ ... closure template newobj closure ] */
-		duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* -> [ ... closure template newobj ] */
+		duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* -> [ ... closure template newobj ] */
 		duk_compact(ctx, -1);  /* compact the prototype */
-		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);     /* -> [ ... closure template ] */
+		duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_W);     /* -> [ ... closure template ] */
 	}
 
 	/*
@@ -400,7 +400,7 @@ void duk_js_push_closure(duk_hthread *thr,
 #ifdef DUK_USE_NONSTD_FUNC_CALLER_PROPERTY
 		DUK_DDD(DUK_DDDPRINT("function is non-strict and non-standard 'caller' property in use, add initial 'null' value"));
 		duk_push_null(ctx);
-		duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_CALLER, DUK_PROPDESC_FLAGS_NONE);
+		duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_CALLER, DUK_PROPDESC_FLAGS_NONE);
 #else
 		DUK_DDD(DUK_DDDPRINT("function is non-strict and non-standard 'caller' property not used"));
 #endif
@@ -419,7 +419,7 @@ void duk_js_push_closure(duk_hthread *thr,
 
 	/* [ ... closure template ] */
 
-	if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_NAME)) {
+	if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_NAME)) {
 		/* [ ... closure template name ] */
 		DUK_ASSERT(duk_is_string(ctx, -1));
 	} else {
@@ -427,7 +427,7 @@ void duk_js_push_closure(duk_hthread *thr,
 		duk_pop(ctx);
 		duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);
 	}
-	duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);  /* -> [ ... closure template ] */
+	duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_NONE);  /* -> [ ... closure template ] */
 
 	/*
 	 *  Compact the closure, in most cases no properties will be added later.
@@ -507,11 +507,11 @@ duk_hobject *duk_create_activation_environment_record(duk_hthread *thr,
 
 	if (DUK_HOBJECT_IS_COMPFUNC(func)) {
 		duk_push_hthread(ctx, thr);
-		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INT_THREAD);
+		duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INT_THREAD);
 		duk_push_hobject(ctx, func);
-		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INT_CALLEE);
+		duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INT_CALLEE);
 		duk_push_size_t(ctx, idx_bottom);
-		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INT_REGBASE);
+		duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INT_REGBASE);
 	}
 
 	return env;
@@ -598,19 +598,19 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 	{
 		/* [... env] */
 
-		if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_CALLEE)) {
+		if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_CALLEE)) {
 			DUK_ASSERT(duk_is_object(ctx, -1));
 			DUK_ASSERT(duk_get_hobject(ctx, -1) == (duk_hobject *) func);
 		}
 		duk_pop(ctx);
 
-		if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_THREAD)) {
+		if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_THREAD)) {
 			DUK_ASSERT(duk_is_object(ctx, -1));
 			DUK_ASSERT(duk_get_hobject(ctx, -1) == (duk_hobject *) thr);
 		}
 		duk_pop(ctx);
 
-		if (duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_REGBASE)) {
+		if (duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_REGBASE)) {
 			DUK_ASSERT(duk_is_number(ctx, -1));
 			DUK_ASSERT(duk_get_number(ctx, -1) == (double) regbase);
 		}
@@ -643,7 +643,7 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 
 		/* [... env] */
 
-		if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_CALLEE)) {
+		if (!duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_CALLEE)) {
 			DUK_DDD(DUK_DDDPRINT("env has no callee property, nothing to close; re-delete the control properties just in case"));
 			duk_pop(ctx);
 			goto skip_varmap;
@@ -651,7 +651,7 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 
 		/* [... env callee] */
 
-		if (!duk_get_prop_stridx(ctx, -1, DUK_STRIDX_INT_VARMAP)) {
+		if (!duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VARMAP)) {
 			DUK_DDD(DUK_DDDPRINT("callee has no varmap property, nothing to close; delete the control properties"));
 			duk_pop_2(ctx);
 			goto skip_varmap;
@@ -702,9 +702,9 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 
 	/* [... env] */
 
-	duk_del_prop_stridx(ctx, -1, DUK_STRIDX_INT_CALLEE);
-	duk_del_prop_stridx(ctx, -1, DUK_STRIDX_INT_THREAD);
-	duk_del_prop_stridx(ctx, -1, DUK_STRIDX_INT_REGBASE);
+	duk_del_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_CALLEE);
+	duk_del_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_THREAD);
+	duk_del_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_REGBASE);
 
 	duk_pop(ctx);
 

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -1123,25 +1123,25 @@ DUK_INTERNAL void duk_regexp_create_instance(duk_hthread *thr) {
 	DUK_HOBJECT_SET_CLASS_NUMBER(h, DUK_HOBJECT_CLASS_REGEXP);
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, h, thr->builtins[DUK_BIDX_REGEXP_PROTOTYPE]);
 
-	duk_xdef_prop_stridx(ctx, -3, DUK_STRIDX_INT_BYTECODE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_INT_BYTECODE, DUK_PROPDESC_FLAGS_NONE);
 
 	/* [ ... regexp_object escaped_source ] */
 
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_SOURCE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_SOURCE, DUK_PROPDESC_FLAGS_NONE);
 
 	/* [ ... regexp_object ] */
 
 	duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_GLOBAL));
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_GLOBAL, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_GLOBAL, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_IGNORE_CASE));
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_IGNORE_CASE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_IGNORE_CASE, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_MULTILINE));
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_MULTILINE, DUK_PROPDESC_FLAGS_NONE);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_MULTILINE, DUK_PROPDESC_FLAGS_NONE);
 
 	duk_push_int(ctx, 0);
-	duk_xdef_prop_stridx(ctx, -2, DUK_STRIDX_LAST_INDEX, DUK_PROPDESC_FLAGS_W);
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_LAST_INDEX, DUK_PROPDESC_FLAGS_W);
 
 	/* [ ... regexp_object ] */
 }

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -718,7 +718,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	h_input = duk_get_hstring(ctx, -1);
 	DUK_ASSERT(h_input != NULL);
 
-	duk_get_prop_stridx(ctx, -2, DUK_STRIDX_INT_BYTECODE);  /* [ ... re_obj input ] -> [ ... re_obj input bc ] */
+	duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_INT_BYTECODE);  /* [ ... re_obj input ] -> [ ... re_obj input bc ] */
 	h_bytecode = duk_require_hstring(ctx, -1);  /* no regexp instance should exist without a non-configurable bytecode property */
 	DUK_ASSERT(h_bytecode != NULL);
 
@@ -797,7 +797,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 
 	/* [ ... re_obj input bc saved_buf ] */
 
-	duk_get_prop_stridx(ctx, -4, DUK_STRIDX_LAST_INDEX);  /* -> [ ... re_obj input bc saved_buf lastIndex ] */
+	duk_get_prop_stridx_short(ctx, -4, DUK_STRIDX_LAST_INDEX);  /* -> [ ... re_obj input bc saved_buf lastIndex ] */
 	(void) duk_to_int(ctx, -1);  /* ToInteger(lastIndex) */
 	d = duk_get_number(ctx, -1);  /* integer, but may be +/- Infinite, +/- zero (not NaN, though) */
 	duk_pop(ctx);
@@ -934,10 +934,10 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		/* [ ... re_obj input bc saved_buf res_obj ] */
 
 		duk_push_u32(ctx, char_offset);
-		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INDEX);
+		duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INDEX);
 
 		duk_dup_m4(ctx);
-		duk_xdef_prop_stridx_wec(ctx, -2, DUK_STRIDX_INPUT);
+		duk_xdef_prop_stridx_short_wec(ctx, -2, DUK_STRIDX_INPUT);
 
 		for (i = 0; i < re_ctx.nsaved; i += 2) {
 			/* Captures which are undefined have NULL pointers and are returned
@@ -971,7 +971,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		if (global) {
 			/* global regexp: lastIndex updated on match */
 			duk_push_u32(ctx, char_end_offset);
-			duk_put_prop_stridx(ctx, -6, DUK_STRIDX_LAST_INDEX);
+			duk_put_prop_stridx_short(ctx, -6, DUK_STRIDX_LAST_INDEX);
 		} else {
 			/* non-global regexp: lastIndex never updated on match */
 			;
@@ -990,7 +990,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		/* [ ... re_obj input bc saved_buf res_obj ] */
 
 		duk_push_int(ctx, 0);
-		duk_put_prop_stridx(ctx, -6, DUK_STRIDX_LAST_INDEX);
+		duk_put_prop_stridx_short(ctx, -6, DUK_STRIDX_LAST_INDEX);
 	}
 
 	/* [ ... re_obj input bc saved_buf res_obj ] */


### PR DESCRIPTION
Goal is to reduce footprint for call sites that occur very often. Almost all call sites use a small negative or positive value stack index and a stridx; these can be packed into a 32-bit argument which removes one argument load.

- [x] Check footprint potential
- [x] Check all call sites and ensure arguments are in range (if e.g. value stack index is a variable, may not be able to use internal packed args helper)
- [x] Rename callsites to highlight they expect packed arguments?
- [x] Releases entry