### PR TITLE
Add DUK_UNPREDICTABLE() placeholder

### DIFF
--- a/config/compilers/compiler_clang.h.in
+++ b/config/compilers/compiler_clang.h.in
@@ -17,6 +17,11 @@
 #define DUK_USE_BRANCH_HINTS
 #define DUK_LIKELY(x)    __builtin_expect((x), 1)
 #define DUK_UNLIKELY(x)  __builtin_expect((x), 0)
+#if defined(__clang__) && defined(__has_builtin)
+#if __has_builtin(__builtin_unpredictable)
+#define DUK_UNPREDICTABLE()  do { __builtin_unpredictable(); } while (0)
+#endif
+#endif
 
 #if defined(DUK_F_C99) || defined(DUK_F_CPP11)
 #define DUK_NOINLINE        __attribute__((noinline))

--- a/config/compilers/compiler_emscripten.h.in
+++ b/config/compilers/compiler_emscripten.h.in
@@ -9,6 +9,11 @@
 #define DUK_USE_BRANCH_HINTS
 #define DUK_LIKELY(x)    __builtin_expect((x), 1)
 #define DUK_UNLIKELY(x)  __builtin_expect((x), 0)
+#if defined(__clang__) && defined(__has_builtin)
+#if __has_builtin(__builtin_unpredictable)
+#define DUK_UNPREDICTABLE()  do { __builtin_unpredictable(); } while (0)
+#endif
+#endif
 
 #if defined(DUK_F_C99) || defined(DUK_F_CPP11)
 #define DUK_NOINLINE        __attribute__((noinline))

--- a/config/compilers/compiler_gcc.h.in
+++ b/config/compilers/compiler_gcc.h.in
@@ -24,6 +24,7 @@
 #define DUK_LIKELY(x)    __builtin_expect((x), 1)
 #define DUK_UNLIKELY(x)  __builtin_expect((x), 0)
 #endif
+/* XXX: equivalent of clang __builtin_unpredictable? */
 
 #if (defined(DUK_F_C99) || defined(DUK_F_CPP11)) && \
     defined(DUK_F_GCC_VERSION) && (DUK_F_GCC_VERSION >= 30101)

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -66,6 +66,9 @@
 #if !defined(DUK_UNLIKELY)
 #define DUK_UNLIKELY(x)  (x)
 #endif
+#if !defined(DUK_UNPREDICTABLE)
+#define DUK_UNPREDICTABLE(x)  (x)
+#endif
 
 #if !defined(DUK_NOINLINE)
 #define DUK_NOINLINE       /*nop*/


### PR DESCRIPTION
`__builtin_unpredictable()` is available in newer Clang versions and may be useful in performance optimizing e.g. refcounting for Clang. This pull adds `DUK_UNPREDICTABLE(x)` but doesn't add any call sites yet.