### PR TITLE
Change API time components type to use doubles instead of uints

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1965,7 +1965,7 @@ Planned
 
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
-  same time provider as seen by Ecmascript code (GH-771, GH-1209)
+  same time provider as seen by Ecmascript code (GH-771, GH-1209, GH-1211)
 
 * Add duk_push_bare_object() API call which pushes an object without an
   internal prototype, equivalent to Object.create(null) (GH-1126)

--- a/extras/logging/duk_logging.c
+++ b/extras/logging/duk_logging.c
@@ -182,9 +182,9 @@ static duk_ret_t duk__logger_prototype_log_shared(duk_context *ctx) {
 	now = duk_get_now(ctx);
 	duk_time_to_components(ctx, now, &comp);
 	sprintf((char *) date_buf, "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
-	        (int) comp.year, (int) comp.month, (int) comp.day,
-	        (int) comp.hour, (int) comp.minute, (int) comp.second,
-	        (int) comp.millisecond);
+	        (int) comp.year, (int) comp.month + 1, (int) comp.day,
+	        (int) comp.hours, (int) comp.minutes, (int) comp.seconds,
+	        (int) comp.milliseconds);
 
 	date_len = strlen((const char *) date_buf);
 

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -90,14 +90,14 @@ struct duk_number_list_entry {
 };
 
 struct duk_time_components {
-	duk_uint_t year;            /* year, e.g. 2016, Ecmascript year range */
-	duk_uint_t month;           /* month: 1-12 */
-	duk_uint_t day;             /* day: 1-31 */
-	duk_uint_t hour;            /* hour: 0-59 */
-	duk_uint_t minute;          /* minute: 0-59 */
-	duk_uint_t second;          /* second: 0-59 (in POSIX time no leap second) */
-	duk_uint_t weekday;         /* weekday: 0-6, 0=Sunday, 1=Monday, ..., 6=Saturday */
-	duk_double_t millisecond;   /* may contain sub-millisecond fractions */
+	duk_double_t year;          /* year, e.g. 2016, Ecmascript year range */
+	duk_double_t month;         /* month: 1-12 */
+	duk_double_t day;           /* day: 1-31 */
+	duk_double_t hours;         /* hour: 0-59 */
+	duk_double_t minutes;       /* minute: 0-59 */
+	duk_double_t seconds;       /* second: 0-59 (in POSIX time no leap second) */
+	duk_double_t milliseconds;  /* may contain sub-millisecond fractions */
+	duk_double_t weekday;       /* weekday: 0-6, 0=Sunday, 1=Monday, ..., 6=Saturday */
 };
 
 /*

--- a/src-input/duk_api_time.c
+++ b/src-input/duk_api_time.c
@@ -24,16 +24,15 @@ DUK_EXTERNAL void duk_time_to_components(duk_context *ctx, duk_double_t timeval,
 
 	duk_bi_date_timeval_to_parts(timeval, parts, dparts, flags);
 
-	/* XXX: expensive conversion */
-	DUK_ASSERT(comp->month >= 1 && comp->month <= 12);
-	comp->year = (duk_uint_t) parts[DUK_DATE_IDX_YEAR];
-	comp->month = (duk_uint_t) parts[DUK_DATE_IDX_MONTH] - 1;
-	comp->day = (duk_uint_t) parts[DUK_DATE_IDX_DAY];
-	comp->hour = (duk_uint_t) parts[DUK_DATE_IDX_HOUR];
-	comp->minute = (duk_uint_t) parts[DUK_DATE_IDX_MINUTE];
-	comp->second = (duk_uint_t) parts[DUK_DATE_IDX_SECOND];
-	comp->weekday = (duk_uint_t) parts[DUK_DATE_IDX_WEEKDAY];
-	comp->millisecond = (duk_double_t) parts[DUK_DATE_IDX_MILLISECOND];
+	DUK_ASSERT(comp->month >= 1.0 && comp->month <= 12.0);
+	comp->year = dparts[DUK_DATE_IDX_YEAR];
+	comp->month = dparts[DUK_DATE_IDX_MONTH] - 1.0;
+	comp->day = dparts[DUK_DATE_IDX_DAY];
+	comp->hours = dparts[DUK_DATE_IDX_HOUR];
+	comp->minutes = dparts[DUK_DATE_IDX_MINUTE];
+	comp->seconds = dparts[DUK_DATE_IDX_SECOND];
+	comp->milliseconds = dparts[DUK_DATE_IDX_MILLISECOND];
+	comp->weekday = dparts[DUK_DATE_IDX_WEEKDAY];
 }
 
 DUK_EXTERNAL duk_double_t duk_components_to_time(duk_context *ctx, duk_time_components *comp) {
@@ -56,13 +55,13 @@ DUK_EXTERNAL duk_double_t duk_components_to_time(duk_context *ctx, duk_time_comp
 	 * time provider and time API to use same struct?
 	 */
 
-	dparts[DUK_DATE_IDX_YEAR] = (duk_double_t) comp->year;
-	dparts[DUK_DATE_IDX_MONTH] = (duk_double_t) comp->month;
-	dparts[DUK_DATE_IDX_DAY] = (duk_double_t) comp->day - 1.0;
-	dparts[DUK_DATE_IDX_HOUR] = (duk_double_t) comp->hour;
-	dparts[DUK_DATE_IDX_MINUTE] = (duk_double_t) comp->minute;
-	dparts[DUK_DATE_IDX_SECOND] = (duk_double_t) comp->second;
-	dparts[DUK_DATE_IDX_MILLISECOND] = comp->millisecond;
+	dparts[DUK_DATE_IDX_YEAR] = comp->year;
+	dparts[DUK_DATE_IDX_MONTH] = comp->month;
+	dparts[DUK_DATE_IDX_DAY] = comp->day - 1.0;
+	dparts[DUK_DATE_IDX_HOUR] = comp->hours;
+	dparts[DUK_DATE_IDX_MINUTE] = comp->minutes;
+	dparts[DUK_DATE_IDX_SECOND] = comp->seconds;
+	dparts[DUK_DATE_IDX_MILLISECOND] = comp->milliseconds;
 	dparts[DUK_DATE_IDX_WEEKDAY] = 0;  /* ignored */
 
 	d = duk_bi_date_get_timeval_from_dparts(dparts, flags);

--- a/tests/api/test-time-components.c
+++ b/tests/api/test-time-components.c
@@ -16,10 +16,10 @@ weekday 6
 year: 2016
 month: 0
 day: 2
-hour: 3
-minute: 4
-second: 5
-millisecond: 6.000000
+hours: 3
+minutes: 4
+seconds: 5
+milliseconds: 6.000000
 weekday: 6
 final top: 0
 ==> rc=0, result='undefined'
@@ -57,10 +57,10 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	printf("year: %d\n", (int) comp.year);
 	printf("month: %d\n", (int) comp.month);
 	printf("day: %d\n", (int) comp.day);
-	printf("hour: %d\n", (int) comp.hour);
-	printf("minute: %d\n", (int) comp.minute);
-	printf("second: %d\n", (int) comp.second);
-	printf("millisecond: %lf\n", (double) comp.millisecond);
+	printf("hours: %d\n", (int) comp.hours);
+	printf("minutes: %d\n", (int) comp.minutes);
+	printf("seconds: %d\n", (int) comp.seconds);
+	printf("milliseconds: %lf\n", (double) comp.milliseconds);
 	printf("weekday: %d\n", (int) comp.weekday);
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
@@ -110,11 +110,11 @@ static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	comp.year = 2016;
 	comp.month = 0;
 	comp.day = 2;
-	comp.hour = 3;
-	comp.minute = 4;
-	comp.second = 5;
+	comp.hours = 3;
+	comp.minutes = 4;
+	comp.seconds = 5;
+	comp.milliseconds = 6.0;
 	comp.weekday = 0;  /* ignored */
-	comp.millisecond = 6.0;
 
 	t = duk_components_to_time(ctx, &comp);
 	printf("time: %lf\n", t);
@@ -123,11 +123,11 @@ static duk_ret_t test_2(duk_context *ctx, void *udata) {
 	comp.year = 2016;
 	comp.month = 0;
 	comp.day = 2;
-	comp.hour = 3;
-	comp.minute = 0;
-	comp.second = 4 * 60 + 5;  /* wrapping: 4 minutes, 5 seconds */
+	comp.hours = 3;
+	comp.minutes = 0;
+	comp.seconds = 4 * 60 + 5;  /* wrapping: 4 minutes, 5 seconds */
+	comp.milliseconds = 6.0;
 	comp.weekday = 0;  /* ignored */
-	comp.millisecond = 6.0;
 
 	t = duk_components_to_time(ctx, &comp);
 	printf("time: %lf\n", t);

--- a/website/api/duk_components_to_time.yaml
+++ b/website/api/duk_components_to_time.yaml
@@ -20,9 +20,8 @@ summary: |
 
   <p>Like the Ecmascript primitives, the components can exceed their natural
   range and are normalized.  For example, specifying <code>comp-&gt;minutes</code>
-  as 120 is interpreted as adding 2 hours to the time value.  Note, however,
-  that components other than milliseconds are <code>duk_uint_t</code> so they
-  may wrap for very large values.</p>
+  as 120 is interpreted as adding 2 hours to the time value.  The components are
+  expressed as IEEE doubles to allow large and negative values to be used.</p>
 
 example: |
   duk_time_components comp;
@@ -32,11 +31,11 @@ example: |
   comp.year = 2016;
   comp.month = 0;  /* 0-based, 1=January */
   comp.day = 2;    /* 1-based: second of January */
-  comp.hour = 3;
-  comp.minute = 4;
-  comp.second = 5;
+  comp.hours = 3;
+  comp.minutes = 4;
+  comp.seconds = 5;
+  comp.milliseconds = 6.0;  /* allows sub-millisecond resolution */
   comp.weekday = 0;  /* ignored */
-  comp.millisecond = 6.0;  /* duk_double_t typing, to allow sub-millisecond resolution */
 
   time = duk_components_to_time(ctx, &comp);
   printf("2016-01-02 03:04:05.006Z -> %lf\n", (double) time);

--- a/website/api/duk_time_to_components.yaml
+++ b/website/api/duk_time_to_components.yaml
@@ -25,15 +25,16 @@ example: |
   };
 
   /* Note that month is zero-based to match the Ecmascript API, so for
-   * human readable printing add 1 to the month.
+   * human readable printing add 1 to the month.  Time components are
+   * IEEE doubles to match Ecmascript Date behavior.
    */
   duk_time_components(ctx, time, &comp);
   printf("Datetime: %04d-%02d-%02d %02d:%02d:%02d.%03dZ\n",
-         (int) comp.year, (int) (comp.month + 1), (int) comp.day,
-         (int) comp.hour, (int) comp.minute, (int) comp.second,
-         (int) comp.millisecond);
+         (int) comp.year, (int) comp.month + 1, (int) comp.day,
+         (int) comp.hours, (int) comp.minutes, (int) comp.seconds,
+         (int) comp.milliseconds);
 
-  printf("Weekday is: %s\n", weekdays[comp.weekday]);  /* 0=Sunday */
+  printf("Weekday is: %s\n", weekdays[(int) comp.weekday]);  /* 0=Sunday */
 
 tags:
   - time


### PR DESCRIPTION
Using doubles allows larger unnormalized values (`duk_uint_t` or `duk_int_t` may be too limiting when 32 bit) and matches how Ecmascript Date handling works.

Also rename component fields to match Ecmascript APIs better: hour -> hours, minute -> minutes, second -> seconds, millisecond -> milliseconds.