### PR TITLE
Implement an initial version of property caching

### DIFF
--- a/doc/property-cache.rst
+++ b/doc/property-cache.rst
@@ -1,0 +1,166 @@
+==============
+Property cache
+==============
+
+This document describes property caching, a mechanism added in Duktape 2.1.0
+to speed up property reads (and maybe writes in the future).
+
+Data structure
+==============
+
+The property cache is an array of entries to speed up GETPROP operations.
+Each entry contains:
+
+* Object and key reference for original lookup.  The object reference stored
+  is for the lookup starting point, which is often different than the object
+  actually holding the property (inheritance).
+
+* Property value.
+
+* Generation count to allow quick invalidation.
+
+All key/value references are borrowed.  Only concrete properties (not getters
+or virtual property values) can be cached due to the property value not being
+reference counted.  In other words, when a property is cached:
+
+* There must be a guarantee that the object, key, and value are reachable by
+  some means.
+
+* A GETPROP operation from the same starting point using the same key would
+  yield the same value.
+
+The ``duk_heap`` structure holds the property cache which is just an array of
+entries of (preferably) 2^N size.  The heap structure also holds the current
+generation count which starts from 1; entries with generation count 0 are thus
+ignored automatically.
+
+Read handling
+=============
+
+* When GETPROP is called, compute a property cache lookup key by combining
+  object pointer (for lack of an object hash) with the key string hash.
+
+* Check the entry at the hash index.  If the generation count doesn't match
+  current generation count (which is a heap-wide value), the entry must be
+  ignored as obsolete.  Otherwise check if the object and the key match, and
+  if so, use the cached value.
+
+* If there's a cache miss, proceed with normal property lookup.
+
+* If no property is found, no property cache changes are made.  It would be
+  possible to implement negative property caching.
+
+* If a property is found, and there are no conditions to prevent caching,
+  overwrite the cache entry at prophash: set generation count to current,
+  set object and key reference (object reference must be for the lookup
+  starting point -- not the final object), and property value.
+
+* There is currently no hash chaining: the existing entry is simply overwritten
+  with the hope that collision are relatively rare.
+
+* Conditions preventing caching:
+
+  - Value came from a getter: side effects, value may change per lookup.
+
+  - Value came from a Proxy: side effects, value may change per lookup.
+
+  - Value is virtual and may change per lookup.  Virtual values that won't
+    change over time can be read cached however.
+
+  - Array index lookups probably shouldn't be cached because the same index
+    is not usually read many times for caching to be useful.  These entries
+    would also purge useful entries unnecessarily.
+
+Invalidation
+============
+
+Invalidation must be triggered by any operation that might compromise the
+cache integrity requirements, i.e.:
+
+* The operation might cause object, key, or value (all borrowed) to become
+  unreachable, thus leading to memory unsafe behavior.
+
+* The operation might change the property value if a GETPROP were done.
+  For example, looking up a property storage location is by itself not an
+  issue, but overwriting the value there is.
+
+The basic challenge with partial invalidation where only actually affected
+entries are removed is that: (1) knowing what entries to remove requires
+complicated tracking state, and (2) actually scrubbing affected entries
+may require multiple lookups if a change in an inherited property affects
+multiple lookup cache entries.
+
+The current solution is thus to invalidate the entire cache very cheaply by
+using a generation count.  Entries whose generation count don't match current
+are entirely ignored, so that simply bumping the current generation count is
+enough to invalidate all entries without touching the entries themselves.
+
+Technically, if the generation count wraps, entries should be scrubbed
+fully.  This can be achieved by detecting that the generation count became
+zero, setting the whole cache to zero, and then bumping the generation count
+once more to ignore the zeroed entries.
+
+Operations that require invalidation include:
+
+* PUTPROP
+
+* DELPROP
+
+* defineProperty() and all its variants
+
+* Changes to object internal prototypes: duk_set_prototype(),
+  Object.setPrototypeOf(), etc.  Internal direct prototype changes when there's
+  any possibility a property access might have happened.
+
+* Any code that looks up an existing property and modifies its storage location
+  directly.  Easiest approach, at least initially, is to invalide the cache on
+  that storage lookup.
+
+* Any code modifying structures that affect non-array-index virtual properties.
+  For example, writing to ``duk_harray.length`` which appears as a virtual
+  ``.length`` property.
+
+* Mark-and-sweep might do compaction which affects property storage locations.
+  But currently only the value, not its storage location, is cached so that
+  compaction by itself is not an issue.
+
+* Mark-and-sweep may finalize objects and then free them however.
+
+* Assuming that the property keys are reachable through the object, there
+  should be no chance that the cached key would be freed without the object
+  being freed.
+
+* An object may be freed however without any property related operation
+  taking place.  There are only a few places where the object is actually
+  freed, and those locations can invalidate the property cache.
+
+Future work
+===========
+
+* Caching "own property" lookups would speed up some cases where the same
+  inheritance path is used by multiple lookups.  Intuitively this would seem
+  to be of less practical use.
+
+* Caching property misses would be straightforward; use DUK_TVAL_SET_UNUSED()
+  to flag the value as missing.  However, negative caching seems of little
+  practical use because most repeated property lookups are for property hits.
+
+* Caching property writes would be possible by caching the storage location
+  rather than the value only.
+
+* Caching array reads/writes would be possible to some extent, but would
+  require a slightly different approach to avoid polluting the property
+  cache with array indices.  The caching approach could speed up locating
+  the ultimate array/array-like object for the index read/write to avoid
+  walking through the inheritance chain.  However, subclassed Arrays or
+  typed arrays are relatively rare (though Node.js Buffer instances inherit
+  from Uint8Array).
+
+* Hash probing for the cache locations might help some cases where property
+  lookup hashes collide.  However, it adds another step to the property
+  lookup, and more importantly causes another cache line to be fetched.
+  So it may be of relatively little practical value, at least when the
+  property cache can just be made larger instead.
+
+* Making ``duk_propcache_entry`` size 2^N would speed up the cache lookup
+  and align the lookups better.

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -419,6 +419,11 @@ DUK_LOCAL duk_ret_t duk__array_pop_fastpath(duk_context *ctx, duk_harray *h_arr)
 		return 0;
 	}
 
