### PR TITLE
String creation safety, footprint trivia

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2285,7 +2285,7 @@ Planned
   packed arguments for some internal helper calls (GH-1158, GH-1172); misc
   internal helpers to reduce call site size (GH-1166, GH-1173); config options
   for function .name and .fileName control (GH-1153); internal helper
-  duk_push_hstring_empty() (GH-1186)
+  duk_push_hstring_empty() (GH-1186, GH-1220)
 
 * Internal change: rework shared internal string handling so that shared
   strings are plain string constants used in macro values, rather than

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -970,10 +970,10 @@ static duk_ret_t fileio_write_file(duk_context *ctx) {
 #endif  /* DUK_CMDLINE_FILEIO */
 
 /*
- *  String.fromBuffer()
+ *  String.fromBufferRaw()
  */
 
-static duk_ret_t string_frombuffer(duk_context *ctx) {
+static duk_ret_t string_frombufferraw(duk_context *ctx) {
 	duk_buffer_to_string(ctx, 0);
 	return 1;
 }
@@ -1142,8 +1142,8 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 	duk_print_alert_init(ctx, 0 /*flags*/);
 #endif
 
-	/* Register String.fromBuffer() which does a 1:1 buffer-to-string
-	 * coercion needed by testcases.  String.fromBuffer() is -not- a
+	/* Register String.fromBufferRaw() which does a 1:1 buffer-to-string
+	 * coercion needed by testcases.  String.fromBufferRaw() is -not- a
 	 * default built-in!  For stripped builds the 'String' built-in
 	 * doesn't exist and we create it here; for ROM builds it may be
 	 * present but unwritable (which is ignored).
@@ -1151,9 +1151,9 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 	duk_eval_string(ctx,
 		"(function(v){"
 		    "if (typeof String === 'undefined') { String = {}; }"
-		    "Object.defineProperty(String, 'fromBuffer', {value:v, configurable:true});"
+		    "Object.defineProperty(String, 'fromBufferRaw', {value:v, configurable:true});"
 		"})");
-	duk_push_c_function(ctx, string_frombuffer, 1 /*nargs*/);
+	duk_push_c_function(ctx, string_frombufferraw, 1 /*nargs*/);
 	(void) duk_pcall(ctx, 1);
 	duk_pop(ctx);
 

--- a/src-input/duk_api_codec.c
+++ b/src-input/duk_api_codec.c
@@ -403,7 +403,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_context *ctx, duk_idx_t idx) {
 
 	duk__base64_encode_helper((const duk_uint8_t *) src, srclen, dst);
 
-	ret = duk_buffer_to_string(ctx, -1);
+	ret = duk_buffer_to_string(ctx, -1);  /* Safe, result is ASCII. */
 	duk_replace(ctx, idx);
 	return ret;
 
@@ -507,7 +507,7 @@ DUK_EXTERNAL const char *duk_hex_encode(duk_context *ctx, duk_idx_t idx) {
 	 * caller coerce to string if necessary?
 	 */
 
-	ret = duk_buffer_to_string(ctx, -1);
+	ret = duk_buffer_to_string(ctx, -1);  /* Safe, result is ASCII. */
 	duk_replace(ctx, idx);
 	return ret;
 }

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -98,7 +98,7 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_context *ctx, duk_idx_t count_in,
 
 	/* [ ... buf ] */
 
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe if inputs are safe. */
 
 	/* [ ... res ] */
 	return;
@@ -184,7 +184,7 @@ DUK_EXTERNAL void duk_map_string(duk_context *ctx, duk_idx_t idx, duk_map_char_f
 	}
 
 	DUK_BW_COMPACT(thr, bw);
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe, extended UTF-8 encoded. */
 	duk_replace(ctx, idx);
 }
 

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -70,7 +70,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_context *ctx) {
 	duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_MESSAGE);
 	if (duk_is_undefined(ctx, -1)) {
 		duk_pop(ctx);
-		duk_push_string(ctx, "");
+		duk_push_hstring_empty(ctx);
 	} else {
 		duk_to_string(ctx, -1);
 	}

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -30,11 +30,11 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	}
 
 	if (nargs == 0) {
-		duk_push_string(ctx, "");
-		duk_push_string(ctx, "");
+		duk_push_hstring_empty(ctx);
+		duk_push_hstring_empty(ctx);
 	} else if (nargs == 1) {
 		/* XXX: cover this with the generic >1 case? */
-		duk_push_string(ctx, "");
+		duk_push_hstring_empty(ctx);
 	} else {
 		duk_insert(ctx, 0);   /* [ arg1 ... argN-1 body] -> [body arg1 ... argN-1] */
 		duk_push_string(ctx, ",");

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -137,7 +137,7 @@ DUK_LOCAL int duk__transform_helper(duk_context *ctx, duk__transform_callback ca
 
 	DUK_BW_COMPACT(thr, &tfm_ctx->bw);
 
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe if transform is safe. */
 	return 1;
 }
 

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -475,7 +475,7 @@ DUK_LOCAL void duk__dec_string(duk_json_dec_ctx *js_ctx) {
 #endif  /* DUK_USE_JSON_DECSTRING_FASTPATH */
 
 	DUK_BW_SETPTR_AND_COMPACT(js_ctx->thr, bw, q);
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe if input string is safe. */
 
 	/* [ ... str ] */
 

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -119,7 +119,7 @@ DUK_LOCAL duk_ret_t duk__construct_from_codepoints(duk_context *ctx, duk_bool_t 
 	}
 
 	DUK_BW_COMPACT(thr, bw);
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe, extended UTF-8 or CESU-8 encoded. */
 	return 1;
 }
 
@@ -842,7 +842,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 
 	DUK_ASSERT_TOP(ctx, 4);
 	DUK_BW_COMPACT(thr, bw);
-	(void) duk_buffer_to_string(ctx, -1);
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe if inputs are safe. */
 	return 1;
 }
 
