### PR TITLE
Make mark-and-sweep mandatory in configuration

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2082,6 +2082,11 @@ Planned
 * Reduce RAM built-ins initdata limitations for custom bindings by using a
   shared varuint encoding in the bit-packed initdata stream (GH-1151, GH-1152)
 
+* Remove support for refcounting-only (= no mark-and-sweep) memory management
+  option as too error prone: without mark-and-sweep garbage containing
+  reference loops or created during debugger paused state (with or without
+  reference loops) would "leak" until heap destruction (GH-1168)
+
 * Fix JSON stringify fastpath handling of array gaps in JX and JC; they
   incorrectly stringified as 'null' (like in JSON) instead of 'undefined'
   and '{"_undef":true}' as intended (GH-859, GH-1149)

--- a/config/config-options/DUK_USE_MARK_AND_SWEEP.yaml
+++ b/config/config-options/DUK_USE_MARK_AND_SWEEP.yaml
@@ -1,5 +1,6 @@
 define: DUK_USE_MARK_AND_SWEEP
 introduced: 1.0.0
+removed: 2.0.0
 default: true
 tags:
   - gc
@@ -14,3 +15,5 @@ description: >
   won't be collected because they're always in a reference cycle with their
   default prototype object.  Unreachable objects are collected if you break
   reference cycles manually (and are always freed when a heap is destroyed).
+
+  NOTE: Removed in Duktape 2.0.0 because mark-and-sweep is no longer optional.

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -3712,9 +3712,7 @@ Improve garbage collection behavior during paused state
 
 Current behavior: garbage generated during paused state (refzero or objects
 in reference loops) will both be left in the heap and collected eventually
-by mark-and-sweep.  When mark-and-sweep is disabled such garbage will remain
-until heap destruction (so the debugger paused state works quite poorly when
-mark-and-sweep is entirely left out of config).
+by mark-and-sweep.
 
 Various improvements are possible, see discussion in
 https://github.com/svaarala/duktape/pull/617.

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -18,11 +18,11 @@ Duktape memory management is based on the following basic concepts:
 * **Heap element tracking**.
   Actual memory management happens on the heap level.  Heap elements
   are tracked after being allocated, which allows unreachable elements
-  to be freed by reference counting and/or mark-and-sweep garbage collection.
+  to be freed by reference counting or mark-and-sweep garbage collection.
   Freeing a heap causes all related allocations to be freed, regardless of
   their reference count or reachability.
 
-* **Reference counting and/or mark-and-sweep**.
+* **Reference counting and mark-and-sweep**.
   These algorithms are used to detect which heap elements can be
   freed.  A finalizer method may be executed when an element is
   about to be freed by reference counting or mark-and-sweep.

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -1077,6 +1077,11 @@ Other incompatible changes
   under version guarantees and may change in an incompatible fashion in even a
   minor release.
 
+* Memory management without mark-and-sweep is no longer supported; relying on
+  only refcounting was error prone because reference cycles or debugger use
+  could result in leaked garbage that would only get collected on heap
+  destruction.
+
 Known issues
 ============
 

