### PR TITLE
Fix some compiler warnings for 2.0.0 release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,11 +29,11 @@ build_script:
 
   # Prep a few variants of headers and sources.
 
-  - cmd: python tools\configure.py --output-directory prep-nondll --source-directory src-input --config-metadata config
+  - cmd: python tools\configure.py --line-directives --output-directory prep-nondll --source-directory src-input --config-metadata config
   - cmd: dir prep-nondll
-  - cmd: python tools\configure.py --output-directory prep-dll --source-directory src-input --config-metadata config --dll
+  - cmd: python tools\configure.py --line-directives --output-directory prep-dll --source-directory src-input --config-metadata config --dll
   - cmd: dir prep-dll
-  - cmd: python tools\configure.py --output-directory prep-cpp --source-directory src-input --config-metadata config -DDUK_USE_CPP_EXCEPTIONS
+  - cmd: python tools\configure.py --line-directives --output-directory prep-cpp --source-directory src-input --config-metadata config -DDUK_USE_CPP_EXCEPTIONS
   - cmd: dir prep-cpp
 
   # --- Visual Studio 2015 ---

--- a/config/compilers/compiler_clang.h.in
+++ b/config/compilers/compiler_clang.h.in
@@ -19,7 +19,7 @@
 #define DUK_UNLIKELY(x)  __builtin_expect((x), 0)
 #if defined(__clang__) && defined(__has_builtin)
 #if __has_builtin(__builtin_unpredictable)
-#define DUK_UNPREDICTABLE()  do { __builtin_unpredictable(); } while (0)
+#define DUK_UNPREDICTABLE(x)  __builtin_unpredictable((x))
 #endif
 #endif
 

--- a/config/compilers/compiler_emscripten.h.in
+++ b/config/compilers/compiler_emscripten.h.in
@@ -11,7 +11,7 @@
 #define DUK_UNLIKELY(x)  __builtin_expect((x), 0)
 #if defined(__clang__) && defined(__has_builtin)
 #if __has_builtin(__builtin_unpredictable)
-#define DUK_UNPREDICTABLE()  do { __builtin_unpredictable(); } while (0)
+#define DUK_UNPREDICTABLE(x)  __builtin_unpredictable((x))
 #endif
 #endif
 

--- a/config/compilers/compiler_msvc.h.in
+++ b/config/compilers/compiler_msvc.h.in
@@ -70,3 +70,6 @@
 #define DUK_SNPRINTF     _snprintf
 #define DUK_VSNPRINTF    _vsnprintf
 #endif
+
+/* Avoid warning when doing DUK_UNREF(some_function). */
+#define DUK_UNREF(x)  do { __pragma(warning(suppress:4100 4101 4550 4551)) (x); } while (0)

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -54,6 +54,7 @@
 #endif
 #if defined(DUK_CMDLINE_LINENOISE)
 #include "linenoise.h"
+#include <stdint.h>  /* Assume C99/C++11 with linenoise. */
 #endif
 #if defined(DUK_CMDLINE_PRINTALERT_SUPPORT)
 #include "duk_print_alert.h"
