### PR TITLE
Align anonymous function handling against ES6/ES7

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2090,6 +2090,13 @@ Planned
   non-writable and non-enumerable) to match ES6 requirements; also change
   .fileName to follow the same attribute convention (GH-1153, GH-1177)
 
+* Remove anonymous function own .name property to match ES6 requirements;
+  anonymous functions inherit an empty string as their name from
+  Function.prototype.name (GH-1183)
+
+* Change functions created using new Function() to have the .name
+  "anonymous" to match ES6 requirements (GH-1183)
+
 * Make Error instance .fileName and .lineNumber properties configurable
   but non-writable and non-enumerable to match function instance property
   behavior; this only matters when tracebacks are disabled and concrete

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -429,12 +429,13 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 	/* Push function object, init flags etc.  This must match
 	 * duk_js_push_closure() quite carefully.
 	 */
-	h_fun = duk_push_compiledfunction(ctx);
+	h_fun = duk_push_hcompfunc(ctx);
 	DUK_ASSERT(h_fun != NULL);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) h_fun));
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_DATA(thr->heap, h_fun) == NULL);
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_FUNCS(thr->heap, h_fun) == NULL);
 	DUK_ASSERT(DUK_HCOMPFUNC_GET_BYTECODE(thr->heap, h_fun) == NULL);
+	DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, (duk_hobject *) h_fun) == thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
 
 	h_fun->nregs = DUK_RAW_READ_U16_BE(p);
 	h_fun->nargs = DUK_RAW_READ_U16_BE(p);

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -156,17 +156,18 @@ DUK_INTERNAL_DECL void duk_push_hobject(duk_context *ctx, duk_hobject *h);
 DUK_INTERNAL_DECL void duk_push_hbuffer(duk_context *ctx, duk_hbuffer *h);
 #define duk_push_hthread(ctx,h) \
 	duk_push_hobject((ctx), (duk_hobject *) (h))
-#define duk_push_hcompfunc(ctx,h) \
-	duk_push_hobject((ctx), (duk_hobject *) (h))
 #define duk_push_hnatfunc(ctx,h) \
 	duk_push_hobject((ctx), (duk_hobject *) (h))
 DUK_INTERNAL_DECL void duk_push_hobject_bidx(duk_context *ctx, duk_small_int_t builtin_idx);
 DUK_INTERNAL_DECL duk_hobject *duk_push_object_helper(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_small_int_t prototype_bidx);
 DUK_INTERNAL_DECL duk_hobject *duk_push_object_helper_proto(duk_context *ctx, duk_uint_t hobject_flags_and_class, duk_hobject *proto);
-DUK_INTERNAL_DECL duk_hcompfunc *duk_push_compiledfunction(duk_context *ctx);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_push_hcompfunc(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_push_c_function_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);
 DUK_INTERNAL_DECL void duk_push_c_function_noconstruct_noexotic(duk_context *ctx, duk_c_function func, duk_int_t nargs);
 
+/* XXX: duk_push_harray() and duk_push_hcompfunc() are inconsistent with
+ * duk_push_hobject() etc which don't create a new value.
+ */
 DUK_INTERNAL_DECL duk_harray *duk_push_harray(duk_context *ctx);
 DUK_INTERNAL_DECL duk_harray *duk_push_harray_with_size(duk_context *ctx, duk_uint32_t size);
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3895,7 +3895,7 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t flags) {
 	return ret;
 }
 
-DUK_INTERNAL duk_hcompfunc *duk_push_compiledfunction(duk_context *ctx) {
+DUK_INTERNAL duk_hcompfunc *duk_push_hcompfunc(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hcompfunc *obj;
 	duk_tval *tv_slot;
@@ -3927,7 +3927,6 @@ DUK_INTERNAL duk_hcompfunc *duk_push_compiledfunction(duk_context *ctx) {
 	DUK_HOBJECT_INCREF(thr, obj);
 	thr->valstack_top++;
 
-	/* default prototype (Note: 'obj' must be reachable) */
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
 
 	return obj;

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -69,6 +69,11 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	               (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_sourcecode),
 	               (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sourcecode),
 	               comp_flags);
+
+	/* Force .name to 'anonymous' (ES6). */
+	duk_push_string(ctx, "anonymous");
+	duk_xdef_prop_stridx_short(ctx, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_C);
+
 	func = (duk_hcompfunc *) duk_known_hobject(ctx, -1);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) func));
 

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -645,7 +645,7 @@ DUK_LOCAL duk_int_t duk__cleanup_varmap(duk_compiler_ctx *comp_ctx) {
 	return ret;
 }
 
