### PR TITLE
Fix ArrayBuffer .byteOffset and .byteLength in duk_push_buffer_object()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2162,6 +2162,13 @@ Planned
   rather than accept such ArrayBuffers without actually respecting the
   view offset/length (GH-1197)
 
+* Fix duk_push_buffer_object() ArrayBuffer .byteLength to use 0 and .byteOffset
+  to use view's (byteOffset + byteLength), so that accesses to the ArrayBuffer
+  at the view's .byteOffset match the view at index 0 as normally expected;
+  previously .byteOffset and .byteLength were copied from the view as is which
+  makes the ArrayBuffer indices behave inconsistently with respect to the
+  view's .byteOffset (GH-1229)
+
 * Fix JSON stringify fastpath handling of array gaps in JX and JC; they
   incorrectly stringified as 'null' (like in JSON) instead of 'undefined'
   and '{"_undef":true}' as intended (GH-859, GH-1149)

--- a/doc/release-notes-v2-0.rst
+++ b/doc/release-notes-v2-0.rst
@@ -233,6 +233,14 @@ changes below.  Here's a summary of changes:
   there is no property table for plain buffers, each ``.buffer`` access creates
   a new ArrayBuffer instance.
 
+* When ``duk_push_buffer_object()`` creates an automatic ArrayBuffer for a
+  view (such as Uint8Array), the ArrayBuffer's .byteOffset will be set to 0
+  and its .byteLength will be set to view.byteOffset + view.byteLength.  This
+  ensures that accessing the ArrayBuffer at view.byteOffset returns the same
+  value as when accessing view at index 0, which is the common relationship.
+  Up to Duktape 1.6.x the ArrayBuffer's .byteOffset and .byteLength would be
+  the same as the view's.
+
 * Non-standard properties, such as virtual indices and ``.length`` have been
   removed from ArrayBuffer and DataView.  The ``.byteOffset``, ``.byteLength``,
   ``.BYTES_PER_ELEMENT``, and ``.buffer`` properties of view objects are now

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4397,6 +4397,10 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_context *ctx, duk_idx_t idx_buffer,
 	 * provided as .buffer property of the view.  The ArrayBuffer is
 	 * referenced via duk_hbufobj->buf_prop and an inherited .buffer
 	 * accessor returns it.
