### PR TITLE
Fix web UI debugger DumpHeap handling

### DIFF
--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -107,9 +107,9 @@ debugCommandNames.forEach(function (k, i) {
 });
 
 // Duktape heaphdr type constants, must match C headers
-var DUK_HTYPE_STRING = 1;
-var DUK_HTYPE_OBJECT = 2;
-var DUK_HTYPE_BUFFER = 3;
+var DUK_HTYPE_STRING = 0;
+var DUK_HTYPE_OBJECT = 1;
+var DUK_HTYPE_BUFFER = 2;
 
 // Duktape internal class numbers, must match C headers
 var dukClassNameMeta = yaml.load('duk_classnames.yaml');

--- a/debugger/static/index.html
+++ b/debugger/static/index.html
@@ -16,20 +16,20 @@
 <div id="part-middle">
 
 <div id="left-area">
-<button id="stepinto-button">Step&#x00a0;into</button>
-<button id="stepover-button">Step&#x00a0;over</button>
-<button id="stepout-button">Step&#x00a0;out</button>
-<button id="resume-button">Resume</button>
-<button id="pause-button">Pause</button>
+<a class="button" href="#" id="stepinto-button">Step&#x00a0;into</a>
+<a class="button" href="#" id="stepover-button">Step&#x00a0;over</a>
+<a class="button" href="#" id="stepout-button">Step&#x00a0;out</a>
+<a class="button" href="#" id="resume-button">Resume</a>
+<a class="button" href="#" id="pause-button">Pause</a>
 <br />
 <br />
 <br />
 <br />
-<button id="attach-button">Attach</button>
-<button id="detach-button">Detach</button>
-<button id="about-button">About</button>
-<button id="heap-dump-download-button"><a id="heap-dump-download" href="/heapDump.json" target="_blank">Dump&#x00a0;heap</a></button>
-<button id="show-bytecode-button">Show bytecode</button>
+<a class="button" href="#" id="attach-button">Attach</a>
+<a class="button" href="#" id="detach-button">Detach</a>
+<a class="button" href="#" id="about-button">About</a>
+<a class="button" id="heap-dump-download-button" href="/heapDump.json" target="_blank">Dump&#x00a0;heap</a>
+<a class="button" href="#" id="show-bytecode-button">Show bytecode</a>
 </div>  <!-- #left-area -->
 
 <div id="center-area">

--- a/debugger/static/style.css
+++ b/debugger/static/style.css
@@ -95,10 +95,11 @@
 	color: #9999ff;
 }
 
-#left-area button {
+#left-area .button {
 	display: inline-block;
-	width: 100%;
-	min-width: 8em;
+	text-align: center;
+	width: 95%;
+	min-width: 6em;
 	background: #226622;
 	color: #ffffff;
 	font: 16pt sans-serif;
@@ -109,18 +110,18 @@
 	border: 2px solid #000000;
 	border-radius: 4px;
 }
-#left-area button a {
+#left-area .button a {
 	color: #ffffff;
 	text-decoration: none;
 }
-#left-area button:hover {
+#left-area .button:hover {
 	background: #55aa55;
 }
-#left-area button:disabled {
+#left-area .button:disabled {
 	background: #555555;
 	color: #888888;
 }
-#left-area button:disabled a {
+#left-area .button:disabled a {
 	background: #555555;
 	color: #888888;
 }


### PR DESCRIPTION
- [x] Fix out-of-date `DUK_HTYPE_xxx` constants (correct for 1.x)
- [x] Fix heap dump link/button issue with Firefox (works in Chrome)