### PR TITLE
ES6 Object constructor coercion cleanups

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1727,9 +1727,13 @@ Planned
   Buffer.prototype.toString() does UTF-8 decoding (previously buffer data
   was copied into internal string representation as is) (GH-1020)
 
-* Incompatible change: ES6 argument policy for Object.keys() etc. Instead of
-  throwing a TypeError, they now either coerce to an object or treat the
-  primitive as a non-extensible object with no properties (GH-1028)
+* Incompatible change: change Object constructor argument coercion policy
+  to match ES6 requirements for .keys(), .getOwnPropertyNames(),
+  .getOwnPropertyDescriptor(), .getPrototypeOf(), .freeze(), .isFrozen(),
+  .seal(), .isSealed(), .preventExtensions(), and .isExtensible();
+  instead of rejecting non-objects with a TypeError, they are now coerced
+  to objects or treated as non-extensible objects with no own properties
+  (GH-1028, GH-1164)
 
 * Incompatible change: plain pointer values now test true in instanceof
   (plainPointer instanceof Duktape.Pointer === true) (GH-864)

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -1066,6 +1066,11 @@ Other incompatible changes
   requirements.  For example ``function foo() {"ecmascript"}`` is now
   ``function foo() { [ecmascript code] }``.
 
+* Object constructor methods like Object.keys(), Object.freeze(), etc now
+  follow more lenient ES6 coercion semantics: non-object arguments are either
+  coerced to objects or treated like non-extensible objects with no own
+  properties.
+
 * Duktape.info() now returns an object rather than an array.  The object has
   named properties like ``.type`` and ``.enext`` for the internal fields which
   is easier to version and work with.  The names of the properties are not

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -216,6 +216,7 @@ DUK_INTERNAL_DECL void duk_require_constructable(duk_context *ctx, duk_idx_t idx
 
 DUK_INTERNAL_DECL void duk_resolve_nonbound_function(duk_context *ctx);
 
+DUK_INTERNAL_DECL duk_idx_t duk_get_top_require_min(duk_context *ctx, duk_idx_t min_top);
 DUK_INTERNAL_DECL duk_idx_t duk_get_top_index_unsafe(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_pop_unsafe(duk_context *ctx);
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -374,6 +374,22 @@ DUK_EXTERNAL duk_idx_t duk_get_top(duk_context *ctx) {
 	return (duk_idx_t) (thr->valstack_top - thr->valstack_bottom);
 }
 
+/* Internal helper to get current top but to require a minimum top value
+ * (TypeError if not met).
+ */
+DUK_INTERNAL duk_idx_t duk_get_top_require_min(duk_context *ctx, duk_idx_t min_top) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_idx_t ret;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	ret = (duk_idx_t) (thr->valstack_top - thr->valstack_bottom);
+	if (ret < min_top) {
+		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+	}
+	return ret;
+}
+
 /* Set stack top within currently allocated range, but don't reallocate.
  * This is performance critical especially for call handling, so whenever
  * changing, profile and look at generated code.

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -36,10 +36,7 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_get(duk_context *ctx) {
 	duk_tval *tv_key;
 	duk_idx_t nargs;
 
-	nargs = duk_get_top(ctx);
-	if (nargs < 2) {
-		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
-	}
+	nargs = duk_get_top_require_min(ctx, 2 /*min_top*/);
 	(void) duk_require_hobject(ctx, 0);
 	(void) duk_to_string(ctx, 1);
 	if (nargs >= 3 && !duk_strict_equals(ctx, 0, 2)) {
@@ -86,10 +83,7 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_set(duk_context *ctx) {
 	duk_idx_t nargs;
 	duk_bool_t ret;
 
-	nargs = duk_get_top(ctx);
-	if (nargs < 3) {
-		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
-	}
+	nargs = duk_get_top_require_min(ctx, 3 /*min_top*/);
 	(void) duk_require_hobject(ctx, 0);
 	(void) duk_to_string(ctx, 1);
 	if (nargs >= 4 && !duk_strict_equals(ctx, 0, 3)) {


### PR DESCRIPTION
- [x] Reword releases entry to list affected functions
- [x] Add 2.0 migration note
- [x] Minor footprint optimization (Object.create() also)