### PR TITLE
Fix compiler warning for shifting a negative value

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2190,7 +2190,7 @@ Planned
   GH-1163)
 
 * Miscellaneous portability improvements: remove dependency on fmin() and
-  fmax() (GH-1072)
+  fmax() (GH-1072); remove signed shifts in lightfunc handling (GH-1172)
 
 * Internal performance improvement: rework bytecode format to use an 8-bit
   opcode field (and 8-bit A, B, and C fields) to speed up opcode dispatch
@@ -2222,8 +2222,8 @@ Planned
   _Formals array when it is safe to do so (GH-1141); omit duk_hcompfunc
   _Varmap in more cases when it is safe to do so (GH-1146); reduce initial
   bytecode allocation in Ecmascript compiler for low memory targets (GH-1146);
-  packed arguments for some internal helper calls (GH-1158); misc internal
-  helpers to reduce call site size (GH-1166)
+  packed arguments for some internal helper calls (GH-1158, GH-1172); misc
+  internal helpers to reduce call site size (GH-1166)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -186,38 +186,38 @@ DUK_INTERNAL_DECL const char *duk_push_string_tval_readable_error(duk_context *c
  */
 
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [] -> [val] */
-DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args);
+DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_get_prop_stridx_short(ctx,obj_idx,stridx) \
 	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
 	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
-	 duk_get_prop_stridx_short_raw((ctx),(((duk_int_t) (obj_idx)) << 16) + ((duk_int_t) (stridx))))
+	 duk_get_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_bool_t *out_has_prop);  /* [] -> [] */
 
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [val] -> [] */
-DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args);
+DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_put_prop_stridx_short(ctx,obj_idx,stridx) \
 	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
 	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
-	 duk_put_prop_stridx_short_raw((ctx),(((duk_int_t) (obj_idx)) << 16) + ((duk_int_t) (stridx))))
+	 duk_put_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 
 DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [] -> [] */
 #if 0  /* Too few call sites to be useful. */
-DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args);
+DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_del_prop_stridx_short(ctx,obj_idx,stridx) \
 	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
 	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
-	 duk_del_prop_stridx_short_raw((ctx),(((duk_int_t) (obj_idx)) << 16) + ((duk_int_t) (stridx))))
+	 duk_del_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 #endif
 #define duk_del_prop_stridx_short(ctx,obj_idx,stridx) \
 	duk_del_prop_stridx((ctx), (obj_idx), (stridx))
 
 DUK_INTERNAL_DECL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [] -> [] */
 #if 0  /* Too few call sites to be useful. */
-DUK_INTERNAL_DECL duk_bool_t duk_has_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args);
+DUK_INTERNAL_DECL duk_bool_t duk_has_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_has_prop_stridx_short(ctx,obj_idx,stridx) \
 	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
 	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
-	 duk_has_prop_stridx_short_raw((ctx),(((duk_int_t) (obj_idx)) << 16) + ((duk_int_t) (stridx))))
+	 duk_has_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 #endif
 #define duk_has_prop_stridx_short(ctx,obj_idx,stridx) \
 	duk_has_prop_stridx((ctx), (obj_idx), (stridx))
@@ -230,12 +230,12 @@ DUK_INTERNAL_DECL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
  * always pack stridx and desc_flags into a single argument.
  */
 DUK_INTERNAL_DECL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_uint_t desc_flags);  /* [val] -> [] */
-DUK_INTERNAL_DECL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args);
+DUK_INTERNAL_DECL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_xdef_prop_stridx_short(ctx,obj_idx,stridx,desc_flags) \
 	(DUK_ASSERT_EXPR((obj_idx) >= -0x80L && (obj_idx) <= 0x7fL), \
 	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
 	 DUK_ASSERT_EXPR((desc_flags) >= 0 && (desc_flags) <= 0xffL), \
-	 duk_xdef_prop_stridx_short_raw((ctx),(((duk_int_t) (obj_idx)) << 24) + (((duk_int_t) (stridx)) << 8) + (desc_flags)))
+	 duk_xdef_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 24) + (((duk_uint_t) (stridx)) << 8) + (duk_uint_t) (desc_flags)))
 
 #define duk_xdef_prop_wec(ctx,obj_idx) \
 	duk_xdef_prop((ctx), (obj_idx), DUK_PROPDESC_FLAGS_WEC)

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -73,8 +73,9 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	return duk_get_prop(ctx, obj_idx);
 }
 
-DUK_INTERNAL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
-	return duk_get_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+DUK_INTERNAL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args) {
+	return duk_get_prop_stridx(ctx, (duk_idx_t) (duk_int16_t) (packed_args >> 16),
+	                                (duk_small_uint_t) (packed_args & 0xffffUL));
 }
 
 DUK_INTERNAL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_bool_t *out_has_prop) {
@@ -171,8 +172,9 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 	return duk__put_prop_shared(ctx, obj_idx, -1);
 }
 