+	/* Index properties are not cached but .length is, so invalidate
+	 * property cache.
+	 */
+	duk_propcache_invalidate(thr);
+
 	len--;
 	h_arr->length = len;
 
@@ -507,6 +512,11 @@ DUK_LOCAL duk_ret_t duk__array_push_fastpath(duk_context *ctx, duk_harray *h_arr
 		 */
 		return 0;
 	}
+
+	/* Index properties are not cached but .length is, so invalidate
+	 * property cache.
+	 */
+	duk_propcache_invalidate(thr);
 
 	tv_src = thr->valstack_bottom;
 	tv_dst = tv_arraypart + len;

--- a/src-input/duk_forwdecl.h
+++ b/src-input/duk_forwdecl.h
@@ -40,9 +40,10 @@ struct duk_breakpoint;
 
 struct duk_activation;
 struct duk_catcher;
-struct duk_strcache;
+struct duk_strcache_entry;
 struct duk_ljstate;
 struct duk_strtab_entry;
+struct duk_propcache_entry;
 
 #if defined(DUK_USE_DEBUG)
 struct duk_fixedbuffer;
@@ -96,9 +97,10 @@ typedef struct duk_breakpoint duk_breakpoint;
 
 typedef struct duk_activation duk_activation;
 typedef struct duk_catcher duk_catcher;
-typedef struct duk_strcache duk_strcache;
+typedef struct duk_strcache_entry duk_strcache_entry;
 typedef struct duk_ljstate duk_ljstate;
 typedef struct duk_strtab_entry duk_strtab_entry;
+typedef struct duk_propcache_entry duk_propcache_entry;
 
 #if defined(DUK_USE_DEBUG)
 typedef struct duk_fixedbuffer duk_fixedbuffer;

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -127,6 +127,9 @@
 #define DUK_HEAP_STRCACHE_SIZE                            4
 #define DUK_HEAP_STRINGCACHE_NOCACHE_LIMIT                16  /* strings up to the this length are not cached */
 
+/* Propache is used for speeding up property accesses. */
+#define DUK_HEAP_PROPCACHE_SIZE                           1024
+
 /* helper to insert a (non-string) heap object into heap allocated list */
 #define DUK_HEAP_INSERT_INTO_HEAP_ALLOCATED(heap,hdr)     duk_heap_insert_into_heap_allocated((heap),(hdr))
 
