### PR TITLE
Disable bufferobjects in lowmem config

### DIFF
--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -65,8 +65,8 @@ DUK_USE_HSTRING_ARRIDX: false
 #DUK_USE_EXTSTR_FREE
 
 # Consider removing Node.js Buffer and Khronos/ES6 typed array support if not
-# needed (about 8-9 kB code footprint difference on x64)
-#DUK_USE_BUFFEROBJECT_SUPPORT: false
+# needed (about 10 kB code footprint difference on x64)
+DUK_USE_BUFFEROBJECT_SUPPORT: false
 
 # Consider to reduce code footprint at the expense of more erratic RAM usage
 #DUK_USE_REFERENCE_COUNTING: false


### PR DESCRIPTION
Lowmem config example is ES5-ish so bufferobjects should be disabled. This has a footprint impact of around 10kB.