### PR TITLE
Add internal duk_remove_m2() helper for footprint

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2217,7 +2217,8 @@ Planned
   _Formals array when it is safe to do so (GH-1141); omit duk_hcompfunc
   _Varmap in more cases when it is safe to do so (GH-1146); reduce initial
   bytecode allocation in Ecmascript compiler for low memory targets (GH-1146);
-  packed arguments for some internal helper calls (GH-1158)
+  packed arguments for some internal helper calls (GH-1158); misc internal
+  helpers to reduce call site size (GH-1166)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -690,7 +690,7 @@ DUK_EXTERNAL void duk_dump_function(duk_context *ctx) {
 
 	DUK_DD(DUK_DDPRINT("serialized result: %!T", duk_get_tval(ctx, -1)));
 
-	duk_remove(ctx, -2);  /* [ ... func buf ] -> [ ... buf ] */
+	duk_remove_m2(ctx);  /* [ ... func buf ] -> [ ... buf ] */
 }
 
 DUK_EXTERNAL void duk_load_function(duk_context *ctx) {
@@ -726,7 +726,7 @@ DUK_EXTERNAL void duk_load_function(duk_context *ctx) {
 		goto format_error;
 	}
 
-	duk_remove(ctx, -2);  /* [ ... buf func ] -> [ ... func ] */
+	duk_remove_m2(ctx);  /* [ ... buf func ] -> [ ... func ] */
 	return;
 
  format_error:

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -323,7 +323,7 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 			goto not_constructable;
 		}
 		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_TARGET);  /* -> [... cons target] */
-		duk_remove(ctx, -2);                                        /* -> [... target] */
+		duk_remove_m2(ctx);                                         /* -> [... target] */
 	}
 	DUK_ASSERT(duk_is_callable(ctx, -1));
 	DUK_ASSERT(duk_is_lightfunc(ctx, -1) ||
@@ -403,7 +403,7 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 	 */
 
 	if (duk_is_object(ctx, -1)) {
-		duk_remove(ctx, -2);
+		duk_remove_m2(ctx);
 	} else {
 		duk_pop(ctx);
 	}

--- a/src-input/duk_api_compile.c
+++ b/src-input/duk_api_compile.c
@@ -123,7 +123,7 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx, void *udata) {
 	if (flags & DUK_COMPILE_NOSOURCE) {
 		;
 	} else {
-		duk_remove(ctx, -2);
+		duk_remove_m2(ctx);
 	}
 
 	/* [ ... func_template ] */
@@ -134,7 +134,7 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx, void *udata) {
 	                   thr->builtins[DUK_BIDX_GLOBAL_ENV],
 	                   thr->builtins[DUK_BIDX_GLOBAL_ENV],
 	                   1 /*add_auto_proto*/);
-	duk_remove(ctx, -2);   /* -> [ ... closure ] */
+	duk_remove_m2(ctx);   /* -> [ ... closure ] */
 
 	/* [ ... closure ] */
 

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -36,6 +36,8 @@ DUK_INTERNAL_DECL void duk_dup_m2(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_dup_m3(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_dup_m4(duk_context *ctx);
 
+DUK_INTERNAL_DECL void duk_remove_m2(duk_context *ctx);
+
 DUK_INTERNAL_DECL duk_int_t duk_get_type_tval(duk_tval *tv);
 DUK_INTERNAL_DECL duk_uint_t duk_get_type_mask_tval(duk_tval *tv);
 

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -31,7 +31,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx) {
 	DUK_ASSERT(rc == 0 || rc == 1);
 	/* a value is left on stack regardless of rc */
 
-	duk_remove(ctx, -2);  /* remove key */
+	duk_remove_m2(ctx);  /* remove key */
 	return rc;  /* 1 if property found, 0 otherwise */
 }
 
@@ -584,7 +584,7 @@ DUK_EXTERNAL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key)
 
 	duk_push_hobject(ctx, thr->builtins[DUK_BIDX_GLOBAL]);
 	ret = duk_get_prop_string(ctx, -1, key);
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 	return ret;
 }
 
