### PR TITLE
Spawn typed array .buffer ArrayBuffer lazily on first access

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2369,5 +2369,9 @@ Planned
 2.1.0 (XXXX-XX-XX)
 ------------------
 
+* Spawn the ArrayBuffer object backing a typed array lazily when its .buffer
+  property is first read, reducing memory usage in common cases where the view
+  is constructed directly without needing the ArrayBuffer object (GH-1225)
+
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -520,19 +520,18 @@ DUK_EXTERNAL_DECL void *duk_push_buffer_raw(duk_context *ctx, duk_size_t size, d
 #define duk_push_external_buffer(ctx) \
 	((void) duk_push_buffer_raw((ctx), 0, DUK_BUF_FLAG_DYNAMIC | DUK_BUF_FLAG_EXTERNAL))
 
-#define DUK_BUFOBJ_CREATE_ARRBUF       (1 << 4)  /* internal flag: create backing ArrayBuffer; keep in one byte */
 #define DUK_BUFOBJ_ARRAYBUFFER         0
-#define DUK_BUFOBJ_NODEJS_BUFFER       (1 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_DATAVIEW            (2 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_INT8ARRAY           (3 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_UINT8ARRAY          (4 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_UINT8CLAMPEDARRAY   (5 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_INT16ARRAY          (6 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_UINT16ARRAY         (7 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_INT32ARRAY          (8 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_UINT32ARRAY         (9 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_FLOAT32ARRAY        (10 | DUK_BUFOBJ_CREATE_ARRBUF)
-#define DUK_BUFOBJ_FLOAT64ARRAY        (11 | DUK_BUFOBJ_CREATE_ARRBUF)
+#define DUK_BUFOBJ_NODEJS_BUFFER       1
+#define DUK_BUFOBJ_DATAVIEW            2
+#define DUK_BUFOBJ_INT8ARRAY           3
+#define DUK_BUFOBJ_UINT8ARRAY          4
+#define DUK_BUFOBJ_UINT8CLAMPEDARRAY   5
+#define DUK_BUFOBJ_INT16ARRAY          6
+#define DUK_BUFOBJ_UINT16ARRAY         7
+#define DUK_BUFOBJ_INT32ARRAY          8
+#define DUK_BUFOBJ_UINT32ARRAY         9
+#define DUK_BUFOBJ_FLOAT32ARRAY        10
+#define DUK_BUFOBJ_FLOAT64ARRAY        11
 
 DUK_EXTERNAL_DECL void duk_push_buffer_object(duk_context *ctx, duk_idx_t idx_buffer, duk_size_t byte_offset, duk_size_t byte_length, duk_uint_t flags);
 

--- a/tests/memory/test-function-expression-1.js
+++ b/tests/memory/test-function-expression-1.js
@@ -1,0 +1,8 @@
+function test() {
+    var arr = [];
+    while (arr.length < 1e5) {
+        arr.push(function () {});
+    }
+    print(arr.length + ' anonymous functions created');
+}
+test();

--- a/tests/memory/test-function-expression-2.js
+++ b/tests/memory/test-function-expression-2.js
@@ -1,0 +1,11 @@
+function test() {
+    var arr = [];
+    var fn;
+    while (arr.length < 1e4) {
+        fn = function () {};
+        fn.prototype = null;
+        arr.push(fn);
+    }
+    print(arr.length + ' anonymous functions created');
+}
+test();

--- a/tests/memory/test-plain-buffer-1.js
+++ b/tests/memory/test-plain-buffer-1.js
@@ -1,0 +1,8 @@
+function test() {
+    var arr = [];
+    while (arr.length < 1e5) {
+        arr.push(Uint8Array.allocPlain(256));
+    }
+    print(arr.length + ' plain buffers created');
+}
+test();

--- a/tests/memory/test-uint8array-1.js
+++ b/tests/memory/test-uint8array-1.js
@@ -1,0 +1,8 @@
+function test() {
+    var arr = [];
+    while (arr.length < 1e5) {
+        arr.push(new Uint8Array(256));
+    }
+    print(arr.length + ' Uint8Arrays created');
+}
+test();


### PR DESCRIPTION
- [x] Remove inline creation of the ArrayBuffer when a typed array is constructed directly without using an ArrayBuffer argument (applies to C API too)
- [x] Spawn ArrayBuffer on first `.buffer` getter access
- [x] Memory test to demonstrate difference
- [x] Releases entry