### PR TITLE
Align RegExp.prototype and instance properties with ES6

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1945,6 +1945,13 @@ Planned
   trap; because "getOwnPropertyDescriptor" trap is not yet supported, the
   check is always made against the target object (GH-1115)
 
+* Align RegExp.prototype behavior more closely with ES6: .source, .global,
+  .ignoreCase, .multiline are now inherited getters; .flags, .sticky, and
+  .unicode have been added (they are inherited getters too); constructor
+  behavior has been revised for ES6 behavior; however, leniency to allow
+  e.g. RegExp.prototype.source (from ES2017 draft) is supported for real
+  world code compatibility (GH-1178)
+
 * Remove no longer needed platform wrappers in duk_config.h: DUK_ABORT(),
   DUK_EXIT(), DUK_PRINTF(), DUK_FPRINTF(), DUK_FOPEN(), DUK_FCLOSE(),
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -10,6 +10,9 @@ Main changes in this release (see RELEASES.rst for full details):
 * Improve buffer bindings: plain buffers now behave like ArrayBuffers,
   and Duktape.Buffer has been removed with ArrayBuffer taking its place.
 
+* Many built-in behaviors have been aligned with ES6 or ES7, so there are
+  small behavioral changes throughout.
+
 * FIXME
 
 The release has API incompatible changes, see upgrading notes below.
@@ -1086,6 +1089,11 @@ Other incompatible changes
   follow more lenient ES6 coercion semantics: non-object arguments are either
   coerced to objects or treated like non-extensible objects with no own
   properties.
+
+* RegExp.prototype follows ES6 behavior more closely: it is no longer a RegExp
+  instance, .source, .global, .ignoreCase, and .multiline are now inherited
+  getters, etc.  However, leniency to allow e.g. RegExp.prototype.source (from
+  ES2017 draft) is supported for real world code compatibility.
 
 * Duktape.info() now returns an object rather than an array.  The object has
   named properties like ``.type`` and ``.enext`` for the internal fields which

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -1774,7 +1774,7 @@ objects:
         attributes: ""
 
   - id: bi_regexp_prototype
-    class: RegExp
+    class: Object  # Object in ES6; RegExp in ES5
     internal_prototype: bi_object_prototype
     bidx: true
     present_if: DUK_USE_REGEXP_SUPPORT
@@ -1786,36 +1786,7 @@ objects:
           id: bi_regexp_constructor
         attributes: "wc"
 
-      # RegExp internal value should match that of new RegExp() (E5 Sections 15.10.6
-      # and 15.10.7), i.e. a bytecode sequence that matches an empty string.
-      # The compiled regexp bytecode for that is embedded here, and must match the
-      # defines in duk_regexp.h.  The bytecode must provide the 0'th capture.
-      #
-      # Note that the property attributes are non-default.
-
-      # Compiled bytecode, must match duk_regexp.h.  Bytecode contains:
-      # 0=flags; 2=nsaved; 11,0=DUK_REOP_SAVE 0; 11,1=DUK_REOP_SAVE 1; 1=DUK_REOP_MATCH
-      - key: "\u00ffBytecode"
-        value: "\u0000\u0002\u000b\u0000\u000b\u0001\u0001"
-        attributes: ""
-        duktape: true
-
-      # An object created as new RegExp("") should have the escaped source
-      # "(?:)" (E5 Section 15.10.4.1).  However, at least V8 and Smjs seem
-      # to have an empty string here.
-      - key: "source"
-        value: "(?:)"
-        attributes: ""
-
-      - key: "global"
-        value: false
-        attributes: ""
-      - key: "ignoreCase"
-        value: false
-        attributes: ""
-      - key: "multiline"
-        value: false
-        attributes: ""
+      # In ES6 RegExp.prototype is no longer a RegExp instance.
 
       # "lastIndex" is writable, even in the RegExp.prototype object.
       # This matches at least V8.
@@ -1836,8 +1807,77 @@ objects:
       - key: "toString"
         value:
           type: function
-          native: duk_bi_regexp_prototype_to_string
+          native: duk_bi_regexp_prototype_tostring
           length: 0
+
+      # In ES6 .source, .global, .ignoreCase, etc are accessors.
+      # .flags is ES6 but must be present because the constructor now
+      # relies on its presence for e.g. new RegExp(/foo/gim).
+
+      - key: "flags"
+        value:
+          type: accessor
+          getter: duk_bi_regexp_prototype_flags
+          getter_nargs: 0
+          getter_magic: 0
+          # setter undefined
+        attributes: "c"
+        es6: true
+
+      - key: "source"
+        value:
+          type: accessor
+          getter: duk_bi_regexp_prototype_shared_getter
+          getter_nargs: 0
+          getter_magic: 16  # default case in shared getter (value quite arbitrary)
+          # setter undefined
+        attributes: "c"
+      - key: "global"
+        value:
+          type: accessor
+          getter: duk_bi_regexp_prototype_shared_getter
+          getter_nargs: 0
+          getter_magic: 0
+          # setter undefined
+        attributes: "c"
+      - key: "ignoreCase"
+        value:
+          type: accessor
+          getter: duk_bi_regexp_prototype_shared_getter
+          getter_nargs: 0
+          getter_magic: 1
+          # setter undefined
+        attributes: "c"
+      - key: "multiline"
+        value:
+          type: accessor
+          getter: duk_bi_regexp_prototype_shared_getter
+          getter_nargs: 0
+          getter_magic: 2
+          # setter undefined
+        attributes: "c"
+      # .sticky and .unicode commented out; don't provide until implemented
+      # to avoid interfering with application feature detection code
+      #- key: "sticky"
+      #  value:
+      #    type: accessor
+      #    getter: duk_bi_regexp_prototype_shared_getter
+      #    getter_nargs: 0
+      #    getter_magic: 3
+      #    # setter undefined
+      #  attributes: "c"
+      #  es6: true
+      #  present_if: DUK_USE_ES6
+      #- key: "unicode"
+      #  value:
+      #    type: accessor
+      #    getter: duk_bi_regexp_prototype_shared_getter
+      #    getter_nargs: 0
+      #    getter_magic: 4
+      #    # setter undefined
+      #  attributes: "c"
+      #  es6: true
+      #  present_if: DUK_USE_ES6
 
   - id: bi_error_constructor
     class: Function

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -31,6 +31,9 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 		/* Called as a function, pattern has [[Class]] "RegExp" and
 		 * flags is undefined -> return object as is.
 		 */