@@ -298,10 +301,22 @@ struct duk_breakpoint {
  *  Thus, string caches are now at the heap level now.
  */
 
-struct duk_strcache {
+struct duk_strcache_entry {
 	duk_hstring *h;
 	duk_uint32_t bidx;
 	duk_uint32_t cidx;
+};
+
+/*
+ *  Property cache
+ */
+
+struct duk_propcache_entry {
+	/* All references are borrowed. */
+	duk_hobject *obj_lookup;
+	duk_hstring *key_lookup;
+	duk_tval value;
+	duk_uint32_t generation;
 };
 
 /*
@@ -499,7 +514,11 @@ struct duk_heap {
 	/* string access cache (codepoint offset -> byte offset) for fast string
 	 * character looping; 'weak' reference which needs special handling in GC.
 	 */
-	duk_strcache strcache[DUK_HEAP_STRCACHE_SIZE];
+	duk_strcache_entry strcache[DUK_HEAP_STRCACHE_SIZE];
+
+	/* Property access cache. */
+	duk_propcache_entry propcache[DUK_HEAP_PROPCACHE_SIZE];
+	duk_uint32_t propcache_generation;
 
 	/* built-in strings */
 #if defined(DUK_USE_ROM_STRINGS)
@@ -606,5 +625,10 @@ DUK_INTERNAL_DECL void duk_heaphdr_decref_norz(duk_hthread *thr, duk_heaphdr *h)
 DUK_INTERNAL_DECL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t flags);
 
 DUK_INTERNAL_DECL duk_uint32_t duk_heap_hashstring(duk_heap *heap, const duk_uint8_t *str, duk_size_t len);
+
+DUK_INTERNAL_DECL void duk_propcache_invalidate_heap(duk_heap *heap);
+DUK_INTERNAL_DECL void duk_propcache_invalidate(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_tval *duk_propcache_lookup(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);
+DUK_INTERNAL_DECL void duk_propcache_insert(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_tval *storage);
 
 #endif  /* DUK_HEAP_H_INCLUDED */

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -22,6 +22,9 @@ DUK_INTERNAL void duk_free_hobject(duk_heap *heap, duk_hobject *h) {
 	DUK_ASSERT(heap != NULL);
 	DUK_ASSERT(h != NULL);
 
+	/* FIXME: heap ref only */
+	duk_propcache_invalidate_heap(heap);
+
 	DUK_FREE(heap, DUK_HOBJECT_GET_PROPS(heap, h));
 
 	if (DUK_HOBJECT_IS_COMPFUNC(h)) {
@@ -589,7 +592,8 @@ DUK_LOCAL void duk__dump_type_sizes(void) {
 #endif
 	DUK__DUMPSZ(duk_activation);
 	DUK__DUMPSZ(duk_catcher);
-	DUK__DUMPSZ(duk_strcache);
+	DUK__DUMPSZ(duk_strcache_entry);
+	DUK__DUMPSZ(duk_propcache_entry);
 	DUK__DUMPSZ(duk_ljstate);
 	DUK__DUMPSZ(duk_fixedbuffer);
 	DUK__DUMPSZ(duk_bitdecoder_ctx);
@@ -818,6 +822,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	}
 #endif
 #endif  /* DUK_USE_ROM_STRINGS */
+	res->propcache_generation = 1;  /* invalidate entries with 0 generation */
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	res->dbg_read_cb = NULL;
 	res->dbg_write_cb = NULL;

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -1205,6 +1205,8 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 	}
 #endif
 
+	/* FIXME: property cache invalidation or comment why not needed. */
+
 	DUK_D(DUK_DPRINT("garbage collect (mark-and-sweep) starting, requested flags: 0x%08lx, effective flags: 0x%08lx",
 	                 (unsigned long) flags, (unsigned long) (flags | heap->mark_and_sweep_base_flags)));
 

--- a/src-input/duk_heap_propcache.c
+++ b/src-input/duk_heap_propcache.c
@@ -1,0 +1,55 @@
+#include "duk_internal.h"
+
+DUK_LOCAL DUK_NOINLINE void duk__propcache_scrub(duk_heap *heap) {
+	/* Explicit scrub to avoid reuse.  Generation counts are set
+	 * to zero, and the generation count is then bumped once more
+	 * to one to invalidate the scrubbed entries.
+	 */
+	DUK_MEMZERO((void *) heap->propcache, sizeof(heap->propcache));
+	heap->propcache_generation++;
+}
+
+DUK_INTERNAL DUK_ALWAYS_INLINE void duk_propcache_invalidate_heap(duk_heap *heap) {
+	if (DUK_UNLIKELY(++heap->propcache_generation == 0)) {
+		duk__propcache_scrub(heap);
+	}
+}
+
+DUK_INTERNAL DUK_ALWAYS_INLINE void duk_propcache_invalidate(duk_hthread *thr) {
+	duk_propcache_invalidate_heap(thr->heap);
+}
+
+DUK_LOCAL duk_size_t duk__compute_prophash(duk_hobject *obj, duk_hstring *key) {
+	duk_size_t prophash;
+	prophash = ((duk_size_t) obj) ^ ((duk_size_t) DUK_HSTRING_GET_HASH(key));
+	prophash = prophash % DUK_HEAP_PROPCACHE_SIZE;  /* FIXME: force to be a mask */
+	return prophash;
+}
+
+DUK_INTERNAL duk_tval *duk_propcache_lookup(duk_hthread *thr, duk_hobject *obj, duk_hstring *key) {
+	duk_size_t prophash;
+	duk_propcache_entry *ent;
+
+	prophash = duk__compute_prophash(obj, key);
+	ent = thr->heap->propcache + prophash;
+
+	if (ent->generation == thr->heap->propcache_generation &&
+	    ent->obj_lookup == obj &&
+	    ent->key_lookup == key) {
+		return &ent->value;
+	}
+
+	return NULL;
+}
+
+DUK_INTERNAL void duk_propcache_insert(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_tval *tv) {
+	duk_size_t prophash;
+	duk_propcache_entry *ent;
+
+	prophash = duk__compute_prophash(obj, key);
+	ent = thr->heap->propcache + prophash;
+	ent->generation = thr->heap->propcache_generation;
+	ent->obj_lookup = obj;
+	ent->key_lookup = key;
+	DUK_TVAL_SET_TVAL(&ent->value, tv);
+}

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -20,7 +20,7 @@
 DUK_INTERNAL void duk_heap_strcache_string_remove(duk_heap *heap, duk_hstring *h) {
 	duk_small_int_t i;
 	for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-		duk_strcache *c = heap->strcache + i;
+		duk_strcache_entry *c = heap->strcache + i;
 		if (c->h == h) {
 			DUK_DD(DUK_DDPRINT("deleting weak strcache reference to hstring %p from heap %p",
 			                   (void *) h, (void *) heap));
@@ -88,7 +88,7 @@ DUK_LOCAL const duk_uint8_t *duk__scan_backwards(const duk_uint8_t *p, const duk
 
 DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *thr, duk_hstring *h, duk_uint_fast32_t char_offset) {
 	duk_heap *heap;
-	duk_strcache *sce;
+	duk_strcache_entry *sce;
 	duk_uint_fast32_t byte_offset;
 	duk_small_int_t i;
 	duk_bool_t use_cache;
@@ -134,14 +134,14 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache before char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 			DUK_DDD(DUK_DDDPRINT("  [%ld] -> h=%p, cidx=%ld, bidx=%ld",
 			                     (long) i, (void *) c->h, (long) c->cidx, (long) c->bidx));
 		}
 #endif
 
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 
 			if (c->h == h) {
 				sce = c;
@@ -270,7 +270,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 			 *   C <- sce    ==>    B
 			 *   D                  D
 			 */
-			duk_strcache tmp;
+			duk_strcache_entry tmp;
 
 			tmp = *sce;
 			DUK_MEMMOVE((void *) (&heap->strcache[1]),
@@ -283,7 +283,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache after char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 			DUK_DDD(DUK_DDDPRINT("  [%ld] -> h=%p, cidx=%ld, bidx=%ld",
 			                     (long) i, (void *) c->h, (long) c->cidx, (long) c->bidx));
 		}

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -625,6 +625,7 @@
 #define DUK_HOBJECT_GET_PROTOTYPE(heap,h) \
 	((duk_hobject *) DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, (h)->prototype16))
 #define DUK_HOBJECT_SET_PROTOTYPE(heap,h,x) do { \
+		/* FIXME: caller property invalidation */ \
 		(h)->prototype16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (x)); \
 	} while (0)
 #else
@@ -635,7 +636,7 @@
 	} while (0)
 #endif
 
-/* note: this updates refcounts */
+/* This updates refcounts and automatically invalidates property cache. */
 #define DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr,h,p)       duk_hobject_set_prototype_updref((thr), (h), (p))
 
 /*

--- a/src-input/duk_hobject_misc.c
+++ b/src-input/duk_hobject_misc.c
@@ -43,10 +43,12 @@ DUK_INTERNAL void duk_hobject_set_prototype_updref(duk_hthread *thr, duk_hobject
 	tmp = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h);
 	DUK_HOBJECT_SET_PROTOTYPE(thr->heap, h, p);
 	DUK_HOBJECT_INCREF_ALLOWNULL(thr, p);  /* avoid problems if p == h->prototype */
+	duk_propcache_invalidate(thr);  /* must be done just before finalizers */
 	DUK_HOBJECT_DECREF_ALLOWNULL(thr, tmp);
 #else
 	DUK_ASSERT(h);
 	DUK_UNREF(thr);
 	DUK_HOBJECT_SET_PROTOTYPE(thr->heap, h, p);
+	duk_propcache_invalidate(thr);
 #endif
 }

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2308,6 +2308,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 	duk_context *ctx = (duk_context *) thr;
 	duk_tval tv_obj_copy;
 	duk_tval tv_key_copy;
+	duk_hobject *orig_base;
 	duk_hobject *curr = NULL;
 	duk_hstring *key = NULL;
 	duk_uint32_t arr_idx = DUK__NO_ARRAY_INDEX;
@@ -2683,6 +2684,22 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_ASSERT(curr != NULL);
 	DUK_ASSERT(key != NULL);
 
+	orig_base = curr;
+	{
+		/* FIXME: when base is primitive, we cache the "wrong" property,
+		 * which is fine.
+		 */
+		duk_tval *storage;
+		storage = duk_propcache_lookup(thr, curr, key);
+		if (storage) {
+			DUK_D(DUK_DPRINT("cached lookup %!O -> %!T", key, storage));
+			duk_pop(ctx);
+			duk_push_tval(ctx, storage);
+			/* FIXME: assume no post process? */
+			return 1;
+		}
+	}
+
 	sanity = DUK_HOBJECT_PROTOTYPE_CHAIN_SANITY;
 	do {
 		if (!duk__get_own_propdesc_raw(thr, curr, key, arr_idx, &desc, DUK_GETDESC_FLAG_PUSH_VALUE)) {
@@ -2692,6 +2709,9 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		if (desc.get != NULL) {
 			/* accessor with defined getter */
 			DUK_ASSERT((desc.flags & DUK_PROPDESC_FLAG_ACCESSOR) != 0);
+
+			DUK_D(DUK_DPRINT("prevent caching, getter"));
+			orig_base = NULL;
 
 			duk_pop(ctx);                     /* [key undefined] -> [key] */
 			duk_push_hobject(ctx, desc.get);
@@ -2735,6 +2755,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 	/*
 	 *  Not found
 	 */
+
+	/* XXX: No negative property caching at present. */
 
 	duk_to_undefined(ctx, -1);  /* [key] -> [undefined] (default value) */
 
@@ -2802,6 +2824,11 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		}
 	}
 #endif   /* !DUK_USE_NONSTD_FUNC_CALLER_PROPERTY */
+
+	if (orig_base && arr_idx == DUK__NO_ARRAY_INDEX) {  /* FIXME: condition */
+		/* FIXME: other conditions, e.g. not a getter */
+		duk_propcache_insert(thr, orig_base, key, DUK_GET_TVAL_NEGIDX(ctx, -1));
+	}
 
 	duk_remove_m2(ctx);  /* [key result] -> [result] */
 
@@ -3357,6 +3384,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_ASSERT(tv_val != NULL);
 
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
+
+	duk_propcache_invalidate(thr);
 
 	/*
 	 *  Make a copy of tv_obj, tv_key, and tv_val to avoid any issues of
@@ -4259,6 +4288,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 	duk_bool_t throw_flag;
 	duk_bool_t force_flag;
 
+	duk_propcache_invalidate(thr);
+
 	throw_flag = (flags & DUK_DELPROP_FLAG_THROW);
 	force_flag = (flags & DUK_DELPROP_FLAG_FORCE);
 
@@ -4623,6 +4654,8 @@ DUK_INTERNAL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hob
 	duk_tval *tv2 = NULL;
 	duk_small_uint_t propflags = flags & DUK_PROPDESC_FLAGS_MASK;  /* mask out flags not actually stored */
 
+	duk_propcache_invalidate(thr);
+
 	DUK_DDD(DUK_DDDPRINT("define new property (internal): thr=%p, obj=%!O, key=%!O, flags=0x%02lx, val=%!T",
 	                     (void *) thr, (duk_heaphdr *) obj, (duk_heaphdr *) key,
 	                     (unsigned long) flags, (duk_tval *) duk_get_tval(ctx, -1)));
@@ -4743,6 +4776,8 @@ DUK_INTERNAL void duk_hobject_define_property_internal_arridx(duk_hthread *thr, 
 	duk_context *ctx = (duk_context *) thr;
 	duk_hstring *key;
 	duk_tval *tv1, *tv2;
+
+	duk_propcache_invalidate(thr);
 
 	DUK_DDD(DUK_DDDPRINT("define new property (internal) arr_idx fast path: thr=%p, obj=%!O, "
 	                     "arr_idx=%ld, flags=0x%02lx, val=%!T",
@@ -5084,6 +5119,8 @@ duk_bool_t duk_hobject_define_property_helper(duk_context *ctx,
 	/* idx_value may be < 0 (no value), set and get may be NULL */
 
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
+
+	duk_propcache_invalidate(thr);
 
 	/* All the flags fit in 16 bits, so will fit into duk_bool_t. */
 

--- a/tests/perf/test-prop-read-long-inherit.js
+++ b/tests/perf/test-prop-read-long-inherit.js
@@ -1,0 +1,20 @@
+function test() {
+    var i;
+    var obj;
+
+    obj = { foo: 123 };
+    for (i = 0; i < 100; i++) {
+        obj = Object.create(obj);
+    }
+
+    for (i = 0; i < 1e7; i++) {
+        void obj.foo;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-prop-read-math-pi.js
+++ b/tests/perf/test-prop-read-math-pi.js
@@ -1,0 +1,14 @@
+function test() {
+    var i;
+
+    for (i = 0; i < 1e7; i++) {
+        void Math.PI
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -453,6 +453,7 @@ def main():
         'duk_heap_markandsweep.c',
         'duk_heap_memory.c',
         'duk_heap_misc.c',
+        'duk_heap_propcache.c',
         'duk_heap_refcount.c',
         'duk_heap_stringcache.c',
         'duk_heap_stringtable.c',

--- a/util/dist.py
+++ b/util/dist.py
@@ -368,6 +368,7 @@ def main():
         'duk_heap_markandsweep.c',
         'duk_heap_memory.c',
         'duk_heap_misc.c',
+        'duk_heap_propcache.c',
         'duk_heap_refcount.c',
         'duk_heap_stringcache.c',
         'duk_heap_stringtable.c',


### PR DESCRIPTION
Implement an initial version of property caching where the property cache key is a (generation, object, key) triple. The cache is implemented in GETPROP (the most common property read operation) and the object in the triple is for the starting point of a property lookup. The generation count is a quick way of invalidating the whole cache on any property write or other operation risking cache integrity: entries can be invalidated by a single heap-level generation counter increment without touching the entries themselves. The generation is checked on a cache lookup; no hash chaining is used, and each property lookup hash has only a single slot.

So far this is pretty experimental, trying to figure out if the approach is workable given all the low level details. Quite possibly some small detail may prevent this from being finished as a viable feature.

Initial results are reasonable however:
- tests/perf/test-array-read-lenloop.js (whose main point is a `for (j = 0; j < arr.length; j++) {...}` loop) runs 2.1 seconds from master and 1.5 seconds with caching.
- tests/perf/test-fib.js runs 7.1 seconds from master and 6.3 seconds with caching.
- tests/perf/test-assign-proprhs.js runs 3.7 seconds from master and 1.7 seconds with caching.
- tests/perf/test-prop-read-long-inherit.js runs 6.9 seconds from master and 0.3 seconds with caching. The speedup here is rather unrealistic, as this microbenchmark just demonstrates performance of looking up a long inheritance chain for which caching is (quite obviously) particularly effective.