### PR TITLE
Add internal APIs to intern a built string without a copy

### DIFF
--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -2,6 +2,8 @@
  *  Heap stringtable handling, string interning.
  */
 
+/*FIXME*/
+
 #include "duk_internal.h"
 
 #if defined(DUK_USE_STRTAB_PROBE)


### PR DESCRIPTION
For example, currently `duk_concat()` creates a fixed buffer for the final result size and writes all string parts into it. The result is then string converted. This means, in practice, that the final string exists in RAM in both the temporary buffer and the final `duk_hstring` for a brief period.

Improve this so that internal call sites can push a `duk_hstring` allocated to a certain size but with uninitialized data. The string would also not be tracked in the string table. The calling code could then write to the string data part e.g. as part of `duk_concat()`. Once the data part is done, the same `duk_hstring` allocation can be finished and be interned into the string table, and then becomes immutable.

If an error is thrown, garbage collection must deal with a string that needs to be freed but without existing in the string table. Other issues to deal with:
- When the final string has been built, it may already be in the string table but this can't be known beforehand. Must allow the string just built to be discarded.
- When using low memory "external strings", the external string can only happen when the string is finished. It may then be necessary to switch to an external string.