@@ -1382,7 +1382,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_context *ctx) {
 	 * intern table (they are not in heap_allocated).
 	 */
 
-	duk_buffer_to_string(ctx, -1);
+	duk_buffer_to_string(ctx, -1);  /* Safe if input is safe. */
 	return 1;
 
  fail_range:

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -355,7 +355,7 @@ DUK_LOCAL duk_hstring *duk__debug_read_hstring_raw(duk_hthread *thr, duk_uint32_
 		p = (duk_uint8_t *) duk_push_fixed_buffer(ctx, (duk_size_t) len);  /* zero for paranoia */
 		DUK_ASSERT(p != NULL);
 		duk_debug_read_bytes(thr, p, (duk_size_t) len);
-		(void) duk_buffer_to_string(ctx, -1);
+		(void) duk_buffer_to_string(ctx, -1);  /* Safety relies on debug client, which is OK. */
 	}
 
 	return duk_require_hstring(ctx, -1);

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -958,7 +958,9 @@ DUK_LOCAL void duk__create_escaped_source(duk_hthread *thr, int idx_pattern) {
 	}
 
 	DUK_BW_SETPTR_AND_COMPACT(thr, bw, q);
-	(void) duk_buffer_to_string(ctx, -1);  /* -> [ ... escaped_source ] */
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe if input is safe. */
+
+	/* [ ... escaped_source ] */
 }
 
 /*
@@ -1071,7 +1073,7 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 	/* [ ... pattern flags escaped_source buffer ] */
 
 	DUK_BW_COMPACT(thr, &re_ctx.bw);
-	(void) duk_buffer_to_string(ctx, -1);  /* coerce to string */
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe because flags is at most 7 bit. */
 
 	/* [ ... pattern flags escaped_source bytecode ] */
 

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -1064,7 +1064,8 @@ DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_small_in
 	}
 
 	DUK_BW_COMPACT(thr, bw);
-	(void) duk_buffer_to_string(ctx, -1);  /* invalidates h_buf pointer */
+	(void) duk_buffer_to_string(ctx, -1);  /* Safe, output is encoded. */
+	/* invalidates h_buf pointer */
 	duk_remove_m2(ctx);
 }
 

