### PR TITLE
Fix object literal getter/setter .prototype and constructability to match ES6

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2106,6 +2106,9 @@ Planned
   from the Error constructor rather than Function.prototype directly as
   required by ES6 (GH-1182)
 
+* Change object literal getter/setter to match ES6 requirements: no automatic
+  .prototype property, and the functions are non-constructable (GH-1188)
+
 * Add a fastint check for duk_put_number_list() values (GH-1086)
 
 * Remove an unintended fastint downgrade check for unary minus executor

--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -161,12 +161,13 @@ struct duk_heaphdr_string {
  */
 
 #define DUK_HEAPHDR_GET_FLAGS_RAW(h)  ((h)->h_flags)
-
+#define DUK_HEAPHDR_SET_FLAGS_RAW(h,val)  do { \
+		(h)->h_flags = (val); } \
+	}
 #define DUK_HEAPHDR_GET_FLAGS(h)      ((h)->h_flags & DUK_HEAPHDR_FLAGS_FLAG_MASK)
 #define DUK_HEAPHDR_SET_FLAGS(h,val)  do { \
 		(h)->h_flags = ((h)->h_flags & ~(DUK_HEAPHDR_FLAGS_FLAG_MASK)) | (val); \
 	} while (0)
-
 #define DUK_HEAPHDR_GET_TYPE(h)       ((h)->h_flags & DUK_HEAPHDR_FLAGS_TYPE_MASK)
 #define DUK_HEAPHDR_SET_TYPE(h,val)   do { \
 		(h)->h_flags = ((h)->h_flags & ~(DUK_HEAPHDR_FLAGS_TYPE_MASK)) | (val); \

--- a/tests/ecmascript/test-dev-object-literal-es6-getset.js
+++ b/tests/ecmascript/test-dev-object-literal-es6-getset.js
@@ -1,0 +1,50 @@
+/*
+ *  In ES6 object literal get/set properties have a few special requirements:
+ *  they are not constructable and they have no .prototype.
+ */
+
+/*===
+true myFunc
+false undefined
+123
+TypeError
+true fooBar
+false undefined
+setter called
+undefined
+TypeError
+===*/
+
+function test() {
+    var tmp = { get myFunc() { return 123; },
+                set fooBar(v) { print('setter called') } };
+    var fun;
+
+    fun = Object.getOwnPropertyDescriptor(tmp, 'myFunc').get;
+    print(fun.hasOwnProperty('name'), fun.name);
+    print(fun.hasOwnProperty('prototype'), fun.prototype);
+    print(fun());
+    try {
+        print(new fun());
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+
+    fun = Object.getOwnPropertyDescriptor(tmp, 'fooBar').set;
+    print(fun.hasOwnProperty('name'), fun.name);
+    print(fun.hasOwnProperty('prototype'), fun.prototype);
+    print(fun('dummy'));
+    try {
+        print(new fun());
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-misc-function-automatic-prototype.js
+++ b/tests/ecmascript/test-misc-function-automatic-prototype.js
@@ -1,8 +1,9 @@
 /*
  *  A newly created function always has a fresh object as its
- *  prototype.
+ *  prototype.  ES5 Sections 15.3.2.1, 15.3.5.2, 15.3.4.5.
  *
- *  E5 Sections 15.3.2.1, 15.3.5.2, 15.3.4.5.
+ *  ES6 removes the .prototype from object literal getter/setter
+ *  notation.
  */
 
 var f, g;
@@ -13,8 +14,8 @@ object
 true
 object
 false
-object
-object
+undefined
+undefined
 ===*/
 
 f = function() { print("f"); };


### PR DESCRIPTION
- [x] Getter/setter in object literal should have no `.prototype` property
- [x] Getter/setter in object literal should not be constructable
- [x] Simplify template -> instance function flag copying
- [x] Testcase coverage
- [x] Releases entry

There are still ES6 issues left; e.g. getter/setter `.name` doesn't match ES6 requirements (ES5 had no requirements) for example.