### PR TITLE
Document the change from strict ES5.1 to ES5-ish

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ to call Ecmascript functions from C code and vice versa.
 Main features:
 
 * Embeddable, portable, compact
-* Ecmascript E5/E5.1 compliant, some features implemented from
-  Ecmascript 2015 (E6) and Ecmascript 2016 (E7)
+* Ecmascript E5/E5.1 compliant, with some semantics updated from ES6+
+* Partial support for Ecmascript 2015 (E6) and Ecmascript 2016 (E7)
 * Khronos/ES6 TypedArray and Node.js Buffer bindings
 * WHATWG Encoding API living standard
 * Built-in debugger

--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -6,11 +6,12 @@ Duktape is a small and portable Ecmascript E5/E5.1 implementation.  It is
 intended to be easily embeddable into C programs, with a C API similar in
 spirit to Lua's.
 
-Duktape supports the full E5/E5.1 feature set including errors, Unicode
-strings, and regular expressions, a subset of Ecmascript 2015 (E6) and
-Ecmascript 2016 (E7) features (e.g. computed property names, Proxy objects,
-exponentiation operator, Reflect), Khronos/ES6 ArrayBuffer/TypedView, Node.js
-Buffer, and WHATWG Encoding API living standard.
+Duktape supports the full E5/E5.1 feature set (with some semantics updated
+from ES6+) including errors, Unicode strings, and regular expressions,
+a subset of Ecmascript 2015 (E6) and Ecmascript 2016 (E7) features (e.g.
+computed property names, Proxy objects, exponentiation operator, Reflect),
+Khronos/ES6 ArrayBuffer/TypedView, Node.js Buffer, and WHATWG Encoding API
+living standard.
 
 Duktape also provides a number of custom features such as error tracebacks,
 additional data types for better C integration, combined reference counting

--- a/website/guide/compatibility.html
+++ b/website/guide/compatibility.html
@@ -6,7 +6,9 @@ extensions, frameworks, and test suites.</p>
 <h2 id="compatibility-e5">Ecmascript E5 / E5.1</h2>
 
 <p>The main compatibility goal of Duktape is to be Ecmascript E5/E5.1
-compatible.  Current level of compatibility should be quite high.</p>
+compatible.  However, ES5 feature semantics are updated to ES6 (or
+later) where incompatible changes have been made in newer specification
+versions.  Current level of compatibility should be quite high.</p>
 
 <h2 id="compatibility-e6">Ecmascript 2015 (E6)</h2>
 

--- a/website/guide/intro.html
+++ b/website/guide/intro.html
@@ -40,7 +40,8 @@ Ecmascript throughout to refer to the language implemented by Duktape.</p>
 
 <h2>Conformance</h2>
 
-<p>Duktape conforms to ES5.0/ES5.1:</p>
+<p>Duktape conforms to ES5.0/ES5.1 with semantics updated from ES6 or later
+where appropriate:</p>
 <ul>
 <li><a href="http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf">ECMAScript Language Specification 5th Edition</a></li>
 <li><a href="http://www.ecma-international.org/ecma-262/5.1/">ECMAScript&#x00ae; Language Specification 5.1 Edition</a></li>

--- a/website/index/index.html
+++ b/website/index/index.html
@@ -38,8 +38,9 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
 <ul>
 <li>Embeddable, portable, compact:
     can run on platforms with 192kB flash and 64kB system RAM</li>
-<li><a href="http://www.ecma-international.org/ecma-262/5.1/">Ecmascript E5/E5.1</a>
-    compliant, some features implemented from
+<li><a href="http://www.ecma-international.org/ecma-262/5.1/">Ecmascript E5/E5.1</a>,
+    with some semantics updated from ES6+</li>
+<li>Partial support for
     <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">Ecmascript 2015 (E6)</a> and
     <a href="http://www.ecma-international.org/ecma-262/7.0/index.html">Ecmascript 2016 (E7)</a></li>
 <li>Khronos/ES6 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>


### PR DESCRIPTION
Prior to Duktape 2.x Duktape targeted ES5/ES5.1 as its primary target, with some features borrowed from ES6. However, ES6 and later add new language features but also update existing ES5/ES5.1 features in an incompatible manner. For example, bound function prototype is set differently, Function.prototype.toString() requirements are opposite to ES5.1 when source code is not available, Object built-in coercions have been changed, etc.

To avoid maintaining multiple ES compliance target, Duktape 2.x will target the ES5/ES5.1 feature set along with additions from ES6 and later, but with feature semantics aligned with the latest available specification version. This means that the ES5 subset is no longer strictly ES5 compliant: while it's possible to use config options to remove ES6 functionality, the ES5 functionality that remains will have ES6 or later semantics tweaks. Overall this is consistent with the Ecmascript language as a "living standard".

This pull makes the necessary documentation changes to describe the new compliance goal.

- [x] Add raw text to relevant places
- [x] Typo check and reword