+		/* XXX: ES6 has a NewTarget SameValue() check which is not
+		 * yet implemented.
+		 */
 		duk_dup_0(ctx);
 		return 1;
 	}
@@ -41,34 +44,26 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 
 	if (h_pattern != NULL &&
 	    DUK_HOBJECT_GET_CLASS_NUMBER(h_pattern) == DUK_HOBJECT_CLASS_REGEXP) {
+		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_SOURCE);
 		if (duk_is_undefined(ctx, 1)) {
-			duk_bool_t flag_g, flag_i, flag_m;
-			duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_SOURCE);
-			flag_g = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_GLOBAL, NULL);
-			flag_i = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_IGNORE_CASE, NULL);
-			flag_m = duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_MULTILINE, NULL);
-
-			duk_push_sprintf(ctx, "%s%s%s",
-			                 (const char *) (flag_g ? "g" : ""),
-			                 (const char *) (flag_i ? "i" : ""),
-			                 (const char *) (flag_m ? "m" : ""));
-
-			/* [ ... pattern flags ] */
+			/* In ES5 one would need to read the flags individually;
+			 * in ES6 just read .flags.
+			 */
+			duk_get_prop_stridx(ctx, 0, DUK_STRIDX_FLAGS);
 		} else {
-			DUK_DCERROR_TYPE_INVALID_ARGS(thr);
+			/* In ES6 allowed; overrides argument RegExp flags. */
+			duk_dup_1(ctx);
 		}
 	} else {
 		if (duk_is_undefined(ctx, 0)) {
-			duk_push_string(ctx, "");
+			duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);
 		} else {
 			duk_dup_0(ctx);
-			duk_to_string(ctx, -1);
 		}
 		if (duk_is_undefined(ctx, 1)) {
-			duk_push_string(ctx, "");
+			duk_push_hstring_stridx(ctx, DUK_STRIDX_EMPTY_STRING);
 		} else {
-			duk_dup(ctx, 1);
-			duk_to_string(ctx, -1);
+			duk_dup_1(ctx);
 		}
 
 		/* [ ... pattern flags ] */
@@ -77,8 +72,10 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_constructor(duk_context *ctx) {
 	DUK_DDD(DUK_DDDPRINT("RegExp constructor/function call, pattern=%!T, flags=%!T",
 	                     (duk_tval *) duk_get_tval(ctx, -2), (duk_tval *) duk_get_tval(ctx, -1)));
 
-	/* [ ... pattern flags ] */
+	/* [ ... pattern flags ] (both uncoerced) */
 
+	duk_to_string(ctx, -2);
+	duk_to_string(ctx, -1);
 	duk_regexp_compile(thr);
 
 	/* [ ... bytecode escaped_source ] */
@@ -117,69 +114,111 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_test(duk_context *ctx) {
 	return 1;
 }
 
-DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_to_string(duk_context *ctx) {
+DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_tostring(duk_context *ctx) {
+	/* This must be generic in ES6 and later. */
+	DUK_ASSERT_TOP(ctx, 0);
+	duk_push_this(ctx);
+	duk_push_string(ctx, "/");
+	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_SOURCE);
+	duk_dup_m2(ctx);  /* another "/" */
+	duk_get_prop_stridx(ctx, 0, DUK_STRIDX_FLAGS);
+	duk_concat(ctx, 4);
+	return 1;
+}
+
+DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_flags(duk_context *ctx) {
+	/* .flags is ES6 but present even when ES6 bindings are
+	 * disabled because the constructor relies on it.
+	 */
+	duk_uint8_t buf[8];  /* enough for all flags + NUL */
+	duk_uint8_t *p = buf;
+
+	/* .flags is generic and works on any object. */
+	duk_push_this(ctx);
+	(void) duk_require_hobject(ctx, -1);
+	if (duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_GLOBAL, NULL)) {
+		*p++ = DUK_ASC_LC_G;
+	}
+	if (duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_IGNORE_CASE, NULL)) {
+		*p++ = DUK_ASC_LC_I;
+	}
+	if (duk_get_prop_stridx_boolean(ctx, 0, DUK_STRIDX_MULTILINE, NULL)) {
+		*p++ = DUK_ASC_LC_M;
+	}
+	/* .unicode: to be added */
+	/* .sticky: to be added */
+	*p++ = DUK_ASC_NUL;
+	DUK_ASSERT((duk_size_t) (p - buf) <= sizeof(buf));
+
+	duk_push_string(ctx, (const char *) buf);
+	return 1;
+}
+
+/* Shared helper for providing .source, .global, .multiline, etc getters. */
+DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_shared_getter(duk_context *ctx) {
+	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hstring *h_bc;
 	duk_small_int_t re_flags;
+	duk_hobject *h;
+	duk_int_t magic;
 
+	DUK_ASSERT_TOP(ctx, 0);
+
+	duk_push_this(ctx);
+	h = duk_require_hobject(ctx, -1);
+	magic = duk_get_current_magic(ctx);
+
+	if (DUK_HOBJECT_GET_CLASS_NUMBER(h) == DUK_HOBJECT_CLASS_REGEXP) {
+		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_SOURCE);
+		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_BYTECODE);
+		h_bc = duk_require_hstring(ctx, -1);
+		re_flags = (duk_small_int_t) DUK_HSTRING_GET_DATA(h_bc)[0];  /* Safe even if h_bc length is 0 (= NUL) */
+		duk_pop(ctx);
+	} else if (h == thr->builtins[DUK_BIDX_REGEXP_PROTOTYPE]) {
+		/* In ES2015 and ES2016 a TypeError would be thrown here.
+		 * However, this had real world issues so ES2017 draft
+		 * allows RegExp.prototype specifically, returning '(?:)'
+		 * for .source and undefined for all flags.
+		 */
+		if (magic != 16 /* .source */) {
+			return 0;
+		}
+		duk_push_string(ctx, "(?:)");  /* .source handled by switch-case */
+		re_flags = 0;
+	} else {
+		DUK_DCERROR_TYPE_INVALID_ARGS(thr);
+	}
+
+	/* [ regexp source ] */
+
+	switch (magic) {
+	case 0: {  /* global */
+		duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_GLOBAL));
+		break;
+	}
+	case 1: {  /* ignoreCase */
+		duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_IGNORE_CASE));
+		break;
+	}
+	case 2: {  /* multiline */
+		duk_push_boolean(ctx, (re_flags & DUK_RE_FLAG_MULTILINE));
+		break;
+	}
 #if 0
