### PR TITLE
Add duk_is_buffer_data() API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1963,6 +1963,9 @@ Planned
   DUK_FREAD(), DUK_FWRITE(), DUK_FSEEK(), DUK_FTELL(), DUK_FFLUSH(),
   DUK_FPUTC(), DUK_STDOUT, DUK_STDERR, DUK_STDIN, duk_file (GH-787, GH-761)
 
+* Add duk_is_buffer_data() API call to reliably test whether a value stack
+  entry is a plain buffer or any buffer object (GH-1221)
+
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
   same time provider as seen by Ecmascript code (GH-771, GH-1209, GH-1211)

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -570,6 +570,7 @@ DUK_EXTERNAL_DECL duk_bool_t duk_is_nan(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_string(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t idx);
+DUK_EXTERNAL_DECL duk_bool_t duk_is_buffer_data(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_lightfunc(duk_context *ctx, duk_idx_t idx);
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3238,6 +3238,34 @@ DUK_EXTERNAL duk_bool_t duk_is_buffer(duk_context *ctx, duk_idx_t idx) {
 	return duk__tag_check(ctx, idx, DUK_TAG_BUFFER);
 }
 
+#if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
+DUK_EXTERNAL duk_bool_t duk_is_buffer_data(duk_context *ctx, duk_idx_t idx) {
+	duk_tval *tv;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	tv = duk_get_tval_or_unused(ctx, idx);
+	DUK_ASSERT(tv != NULL);
+	if (DUK_TVAL_IS_BUFFER(tv)) {
+		return 1;
+	} else if (DUK_TVAL_IS_OBJECT(tv)) {
+		duk_hobject *h = DUK_TVAL_GET_OBJECT(tv);
+		DUK_ASSERT(h != NULL);
+		if (DUK_HOBJECT_IS_BUFOBJ(h)) {
+			return 1;
+		}
+	}
+	return 0;
+}
+#else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
+DUK_EXTERNAL duk_bool_t duk_is_buffer_data(duk_context *ctx, duk_idx_t idx) {
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	return duk_is_buffer(ctx, idx);
+}
+
+#endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
+
 DUK_EXTERNAL duk_bool_t duk_is_pointer(duk_context *ctx, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	return duk__tag_check(ctx, idx, DUK_TAG_POINTER);

--- a/tests/api/test-is-buffer-data.c
+++ b/tests/api/test-is-buffer-data.c
@@ -1,0 +1,67 @@
+/*===
+*** test_basic (duk_safe_call)
+0: 1
+1: 1
+2: 1
+3: 1
+4: 1
+5: 1
+6: 1
+7: 1
+8: 1
+9: 1
+10: 1
+11: 1
+12: 1
+13: 1
+14: 1
+15: 0
+16: 0
+17: 0
+final top: 18
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	duk_idx_t i, n;
+
+	(void) udata;
+
+	duk_push_fixed_buffer(ctx, 128);
+	duk_push_dynamic_buffer(ctx, 256);
+	duk_push_external_buffer(ctx);
+
+	duk_eval_string(ctx, "new Buffer(10)");
+	duk_eval_string(ctx, "new ArrayBuffer(10)");
+	duk_eval_string(ctx, "new Uint8Array(10)");
+	duk_eval_string(ctx, "new Uint8ClampedArray(10)");
+	duk_eval_string(ctx, "new Int8Array(10)");
+	duk_eval_string(ctx, "new Uint16Array(10)");
+	duk_eval_string(ctx, "new Int16Array(10)");
+	duk_eval_string(ctx, "new Uint32Array(10)");
+	duk_eval_string(ctx, "new Int32Array(10)");
+	duk_eval_string(ctx, "new Float32Array(10)");
+	duk_eval_string(ctx, "new Float64Array(10)");
+
+	duk_eval_string(ctx, "new DataView(new ArrayBuffer(10))");
+
+	/* False for non-buffer values. */
+
+	duk_push_null(ctx);
+	duk_push_string(ctx, "foo");
+
+	/* Also false for objects that inherit from buffer objects. */
+
+	duk_eval_string(ctx, "Object.create(new Uint8Array(10))");
+
+	for (i = 0, n = duk_get_top(ctx); i < n; i++) {
+		printf("%ld: %ld\n", (long) i, (long) duk_is_buffer_data(ctx, i));
+	}
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/website/api/buffer-null-pointer-ambiguity.html
+++ b/website/api/buffer-null-pointer-ambiguity.html
@@ -1,6 +1,8 @@
 <div class="note">
 There is no reliable way to distinguish a zero-size buffer from a non-buffer
-based on the return values.  A <code>NULL</code> with zero size is returned for
-a non-buffer.  The same values may be returned for a zero-size buffer (although
-it is also possible that a non-<code>NULL</code> pointer is returned).
+based on the return values alone: a <code>NULL</code> with zero size is returned
+for a non-buffer.  The same values may be returned for a zero-size buffer (although
+it is also possible that a non-<code>NULL</code> pointer is returned).  Use
+<code><a href="#duk_is_buffer_data">duk_is_buffer_data()</a></code> when type
+checking a buffer or a buffer object.
 </div>

--- a/website/api/duk_is_buffer.yaml
+++ b/website/api/duk_is_buffer.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>idx</code> is a buffer, otherwise
+  <p>Returns 1 if value at <code>idx</code> is a plain buffer, otherwise
   returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
 example: |
@@ -18,5 +18,8 @@ example: |
 tags:
   - stack
   - buffer
+
+seealso:
+  - duk_is_buffer_data
 
 introduced: 1.0.0

--- a/website/api/duk_is_buffer_data.yaml
+++ b/website/api/duk_is_buffer_data.yaml
@@ -1,0 +1,26 @@
+name: duk_is_buffer_data
+
+proto: |
+  duk_bool_t duk_is_buffer_data(duk_context *ctx, duk_idx_t idx);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>idx</code> is a plain buffer or any
+  buffer object type, otherwise returns 0.  If <code>idx</code> is invalid,
+  also returns 0.</p>
+
+example: |
+  if (duk_is_buffer_data(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+  - buffer
+
+seealso:
+  - duk_is_buffer
+
+introduced: 2.0.0


### PR DESCRIPTION
Add `duk_is_buffer_data()` API call for reliably checking whether a value stack entry is a plain buffer or any of the buffer types, in other words: "value stack entry has data". Before this addition one could use `duk_get_buffer_data() != NULL` but there are corner cases with zero-size buffers where that method doesn't work.

- [x] Add API call
- [x] Testcase coverage
- [x] Test -UDUK_USE_BUFFEROBJECT_SUPPORT manually
- [x] API docs
- [x] Releases entry