@@ -599,7 +599,7 @@ DUK_EXTERNAL duk_bool_t duk_get_global_lstring(duk_context *ctx, const char *key
 
 	duk_push_hobject(ctx, thr->builtins[DUK_BIDX_GLOBAL]);
 	ret = duk_get_prop_lstring(ctx, -1, key, key_len);
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 	return ret;
 }
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1079,6 +1079,10 @@ DUK_EXTERNAL void duk_remove(duk_context *ctx, duk_idx_t idx) {
 #endif
 }
 
+DUK_INTERNAL_DECL void duk_remove_m2(duk_context *ctx) {
+	duk_remove(ctx, -2);
+}
+
 /*
  *  Stack slice primitives
  */
@@ -3562,7 +3566,7 @@ DUK_LOCAL void duk__push_stash(duk_context *ctx) {
 		duk_dup_top(ctx);
 		duk_xdef_prop_stridx_short(ctx, -3, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_C);  /* [ ... parent stash stash ] -> [ ... parent stash ] */
 	}
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 }
 
 DUK_EXTERNAL void duk_push_heap_stash(duk_context *ctx) {
@@ -3671,7 +3675,7 @@ DUK_EXTERNAL const char *duk_push_vsprintf(duk_context *ctx, const char *fmt, va
 	 */
 	res = duk_push_lstring(ctx, (const char *) buf, (duk_size_t) len);  /* [ buf? res ] */
 	if (pushed_buf) {
-		duk_remove(ctx, -2);
+		duk_remove_m2(ctx);
 	}
 	return res;
 }
@@ -5051,7 +5055,7 @@ DUK_LOCAL const char *duk__push_string_tval_readable(duk_context *ctx, duk_tval 
 			 */
 			duk_push_tval(ctx, tv);
 			duk_push_sprintf(ctx, "(%s)", duk_to_string(ctx, -1));
-			duk_remove(ctx, -2);
+			duk_remove_m2(ctx);
 			break;
 		}
 		default: {

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1968,7 +1968,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 			duk_dup_m2(ctx);          /* -> [ ... key val toJSON val ] */
 			duk_dup_m4(ctx);          /* -> [ ... key val toJSON val key ] */
 			duk_call_method(ctx, 1);  /* -> [ ... key val val' ] */
-			duk_remove(ctx, -2);      /* -> [ ... key val' ] */
+			duk_remove_m2(ctx);       /* -> [ ... key val' ] */
 		} else {
 			duk_pop(ctx);             /* -> [ ... key val ] */
 		}
@@ -1986,7 +1986,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 		duk_dup_m4(ctx);                            /* -> [ ... key val replacer holder key ] */
 		duk_dup_m4(ctx);                            /* -> [ ... key val replacer holder key val ] */
 		duk_call_method(ctx, 2);                    /* -> [ ... key val val' ] */
-		duk_remove(ctx, -2);                        /* -> [ ... key val' ] */
+		duk_remove_m2(ctx);                         /* -> [ ... key val' ] */
 	}
 
 	/* [ ... key val ] */
@@ -2039,7 +2039,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 		case DUK_HOBJECT_CLASS_BOOLEAN: {
 			DUK_DDD(DUK_DDDPRINT("value is a Boolean/Buffer/Pointer object -> get internal value"));
 			duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_VALUE);
-			duk_remove(ctx, -2);
+			duk_remove_m2(ctx);
 			break;
 		}
 		default: {
@@ -2797,7 +2797,7 @@ void duk_bi_json_parse_helper(duk_context *ctx,
 		                     (duk_tval *) duk_get_tval(ctx, -1)));
 
 		duk__dec_reviver_walk(js_ctx);  /* [ ... val root "" ] -> [ ... val val' ] */
