### PR TITLE
Fix temporary register handling for object literal getters/setters

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1904,7 +1904,7 @@ Planned
   ({ [1+2]: 'three' }), identifier shorthand ({ foo, bar }), and method
   definition shorthand ({ func(a,b) { return a+b; } }); however, computed
   name for method definition ({ ['foo' + 'bar'](a,b) { ... } }) is not
-  yet supported (GH-985, GH-1190)
+  yet supported (GH-985, GH-1190, GH-1193)
 
 * Add support for ES7 exponentiation and exponentiation assignment operators,
   e.g. "2 ** 10" evaluates to 1024, avoiding the cost of an Ecmascript call to

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -2951,8 +2951,8 @@ DUK_LOCAL void duk__objlit_flush_keys(duk_compiler_ctx *comp_ctx, duk__objlit_st
 		                st->temp_start,
 		                st->num_pairs * 2);
 		st->num_pairs = 0;
-		DUK__SETTEMP(comp_ctx, st->temp_start);
 	}
+	DUK__SETTEMP(comp_ctx, st->temp_start);
 }
 
 DUK_LOCAL duk_bool_t duk__objlit_load_key(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_token *tok, duk_reg_t reg_temp) {
@@ -3075,6 +3075,7 @@ DUK_LOCAL void duk__nud_object_literal(duk_compiler_ctx *comp_ctx, duk_ivalue *r
 
 			duk__objlit_flush_keys(comp_ctx, &st);
 			DUK_ASSERT(DUK__GETTEMP(comp_ctx) == st.temp_start);  /* 2 regs are guaranteed to be allocated w.r.t. temp_max */
+			reg_temp = DUK__ALLOCTEMPS(comp_ctx, 2);
 
 			if (duk__objlit_load_key(comp_ctx, res, &comp_ctx->curr_token, reg_temp) != 0) {
 				goto syntax_error;
@@ -7602,7 +7603,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
 	comp_ctx->curr_func.is_function = 1;
 	DUK_ASSERT(comp_ctx->curr_func.is_eval == 0);
 	DUK_ASSERT(comp_ctx->curr_func.is_global == 0);
-	comp_ctx->curr_func.is_setget = (flags & DUK__FUNC_FLAG_GETSET);
+	comp_ctx->curr_func.is_setget = ((flags & DUK__FUNC_FLAG_GETSET) != 0);
 	comp_ctx->curr_func.is_namebinding = !(flags & (DUK__FUNC_FLAG_GETSET |
 	                                                DUK__FUNC_FLAG_METDEF |
 	                                                DUK__FUNC_FLAG_DECL));  /* no name binding for: declarations, objlit getset, objlit method def */

--- a/tests/ecmascript/test-bug-object-literal-getset-tempreg.js
+++ b/tests/ecmascript/test-bug-object-literal-getset-tempreg.js
@@ -1,0 +1,37 @@
+// Reported here: https://github.com/svaarala/duktape/pull/1190#issuecomment-267533606
+
+/*===
+still here
+function true true true
+{getMusicFilename:{_func:true},load:{_func:true},fadeIn:{_func:true},fadeOut:{_func:true},update:{_func:true},musicPath:"~/music/",play:{_func:true},playSound:{_func:true},forceFinish:{_func:true},setMaxMusicVolume:{_func:true},setMaxSoundVolume:{_func:true},setVolume:{_func:true},stop:{_func:true},save:{_func:true},done:undefined,volume:undefined,svolume:undefined,mute:undefined}
+===*/
+
+var obj = {
+    getMusicFilename: function() {},
+    load: function() {},
+    fadeIn: function() {},
+    fadeOut: function() {},
+    update: function() {},
+    musicPath: "~/music/",
+    play: function() {},
+    playSound: function() {},
+    forceFinish: function() {},
+    setMaxMusicVolume: function() {},
+    setMaxSoundVolume: function() {},
+    setVolume: function() {},
+    stop: function() {},
+    save: function() {},
+    get done() {},
+    get volume() {},
+    get svolume() {},
+    get mute() {},
+    set mute(value) {}
+};
+
+obj.setMaxSoundVolume();
+print('still here');
+
+var pd = Object.getOwnPropertyDescriptor(obj, 'setMaxSoundVolume');
+print(typeof pd.value, pd.writable, pd.enumerable, pd.configurable);
+
+print(Duktape.enc('jx', obj));


### PR DESCRIPTION
See bug description in https://github.com/svaarala/duktape/pull/1190#issuecomment-267533606. This was introduced by #1190 and is not present in the 1.x release.