### PR TITLE
Make default fatal behavior to call abort() via DUK_ABORT()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1801,9 +1801,10 @@ Planned
   call to match revised fatal error handler function signature (GH-781)
 
 * Incompatible change: default fatal error handler (similar to panic handler
-  in Duktape 1.x) segfaults and infinite loops without calling e.g. abort()
-  (which may not be available); this behavior can be overridden by defining
-  DUK_USE_FATAL_HANDLER() in duk_config.h (GH-781)
+  in Duktape 1.x) calls abort() without printing anything to stdout or stderr
+  (which avoids unnecessary platform dependencies); this behavior can be
+  overridden by defining DUK_USE_FATAL_HANDLER() in duk_config.h (GH-781,
+  GH-1218)
 
 * Incompatible change: change some debugger artificial property names to match
   internal renames: compiledfunction -> compfunc, nativefunction -> natfunc,

--- a/config/config-options/DUK_USE_FATAL_HANDLER.yaml
+++ b/config/config-options/DUK_USE_FATAL_HANDLER.yaml
@@ -6,8 +6,8 @@ tags:
 warn_if_missing: true
 description: >
   Provide a custom default fatal error handler to replace the built-in one
-  (which causes an intentional segfault and forever loops).  The default
-  fatal error gets called when (1) a fatal error occurs and application code
+  (which calls abort() without any error message).  The default fatal error
+  handler gets called when (1) a fatal error occurs and application code
   didn't register a fatal error handler in heap creation or (2) a context-free
   fatal error happens, concretely e.g. an assertion failure.
 

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -29,9 +29,8 @@
 #endif
 
 #if !defined(DUK_CAUSE_SEGFAULT)
-/* This is used by the default fatal error handling to cause the program to
- * intentionally segfault on a fatal error.  Valgrind will then indicate the
- * C call stack leading to the error.
+/* This can be used for testing; valgrind will then indicate the C call stack
+ * leading to the call site.
  */
 #define DUK_CAUSE_SEGFAULT()  do { *((volatile duk_uint32_t *) NULL) = (duk_uint32_t) 0xdeadbeefUL; } while (0)
 #endif

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -1,3 +1,8 @@
+/* An abort()-like primitive is needed by the default fatal error handler. */
+#if !defined(DUK_ABORT)
+#define DUK_ABORT             abort
+#endif
+
 #if !defined(DUK_SETJMP)
 #define DUK_JMPBUF_TYPE       jmp_buf
 #define DUK_SETJMP(jb)        setjmp((jb))

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -951,9 +951,9 @@ To upgrade:
   in heap creation is **strongly recommended**, see
   http://wiki.duktape.org/HowtoFatalErrors.html for instructions.
 
-  The default fatal error handler will by default cause an intentional
-  segfault; to improve this behavior define ``DUK_USE_FATAL_HANDLER()``
-  in your ``duk_config.h``.
+  The default fatal error handler will by default call ``abort()`` with no
+  error message to ``stdout`` or ``stderr``.  To improve this behavior define
+  ``DUK_USE_FATAL_HANDLER()`` in your ``duk_config.h``.
 
 * If you have a fatal error handler, update its signature::
 