-		duk_remove(ctx, -2);            /* -> [ ... val' ] */
+		duk_remove_m2(ctx);             /* -> [ ... val' ] */
 	} else {
 		DUK_DDD(DUK_DDDPRINT("reviver does not exist or is not callable: %!T",
 		                     (duk_tval *) duk_get_tval(ctx, idx_reviver)));

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -28,7 +28,7 @@ DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_context *ctx) {
 	DUK_ASSERT(duk_is_number(ctx, -1));
 	DUK_DDD(DUK_DDDPRINT("number object: %!T, internal value: %!T",
 	                     (duk_tval *) duk_get_tval(ctx, -2), (duk_tval *) duk_get_tval(ctx, -1)));
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 
  done:
 	return duk_get_number(ctx, -1);

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -292,7 +292,7 @@ DUK_LOCAL void duk__add_traceback(duk_hthread *thr, duk_hthread *thr_callstack, 
 	/* [ ... error c_filename? arr ] */
 
 	if (c_filename) {
-		duk_remove(ctx, -2);
+		duk_remove_m2(ctx);
 	}
 
 	/* [ ... error arr ] */

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -357,7 +357,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 	}
 	/* [ ... enum_target res trap_result keys_array ] */
 	duk_pop_2(ctx);
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 
 	/* [ ... res ] */
 
@@ -595,7 +595,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 
 	/* [enum_target res] */
 
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 
 	/* [res] */
 
@@ -709,10 +709,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_context *ctx, duk_bool_t
 			duk_push_hobject(ctx, enum_target);
 			duk_dup_m2(ctx);       /* -> [... enum key enum_target key] */
 			duk_get_prop(ctx, -2); /* -> [... enum key enum_target val] */
-			duk_remove(ctx, -2);   /* -> [... enum key val] */
+			duk_remove_m2(ctx);    /* -> [... enum key val] */
 			duk_remove(ctx, -3);   /* -> [... key val] */
 		} else {
-			duk_remove(ctx, -2);   /* -> [... key] */
+			duk_remove_m2(ctx);    /* -> [... key] */
 		}
 		return 1;
 	} else {
@@ -775,7 +775,7 @@ DUK_INTERNAL duk_ret_t duk_hobject_get_enumerated_keys(duk_context *ctx, duk_sma
 	}
 
 	/* [enum_target enum res] */
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 
 	/* [enum_target res] */
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -1926,7 +1926,7 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 			                     (duk_tval *) duk_get_tval(ctx, -2),
 			                     (duk_tval *) duk_get_tval(ctx, -1)));
 			/* [... old_result result] -> [... result] */
-			duk_remove(ctx, -2);
+			duk_remove_m2(ctx);
 		}
 	}
 
@@ -2500,7 +2500,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 				/* no need for 'caller' post-check, because 'key' must be an array index */
 
-				duk_remove(ctx, -2);  /* [key result] -> [result] */
+				duk_remove_m2(ctx);  /* [key result] -> [result] */
 				return 1;
 			}
 
@@ -2771,7 +2771,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 	}
 #endif   /* !DUK_USE_NONSTD_FUNC_CALLER_PROPERTY */
 
-	duk_remove(ctx, -2);  /* [key result] -> [result] */
+	duk_remove_m2(ctx);  /* [key result] -> [result] */
 
 	DUK_DDD(DUK_DDDPRINT("-> %!T (found)", (duk_tval *) duk_get_tval(ctx, -1)));
 	return 1;
@@ -4828,7 +4828,7 @@ DUK_INTERNAL void duk_hobject_object_get_own_property_descriptor(duk_context *ct
 	rc = duk_hobject_get_own_propdesc(thr, obj, key, &pd, DUK_GETDESC_FLAG_PUSH_VALUE);
 	if (!rc) {
 		duk_push_undefined(ctx);
-		duk_remove(ctx, -2);
+		duk_remove_m2(ctx);
 		return;
 	}
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -155,7 +155,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 		DUK_D(DUK_DPRINT("_Formals is undefined when creating arguments, use n_formals == 0"));
 		n_formals = 0;
 	}
-	duk_remove(ctx, -2);  /* leave formals on stack for later use */
+	duk_remove_m2(ctx);  /* leave formals on stack for later use */
 	i_formals = duk_require_top_index(ctx);
 
 	DUK_ASSERT(n_formals >= 0);
@@ -350,7 +350,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	/* [ args(n) [crud] formals arguments map mappednames ] */
 
 	duk_pop_2(ctx);
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 
 	/* [ args [crud] arguments ] */
 }

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -1065,7 +1065,7 @@ DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_small_in
 
 	DUK_BW_COMPACT(thr, bw);
 	(void) duk_buffer_to_string(ctx, -1);  /* invalidates h_buf pointer */
-	duk_remove(ctx, -2);
+	duk_remove_m2(ctx);
 }
 
 #if defined(DUK_USE_REGEXP_SUPPORT)


### PR DESCRIPTION
Add a helper for `duk_remove(ctx, -2)` which occurs enough many times internally to benefit from a helper. Footprint saved is around 100 bytes.