@@ -465,7 +466,7 @@ static char *linenoise_hints(const char *buf, int *color, int *bold) {
 		*color = 31;  /* red */
 		*bold = 1;
 		duk_pop_2(ctx);
-		return (char *) res;
+		return (char *) (uintptr_t) res;  /* uintptr_t cast to avoid const discard warning. */
 	}
 
 	if (duk_is_object(ctx, -1)) {
@@ -488,7 +489,7 @@ static char *linenoise_hints(const char *buf, int *color, int *bold) {
 		duk_pop(ctx);
 
 		duk_pop_2(ctx);
-		return (char *) res;
+		return (char *) (uintptr_t) res;  /* uintptr_t cast to avoid const discard warning. */
 	}
 
 	duk_pop_2(ctx);

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -206,16 +206,16 @@ DUK_INTERNAL_DECL const char *duk_push_string_tval_readable_error(duk_context *c
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [] -> [val] */
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_get_prop_stridx_short(ctx,obj_idx,stridx) \
-	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
-	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
+	(DUK_ASSERT_EXPR((duk_int_t) (obj_idx) >= -0x8000L && (duk_int_t) (obj_idx) <= 0x7fffL), \
+	 DUK_ASSERT_EXPR((duk_int_t) (stridx) >= 0 && (duk_int_t) (stridx) <= 0xffffL), \
 	 duk_get_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_boolean(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_bool_t *out_has_prop);  /* [] -> [] */
 
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [val] -> [] */
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_put_prop_stridx_short(ctx,obj_idx,stridx) \
-	(DUK_ASSERT_EXPR((obj_idx) >= -0x8000L && (obj_idx) <= 0x7fffL), \
-	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
+	(DUK_ASSERT_EXPR((duk_int_t) (obj_idx) >= -0x8000L && (duk_int_t) (obj_idx) <= 0x7fffL), \
+	 DUK_ASSERT_EXPR((duk_int_t) (stridx) >= 0 && (duk_int_t) (stridx) <= 0xffffL), \
 	 duk_put_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 
 DUK_INTERNAL_DECL duk_bool_t duk_del_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [] -> [] */
@@ -250,9 +250,9 @@ DUK_INTERNAL_DECL void duk_xdef_prop_index(duk_context *ctx, duk_idx_t obj_idx, 
 DUK_INTERNAL_DECL void duk_xdef_prop_stridx(duk_context *ctx, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_uint_t desc_flags);  /* [val] -> [] */
 DUK_INTERNAL_DECL void duk_xdef_prop_stridx_short_raw(duk_context *ctx, duk_uint_t packed_args);
 #define duk_xdef_prop_stridx_short(ctx,obj_idx,stridx,desc_flags) \
-	(DUK_ASSERT_EXPR((obj_idx) >= -0x80L && (obj_idx) <= 0x7fL), \
-	 DUK_ASSERT_EXPR((stridx) >= 0 && (stridx) <= 0xffffL), \
-	 DUK_ASSERT_EXPR((desc_flags) >= 0 && (desc_flags) <= 0xffL), \
+	(DUK_ASSERT_EXPR((duk_int_t) (obj_idx) >= -0x80L && (duk_int_t) (obj_idx) <= 0x7fL), \
+	 DUK_ASSERT_EXPR((duk_int_t) (stridx) >= 0 && (duk_int_t) (stridx) <= 0xffffL), \
+	 DUK_ASSERT_EXPR((duk_int_t) (desc_flags) >= 0 && (duk_int_t) (desc_flags) <= 0xffL), \
 	 duk_xdef_prop_stridx_short_raw((ctx), (((duk_uint_t) (obj_idx)) << 24) + (((duk_uint_t) (stridx)) << 8) + (duk_uint_t) (desc_flags)))
 
 #define duk_xdef_prop_wec(ctx,obj_idx) \

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4662,7 +4662,7 @@ DUK_INTERNAL void duk_push_hstring(duk_context *ctx, duk_hstring *h) {
 DUK_INTERNAL void duk_push_hstring_stridx(duk_context *ctx, duk_small_uint_t stridx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	DUK_UNREF(thr);
-	DUK_ASSERT(stridx >= 0 && stridx < DUK_HEAP_NUM_STRINGS);
+	DUK_ASSERT_STRIDX_VALID(stridx);
 	duk_push_hstring(ctx, DUK_HTHREAD_GET_STRING(thr, stridx));
 }
 

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -2935,7 +2935,8 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_bytelength_getter(duk_context *ctx) {
 		duk_hbuffer *h_buf;
 
 		h_buf = (duk_hbuffer *) h_bufobj;
-		duk_push_uint(ctx, DUK_HBUFFER_GET_SIZE(h_buf));
+		DUK_ASSERT(DUK_HBUFFER_GET_SIZE(h_buf) <= DUK_UINT_MAX);  /* Buffer limits. */
+		duk_push_uint(ctx, (duk_uint_t) DUK_HBUFFER_GET_SIZE(h_buf));
 	} else {
 		/* If neutered must return 0; length is zeroed during
 		 * neutering.

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -276,7 +276,7 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_context *ctx, duk_
 	 * supporting a large time range (the full Ecmascript range).
 	 */
 	if (sizeof(time_t) < 8 &&
-	   (parts[DUK_DATE_IDX_YEAR] < 1970 || parts[DUK_DATE_IDX_YEAR] > 2037)) {
+	    (parts[DUK_DATE_IDX_YEAR] < 1970 || parts[DUK_DATE_IDX_YEAR] > 2037)) {
 		/* be paranoid for 32-bit time values (even avoiding negative ones) */
 		return 0;
 	}

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -739,7 +739,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 	DUK_UNREF(h_trap_result);
 
 	magic = duk_get_current_magic(ctx);
-	DUK_ASSERT(magic >= 0 && magic < sizeof(duk__object_keys_enum_flags) / sizeof(duk_small_uint_t));
+	DUK_ASSERT(magic >= 0 && magic < (duk_int_t) (sizeof(duk__object_keys_enum_flags) / sizeof(duk_small_uint_t)));
 	enum_flags = duk__object_keys_enum_flags[magic];
 
 	duk_proxy_ownkeys_postprocess(ctx, h_proxy_target, enum_flags);
@@ -750,7 +750,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_keys_shared(duk_context *ctx) {
 
 	DUK_ASSERT_TOP(ctx, 1);
 	magic = duk_get_current_magic(ctx);
-	DUK_ASSERT(magic >= 0 && magic < sizeof(duk__object_keys_enum_flags) / sizeof(duk_small_uint_t));
+	DUK_ASSERT(magic >= 0 && magic < (duk_int_t) (sizeof(duk__object_keys_enum_flags) / sizeof(duk_small_uint_t)));
 	enum_flags = duk__object_keys_enum_flags[magic];
 	return duk_hobject_get_enumerated_keys(ctx, enum_flags);
 }

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -178,7 +178,8 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 
 	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr != NULL);  /* call is from executor, so we know we have a jmpbuf */
 	duk_err_longjmp(thr);  /* execution resumes in bytecode executor */
-	return 0;  /* never here */
+	DUK_UNREACHABLE();
+	/* Never here, fall through to error (from compiler point of view). */
 
  state_error:
 	DUK_DCERROR_TYPE_INVALID_STATE(thr);
@@ -292,7 +293,8 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 
 	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr != NULL);  /* call is from executor, so we know we have a jmpbuf */
 	duk_err_longjmp(thr);  /* execution resumes in bytecode executor */
-	return 0;  /* never here */
+	DUK_UNREACHABLE();
+	/* Never here, fall through to error (from compiler point of view). */
 
  state_error:
 	DUK_DCERROR_TYPE_INVALID_STATE(thr);

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -156,6 +156,6 @@ DUK_INTERNAL void duk_error_throw_from_negative_rc(duk_hthread *thr, duk_ret_t r
 	 *  minimal: they're only really useful for low memory targets.
 	 */
 
-	(void) duk_error_raw(ctx, -rc, NULL, 0, "error (rc %ld)", (long) rc);
+	duk_error_raw(ctx, -rc, NULL, 0, "error (rc %ld)", (long) rc);
 	DUK_UNREACHABLE();
 }

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -1007,9 +1007,16 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	 * sequence (unless e.g. virtual memory addresses cause also the
 	 * heap object pointer to be the same).
 	 */
-	res->rnd_state[1] ^= (duk_uint64_t) (void *) res;
+	{
+		duk_uint64_t tmp_u64;
+		tmp_u64 = 0;
+		DUK_MEMCPY((void *) &tmp_u64,
+		           (const void *) &res,
+		           (size_t) (sizeof(void *) >= sizeof(duk_uint64_t) ? sizeof(duk_uint64_t) : sizeof(void *)));
+		res->rnd_state[1] ^= tmp_u64;
+	}
 	do {
-		duk_small_int_t i;
+		duk_small_uint_t i;
 		for (i = 0; i < 10; i++) {
 			/* Throw away a few initial random numbers just in
 			 * case.  Probably unnecessary due to SplitMix64


### PR DESCRIPTION
Fix a few Clang and MSVC warnings. Clang warning for `if (sizeof(x) < y) {...}` remains.

Also fix DUK_UNPREDICTABLE() placeholder.