--- a/src-input/duk_api_memory.c
+++ b/src-input/duk_api_memory.c
@@ -79,7 +79,6 @@ DUK_EXTERNAL void duk_get_memory_functions(duk_context *ctx, duk_memory_function
 }
 
 DUK_EXTERNAL void duk_gc(duk_context *ctx, duk_uint_t flags) {
-#if defined(DUK_USE_MARK_AND_SWEEP)
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_heap *heap;
 	duk_small_uint_t ms_flags;
@@ -92,9 +91,4 @@ DUK_EXTERNAL void duk_gc(duk_context *ctx, duk_uint_t flags) {
 	DUK_ASSERT(DUK_GC_COMPACT == DUK_MS_FLAG_EMERGENCY);  /* Compact flag is 1:1 with emergency flag which forces compaction. */
 	ms_flags = (duk_small_uint_t) flags;
 	duk_heap_mark_and_sweep(heap, ms_flags);
-#else
-	DUK_D(DUK_DPRINT("mark-and-sweep requested by application but mark-and-sweep not enabled, ignoring"));
-	DUK_UNREF(ctx);
-	DUK_UNREF(flags);
-#endif
 }

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4343,7 +4343,6 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 	 */
 
 #if defined(DUK_USE_ASSERTIONS)
-#if defined(DUK_USE_MARK_AND_SWEEP)
 	{
 		/* One particular problem case is where an object has been
 		 * queued for finalization but the finalizer hasn't been
@@ -4356,7 +4355,6 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 			DUK_ASSERT(curr != (duk_heaphdr *) ptr);
 		}
 	}
-#endif
 #endif
 
 	ret = (duk_idx_t) (thr->valstack_top - thr->valstack_bottom);

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -27,7 +27,6 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_act(duk_context *ctx) {
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_duktape_object_gc(duk_context *ctx) {
-#ifdef DUK_USE_MARK_AND_SWEEP
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_small_uint_t flags;
 	duk_bool_t rc;
@@ -40,10 +39,6 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_gc(duk_context *ctx) {
 	 */
 	duk_push_boolean(ctx, !rc);
 	return 1;
-#else
-	DUK_UNREF(ctx);
-	return 0;
-#endif
 }
 
 #if defined(DUK_USE_FINALIZER_SUPPORT)

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -3032,9 +3032,7 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 	if (js_ctx->h_replacer == NULL &&  /* replacer is a mutation risk */
 	    js_ctx->idx_proplist == -1) {  /* proplist is very rare */
 		duk_int_t pcall_rc;
-#ifdef DUK_USE_MARK_AND_SWEEP
 		duk_small_uint_t prev_mark_and_sweep_base_flags;
-#endif
 
 		DUK_DD(DUK_DDPRINT("try JSON.stringify() fast path"));
 
@@ -3055,19 +3053,16 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 
 		duk_dup(ctx, idx_value);
 
-#if defined(DUK_USE_MARK_AND_SWEEP)
 		/* Must prevent finalizers which may have arbitrary side effects. */
 		prev_mark_and_sweep_base_flags = thr->heap->mark_and_sweep_base_flags;
 		thr->heap->mark_and_sweep_base_flags |=
 			DUK_MS_FLAG_NO_FINALIZERS |         /* avoid attempts to add/remove object keys */
 		        DUK_MS_FLAG_NO_OBJECT_COMPACTION;   /* avoid attempt to compact any objects */
-#endif
 
 		pcall_rc = duk_safe_call(ctx, duk__json_stringify_fast, (void *) js_ctx /*udata*/, 1 /*nargs*/, 0 /*nret*/);
 
-#if defined(DUK_USE_MARK_AND_SWEEP)
 		thr->heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
-#endif
+
 		if (pcall_rc == DUK_EXEC_SUCCESS) {
 			DUK_DD(DUK_DDPRINT("fast path successful"));
 			DUK_BW_PUSH_AS_STRING(thr, &js_ctx->bw);

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -111,7 +111,6 @@
  * GC is skipped because there is no thread do it with yet (happens
  * only during init phases).
  */
-#if defined(DUK_USE_MARK_AND_SWEEP)
 #if defined(DUK_USE_REFERENCE_COUNTING)
 #define DUK_HEAP_MARK_AND_SWEEP_TRIGGER_MULT              12800L  /* 50x heap size */
 #define DUK_HEAP_MARK_AND_SWEEP_TRIGGER_ADD               1024L
@@ -120,7 +119,6 @@
 #define DUK_HEAP_MARK_AND_SWEEP_TRIGGER_MULT              256L    /* 1x heap size */
 #define DUK_HEAP_MARK_AND_SWEEP_TRIGGER_ADD               1024L
 #define DUK_HEAP_MARK_AND_SWEEP_TRIGGER_SKIP              256L
-#endif
 #endif
 
 /* Stringcache is used for speeding up char-offset-to-byte-offset
@@ -384,7 +382,6 @@ struct duk_heap {
 	duk_heaphdr *refzero_list_tail;
 #endif
 
-#if defined(DUK_USE_MARK_AND_SWEEP)
 	/* mark-and-sweep control */
 #if defined(DUK_USE_VOLUNTARY_GC)
 	duk_int_t mark_and_sweep_trigger_counter;
@@ -396,7 +393,6 @@ struct duk_heap {
 
 	/* work list for objects to be finalized (by mark-and-sweep) */
 	duk_heaphdr *finalize_list;
-#endif
 
 	/* longjmp state */
 	duk_ljstate lj;
@@ -547,7 +543,7 @@ DUK_INTERNAL_DECL duk_hstring *duk_heap_string_intern_u32_checked(duk_hthread *t
 #if defined(DUK_USE_REFERENCE_COUNTING)
 DUK_INTERNAL_DECL void duk_heap_string_remove(duk_heap *heap, duk_hstring *h);
 #endif
-#if defined(DUK_USE_MARK_AND_SWEEP) && defined(DUK_USE_MS_STRINGTABLE_RESIZE)
+#if defined(DUK_USE_MS_STRINGTABLE_RESIZE)
 DUK_INTERNAL_DECL void duk_heap_force_strtab_resize(duk_heap *heap);
 #endif
 DUK_INTERNAL void duk_heap_free_strtab(duk_heap *heap);
@@ -600,9 +596,7 @@ DUK_INTERNAL_DECL void duk_heaphdr_decref_norz(duk_hthread *thr, duk_heaphdr *h)
 /* no refcounting */
 #endif  /* DUK_USE_REFERENCE_COUNTING */
 
-#if defined(DUK_USE_MARK_AND_SWEEP)
 DUK_INTERNAL_DECL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t flags);
-#endif
 
 DUK_INTERNAL_DECL duk_uint32_t duk_heap_hashstring(duk_heap *heap, const duk_uint8_t *str, duk_size_t len);
 

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -4,8 +4,6 @@
 
 #include "duk_internal.h"
 
-#ifdef DUK_USE_MARK_AND_SWEEP
-
 DUK_LOCAL_DECL void duk__mark_heaphdr(duk_heap *heap, duk_heaphdr *h);
 DUK_LOCAL_DECL void duk__mark_tval(duk_heap *heap, duk_tval *tv);
 
@@ -1434,9 +1432,3 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 
 	return 0;  /* OK */
 }
-
-#else  /* DUK_USE_MARK_AND_SWEEP */
-
-/* no mark-and-sweep gc */
-
-#endif  /* DUK_USE_MARK_AND_SWEEP */

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -4,9 +4,9 @@
 
 #include "duk_internal.h"
 
-#ifdef DUK_USE_REFERENCE_COUNTING
+#if defined(DUK_USE_REFERENCE_COUNTING)
 
-#ifndef DUK_USE_DOUBLE_LINKED_HEAP
+#if !defined(DUK_USE_DOUBLE_LINKED_HEAP)
 #error internal error, reference counting requires a double linked heap
 #endif
 
@@ -429,7 +429,7 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 	 *  a voluntary mark-and-sweep.
 	 */
 
-#if defined(DUK_USE_MARK_AND_SWEEP) && defined(DUK_USE_VOLUNTARY_GC)
+#if defined(DUK_USE_VOLUNTARY_GC)
 	/* 'count' is more or less comparable to normal trigger counter update
 	 * which happens in memory block (re)allocation.
 	 */
@@ -442,7 +442,7 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 		DUK_UNREF(rc);
 		DUK_D(DUK_DPRINT("refcount triggered mark-and-sweep => rc %ld", (long) rc));
 	}
-#endif  /* DUK_USE_MARK_AND_SWEEP && DUK_USE_VOLUNTARY_GC */
+#endif  /* DUK_USE_VOLUNTARY_GC */
 }
 
 /*

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -511,9 +511,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
                                             duk_uint32_t new_h_size,
                                             duk_bool_t abandon_array) {
 	duk_context *ctx = (duk_context *) thr;
-#ifdef DUK_USE_MARK_AND_SWEEP
 	duk_small_uint_t prev_mark_and_sweep_base_flags;
-#endif
 	duk_uint32_t new_alloc_size;
 	duk_uint32_t new_e_size_adjusted;
 	duk_uint8_t *new_p;
@@ -619,12 +617,10 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 	 *  would be enough to restrict it only for the current object.
 	 */
 
-#ifdef DUK_USE_MARK_AND_SWEEP
 	prev_mark_and_sweep_base_flags = thr->heap->mark_and_sweep_base_flags;
 	thr->heap->mark_and_sweep_base_flags |=
 	        DUK_MS_FLAG_NO_FINALIZERS |         /* avoid attempts to add/remove object keys */
 	        DUK_MS_FLAG_NO_OBJECT_COMPACTION;   /* avoid attempt to compact the current object */
-#endif
 
 	new_alloc_size = DUK_HOBJECT_P_COMPUTE_SIZE(new_e_size_adjusted, new_a_size, new_h_size);
 	DUK_DDD(DUK_DDDPRINT("new hobject allocation size is %ld", (long) new_alloc_size));
@@ -920,9 +916,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 
 	DUK_DDD(DUK_DDDPRINT("resize result: %!O", (duk_heaphdr *) obj));
 
-#ifdef DUK_USE_MARK_AND_SWEEP
 	thr->heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
-#endif
 
 	/*
 	 *  Post resize assertions.
@@ -948,9 +942,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 		DUK_HSTRING_DECREF(thr, new_e_k[i]);  /* side effects */
 	}
 