-	/* A little tricky string approach to provide the flags string.
-	 * This depends on the specific flag values in duk_regexp.h,
-	 * which needs to be asserted for.  In practice this doesn't
-	 * produce more compact code than the easier approach in use.
+	/* Don't provide until implemented to avoid interfering with feature
+	 * detection in user code.
 	 */
-
-	const char *flag_strings = "gim\0gi\0gm\0g\0";
-	duk_uint8_t flag_offsets[8] = {
-		(duk_uint8_t) 3,   /* flags: ""    */
-		(duk_uint8_t) 10,  /* flags: "g"   */
-		(duk_uint8_t) 5,   /* flags: "i"   */
-		(duk_uint8_t) 4,   /* flags: "gi"  */
-		(duk_uint8_t) 2,   /* flags: "m"   */
-		(duk_uint8_t) 7,   /* flags: "gm"  */
-		(duk_uint8_t) 1,   /* flags: "im"  */
-		(duk_uint8_t) 0,   /* flags: "gim" */
-	};
-	DUK_ASSERT(DUK_RE_FLAG_GLOBAL == 1);
-	DUK_ASSERT(DUK_RE_FLAG_IGNORE_CASE == 2);
-	DUK_ASSERT(DUK_RE_FLAG_MULTILINE == 4);
+	case 3:    /* sticky */
+	case 4: {  /* unicode */
+		duk_push_false(ctx);
+		break;
+	}
 #endif
-
-	duk__get_this_regexp(ctx);
-
-	/* [ regexp ] */
-
-	duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_SOURCE);
-	duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_BYTECODE);
-	h_bc = duk_require_hstring(ctx, -1);
-	DUK_ASSERT(h_bc != NULL);
-	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(h_bc) >= 1);
-	DUK_ASSERT(DUK_HSTRING_GET_CHARLEN(h_bc) >= 1);
-	DUK_ASSERT(DUK_HSTRING_GET_DATA(h_bc)[0] < 0x80);
-	re_flags = (duk_small_int_t) DUK_HSTRING_GET_DATA(h_bc)[0];
-
-	/* [ regexp source bytecode ] */
-
-#if 1
-	/* This is a cleaner approach and also produces smaller code than
-	 * the other alternative.  Use duk_require_string() for format
-	 * safety (although the source property should always exist).
-	 */
-	duk_push_sprintf(ctx, "/%s/%s%s%s",
-	                 (const char *) duk_require_string(ctx, -2),  /* require to be safe */
-	                 (re_flags & DUK_RE_FLAG_GLOBAL) ? "g" : "",
-	                 (re_flags & DUK_RE_FLAG_IGNORE_CASE) ? "i" : "",
-	                 (re_flags & DUK_RE_FLAG_MULTILINE) ? "m" : "");
-#else
-	/* This should not be necessary because no-one should tamper with the
-	 * regexp bytecode, but is prudent to avoid potential segfaults if that
-	 * were to happen for some reason.
-	 */
-	re_flags &= 0x07;
-	DUK_ASSERT(re_flags >= 0 && re_flags <= 7);  /* three flags */
-	duk_push_sprintf(ctx, "/%s/%s",
-	                 (const char *) duk_require_string(ctx, -2),
-	                 (const char *) (flag_strings + flag_offsets[re_flags]));
-#endif
+	default: {  /* source */
+		/* leave 'source' on top */
+		break;
+	}
+	}
 
 	return 1;
 }

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -306,7 +306,9 @@ strings:
   - str: "ignoreCase"
   - str: "multiline"
   - str: "lastIndex"
-  - str: "(?:)"
+  - str: "flags"
+#  - str: "unicode"
+#  - str: "sticky"
 
   # RegExp exec() results
   - str: "index"
@@ -1155,7 +1157,6 @@ special_define_names:
   "MAX_VALUE": "MAX_VALUE"
   "NEGATIVE_INFINITY": "NEGATIVE_INFINITY"
   "POSITIVE_INFINITY": "POSITIVE_INFINITY"
-  "(?:)": "ESCAPED_EMPTY_REGEXP"
   "Invalid Date": "INVALID_DATE"
 
   "decodeURIComponent": "DECODE_URI_COMPONENT"

--- a/tests/api/test-set-global-object.c
+++ b/tests/api/test-set-global-object.c
@@ -69,7 +69,7 @@ ctx1
 object
 set proto foo to quux
 set proto bar to proto itself for comparison
-result: /(?:)/
+result: undefined
 ctx2
 object
 foo: quux
@@ -378,13 +378,15 @@ static duk_ret_t test_regexp_prototype_shared(duk_context *ctx_root, void *udata
 	duk_eval_string_noresult(ctx1, "var re1 = /foo/;\n");
 	duk_eval_string_noresult(ctx2, "var re2 = /bar/;\n");
 
+	/* avoid String coercing RegExp.prototype; it's a TypeError in ES6/ES7 */
+
 	(void) duk_peval_string(ctx1,
 		"print(name);\n"
 		"print(typeof getProto(re1));\n"
 		"print('set proto foo to quux');\n"
 		"getProto(re1).foo = 'quux';\n"
 		"print('set proto bar to proto itself for comparison');\n"
-		"getProto(re1).bar = getProto(re1);\n");
+		"getProto(re1).bar = getProto(re1); void 0;\n");
 	printf("result: %s\n", duk_safe_to_string(ctx1, -1));
 	duk_pop(ctx1);
 