-DUK_INTERNAL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
-	return duk_put_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+DUK_INTERNAL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args) {
+	return duk_put_prop_stridx(ctx, (duk_idx_t) (duk_int16_t) (packed_args >> 16),
+	                                (duk_small_uint_t) (packed_args & 0xffffUL));
 }
 
 DUK_EXTERNAL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx) {
@@ -238,8 +240,9 @@ DUK_INTERNAL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 }
 
 #if 0
-DUK_INTERNAL duk_bool_t duk_del_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
-	return duk_del_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+DUK_INTERNAL duk_bool_t duk_del_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args) {
+	return duk_del_prop_stridx(ctx, (duk_idx_t) (duk_int16_t) (packed_args >> 16),
+	                                (duk_small_uint_t) (packed_args & 0xffffUL));
 }
 #endif
 
@@ -304,8 +307,9 @@ DUK_INTERNAL duk_bool_t duk_has_prop_stridx(duk_context *ctx, duk_idx_t obj_idx,
 }
 
 #if 0
-DUK_INTERNAL duk_bool_t duk_has_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
-	return duk_has_prop_stridx(ctx, packed_args >> 16, packed_args & 0xffffL);
+DUK_INTERNAL duk_bool_t duk_has_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args) {
+	return duk_has_prop_stridx(ctx, (duk_idx_t) (duk_int16_t) (packed_args >> 16),
+	                                (duk_small_uint_t) (packed_args & 0xffffUL));
 }
 #endif
 
@@ -363,8 +367,10 @@ DUK_INTERNAL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_
 	/* value popped by call */
 }
 
-DUK_INTERNAL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_int_t packed_args) {
-	duk_xdef_prop_stridx(ctx, packed_args >> 24, (packed_args >> 8) & 0xffffL, packed_args & 0xffL);
+DUK_INTERNAL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args) {
+	duk_xdef_prop_stridx(ctx, (duk_idx_t) (duk_int8_t) (packed_args >> 24),
+	                          (duk_small_uint_t) (packed_args >> 8) & 0xffffUL,
+	                          (duk_small_uint_t) (packed_args & 0xffL));
 }
 
 DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -596,9 +596,11 @@ DUK_INTERNAL_DECL duk_double_t duk_tval_get_number_unpacked_fastint(duk_tval *tv
 #define DUK_TVAL_SET_BOOLEAN_FALSE(tv)       DUK_TVAL_SET_BOOLEAN((tv), 0)
 
 /* Lightfunc flags packing and unpacking. */
-/* Sign extend: 0x0000##00 -> 0x##000000 -> sign extend to 0xssssss## */
+/* Sign extend: 0x0000##00 -> 0x##000000 -> sign extend to 0xssssss##.
+ * Avoid signed shifts due to portability limitations.
+ */
 #define DUK_LFUNC_FLAGS_GET_MAGIC(lf_flags) \
-	((((duk_int32_t) (lf_flags)) << 16) >> 24)
+	((duk_int32_t) (duk_int8_t) (((duk_uint16_t) (lf_flags)) >> 8))
 #define DUK_LFUNC_FLAGS_GET_LENGTH(lf_flags) \
 	(((lf_flags) >> 4) & 0x0f)
 #define DUK_LFUNC_FLAGS_GET_NARGS(lf_flags) \

--- a/tests/ecmascript/test-dev-lightfunc.js
+++ b/tests/ecmascript/test-dev-lightfunc.js
@@ -1662,11 +1662,11 @@ Error: for traceback
     at light_PTR_0212 light strict preventsyield
     at duktapeActTest (TESTCASE:NNN)
     at global (TESTCASE:NNN) preventsyield
--1 ["lineNumber","pc","function"] light_PTR_0011
--2 ["lineNumber","pc","function"] callback
--3 ["lineNumber","pc","function"] light_PTR_0212
--4 ["lineNumber","pc","function"] duktapeActTest
--5 ["lineNumber","pc","function"] global
+-1 ["pc","lineNumber","function"] light_PTR_0011
+-2 ["pc","lineNumber","function"] callback
+-3 ["pc","lineNumber","function"] light_PTR_0212
+-4 ["pc","lineNumber","function"] duktapeActTest
+-5 ["pc","lineNumber","function"] global
 ===*/
 
 function duktapeActTest() {


### PR DESCRIPTION
Introduced by internal packed arguments.

- [x] Fix by using unsigned shifts, cast to a small signed type and then cast again to a large type to sign extend, e.g. `(duk_int32_t) (duk_int8_t) (unsignedValue >> 24)`
- [x] Check lightfunc behavior manually