--- a/src-input/duk_error_macros.c
+++ b/src-input/duk_error_macros.c
@@ -118,17 +118,15 @@ DUK_INTERNAL void duk_default_fatal_handler(void *udata, const char *msg) {
 	DUK_D(DUK_DPRINT("custom default fatal error handler called: %s", msg ? msg : "NULL"));
 	DUK_USE_FATAL_HANDLER(udata, msg);
 #else
-	/* Since we don't want to rely on stdio being available, we'll just
-	 * cause a segfault on purpose: it's a portable way to usually cause
-	 * a process to finish, and when used with valgrind it also gives us
-	 * a nice stack trace.  For better behavior application code should
-	 * provide a fatal error handler.
+	/* Default behavior is to abort() on error.  There's no printout
+	 * which makes this awkward, so it's always recommended to use an
+	 * explicit fatal error handler.
 	 */
 	DUK_D(DUK_DPRINT("built-in default fatal error handler called: %s", msg ? msg : "NULL"));
-	DUK_CAUSE_SEGFAULT();  /* SCANBUILD: "Dereference of null pointer", normal */
+	DUK_ABORT();
 #endif
 
-	DUK_D(DUK_DPRINT("fatal error handler returned or segfault didn't succeed, enter forever loop"));
+	DUK_D(DUK_DPRINT("fatal error handler returned, enter forever loop"));
 	for (;;) {
 		/* Loop forever to ensure we don't return. */
 	}

--- a/website/api/duk_create_heap.yaml
+++ b/website/api/duk_create_heap.yaml
@@ -27,9 +27,9 @@ summary: |
   errors, out-of-memory errors not resolved by garbage collection, self test
   errors, etc.  A caller SHOULD implement a fatal error handler in most
   applications.  If not given, a default fatal error handler built into
-  Duktape is used instead.  <b>Note that the default fatal error handler (unless
-  overridden by <code>duk_config.h</code>) causes an intentional segfault to
-  exit a process to avoid relying on platform API calls like abort().</b>  See
+  Duktape is used instead.  The default fatal error handler (unless overridden
+  by <code>duk_config.h</code>) calls <code>abort()</code> with no error
+  message printed to stdout or stderr.  See
   <a href="http://wiki.duktape.org/HowtoFatalErrors.html">How to handle fatal errors</a>
   for more detail and examples.</p>
 

--- a/website/guide/compiling.html
+++ b/website/guide/compiling.html
@@ -141,14 +141,13 @@ for more practical details.</p>
 <p>Some commonly needed configuration options are:</p>
 
 <ul>
-<li><b>DUK_USE_FATAL_HANDLER, strongly recommended</b>.  The built-in default fatal error handler
-    will write a debug log message (but <b>won't</b> write anything to
-    <code>stdout</code> to <code>stderr</code>), and will then cause an
-    <b>intentional segfault</b>; if that fails, it enters an infinite loop
-    to ensure execution doesn't resume after a fatal error.
-    This is usually not the best behavior for production applications which
-    may already have better fatal error recovery mechanisms.  To replace the
-    default fatal handler, see
+<li><b>DUK_USE_FATAL_HANDLER, strongly recommended</b>.  The built-in default fatal
+    error handler will write a debug log message (but <b>won't</b> write anything to
+    <code>stdout</code> to <code>stderr</code>), and will then call <code>abort()</code>.
+    If that fails, it enters an infinite loop to ensure execution doesn't resume
+    after a fatal error. This is usually not the best behavior for production
+    applications which may already have better fatal error recovery mechanisms.
+    To replace the default fatal handler, see
     <a href="http://wiki.duktape.org/HowtoFatalErrors.html">How to handle fatal errors</a>.</li>
 <li><b>Long control transfer: setjmp/longjmp and C++ exceptions</b>.
     By default Duktape uses <code>setjmp()</code> and <code>longjmp()</code>

--- a/website/guide/programming.html
+++ b/website/guide/programming.html
@@ -725,7 +725,7 @@ heap-associated fatal error handler which is in direct application control.</p>
 <div class="note">
 The built-in default fatal error handler will write a debug log message
 (but <b>won't</b> write anything to <code>stdout</code> to <code>stderr</code>),
-and will then cause an <b>intentional segfault</b>; if that fails, it enters an
+and will then call <code>abort()</code>; if that fails, it enters an
 infinite loop to ensure execution doesn't resume after a fatal error.  It is
 <b>strongly recommended</b> to both (1) provide a custom fatal error handler
 in heap creation and (2) replace the built-in default fatal error handler using


### PR DESCRIPTION
Current behavior in master is to cause an intentional segfault from a fatal error. Even with suggestions to define a fatal error handler users often still don't do that (at least when exploring things, which is quite understandable). The segfault then causes confusion regarding memory safety, etc.

So add back `DUK_ABORT()` to `duk_config.h` and use `abort()` by default for fatal errors. There's still no I/O (stderr) on fatal error however. But the "aborted" text is more easy to associate with a fatal error. The downside is stubbing out `DUK_ABORT()` on platforms where that binding doesn't exist (bare metal systems etc).

The main reason I don't want to print to stderr is that it pulls in an I/O dependency which is otherwise entirely avoided. When debug prints are enabled, fatal errors are debug logged though.