-#ifdef DUK_USE_MARK_AND_SWEEP
 	thr->heap->mark_and_sweep_base_flags = prev_mark_and_sweep_base_flags;
-#endif
 
 	DUK_ERROR_ALLOC_FAILED(thr);
 }

--- a/website/guide/compiling.html
+++ b/website/guide/compiling.html
@@ -177,7 +177,7 @@ for more practical details.</p>
 <!-- XXX: this might be more suited to the Wiki -->
 <h3>Memory management alternatives</h3>
 
-<p>There are three supported memory management alternatives:</p>
+<p>There are two supported memory management alternatives:</p>
 <ul>
 <li><b>Reference counting and mark-and-sweep (default)</b>: heap objects are
     freed immediately when they become unreachable except for objects
@@ -190,31 +190,16 @@ for more practical details.</p>
     memory usage variance than in the default case.  The frequency of voluntary,
     stop the world mark-and-sweep collections is also higher than in the default
     case where reference counting is expected to handle almost all memory
-    management.</li>
-<li><b>Reference counting only</b>: reduces code footprint and eliminates
-    garbage collection pauses, but has major limitations and is not recommended.
-    Objects in unreachable reference cycles are not collected until the Duktape
-    heap is destroyed.  Garbage created during debugger paused state is also not
-    collected until heap destruction.  This option will most likely be removed
-    in Duktape 2.x.</li>
+    management.  Voluntary (non-emergency) mark-and-sweep can be disabled via
+    config options.</li>
 </ul>
 