+	 *
+	 * The ArrayBuffer offset is always set to zero, so that if one
+	 * accesses the ArrayBuffer at the view's .byteOffset, the value
+	 * matches the view at index 0.
 	 */
 	if (flags & DUK_BUFOBJ_CREATE_ARRBUF) {
 		duk_hbufobj *h_arrbuf;
@@ -4410,8 +4414,8 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_context *ctx, duk_idx_t idx_buffer,
 
 		h_arrbuf->buf = h_val;
 		DUK_HBUFFER_INCREF(thr, h_val);
-		h_arrbuf->offset = uint_offset;
-		h_arrbuf->length = uint_length;
+		h_arrbuf->offset = 0;
+		h_arrbuf->length = uint_offset + uint_length;  /* Wrap checked above. */
 		DUK_ASSERT(h_arrbuf->shift == 0);
 		h_arrbuf->elem_type = DUK_HBUFOBJ_ELEM_UINT8;
 		DUK_ASSERT(h_arrbuf->is_typedarray == 0);

--- a/tests/api/test-bug-bufferobject-arraybuffer-offset-length.c
+++ b/tests/api/test-bug-bufferobject-arraybuffer-offset-length.c
@@ -1,0 +1,74 @@
+/*===
+*** test_basic (duk_safe_call)
+uint8array index 10: 20
+arraybuffer index 10: 10
+arraybuffer index byteOffset + 10: 20
+uint8array index 10: 20
+arraybuffer index 10: 10
+arraybuffer index byteOffset + 10: 20
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	unsigned char *p;
+	int i;
+
+	(void) udata;
+
+	p = (unsigned char *) duk_push_fixed_buffer(ctx, 128);
+	for (i = 0; i < 128; i++) {
+		p[i] = (unsigned char) i;
+	}
+
+	duk_push_buffer_object(ctx, -1, 10, 40, DUK_BUFOBJ_UINT8ARRAY);
+
+	/* Up to Duktape 1.6.x duk_push_buffer_object() creates an Uint8Array
+	 * with a certain offset/length, and uses that same offset/length for
+	 * the underlying ArrayBuffer.
+	 *
+	 * This makes the ArrayBuffer offsetted (offset != 0).  It also means
+	 * that accessing the ArrayBuffer at index .byteOffset + N does -not-
+	 * match Uint8Array at offset N as one would normally expect.  Instead
+	 * the .byteOffset is already account for in the ArrayBuffer internally.
+	 *
+	 * Duktape 1.7.x and 2.0.x changes this so that the .byteOffset is 0,
+	 * and the ArrayBuffer .byteLength is set to .byteOffset + .byteLength
+	 * so that the entire constructed view is visible also in the ArrayBuffer.
+	 */
+
+	duk_eval_string(ctx,
+		"(function (buf) {\n"
+		"    var arrbuf = buf.buffer;\n"
+		"    print('uint8array index 10:', buf[10]);\n"
+		"    print('arraybuffer index 10:', new Uint8Array(arrbuf)[10]);\n"
+		"    var byteOffset = buf.byteOffset;\n"
+		"    print('arraybuffer index byteOffset + 10:', new Uint8Array(arrbuf)[byteOffset + 10]);\n"
+		"})");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+
+	duk_pop(ctx);  /* eval result */
+	duk_pop_2(ctx);  /* fixed buffer, buffer object */
+
+	/* Ecmascript equivalent. */
+
+	duk_eval_string_noresult(ctx,
+		"(function (buf) {\n"
+	        "    var arrbuf = new ArrayBuffer(50);\n"
+		"    var u8 = new Uint8Array(arrbuf);  // for init\n"
+		"    for (var i = 0; i < 50; i++) { u8[i] = i; }\n"
+		"    var buf = new Uint8Array(arrbuf, 10, 40);\n"
+		"    print('uint8array index 10:', buf[10]);\n"
+		"    print('arraybuffer index 10:', new Uint8Array(arrbuf)[10]);\n"
+		"    var byteOffset = buf.byteOffset;\n"
+		"    print('arraybuffer index byteOffset + 10:', new Uint8Array(arrbuf)[byteOffset + 10]);\n"
+		"})()");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/api/test-push-buffer-object.c
+++ b/tests/api/test-push-buffer-object.c
@@ -146,12 +146,12 @@ false false false false true false false false false false false false -> Uint8A
 [object ArrayBuffer]
 function undefined false false
 [object ArrayBuffer]
-object [object ArrayBuffer] undefined undefined 22 undefined undefined
+object [object ArrayBuffer] undefined undefined 38 undefined undefined
 false true false false false false false false false false false false -> ArrayBuffer
 false true false false false false false false false false false false -> ArrayBuffer.prototype
 undefined
 undefined
-22
+38
 undefined
 undefined
 123 123
@@ -195,7 +195,7 @@ static duk_ret_t test_view_buffer_prop(duk_context *ctx, void *udata) {
 		"    print(v.buffer.BYTES_PER_ELEMENT);\n"
 		"    print(v.buffer.buffer);\n"
 		"    v[3] = 123;  /* check that backing buffer and slice matches */\n"
-		"    print(v[3], new Uint8Array(v.buffer)[3]);\n"
+		"    print(v[3], new Uint8Array(v.buffer)[v.byteOffset + 3]);\n"
 		"})");
 	duk_dup(ctx, -2);
 	duk_call(ctx, 1);
@@ -389,7 +389,7 @@ final top: 2
 ==> rc=1, result='TypeError: invalid args'
 ===*/
 
-/* If 'flags' is given as zero, it will match a DUK_BUFOBJ_DUKTAPEBUFFER.
+/* If 'flags' is given as zero, it will match a DUK_BUFOBJ_ARRAYBUFFER.
  * So this test succeeds which is intentional.
  */
 static duk_ret_t test_invalid_flags1(duk_context *ctx, void *udata) {

--- a/website/api/duk_push_buffer_object.yaml
+++ b/website/api/duk_push_buffer_object.yaml
@@ -33,7 +33,10 @@ summary: |
   <p>When anything other than an <code>ArrayBuffer</code> is pushed, an
   <code>ArrayBuffer</code> backing the view is automatically created.
   It is accessible through the <code>buffer</code> property of the view
-  object.</p>
+  object.  The ArrayBuffer's internal byteOffset will be zero so that
+  the ArrayBuffer's index byteOffset matches the view's index 0.  The
+  ArrayBuffer's byteLength will be byteLength will be <code>byte_offset +
+  byte_length</code> so that the view range is valid for the ArrayBuffer.</p>
 
   <p>The underlying plain buffer should normally cover the range indicated by
   the <code>byte_offset</code> and <code>byte_length</code> arguments, but


### PR DESCRIPTION
When pushing e.g. an Uint8Array using `duk_push_buffer_object()` the current behavior is to create an ArrayBuffer and set its internal .byteOffset and .byteLength to the same values as the view's. For example, if the view has .byteOffset 10 and .byteLength 40 (byte range [10,50[) the ArrayBuffer will get these same values.

Normally the relationship between a typed array and its underlying ArrayBuffer is that the index `N` of the view maps to the index `view.byteOffset + N` of the ArrayBuffer. The current initialization approach breaks this relationship because the ArrayBuffer also applies the .byteOffset.

Fix the ArrayBuffer initialization by setting the ArrayBuffer's .byteOffset to 0 so that the usual index / offset relationship comes out as expected. Set the ArrayBuffer's .byteLength to `view.byteOffset + view.byteLength` so that the ArrayBuffer covers the entire view.