--- a/tests/ecmascript/test-bi-duktape-json-custom.js
+++ b/tests/ecmascript/test-bi-duktape-json-custom.js
@@ -316,7 +316,7 @@ SyntaxError
 
 function characterEscapeEncodeTest() {
     function mk(hex) {
-        return bufferToString(Duktape.dec('hex', hex));
+        return bufferToStringRaw(Duktape.dec('hex', hex));
     }
 
     var values = [
@@ -758,7 +758,7 @@ function invalidXutf8Test() {
     // Because standard JSON does not escape non-ASCII codepoints, hex
     // encode its output
     values.forEach(function (v) {
-        var t = bufferToString(Duktape.dec('hex', v));
+        var t = bufferToStringRaw(Duktape.dec('hex', v));
         print(v);
         print('json ', Duktape.enc('hex', JSON.stringify(t)));
         print('jx', encJx(t));

--- a/tests/ecmascript/test-bi-duktape.js
+++ b/tests/ecmascript/test-bi-duktape.js
@@ -155,7 +155,7 @@ function printEnc(x) {
 
 function printDec(x) {
     print(typeof x);
-    x = bufferToString(x);
+    x = bufferToStringRaw(x);
     var res = [];
     for (var i = 0; i < x.length; i++) {
         res.push(x.charCodeAt(i));

--- a/tests/ecmascript/test-bi-json-dec-clipped.js
+++ b/tests/ecmascript/test-bi-json-dec-clipped.js
@@ -53,7 +53,7 @@ function jsonClipTest(input, parser) {
                 if (j >= 0) {
                     buf = createPlainBuffer(1);
                     buf[0] = j;
-                    t = t + bufferToString(buf);
+                    t = t + bufferToStringRaw(buf);
                 }
                 if (parser === 'json') {
                     t = JSON.parse(t);

--- a/tests/ecmascript/test-bi-json-enc-nonbmp.js
+++ b/tests/ecmascript/test-bi-json-enc-nonbmp.js
@@ -92,9 +92,9 @@ function nonBmpTest() {
     for (i = 0; i < buffers.length; i++) {
         buf = buffers[i];
 
-        t = Duktape.enc('jx', { string: bufferToString(buf) });
+        t = Duktape.enc('jx', { string: bufferToStringRaw(buf) });
         safePrint(t);
-        t = JSON.stringify({ string: bufferToString(buf) });
+        t = JSON.stringify({ string: bufferToStringRaw(buf) });
         safePrint(t);
         codepointDump(t);
     }

--- a/tests/ecmascript/test-bi-logger.js
+++ b/tests/ecmascript/test-bi-logger.js
@@ -14,7 +14,7 @@
 
 function raw_replacement(msg) {
     // Timestamp is non-predictable
-    msg = bufferToString(msg);  // arg is a buffer
+    msg = bufferToStringRaw(msg);  // arg is a buffer
     msg = msg.replace(/^\S+/, 'TIMESTAMP');
     print(msg);
 }
@@ -465,7 +465,7 @@ function lengthTest() {
     // Replace raw() with something that just prints the result length.
 
     function raw_printlen(msg) {
-        print(bufferToString(msg).length);
+        print(bufferToStringRaw(msg).length);
     }
     Duktape.Logger.prototype.raw = raw_printlen;
 

--- a/tests/ecmascript/test-bi-proxy-property-safety.js
+++ b/tests/ecmascript/test-bi-proxy-property-safety.js
@@ -55,9 +55,9 @@ function proxyPropertyTest(key) {
 
 function proxyInternalKeysSandboxTest() {
     print('_Target');
-    proxyPropertyTest(bufferToString(Duktape.dec('hex', 'ff546172676574')));
+    proxyPropertyTest(bufferToStringRaw(Duktape.dec('hex', 'ff546172676574')));
     print('_Handler');
-    proxyPropertyTest(bufferToString(Duktape.dec('hex', 'ff48616e646c6572')));
+    proxyPropertyTest(bufferToStringRaw(Duktape.dec('hex', 'ff48616e646c6572')));
 }
 
 try {

--- a/tests/ecmascript/test-bi-string-frombuffer.js
+++ b/tests/ecmascript/test-bi-string-frombuffer.js
@@ -1,7 +1,7 @@
 /*
- *  String.fromBuffer() provided by the "duk" command.
+ *  String.fromBufferRaw() provided by the "duk" command.
  *
- *  NOTE: String.fromBuffer() is -not- part of the default built-ins.  It is
+ *  NOTE: String.fromBufferRaw() is -not- part of the default built-ins.  It is
  *  provided by "duk" command to support testcases which need to deal with
  *  the internal string representation.
  */
@@ -85,7 +85,7 @@ function test() {
         new Uint16Array([ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]).subarray(3, 7)
     ].forEach(function (v) {
         try {
-            var p = String.fromBuffer(v);
+            var p = String.fromBufferRaw(v);
             print(Duktape.enc('jx', p));
             print(typeof p, safeEscapeString(p));
             print(Duktape.enc('jx', stringToBuffer(p)));

--- a/tests/ecmascript/test-bi-string-proto-repeat-internalstring.js
+++ b/tests/ecmascript/test-bi-string-proto-repeat-internalstring.js
@@ -9,6 +9,8 @@
  *  prefix byte by repeating something.
  */
 
+/*@include util-buffer.js@*/
+
 /*---
 {
     "custom": true
@@ -34,7 +36,7 @@ function test() {
     }
 
     // Internal prefix 0xFE is just repeated, unaffected.
-    str = String.fromBuffer(new Uint8Array([ 0xfe, 0x41, 0x42, 0x43 ]));
+    str = bufferToStringRaw(new Uint8Array([ 0xfe, 0x41, 0x42, 0x43 ]));
     print(str.length);
     dump(str);
     res = str.repeat(3);

--- a/tests/ecmascript/test-bi-symbol-custom.js
+++ b/tests/ecmascript/test-bi-symbol-custom.js
@@ -2,6 +2,8 @@
  *  Some Duktape specific Symbol tests.
  */
 
+/*@include util-buffer.js@*/
+
 /*===
 TypeError
 TypeError
@@ -18,7 +20,7 @@ function test() {
     // Because Symbols fail with TypeError in string concatenation, this
     // Duktape 1.x idiom to create an internal string no longer works.
     try {
-        print(Duktape.enc('jx', String.fromBuffer(Duktape.dec('hex', 'ff')) + 'Value'));
+        print(Duktape.enc('jx', bufferToStringRaw(Duktape.dec('hex', 'ff')) + 'Value'));
     } catch (e) {
         print(e.name);
     }

--- a/tests/ecmascript/test-bi-symbol-enumeration.js
+++ b/tests/ecmascript/test-bi-symbol-enumeration.js
@@ -3,6 +3,7 @@
  */
 
 /*@include util-symbol.js@*/
+/*@include util-buffer.js@*/
 
 /*===
 symbol enumeration
@@ -32,10 +33,10 @@ function symbolEnumerationTest() {
     var obj = {};
     var ancestor = {};
     if (typeof Duktape === 'object') {
-        var internalKey1 = String.fromBuffer(Duktape.dec('hex', 'ff696e68456e756d53796d48696464656e'));  // _InhEnumSymHidden
-        var internalKey2 = String.fromBuffer(Duktape.dec('hex', 'ff696e684e6f6e456e756d53796d48696464656e'));  // _InhNonEnumSymHidden
-        var internalKey3 = String.fromBuffer(Duktape.dec('hex', 'ff4f776e456e756d53796d48696464656e'));  // _OwnEnumSymHidden
-        var internalKey4 = String.fromBuffer(Duktape.dec('hex', 'ff4f776e4e6f6e456e756d53796d48696464656e'));  // _OwnNonEnumSymHidden
+        var internalKey1 = bufferToStringRaw(Duktape.dec('hex', 'ff696e68456e756d53796d48696464656e'));  // _InhEnumSymHidden
+        var internalKey2 = bufferToStringRaw(Duktape.dec('hex', 'ff696e684e6f6e456e756d53796d48696464656e'));  // _InhNonEnumSymHidden
+        var internalKey3 = bufferToStringRaw(Duktape.dec('hex', 'ff4f776e456e756d53796d48696464656e'));  // _OwnEnumSymHidden
+        var internalKey4 = bufferToStringRaw(Duktape.dec('hex', 'ff4f776e4e6f6e456e756d53796d48696464656e'));  // _OwnNonEnumSymHidden
     } else {
         // For manual testing with e.g. Node.js; output will naturally differ for these.
         var internalKey1 = 'fake1';

--- a/tests/ecmascript/test-bug-base64-dec-whitespace-padding.js
+++ b/tests/ecmascript/test-bug-base64-dec-whitespace-padding.js
@@ -18,33 +18,33 @@ TypeError
 
 function test() {
     // Whitespace is accepted at any point.
-    print(bufferToString(Duktape.dec('base64', 'Zm9v')));
-    print(bufferToString(Duktape.dec('base64', ' Z m 9 v ')));
+    print(bufferToStringRaw(Duktape.dec('base64', 'Zm9v')));
+    print(bufferToStringRaw(Duktape.dec('base64', ' Z m 9 v ')));
 
     // Works also for padding.
-    print(bufferToString(Duktape.dec('base64', 'Zm9=')));
-    print(bufferToString(Duktape.dec('base64', ' Z m 9 =')));
+    print(bufferToStringRaw(Duktape.dec('base64', 'Zm9=')));
+    print(bufferToStringRaw(Duktape.dec('base64', ' Z m 9 =')));
 
     // Whitespace between padding bytes was not accepted by Duktape 1.3.0.
     try {
-        print(bufferToString(Duktape.dec('base64', 'Zm==')));
+        print(bufferToStringRaw(Duktape.dec('base64', 'Zm==')));
     } catch (e) {
         print(e);
     }
     try {
-        print(bufferToString(Duktape.dec('base64', 'Zm==')));
+        print(bufferToStringRaw(Duktape.dec('base64', 'Zm==')));
     } catch (e) {
         print(e);
     }
     try {
-        print(bufferToString(Duktape.dec('base64', ' Z m = = ')));
+        print(bufferToStringRaw(Duktape.dec('base64', ' Z m = = ')));
     } catch (e) {
         print(e);
     }
 
     // Mixed padding not allowed.
     try {
-        print(bufferToString(Duktape.dec('base64', 'Z=m=')));
+        print(bufferToStringRaw(Duktape.dec('base64', 'Z=m=')));
     } catch (e) {
         print(e.name);
     }

--- a/tests/ecmascript/test-commonjs-module-filename.js
+++ b/tests/ecmascript/test-commonjs-module-filename.js
@@ -38,7 +38,7 @@ function test() {
     // Replace Duktape.Logger.prototype.raw to censor timestamps.
 
     Duktape.Logger.prototype.raw = function (buf) {
-        print(bufferToString(buf).replace(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.*?Z/, 'TIME'));
+        print(bufferToStringRaw(buf).replace(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.*?Z/, 'TIME'));
     };
 
     // Default behavior, module wrapper .fileName is resolved module ID,

--- a/tests/ecmascript/test-commonjs-module-logname.js
+++ b/tests/ecmascript/test-commonjs-module-logname.js
@@ -20,7 +20,7 @@ function moduleLogNameTest() {
         return 'var logger = new Duktape.Logger(); logger.info("hello from module");';
     };
     Duktape.Logger.prototype.raw = function (buf) {
-        var str = bufferToString(buf);
+        var str = bufferToStringRaw(buf);
         str = str.replace(/^\S+/, 'TIMESTAMP');
         print(str);
     };

--- a/tests/ecmascript/test-dev-base64-enc.js
+++ b/tests/ecmascript/test-dev-base64-enc.js
@@ -22,7 +22,7 @@ function encPrint(x) {
 }
 
 function decPrint(x) {
-    print(bufferToString(Duktape.dec('base64', x)));
+    print(bufferToStringRaw(Duktape.dec('base64', x)));
 }
 
 /*===
@@ -71,7 +71,7 @@ Zm9v4Yi0
 // U+1234 -> 0xe1 0x88 0xb4
 encPrint('foo\u1234');
 
-t = bufferToString(Duktape.dec('base64', 'Zm9v4Yi0'));
+t = bufferToStringRaw(Duktape.dec('base64', 'Zm9v4Yi0'));
 print(t.charCodeAt(0), t.charCodeAt(1), t.charCodeAt(2), t.charCodeAt(3));
 
 /*===

--- a/tests/ecmascript/test-dev-buffer-copy-example.js
+++ b/tests/ecmascript/test-dev-buffer-copy-example.js
@@ -23,7 +23,7 @@ false
 function bufferCopyTest() {
     // Create a plain buffer.
     var buf = Duktape.dec('hex', '41424344');  // ABCD
-    print(typeof buf, buf, isPlainBuffer(buf), bufferToString(buf));
+    print(typeof buf, buf, isPlainBuffer(buf), bufferToStringRaw(buf));
 
     // Plain buffer mimics ArrayBuffer so use .slice() to create a copy.
     // When called with a plain buffer the slice will also be a plain
@@ -33,18 +33,18 @@ function bufferCopyTest() {
     // var copy = ArrayBuffer.createPlain(buf);
 
     var copy = buf.slice();
-    print(typeof copy, copy, isPlainBuffer(copy), bufferToString(buf));
+    print(typeof copy, copy, isPlainBuffer(copy), bufferToStringRaw(buf));
     print(copy === buf);
 
     // Demonstrate independence.
     copy[0] = ('X').charCodeAt(0);
-    print('buf:', bufferToString(buf));
-    print('copy:', bufferToString(copy));
+    print('buf:', bufferToStringRaw(buf));
+    print('copy:', bufferToStringRaw(copy));
 
     // If argument to .slice() is Object coerced, the result is also a
     // full ArrayBuffer object.
     var copy = Object(buf).slice();
-    print(typeof copy, copy, isPlainBuffer(copy), bufferToString(buf));
+    print(typeof copy, copy, isPlainBuffer(copy), bufferToStringRaw(buf));
     print(copy === buf);
 }
 

--- a/tests/ecmascript/test-dev-buffer-interop.js
+++ b/tests/ecmascript/test-dev-buffer-interop.js
@@ -26,9 +26,9 @@ function plainBufferTest() {
     // plain buffer, mimics ArrayBuffer
 
     a = Duktape.dec('hex', '41424344');
-    print(typeof a, a, bufferToString(a));
+    print(typeof a, a, bufferToStringRaw(a));
     b = Object(a);
-    print(typeof b, b, bufferToString(b));
+    print(typeof b, b, bufferToStringRaw(b));
     c = a.valueOf();  // .valueOf returns Object(plainBuffer) now
     d = b.valueOf();
     print(typeof c, typeof d);

--- a/tests/ecmascript/test-dev-buffer-to-string.js
+++ b/tests/ecmascript/test-dev-buffer-to-string.js
@@ -68,7 +68,7 @@ function test() {
     print(Duktape.enc('jx', stringToBuffer(s)));
 
     // In Duktape 2.x there's no default Ecmascript built-in for doing a
-    // 1:1 string conversion, but "duk" command fills in String.fromBuffer().
+    // 1:1 string conversion, but "duk" command fills in String.fromBufferRaw().
     // The active slice of any buffer or buffer object argumented is
     // interpreted as bytes (even for e.g. Uint32Array) and copied 1:1 into
     // the internal string representation.
@@ -77,7 +77,7 @@ function test() {
     // initial byte is 0xff the string coercion will actually create a
     // symbol because symbols and strings share the same internal representation.
     b = new Uint8Array([ 0xfe, 0x61, 0x62, 0x63 ]);
-    s = String.fromBuffer(b);
+    s = String.fromBufferRaw(b);
     print(s.length, Duktape.enc('jx', s));
     print(Duktape.enc('jx', stringToBuffer(s)));
 }

--- a/tests/ecmascript/test-dev-hex-dec-brute.js
+++ b/tests/ecmascript/test-dev-hex-dec-brute.js
@@ -97,7 +97,7 @@ function testLengths() {
                 failure++;
             }
             try {
-                res2 = Duktape.enc('jx', Duktape.dec('hex', bufferToString(buf)));
+                res2 = Duktape.enc('jx', Duktape.dec('hex', bufferToStringRaw(buf)));
             } catch (e) {
                 res2 = e.name;
             }

--- a/tests/ecmascript/test-dev-hex-enc.js
+++ b/tests/ecmascript/test-dev-hex-enc.js
@@ -15,5 +15,5 @@ var t;
 
 print(Duktape.enc('hex', 'foo\u1234'));
 
-t = bufferToString(Duktape.dec('hex', '666f6fe188b4'));
+t = bufferToStringRaw(Duktape.dec('hex', '666f6fe188b4'));
 print(t.charCodeAt(0), t.charCodeAt(1), t.charCodeAt(2), t.charCodeAt(3));

--- a/tests/ecmascript/test-dev-internal-key-access.js
+++ b/tests/ecmascript/test-dev-internal-key-access.js
@@ -35,11 +35,11 @@ function test() {
     buf[3] = 'l'.charCodeAt(0);
     buf[4] = 'u'.charCodeAt(0);
     buf[5] = 'e'.charCodeAt(0);
-    key = bufferToString(buf);
+    key = bufferToStringRaw(buf);
     print('using ArrayBuffer, date \\xFFValue:', dt[key]);
 
     // Using Duktape.dec()
-    key = bufferToString(Duktape.dec('hex', 'ff56616c7565'));  // \xFFValue
+    key = bufferToStringRaw(Duktape.dec('hex', 'ff56616c7565'));  // \xFFValue
     print('using Duktape.dec, date \\xFFValue:', dt[key]);
 }
 

--- a/tests/ecmascript/test-dev-internal-property-basics.js
+++ b/tests/ecmascript/test-dev-internal-property-basics.js
@@ -52,7 +52,7 @@ function test() {
 
     // Internal key \xFF\xFFabc is in principle enumerable, but because
     // internal keys have special behavior, it is never enumerated.
-    internalKey = bufferToString(Duktape.dec('hex', 'ffff616264'));  // \xFF\xFFabc
+    internalKey = bufferToStringRaw(Duktape.dec('hex', 'ffff616264'));  // \xFF\xFFabc
     obj[internalKey] = 3;
 
     // The key \x20\xFFquux is invalid UTF-8 but not an internal string,
@@ -60,7 +60,7 @@ function test() {
     // varies.  For example, JSON.stringify() will encounter the invalid
     // UTF-8 initial byte \xFF and serialize it like it had encountered
     // the codepoint U+00FF (writing out the bytes c3 bf).
-    invalidUtf8Key = bufferToString(Duktape.dec('hex', '20ff71757578'));  // \x20\xFFquux
+    invalidUtf8Key = bufferToStringRaw(Duktape.dec('hex', '20ff71757578'));  // \x20\xFFquux
     obj[invalidUtf8Key] = 4;
 
     // For-in only lists enumerable keys

--- a/tests/ecmascript/test-dev-lightfunc.js
+++ b/tests/ecmascript/test-dev-lightfunc.js
@@ -2404,7 +2404,7 @@ function duktapeBuiltinTest() {
     // attempt to set finalizer
     testTypedJx(function () { return Duktape.fin(lfunc, function () {}); }, 'fin-set');
 
-    testTypedJx(function () { return sanitizeLfunc(bufferToString(Duktape.dec('hex', Duktape.enc('hex', lfunc)))); }, 'encdec-hex');
+    testTypedJx(function () { return sanitizeLfunc(bufferToStringRaw(Duktape.dec('hex', Duktape.enc('hex', lfunc)))); }, 'encdec-hex');
     testTypedJx(function () { return Duktape.dec('hex', lfunc); }, 'dec-hex');
 
     // attempt to compact is a no-op
@@ -2561,7 +2561,7 @@ function duktapeLoggerBuiltinTest() {
 
     old_raw = Duktape.Logger.prototype.old_raw;
     Duktape.Logger.prototype.raw = function (buf) {
-        var msg = sanitizeLfunc(bufferToString(buf));
+        var msg = sanitizeLfunc(bufferToStringRaw(buf));
         msg = msg.replace(/^\S+/, 'TIMESTAMP');
         print(msg);
     };

--- a/tests/ecmascript/test-dev-plain-buffer.js
+++ b/tests/ecmascript/test-dev-plain-buffer.js
@@ -506,7 +506,7 @@ function jsonTest() {
             return {
                 bufferLength: this.length,
                 plain: isPlainBuffer(this),
-                data: bufferToString(this)
+                data: bufferToStringRaw(this)
             };
         };
         print(JSON.stringify(pb, repl));
@@ -1186,7 +1186,7 @@ function duktapeMethodTest() {
     pb[3] = t.charCodeAt(3);
     pb[4] = t.charCodeAt(4);
     pb[5] = t.charCodeAt(5);
-    print(bufferToString(Duktape.dec('hex', pb)));  // hex decode '666f6f' to buffer containing 'foo'
+    print(bufferToStringRaw(Duktape.dec('hex', pb)));  // hex decode '666f6f' to buffer containing 'foo'
     ab = new ArrayBuffer(6);
     ab[0] = t.charCodeAt(0);
     ab[1] = t.charCodeAt(1);
@@ -1194,7 +1194,7 @@ function duktapeMethodTest() {
     ab[3] = t.charCodeAt(3);
     ab[4] = t.charCodeAt(4);
     ab[5] = t.charCodeAt(5);
-    print(bufferToString(Duktape.dec('hex', ab)));
+    print(bufferToStringRaw(Duktape.dec('hex', ab)));
 
     // Duktape.dec() outputs a plain buffer.
     pb = createPlainBuffer(4);
@@ -1206,7 +1206,7 @@ function duktapeMethodTest() {
     t = Duktape.enc('hex', pb);
     print(typeof t, t);
     t = Duktape.dec('hex', t);
-    print(bufferToString(t));
+    print(bufferToStringRaw(t));
     print(isPlainBuffer(t));
     ab = new ArrayBuffer(4);
     ab[0] = 0x61;
@@ -1217,7 +1217,7 @@ function duktapeMethodTest() {
     t = Duktape.enc('hex', ab);
     print(typeof t, t);
     t = Duktape.dec('hex', t);
-    print(bufferToString(t));
+    print(bufferToStringRaw(t));
     print(isPlainBuffer(t));
 
     // compact() is a no-op and returns input value
@@ -1542,16 +1542,16 @@ function nodejsBufferPrototypeMethodTest() {
 
     resetValues();
     print('- write');
-    print(Duktape.enc('jx', pb), bufferToString(pb));
+    print(Duktape.enc('jx', pb), bufferToStringRaw(pb));
     print(Buffer.prototype.write.call(pb, 'FOO', 3));
-    print(Duktape.enc('jx', pb), bufferToString(pb));
+    print(Duktape.enc('jx', pb), bufferToStringRaw(pb));
     print(Buffer.prototype.write.call(pb, 'BARQUUX', 7, 2));
-    print(Duktape.enc('jx', pb), bufferToString(pb));
-    print(Duktape.enc('jx', ab), bufferToString(ab));
+    print(Duktape.enc('jx', pb), bufferToStringRaw(pb));
+    print(Duktape.enc('jx', ab), bufferToStringRaw(ab));
     print(Buffer.prototype.write.call(ab, 'FOO', 3));
-    print(Duktape.enc('jx', ab), bufferToString(ab));
+    print(Duktape.enc('jx', ab), bufferToStringRaw(ab));
     print(Buffer.prototype.write.call(ab, 'BARQUUX', 7, 2));
-    print(Duktape.enc('jx', ab), bufferToString(ab));
+    print(Duktape.enc('jx', ab), bufferToStringRaw(ab));
 
     // Spot check one read method
     resetValues();

--- a/tests/ecmascript/test-dev-string-charlen-correctness.js
+++ b/tests/ecmascript/test-dev-string-charlen-correctness.js
@@ -43,7 +43,7 @@ function testOne(blen) {
         }
     }
 
-    str = bufferToString(buf);
+    str = bufferToStringRaw(buf);
     if (str.length != clen) {
         throw new Error('mismatch: ' + str.length + ' vs ' + clen);
     }

--- a/tests/ecmascript/util-buffer.js
+++ b/tests/ecmascript/util-buffer.js
@@ -253,10 +253,10 @@ function printBuffer(b) {
 // using String(plainBuffer) in Duktape 2.x; this helper hides the mechanism
 // needed, as it may change later.
 
-function bufferToString(buf) {
+function bufferToStringRaw(buf) {
     // Prefer the cleaner, explicit custom method.  This is provided by "duk"
     // and is NOT a part of the default Ecmascript built-ins!
-    return String.fromBuffer(buf);
+    return String.fromBufferRaw(buf);
 }
 
 // Convert any string into a buffer, interpreting the internal string

--- a/tests/perf/test-base64-decode-whitespace.js
+++ b/tests/perf/test-base64-decode-whitespace.js
@@ -7,25 +7,28 @@ function test() {
     var i, n, buf;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
-        if (i == 0 && (buf[i] == 0xff || (buf[i] & 0xc0) == 0x80)) { buf[i] &= 0x7f; }  // avoid symbols
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
     tmp2 = tmp2.join('');
+    print(tmp2.length);
+
     tmp2 = Duktape.enc('base64', tmp2);
+    print(tmp2.length);
 
     // add newlines, intentionally not a multiple of 4
     for (i = 0; i < tmp2.length; i += 77) {
        tmp3.push(tmp2.substring(i, i + 77));
     }
     tmp2 = tmp3.join('\n') + '\n';
-
     print(tmp2.length);
+
     print('run');
     for (i = 0; i < 2000; i++) {
         // Assigning to 'res' avoids garbage collection of result; this is

--- a/tests/perf/test-base64-decode.js
+++ b/tests/perf/test-base64-decode.js
@@ -6,19 +6,21 @@ function test() {
     var i, n, buf;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
-        if (i == 0 && (buf[i] == 0xff || (buf[i] & 0xc0) == 0x80)) { buf[i] &= 0x7f; }  // avoid symbols
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
     tmp2 = tmp2.join('');
-    tmp2 = Duktape.enc('base64', tmp2);
-
     print(tmp2.length);
+
+    tmp2 = Duktape.enc('base64', tmp2);
+    print(tmp2.length);
+
     print('run');
     for (i = 0; i < 2000; i++) {
         // Assigning to 'res' avoids garbage collection of result; this is

--- a/tests/perf/test-base64-encode.js
+++ b/tests/perf/test-base64-encode.js
@@ -6,18 +6,18 @@ function test() {
     var i, n, buf;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
-        if (i == 0 && (buf[i] == 0xff || (buf[i] & 0xc0) == 0x80)) { buf[i] &= 0x7f; }  // avoid symbols
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
-    tmp2 = (ArrayBuffer.allocPlain || Duktape.Buffer)(tmp2.join(''));
-
+    tmp2 = new TextEncoder().encode(tmp2.join(''));
     print(tmp2.length);
+
     print('run');
     for (i = 0; i < 2000; i++) {
         // Assigning to 'res' avoids garbage collection of result; this is

--- a/tests/perf/test-hex-encode.js
+++ b/tests/perf/test-hex-encode.js
@@ -6,17 +6,18 @@ function test() {
     var i, n, buf;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
-    tmp2 = (ArrayBuffer.allocPlain || Duktape.Buffer)(tmp2.join(''));
-
+    tmp2 = new TextEncoder().encode(tmp2.join(''));
     print(tmp2.length);
+
     print('run');
     for (i = 0; i < 5000; i++) {
         // Assigning to 'res' avoids garbage collection of result; this is

--- a/tests/perf/test-json-parse-hex.js
+++ b/tests/perf/test-json-parse-hex.js
@@ -7,17 +7,18 @@ function test() {
     var inp1, inp2;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
-    tmp2 = (ArrayBuffer.allocPlain || Duktape.Buffer)(tmp2.join(''));
-
+    tmp2 = new TextEncoder().encode(tmp2.join(''));
     print(tmp2.length);
+
     print('run');
     inp1 = Duktape.enc('jx', { foo: tmp2 });
     inp2 = Duktape.enc('jx', { foox: tmp2 });

--- a/tests/perf/test-json-serialize-hex.js
+++ b/tests/perf/test-json-serialize-hex.js
@@ -6,17 +6,18 @@ function test() {
     var i, n, buf;
 
     print('build');
-    buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(1024);
+    buf = new Uint8Array(1024);
     for (i = 0; i < 1024; i++) {
-        buf[i] = Math.random() * 256;
+        buf[i] = Math.random() * 128;  // restrict to ASCII
     }
-    tmp1 = (String.fromBuffer || String)(buf);
+    tmp1 = new TextDecoder().decode(buf);
+    print(tmp1.length);
     for (i = 0; i < 1024; i++) {
         tmp2.push(tmp1);
     }
-    tmp2 = (ArrayBuffer.allocPlain || Duktape.Buffer)(tmp2.join(''));
-
+    tmp2 = new TextEncoder().encode(tmp2.join(''));
     print(tmp2.length);
+
     print('run');
     for (i = 0; i < 1000; i++) {
         // Assigning to 'res1' and 'res2' avoids garbage collection of result;

--- a/tests/perf/test-string-intern-grow-short.js
+++ b/tests/perf/test-string-intern-grow-short.js
@@ -4,7 +4,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(31);
     var i, j;
     var arr;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-grow-short2.js
+++ b/tests/perf/test-string-intern-grow-short2.js
@@ -4,7 +4,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(31);
     var i, j;
     var arr;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-grow.js
+++ b/tests/perf/test-string-intern-grow.js
@@ -11,7 +11,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(2048);
     var i, j;
     var arr;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-grow2.js
+++ b/tests/perf/test-string-intern-grow2.js
@@ -4,7 +4,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(2048);
     var i, j;
     var arr;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-match-short.js
+++ b/tests/perf/test-string-intern-match-short.js
@@ -4,7 +4,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(31);
     var ref;
     var i;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-match.js
+++ b/tests/perf/test-string-intern-match.js
@@ -10,7 +10,7 @@ function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(2048);
     var ref;
     var i;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-miss-short.js
+++ b/tests/perf/test-string-intern-miss-short.js
@@ -3,7 +3,7 @@ if (typeof print !== 'function') { print = console.log; }
 function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(31);
     var i;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;

--- a/tests/perf/test-string-intern-miss.js
+++ b/tests/perf/test-string-intern-miss.js
@@ -9,7 +9,7 @@ if (typeof print !== 'function') { print = console.log; }
 function test() {
     var buf = (ArrayBuffer.allocPlain || Duktape.Buffer)(2048);
     var i;
-    var bufferToString = String.fromBuffer || String;
+    var bufferToString = String.fromBufferRaw || String;
 
     for (i = 0; i < buf.length; i++) {
         buf[i] = i;


### PR DESCRIPTION
Buffer-to-string safety checks related to #1005:
- [x] Comment on duk_buffer_to_string() safety w.r.t. potentially pushing Symbol values.
- [x] Go through all duk_push_(l)string() call sites too.
- [x] Minor footprint optimization for pushing empty strings (use more compact internal helper).
- [x] Rename String.fromBuffer() to String.fromBufferRaw() to ensure meaning is clear.
- [x] Minimize call sites for String.fromBufferRaw() wherever possible (using util-buffer.js or standard buffer types)