--- a/tests/ecmascript/test-bi-properties.js
+++ b/tests/ecmascript/test-bi-properties.js
@@ -439,7 +439,7 @@ var obj_data = [
         obj: RegExp.prototype,
         name: 'RegExp.prototype',
         proto: 'Object.prototype',
-        class: 'RegExp',  // E5 Section 15.10.6
+        class: 'Object',  // 'RegExp' in E5 Section 15.10.6 -> changed to 'Object' in ES6
         props: [
             { key: 'constructor', 'attrs': 'wc' },
             { key: 'exec', 'attrs': 'wc' },
@@ -1084,7 +1084,7 @@ PROPERTY: "prototype" !writable !enumerable !configurable
 
 OBJECT: "RegExp.prototype" !sealed !frozen extensible
 PROTOTYPE: "Object.prototype"
-CLASS: RegExp
+CLASS: Object
 PROPERTY: "constructor" writable !enumerable configurable
 PROPERTY: "exec" writable !enumerable configurable
 PROPERTY: "test" writable !enumerable configurable

--- a/tests/ecmascript/test-bi-regexp-constructor.js
+++ b/tests/ecmascript/test-bi-regexp-constructor.js
@@ -1,0 +1,42 @@
+/*
+ *  RegExp constructor
+ */
+
+/*===
+true /foo/gm
+true /foo/gm
+false /foo/gm
+false /foo/i
+/foo/gim
+/foo/m
+===*/
+
+function test() {
+    var x, y;
+
+    // XXX: add basic cases, this testcase now mostly tests for ES6 differences.
+
+    // Constructor called as a plain function, with a RegExp instance argument
+    // and undefined flags -> return as is.
+    x = /foo/gm;
+    y = RegExp(x);
+    print(x === y, y.toString());
+    y = RegExp(x, void 0);  // same as missing
+    print(x === y, y.toString());
+    y = RegExp(x, 'gm');  // present -> create copy
+    print(x === y, y.toString());
+    y = RegExp(x, 'i');  // present -> create copy
+    print(x === y, y.toString());
+
+    // New in ES6: argument can be a regexp instance and overriding flags given.
+    x = /foo/gim;
+    print(x.toString());
+    y = new RegExp(x, 'm');
+    print(y.toString());
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-regexp-proto-tostring.js
+++ b/tests/ecmascript/test-bi-regexp-proto-tostring.js
@@ -1,0 +1,27 @@
+/*===
+/foo/gm
+/(?:)/
+/undefined/undefined
+/troll/face
+===*/
+
+function test() {
+    var re = /foo/gm;
+    print(RegExp.prototype.toString.call(re));
+
+    // Must be generic: for RegExp.prototype or any other object
+    // would normally return '/undefined/undefined', based on an
+    // actual .source and .flags lookup.
+    re = RegExp.prototype;
+    print(RegExp.prototype.toString.call(re));
+    re = {};
+    print(RegExp.prototype.toString.call(re));
+    re = { source: 'troll', flags: 'face' };
+    print(RegExp.prototype.toString.call(re));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-regexp-prototype.js
+++ b/tests/ecmascript/test-bi-regexp-prototype.js
@@ -1,0 +1,172 @@
+/*
+ *  RegExp.prototype
+ *
+ *  Changed in ES6 in many ways, check for ES6 behavior with some draft ES2017
+ *  behavior for accepting RegExp.prototype as a 'this' binding.
+ */
+
+/*===
+[object Function]
+[object Object]
+/(?:)/
+(?:)
+
+undefined
+undefined
+undefined
+undefined
+foo
+gm
+true
+true
+false
+undefined
+undefined
+false true
+false true
+false true
+false true
+false true
+false false
+false false
+function undefined false true
+function undefined false true
+function undefined false true
+function undefined false true
+function undefined false true
+undefined
+undefined
+gm
+TypeError
+gm
+gi
+
+g
+i
+gi
+m
+gm
+im
+gim
+===*/
+
+function test() {
+    print(Object.prototype.toString.call(RegExp));
+
+    // In ES6 RegExp.prototype is no longer a regexp instance.
+    print(Object.prototype.toString.call(RegExp.prototype));
+
+    // In ES2015 and ES2016 the .source, .flags etc accessors will TypeError
+    // if called with RegExp.prototype or any other non-RegExp-instance.
+    // Draft ES2017 changes that so that RegExp.prototype gets special
+    // treatment, to fix real world issues with the ES2015/ES2016 behavior.
+    // Test for draft ES8 behavior (also implemented by V8 and Firefox).
+    try {
+        print(RegExp.prototype.toString());
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.source);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.flags);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.multiline);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.ignoreCase);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.sticky);
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(RegExp.prototype.unicode);
+    } catch (e) {
+        print(e.name);
+    }
+
+    var x = /foo/gm;
+
+    print(x.source);
+    print(x.flags);
+    print(x.global);
+    print(x.multiline);
+    print(x.ignoreCase);
+    print(x.sticky);
+    print(x.unicode);
+
+    print(Object.hasOwnProperty(x, 'source'), 'source' in x);
+    print(Object.hasOwnProperty(x, 'flags'), 'flags' in x);
+    print(Object.hasOwnProperty(x, 'global'), 'global' in x);
+    print(Object.hasOwnProperty(x, 'multiline'), 'multiline' in x);
+    print(Object.hasOwnProperty(x, 'ignoreCase'), 'ignoreCase' in x);
+    print(Object.hasOwnProperty(x, 'sticky'), 'sticky' in x);
+    print(Object.hasOwnProperty(x, 'unicode'), 'unicode' in x);
+
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'source');
+    print(typeof pd.get, typeof pd.set, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags');
+    print(typeof pd.get, typeof pd.set, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'global');
+    print(typeof pd.get, typeof pd.set, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'multiline');
+    print(typeof pd.get, typeof pd.set, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'ignoreCase');
+    print(typeof pd.get, typeof pd.set, pd.enumerable, pd.configurable);
+
+    // .sticky and .unicode not implemented yet to avoid interfering with
+    // feature detection code; document absence
+    /*
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky');
+    print(typeof pd.get, typeof pd.set);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode');
+    print(typeof pd.get, typeof pd.set);
+    */
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky');
+    print(typeof pd);
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'unicode');
+    print(typeof pd);
+
+    // If a new RegExp is created from an existing one, ES6 reads .flags
+    // and uses it as an argument.
+    y = new RegExp(x);
+    print(y.flags);
+
+    // The .flags getter is generic.
+    pd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags');
+    try {
+        pd.get.call('foo');  // argument must still be an Object
+    } catch (e) {
+        print(e.name);
+    }
+    print(pd.get.call(/foo/gm));
+    print(pd.get.call({ global: 'yes', ignoreCase: 1, multiline: 0, something: 'else' }));
+
+    // .flags coverage for GIM flags.
+    print(/foo/.flags);
+    print(/foo/g.flags);
+    print(/foo/i.flags);
+    print(/foo/gi.flags);
+    print(/foo/m.flags);
+    print(/foo/gm.flags);
+    print(/foo/im.flags);
+    print(/foo/gim.flags);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-regexp.js
+++ b/tests/ecmascript/test-bi-regexp.js
@@ -51,10 +51,10 @@ try {
 
 /*===
 instance
-source true true
-global true true
-ignoreCase true true
-multiline true true
+source true false
+global true false
+ignoreCase true false
+multiline true false
 lastIndex true true
 ===*/
 
@@ -71,6 +71,10 @@ function regexpInstanceTest() {
     // own properties (not inherited).  Check for that, although it's quite
     // likely at least the the flag-related properties will be converted to
     // accessors at some point to save memory.
+    //
+    // ES6 actually changes .source, .global, .ignoreCase, and .multiline to
+    // inherited getters, check for that behavior.  .lastIndex remains own
+    // property.
 
     check('source');
     check('global');

--- a/tests/ecmascript/test-bug-string-replace-assert-gh492.js
+++ b/tests/ecmascript/test-bug-string-replace-assert-gh492.js
@@ -3,26 +3,39 @@
  */
 
 /*===
-undefined
+
 still here
-undefinedfoo
+foo
 still here
-string ""
+TypeError
+still here
 ===*/
 
 function test() {
     // Caused an assert failure in Duktape 1.3.0 and prior, and with asserts
     // disabled memory unsafe behavior.
-    print(String.prototype.replace(RegExp.prototype));
+    try {
+        print(String.prototype.replace(RegExp.prototype));
+    } catch (e) {
+        print(e.name);
+    }
     print('still here');
 
     // Similar case
-    print('foo'.replace(RegExp.prototype));
+    try {
+        print('foo'.replace(RegExp.prototype));
+    } catch (e) {
+        print(e.name);
+    }
     print('still here');
 
-    // Ensure RegExp.prototype matches correctly (it's a RegExp instance too).
-    var m = RegExp.prototype.exec('foo');
-    print(typeof m[0], JSON.stringify(m[0]));
+    try {
+        var m = RegExp.prototype.exec('foo');
+        print(typeof m[0], JSON.stringify(m[0]));
+    } catch (e) {
+        print(e.name);
+    }
+    print('still here');
 }
 
 try {

--- a/tests/ecmascript/test-regexp-constructor-calls.js
+++ b/tests/ecmascript/test-regexp-constructor-calls.js
@@ -16,7 +16,8 @@ var r, t;
 
 true
 true
-TypeError
+SyntaxError
+no error
 Foo
 ===*/
 
@@ -58,7 +59,14 @@ try {
 }
 
 try {
-    t = RegExp(r, 1);
+    t = RegExp(r, 1);  // rejected in ES5 with TypeError, SyntaxError in ES6 because '1' is not a proper flag
+    print('no error');
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    t = RegExp(r, 'i');  // rejected in ES5 with TypeError, OK in ES6
     print('no error');
 } catch (e) {
     print(e.name);
@@ -78,7 +86,8 @@ try {
 
 /*===
 false
-TypeError
+SyntaxError
+no error
 Foo
 SyntaxError
 SyntaxError
@@ -95,7 +104,14 @@ try {
 }
 
 try {
-    t = new RegExp(r, 1);
+    t = new RegExp(r, 1);  // TypeError in ES5.1, SyntaxError in ES6 because '1' is not a valid flag
+    print('no error');
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    t = new RegExp(r, 'm');  // TypeError in ES5.1, OK in ES6
     print('no error');
 } catch (e) {
     print(e.name);

--- a/tests/knownissues/test-dev-lightfunc-6.txt
+++ b/tests/knownissues/test-dev-lightfunc-6.txt
@@ -1,0 +1,748 @@
+summary: requires DUK_USE_LIGHTFUNC_BUILTINS
+---
+light func support test
+false
+typeof test
+function
+property assignment test
+strPlainNonStrict: success
+strPlainStrict: TypeError
+strObjectNonStrict: success
+strObjectStrict: success
+strObjectNonextNonStrict: success
+strObjectNonextStrict: TypeError
+lfuncNonStrict1: success
+lfuncNonStrict2: success
+lfuncStrict1: TypeError
+lfuncStrict2: success
+instanceof test
+{} instanceof lightfunc: TypeError
+false
+{} instanceof func-wo-prototype: TypeError
+lightFunc instanceof Function: true
+lightFunc instanceof Number: false
+lightFunc instanceof Object: true
+comparison test
+0 0 true true
+0 1 false false
+0 2 false false
+0 3 true true
+0 4 false false
+0 5 false false
+0 6 false false
+1 0 false false
+1 1 true true
+1 2 false false
+1 3 false false
+1 4 true true
+1 5 false false
+1 6 false false
+2 0 false false
+2 1 false false
+2 2 true true
+2 3 false false
+2 4 false false
+2 5 true true
+2 6 false false
+3 0 true true
+3 1 false false
+3 2 false false
+3 3 true true
+3 4 false false
+3 5 false false
+3 6 false false
+4 0 false false
+4 1 true true
+4 2 false false
+4 3 false false
+4 4 true true
+4 5 false false
+4 6 false false
+5 0 false false
+5 1 false false
+5 2 true true
+5 3 false false
+5 4 false false
+5 5 true true
+5 6 false false
+6 0 false false
+6 1 false false
+6 2 false false
+6 3 false false
+6 4 false false
+6 5 false false
+6 6 true true
+arithmetic test
+string: testfunction cos() { [native code] }function sin() { [native code] }
+string: function cos() { [native code] }function sin() { [native code] }
+string: function foo() { [ecmascript code] }function bar() { [ecmascript code] }
+toString() test
+function max() { [native code] }
+function max() { [native code] }
+function max() { [native code] }
+true
+true
+toObject() test
+caching: true
+length: 2 2
+name: max max
+typeof: function function
+internal prototype is Function.prototype: true true
+external prototype is not set: true
+internal prototypes match: true
+external prototypes match (do not exist): true
+isExtensible: true true
+Math.max test: 9 9
+length: 1 1
+toBoolean() test
+true
+true
+toBuffer() test
+object: function cos() { [native code] }
+object: function sin() { [native code] }
+toPointer() test
+pointer false
+object false
+number coercion test
+NaN
+NaN
+0
+0
+0
+0
+0
+0
+call and apply test
+call
+321
+apply
+987
+this coercion test
+function false
+function false
+inherit from Function.prototype test
+testValue
+Object.prototype.toString() test
+[object Function]
+JSON/JX/JC test
+json
+undefined
+undefined
+jx
+{_func:true}
+{_func:true}
+jc
+{"_func":true}
+{"_func":true}
+json
+undefined
+undefined
+jx
+{_func:true}
+{_func:true}
+jc
+{"_func":true}
+{"_func":true}
+json
+{"array":[100,null,200,null,300]}
+{
+    "array": [
+        100,
+        null,
+        200,
+        null,
+        300
+    ]
+}
+jx
+{lf:{_func:true},nf:{_func:true},array:[100,{_func:true},200,{_func:true},300]}
+{
+    lf: {_func:true},
+    nf: {_func:true},
+    array: [
+        100,
+        {_func:true},
+        200,
+        {_func:true},
+        300
+    ]
+}
+jc
+{"lf":{"_func":true},"nf":{"_func":true},"array":[100,{"_func":true},200,{"_func":true},300]}
+{
+    "lf": {"_func":true},
+    "nf": {"_func":true},
+    "array": [
+        100,
+        {"_func":true},
+        200,
+        {"_func":true},
+        300
+    ]
+}
+json
+"toJsonRetval"
+"toJsonRetval"
+jx
+"toJsonRetval"
+"toJsonRetval"
+jc
+"toJsonRetval"
+"toJsonRetval"
+json
+"toJsonRetval"
+"toJsonRetval"
+jx
+"toJsonRetval"
+"toJsonRetval"
+jc
+"toJsonRetval"
+"toJsonRetval"
+json
+{"lf":"toJsonRetval","nf":"toJsonRetval","array":[100,"toJsonRetval",200,"toJsonRetval",300]}
+{
+    "lf": "toJsonRetval",
+    "nf": "toJsonRetval",
+    "array": [
+        100,
+        "toJsonRetval",
+        200,
+        "toJsonRetval",
+        300
+    ]
+}
+jx
+{lf:"toJsonRetval",nf:"toJsonRetval",array:[100,"toJsonRetval",200,"toJsonRetval",300]}
+{
+    lf: "toJsonRetval",
+    nf: "toJsonRetval",
+    array: [
+        100,
+        "toJsonRetval",
+        200,
+        "toJsonRetval",
+        300
+    ]
+}
+jc
+{"lf":"toJsonRetval","nf":"toJsonRetval","array":[100,"toJsonRetval",200,"toJsonRetval",300]}
+{
+    "lf": "toJsonRetval",
+    "nf": "toJsonRetval",
+    "array": [
+        100,
+        "toJsonRetval",
+        200,
+        "toJsonRetval",
+        300
+    ]
+}
+json
+0
+0
+jx
+0
+0
+jc
+0
+0
+json
+0
+0
+jx
+0
+0
+jc
+0
+0
+json
+{"lf":null,"nf":null,"array":[100,1,200,3,300]}
+{
+    "lf": null,
+    "nf": null,
+    "array": [
+        100,
+        1,
+        200,
+        3,
+        300
+    ]
+}
+jx
+{lf:NaN,nf:NaN,array:[100,1,200,3,300]}
+{
+    lf: NaN,
+    nf: NaN,
+    array: [
+        100,
+        1,
+        200,
+        3,
+        300
+    ]
+}
+jc
+{"lf":{"_nan":true},"nf":{"_nan":true},"array":[100,1,200,3,300]}
+{
+    "lf": {"_nan":true},
+    "nf": {"_nan":true},
+    "array": [
+        100,
+        1,
+        200,
+        3,
+        300
+    ]
+}
+bound function test
+F: function max() { [native code] }
+F type tag: 6
+G: function bound max() { [bound code] }
+G type tag: 6
+G.length: 1
+H: function bound bound max() { [bound code] }
+H type tag: 6
+H.length: 0
+I: function bound bound bound max() { [bound code] }
+I type tag: 6
+I.length: 0
+G(123): 234
+G(123,987): 987
+property get test
+length directly: 2
+toString coerced object (return "length")
+objLengthKey coerced to string: length
+toString coerced object (return "length")
+length through object coercion: 2
+read from length -> 2
+read from prototype -> undefined
+read from name -> max
+toString coerced object (return "length")
+toString coerced object (return "length")
+read from length -> 2
+read from testWritable -> 123
+read from testNonWritable -> 234
+read from call -> function call() { [native code] }
+read from apply -> function apply() { [native code] }
+read from nonexistent -> 123
+property put test
+write to length -> silent error
+write to prototype -> silent error
+write to name -> silent error
+toString coerced object (return "length")
+toString coerced object (return "length")
+write to length -> silent error
+write to testWritable -> silent error
+write to testNonWritable -> silent error
+write to call -> silent error
+write to apply -> silent error
+write to nonexistent -> silent error
+write to length -> TypeError
+never here: prototype
+write to name -> TypeError
+toString coerced object (return "length")
+toString coerced object (return "length")
+write to length -> TypeError
+never here: testWritable
+write to testNonWritable -> TypeError
+never here: call
+never here: apply
+never here: nonexistent
+property has test
+existence: length -> true
+existence: prototype -> true
+existence: name -> true
+toString coerced object (return "length")
+toString coerced object (return "length")
+existence: length -> true
+existence: testWritable -> true
+existence: testNonWritable -> true
+existence: call -> true
+existence: apply -> true
+existence: nonexistent -> true
+property delete test
+delete: length -> false
+delete: prototype -> true
+delete: name -> false
+toString coerced object (return "length")
+toString coerced object (return "length")
+delete: length -> false
+delete: testWritable -> true
+delete: testNonWritable -> true
+delete: call -> true
+delete: apply -> true
+delete: nonexistent -> true
+delete: length -> TypeError
+delete: prototype -> true
+delete: name -> TypeError
+toString coerced object (return "length")
+toString coerced object (return "length")
+delete: length -> TypeError
+delete: testWritable -> true
+delete: testNonWritable -> true
+delete: call -> true
+delete: apply -> true
+delete: nonexistent -> true
+non-strict: true
+strict: true
+property accessor this binding test
+getter, strict
+strict getter "this" binding test
+typeof this: function
+this == lightFunc: true
+this === lightFunc: true
+this.name: max
+type tag: 6
+getter retval
+setter, strict
+strict setter "this" binding test
+typeof this: function
+this == lightFunc: true
+this === lightFunc: true
+this.name: max
+type tag: 6
+getter, non-strict
+non-strict getter "this" binding test
+typeof this: function
+this == lightFunc: true
+this === lightFunc: true
+this.name: max
+type tag: 6
+getter retval
+setter, non-strict
+non-strict setter "this" binding test
+typeof this: function
+this == lightFunc: true
+this === lightFunc: true
+this.name: max
+type tag: 6
+property misc test
+isSealed: false
+isFrozen: false
+isExtensible: true
+for-in: "inheritTestProperty"
+Object.getOwnPropertyNames: "length"
+Object.getOwnPropertyNames: "name"
+lightFunc.name matches regexp: false
+censored lightFunc.name: max_
+traceback test
+URIError: invalid input
+    at [anon] (duk_bi_global.c:NNN) internal
+    at decodeURIComponent () native strict preventsyield
+    at tracebackTest (TESTCASE:NNN)
+    at global (TESTCASE:NNN) preventsyield
+Duktape.act() test
+Error: for traceback
+    at callback (TESTCASE:NNN) preventsyield
+    at forEach () native strict preventsyield
+    at duktapeActTest (TESTCASE:NNN)
+    at global (TESTCASE:NNN) preventsyield
+-1 ["pc","lineNumber","function"] act
+-2 ["pc","lineNumber","function"] callback
+-3 ["pc","lineNumber","function"] forEach
+-4 ["pc","lineNumber","function"] duktapeActTest
+-5 ["pc","lineNumber","function"] global
+exempt built-ins test
+Math.max (is lightfunc): function false
+eval: function false
+yield: function false
+resume: function false
+require: function false
+Object: function false
+Function: function false
+Array: function false
+String: function false
+Boolean: function false
+Number: function false
+Date: function false
+RegExp: function false
+Error: function false
+EvalError: function false
+RangeError: function false
+ReferenceError: function false
+SyntaxError: function false
+TypeError: function false
+URIError: function false
+Proxy: function false
+Duktape.Pointer: function false
+Duktape.Thread: function false
+Duktape.Logger: function false
+Duktape: object false
+Math: object false
+JSON: object false
+getOwnPropertyNames() test
+length,name
+length
+name
+getOwnPropertyDescriptor() test
+key: name
+value: string cos
+writable: boolean false
+enumerable: boolean false
+configurable: boolean false
+key: length
+value: number 1
+writable: boolean false
+enumerable: boolean false
+configurable: boolean false
+key: nonExistent
+no descriptor
+hasOwnProperty() test
+true
+true
+false
+false
+propertyIsEnumerable() test
+false
+false
+false
+false
+defineProperty() test
+nonexistent: success
+name: TypeError
+length: success
+defineProperties() test
+nonexistent: success
+name: TypeError
+length: success
+getPrototypeOf() test
+true
+true
+setPrototypeOf() test
+TypeError
+never here
+TypeError
+never here
+success
+success
+success
+success
+Array built-in test
+Array: object [{_func:true}]
+new Array: object [{_func:true}]
+isArray: boolean false
+toString: string "[object Function]"
+valueOf: function {_func:true}
+concat: object [{_func:true}]
+pop: TypeError
+push: TypeError
+sort: function {_func:true}
+splice: TypeError
+reverse: function {_func:true}
+shift: TypeError
+unshift: TypeError
+every: TypeError
+some: TypeError
+forEach: TypeError
+map: TypeError
+filter: TypeError
+reduce: TypeError
+reduceRight: TypeError
+Boolean built-in test
+Boolean: boolean true
+new Boolean: object true
+toString: TypeError
+valueOf: TypeError
+Duktape.Buffer built-in test
+Duktape.Buffer: TypeError
+new Duktape.buffer: TypeError
+toString: TypeError
+valueOf: TypeError
+Date built-in test
+Date: string "string"
+new Date: string "object"
+parse: number NaN
+UTC: number NaN
+now: string "number"
+toString: TypeError
+valueOf: TypeError
+toDateString: TypeError
+toTimeString: TypeError
+toLocaleString: TypeError
+toLocaleDateString: TypeError
+toLocaleTimeString: TypeError
+getTime: TypeError
+getFullYear: TypeError
+getUTCFullYear: TypeError
+getMonth: TypeError
+getUTCFullMonth: TypeError
+getDate: TypeError
+getUTCDate: TypeError
+getDay: TypeError
+getUTCDay: TypeError
+getHours: TypeError
+getUTCHours: TypeError
+getMinutes: TypeError
+getUTCMinutes: TypeError
+getSeconds: TypeError
+getUTCSeconds: TypeError
+getMilliseconds: TypeError
+getUTCMilliseconds: TypeError
+getTimezoneOffset: TypeError
+setTime: TypeError
+setMilliseconds: TypeError
+setUTCMilliseconds: TypeError
+setSeconds: TypeError
+setUTCSeconds: TypeError
+setMinutes: TypeError
+setUTCMinutes: TypeError
+setHours: TypeError
+setUTCHours: TypeError
+setDate: TypeError
+setUTCDate: TypeError
+setMonth: TypeError
+setUTCMonth: TypeError
+setFullYear: TypeError
+setUTCFullYear: TypeError
+toUTCString: TypeError
+toISOString: TypeError
+toJSON: TypeError
+setYear: TypeError
+getYear: TypeError
+Duktape built-in test
+info: number 6
+act: undefined undefined
+gc: boolean true
+fin-get: undefined undefined
+fin-set: undefined undefined
+encdec-hex: string "function cos() { [native code] }"
+dec-hex: TypeError
+compact: function {_func:true}
+Error built-in test
+Error: object {}
+new Error: object {}
+toString: string "cos"
+valueOf: function {_func:true}
+Function built-in test
+Function: SyntaxError
+new Function: SyntaxError
+toString: string "function cos() { [native code] }"
+valueOf: function {_func:true}
+global built-in test
+eval: function {_func:true}
+parseInt: number NaN
+parseFloat: number NaN
+isNaN: boolean true
+isFinite: boolean false
+decodeURI: string "function cos() { [native code] }"
+decodeURIComponent: string "function cos() { [native code] }"
+encodeURI: string "string"
+encodeURIComponent: string "string"
+escape: string "string"
+unescape: string "string"
+JSON built-in test
+parse: SyntaxError
+stringify: undefined undefined
+Duktape.Logger built-in test
+Duktape.Logger: TypeError
+new Duktape.Logger: object {}
+fmt: TypeError
+raw: TypeError
+TIMESTAMP INF test: My light func is: function cos() { [native code] }
+Math built-in test
+abs: number NaN
+acos: number NaN
+asin: number NaN
+atan: number NaN
+atan2: number NaN
+ceil: number NaN
+cos: number NaN
+exp: number NaN
+floor: number NaN
+log: number NaN
+max: number NaN
+min: number NaN
+pow: number NaN
+random: string "number"
+round: number NaN
+sin: number NaN
+sqrt: number NaN
+tan: number NaN
+Number built-in test
+Number: number NaN
+new Number: object NaN
+toString: TypeError
+toLocaleString: TypeError
+valueOf: TypeError
+toFixed: TypeError
+toExponential: TypeError
+toPrecision: TypeError
+Object built-in test
+Object: function {_func:true}
+new Object: function {_func:true}
+getPrototypeOf: function {_func:true}
+setPrototypeOf: function {_func:true}
+seal: function {_func:true}
+freeze: function {_func:true}
+preventExtensions: function {_func:true}
+isSealed: boolean true
+isFrozen: boolean true
+isExtensible: boolean false
+toString: string "[object Function]"
+toLocaleString: string "[object Function]"
+valueOf: function {_func:true}
+isPrototypeOf: boolean false
+Duktape.Pointer built-in test
+false
+false
+toString: TypeError
+valueOf: TypeError
+Proxy built-in test
+get
+this: object false [object Object]
+target: function false [object Function]
+key: string name
+proxy.name: cos
+get
+this: object false [object Object]
+target: function false [object Function]
+key: string length
+proxy.length: 1
+get
+this: object false [object Object]
+target: function false [object Function]
+key: string nonExistent
+proxy.nonExistent: dummy
+proxy.foo: bar
+proxy.nonExistent: undefined
+RegExp built-in test
+RegExp: object {}
+new RegExp: object {}
+exec: TypeError
+test: TypeError
+toString: string "/undefined/undefined"
+valueOf: function {_func:true}
+String built-in test
+String: string "[object Function]"
+new String: string "[object Function]"
+new String: string "object"
+fromCharCode: string "\x00"
+toString: TypeError
+valueOf: TypeError
+charAt: string "["
+charCodeAt: number 91
+concat: string "[object Function][object Function]"
+indexOf: number 0
+lastIndexOf: number 0
+localeCompare: number 0
+match: object ["o"]
+replace: string "undefined"
+search: number 1
+slice: string "[object Function]"
+split: object ["",""]
+substring: string "[object Function]"
+toLowerCase: string "[object function]"
+toLocaleLowerCase: string "[object function]"
+toUpperCase: string "[OBJECT FUNCTION]"
+toLocaleUpperCase: string "[OBJECT FUNCTION]"
+trim: string "[object Function]"
+substr: string "[object Function]"
+Duktape.Thread built-in test
+TypeError
+TypeError
+Object .valueOf() test
+true
+function function
+true
+6
+6


### PR DESCRIPTION
- [x] RegExp.prototype is no longer a RegExp instance
- [x] .source, .global, .ignoreCase, .multiline are inherited getters instead of own properties
- [x] .sticky, .unicode are new in ES6 (return false for now)
- [x] Change .sticky and .unicode to be absent until implemented (otherwise may interfere with feature detection)
- [x] .flags is new in ES6, implement
- [x] RegExp constructor looks up .flags rather than .global, .ignoreCase, .multiline when argument is a RegExp instance
- [x] RegExp constructor allows a RegExp instance and an (overriding) flags argument
- [x] RegExp constructor non-constructor call handling (maybe future work) #1179
- [x] RegExp .flags implementation future work (should do explicit property accesses which matters if getters are replaced) #1179
- [x] RegExp.prototype draft ES8 fixes
- [x] Testcase coverage
- [x] Test coverage for draft ES8 fixes
- [x] The .flags getter should read other flag fields explicitly using property reads. This matters if the getters have been replaced. Easy to demonstrate by replacing the getters with logging variants.
- [x] For some reason V8 and Firefox won't TypeError for e.g. `RegExp.prototype.source`. This seems incorrect because `.source` should TypeError if the `this` binding doesn't have RegExp internal slots. With RegExp.prototype now a plain object (and explicitly without RegExp internal slots) a TypeError should result. This should be double checked because it's quite possible V8 and Firefox are correct. => Draft ES2017 behavior.
- [x] The .toString() method is generic and should work on any object; however, it reads `.source` and `.flags` which should (again) cause a TypeError when applied to RegExp.prototype. As a result, `String(RegExp.prototype)` should be a TypeError as far as I can see. => Draft ES2017 behavior.
- [x] 2.0 migration notes
- [x] Releases entry
- [x] Migration notes and releases changes for draft ES8 fixes