### PR TITLE
Fix duk_safe_call() introduced version

### DIFF
--- a/website/api/duk_safe_call.yaml
+++ b/website/api/duk_safe_call.yaml
@@ -134,4 +134,4 @@ tags:
   - protected
 
 # Introduced in 1.0.0 but incompatible change in 2.0.0.
-introduced: 2.0.0
+introduced: 1.0.0


### PR DESCRIPTION
Keep 1.0.0 despite the argument list having an incompatible change. Fixes #749.