### PR TITLE
Change NativeError (TypeError, etc) constructor to inherit from Error constructor

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2088,6 +2088,10 @@ Planned
   behavior; this only matters when tracebacks are disabled and concrete
   error instance properties are in use (GH-1153)
 
+* Change NativeError (TypeError, RangeError, etc) constructor to inherit
+  from the Error constructor rather than Function.prototype directly as
+  required by ES6 (GH-1182)
+
 * Add a fastint check for duk_put_number_list() values (GH-1086)
 
 * Remove an unintended fastint downgrade check for unary minus executor

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -1948,7 +1948,7 @@ objects:
 
   - id: bi_eval_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true
@@ -1988,7 +1988,7 @@ objects:
 
   - id: bi_range_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true
@@ -2028,7 +2028,7 @@ objects:
 
   - id: bi_reference_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true
@@ -2068,7 +2068,7 @@ objects:
 
   - id: bi_syntax_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true
@@ -2108,7 +2108,7 @@ objects:
 
   - id: bi_type_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true
@@ -2148,7 +2148,7 @@ objects:
 
   - id: bi_uri_error_constructor
     class: Function
-    internal_prototype: bi_function_prototype
+    internal_prototype: bi_error_constructor
     native: duk_bi_error_constructor_shared
     callable: true
     constructable: true

--- a/tests/ecmascript/test-bi-error-constructor.js
+++ b/tests/ecmascript/test-bi-error-constructor.js
@@ -1,0 +1,34 @@
+/*===
+true
+true
+true
+true
+true
+true
+true
+bar
+===*/
+
+function test() {
+    // Error constructor inheritance chains were changed in ES6.
+    // E.g. TypeError constructor internal prototype is the Error
+    // constructor rather than Function.prototype directly.
+
+    print(Object.getPrototypeOf(Error) === Function.prototype);
+    print(Object.getPrototypeOf(EvalError) === Error);
+    print(Object.getPrototypeOf(RangeError) === Error);
+    print(Object.getPrototypeOf(ReferenceError) === Error);
+    print(Object.getPrototypeOf(SyntaxError) === Error);
+    print(Object.getPrototypeOf(TypeError) === Error);
+    print(Object.getPrototypeOf(URIError) === Error);
+
+    // Demonstrate using an actual inherited property access.
+    Error.foo = 'bar';
+    print(RangeError.foo);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-properties.js
+++ b/tests/ecmascript/test-bi-properties.js
@@ -480,7 +480,7 @@ var obj_data = [
     {
         obj: EvalError,
         name: 'EvalError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -506,7 +506,7 @@ var obj_data = [
     {
         obj: RangeError,
         name: 'RangeError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -532,7 +532,7 @@ var obj_data = [
     {
         obj: ReferenceError,
         name: 'ReferenceError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -558,7 +558,7 @@ var obj_data = [
     {
         obj: SyntaxError,
         name: 'SyntaxError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -584,7 +584,7 @@ var obj_data = [
     {
         obj: TypeError,
         name: 'TypeError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -610,7 +610,7 @@ var obj_data = [
     {
         obj: URIError,
         name: 'URIError',
-        proto: 'Function.prototype',
+        proto: 'Error',
         class: 'Function',
         props: [
             { key: 'length', 'attrs': '', value: 1 },
@@ -1107,7 +1107,7 @@ PROPERTY: "toString" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "EvalError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable
@@ -1121,7 +1121,7 @@ PROPERTY: "message" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "RangeError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable
@@ -1135,7 +1135,7 @@ PROPERTY: "message" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "ReferenceError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable
@@ -1149,7 +1149,7 @@ PROPERTY: "message" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "SyntaxError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable
@@ -1163,7 +1163,7 @@ PROPERTY: "message" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "TypeError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable
@@ -1177,7 +1177,7 @@ PROPERTY: "message" writable !enumerable configurable
 NOPROPERTY: "length" 
 
 OBJECT: "URIError" !sealed !frozen extensible
-PROTOTYPE: "Function.prototype"
+PROTOTYPE: "Error"
 CLASS: Function
 PROPERTY: "length" !writable !enumerable !configurable
 PROPERTY: "prototype" !writable !enumerable !configurable


### PR DESCRIPTION
In ES5 e.g. TypeError would inherit from Function.prototype. In ES6 it inherits from the Error constructor (which inherits from Function.prototype). See http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-nativeerror-constructors.

- [x] Change inheritance
- [x] Testcase coverage and fixes
- [x] Releases entry