-<p>When using only reference counting it is important to avoid creating
-unreachable reference cycles.  Reference cycles are usually easy to avoid in
-application code e.g. by using only forward pointers in data structures.  Even
-if reference cycles are necessary, garbage collection can be allowed to work
-simply by breaking the cycles before deleting the final references to such objects.
-For example, if you have a tree structure where nodes maintain references to
-both children and parents (creating reference cycles for each node) you could
-walk the tree and set the parent reference to <code>null</code> before deleting
-the final reference to the tree.</p>
-
-<p>Unfortunately every Ecmascript function instance is required to be in a
+<p>Reference counting relies on mark-and-sweep to handle reference cycles.
+For example, every Ecmascript function instance is required to be in a
 reference loop with an automatic prototype object created for the function.
 You can break this loop manually if you wish.  For internal technical reasons,
 named function expressions are also in a reference loop; this loop cannot be
-broken from user code and only mark-and-sweep can collect such functions.
-See <a href="#limitations">Limitations</a>.</p>
+broken from user code and only mark-and-sweep can collect such functions.</p>
 
 <h2>Compiling</h2>
 

--- a/website/guide/duktapebuiltins.html
+++ b/website/guide/duktapebuiltins.html
@@ -254,11 +254,11 @@ print('running on line:', getCurrentLine());
 
 <h3 id="builtin-duktape-gc">gc()</h3>
 
-<p>Trigger a forced mark-and-sweep collection.  If mark-and-sweep is disabled,
-this call is a no-op.</p>
+<p>Trigger a forced mark-and-sweep collection.  The call takes an optional
+integer flags field, see <code>duktape.h</code> for constants.</p>
 
 <!-- Return value is undocumented for now, which is probably good for now.
-     Not sure what the best return value would be.  Arguments are undocumented.
+     Not sure what the best return value would be.
 -->
 
 <h3 id="builtin-duktape-compact">compact()</h3>

--- a/website/guide/limitations.html
+++ b/website/guide/limitations.html
@@ -179,8 +179,10 @@ var fn = function myfunc() {
 }
 </pre>
 
-<p>These issues can be avoided by compiling Duktape with mark-and-sweep
-enabled (which is the default).</p>
+<p>Since Duktape 2.x mark-and-sweep is always enabled so that objects
+participating in reference loops are eventually freed.  You can disable
+periodic "voluntary" (non-emergency) mark-and-sweep via config options
+to reduce collection pauses in time sensitive environments.</p>
 
 <h2>Non-standard function 'caller' property limitations</h2>
 
@@ -210,11 +212,6 @@ case for further details.</p>
 Duktape is paused, there are a few current limitations:</p>
 
 <ul>
-<li>When Duktape is built with reference counting only (mark-and-sweep left
-    out of config options), garbage created during the debugger paused state
-    will be left in the Duktape heap and freed only when the heap is destroyed.
-    The option to build with reference counting only is not recommended and will
-    most likely be removed in future versions.</li>
 <li>Because garbage collection is disabled during the paused state, calls to
     <code>Duktape.gc()</code> and <code>duk_gc()</code> will be silently
     ignored.</li>


### PR DESCRIPTION
Duktape 1.x supported a configuration where refcounting was enabled but mark-and-sweep was not. This mode is rather error prone:
- Objects that are otherwise unreachable but participate in reference loops would "leak" until heap destruction. This would either need to be acceptable to user code or it needed to break the loops manually when creating objects. (Sometimes this *was* acceptable to applications, e.g. when they executed some script in a Duktape heap that got immediately destroyed afterwards.)
- Objects that became unreachable during debugger paused state -- with or without reference loops -- would also "leak" until heap destruction.

Remove support for disabling mark-and-sweep. Keep the option to disable voluntary mark-and-sweep, so that a mark-and-sweep collection pause only happens in emergency mode (= when we've already run out of memory and encountered an allocation error).