-/* convert duk_compiler_func into a function template, leaving the result
+/* Convert duk_compiler_func into a function template, leaving the result
  * on top of stack.
  */
 /* XXX: awkward and bloated asm -- use faster internal accesses */
@@ -681,8 +681,10 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx, duk_sma
 
 	/* Valstack should suffice here, required on function valstack init */
 
-	h_res = duk_push_compiledfunction(ctx);
+	h_res = duk_push_hcompfunc(ctx);
 	DUK_ASSERT(h_res != NULL);
+	DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, (duk_hobject *) h_res) == thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
+	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, (duk_hobject *) h_res, NULL);  /* Function templates are "bare objects". */
 
 	if (func->is_function) {
 		DUK_DDD(DUK_DDDPRINT("function -> set NEWENV"));

--- a/tests/ecmascript/test-bi-function-constructor.js
+++ b/tests/ecmascript/test-bi-function-constructor.js
@@ -19,6 +19,10 @@ seven args foo bar quux undefined undefined undefined undefined
 foobarquux
 foobarquux
 foobarquux
+string anonymous false false true
+number 0 false false true
+string anonymous false false true
+number 2 false false true
 ===*/
 
 function functionConstructorTest() {
@@ -56,14 +60,26 @@ function functionConstructorTest() {
     f = new Function('a', 'b', 'c', 'd', 'e', 'f', 'g', 'print("seven args", a, b, c, d, e, f, g);');
     f('foo', 'bar', 'quux');
 
-    /* Example from specification (E5.1, Section 15.3.2.1, NOTE at bottom). */
+    // Example from specification (E5.1, Section 15.3.2.1, NOTE at bottom).
 
-    f = new Function("a", "b", "c", "return a+b+c");
+    f = new Function('a', 'b', 'c', 'return a+b+c');
     print(f('foo', 'bar', 'quux', 'baz'));
-    f = new Function("a, b, c", "return a+b+c");
+    f = new Function('a, b, c', 'return a+b+c');
     print(f('foo', 'bar', 'quux', 'baz'));
-    f = new Function("a,b", "c", "return a+b+c");
+    f = new Function('a,b', 'c', 'return a+b+c');
     print(f('foo', 'bar', 'quux', 'baz'));
+
+    // In ES6 the resulting function must have a .name of 'anonymous'.
+    f = new Function('');
+    pd = Object.getOwnPropertyDescriptor(f, 'name');
+    print(typeof pd.value, pd.value, pd.writable, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(f, 'length');
+    print(typeof pd.value, pd.value, pd.writable, pd.enumerable, pd.configurable);
+    f = new Function('a', 'b', 'return a+b');
+    pd = Object.getOwnPropertyDescriptor(f, 'name');
+    print(typeof pd.value, pd.value, pd.writable, pd.enumerable, pd.configurable);
+    pd = Object.getOwnPropertyDescriptor(f, 'length');
+    print(typeof pd.value, pd.value, pd.writable, pd.enumerable, pd.configurable);
 }
 
 try {

--- a/tests/ecmascript/test-bi-function-instance.js
+++ b/tests/ecmascript/test-bi-function-instance.js
@@ -15,9 +15,9 @@ false false true
 true test
 false false true
 ""
-true true
+true false
 ""
-true true
+true false
 "forcedName2"
 true true
 ===*/
@@ -47,8 +47,6 @@ function functionInstanceTest() {
     // an empty string name from Function.prototype.  The property .name in
     // Function.prototype is not writable, but it is configurable, so that
     // Object.defineProperty() can be used to add a name later on.
-
-    // XXX: not yet implemented, expect string for having a .name.
 
     var anon = (1, 2, 3, function () {});
     print(JSON.stringify(anon.name));  // inherited

--- a/tests/ecmascript/test-bi-reflect-arg-policy.js
+++ b/tests/ecmascript/test-bi-reflect-arg-policy.js
@@ -48,7 +48,7 @@ true
 function () { [native code] }
 false
 true
-name,fileName,length,prototype,test
+fileName,length,prototype,test
 true
 false
 false


### PR DESCRIPTION
Currently an empty string `.name` is set on the function instance. Check ES6/ES7 behavior.

- [x] Change anonymous function `.name` behavior to match ES6
- [x] Change `.name` for Function constructor result
- [x] Testcase for anonymous function name in ES6
- [x] Testcase for new Function() .name
- [x] Migration notes
- [x] Releases entry