### PR TITLE
Add JSON.stringify() fast path for plain buffers

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2378,5 +2378,7 @@ Planned
   property is first read, reducing memory usage in common cases where the view
   is constructed directly without needing the ArrayBuffer object (GH-1225)
 
+* Add a JSON.stringify() fast path for plain buffers (GH-1238)
+
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/tests/ecmascript/test-bi-json-enc-fastpath-plainbuf.js
+++ b/tests/ecmascript/test-bi-json-enc-fastpath-plainbuf.js
@@ -1,0 +1,80 @@
+/*@include util-buffer.js@*/
+
+/*===
+{"buf":{}}
+{
+    "buf": {}
+}
+{buf:||}
+{
+    buf: ||
+}
+{"buf":{"0":18,"1":35,"2":52}}
+{
+    "buf": {
+        "0": 18,
+        "1": 35,
+        "2": 52
+    }
+}
+{buf:|122334|}
+{
+    buf: |122334|
+}
+{"buf":{}}
+{
+    "buf": {}
+}
+{buf:||}
+{
+    buf: ||
+}
+{"buf":{"0":18,"1":35,"2":52}}
+{
+    "buf": {
+        "0": 18,
+        "1": 35,
+        "2": 52
+    }
+}
+{buf:|122334|}
+{
+    buf: |122334|
+}
+===*/
+
+function test() {
+    var b;
+
+    function f(v) {
+        v = { buf: v };
+        print(JSON.stringify(v));
+        print(JSON.stringify(v, null, 4));
+        print(Duktape.enc('jx', v));
+        print(Duktape.enc('jx', v, null, 4));
+    }
+
+    b = new Uint8Array(0);
+    f(b);
+
+    b = new Uint8Array(3);
+    b[0] = 0x12;
+    b[1] = 0x23;
+    b[2] = 0x34;
+    f(b);
+
+    b = createPlainBuffer(0);
+    f(b);
+
+    b = createPlainBuffer(3);
+    b[0] = 0x12;
+    b[1] = 0x23;
+    b[2] = 0x34;
+    f(b);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-json-serialize-plainbuf.js
+++ b/tests/perf/test-json-serialize-plainbuf.js
@@ -1,0 +1,25 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var tmp1 = [];
+    var tmp2 = [];
+    var i, n, buf;
+
+    print('build');
+    buf = (Uint8Array.allocPlain || Duktape.Buffer)(1024 * 1024);
+    for (i = 0; i < buf.length; i++) {
+        buf[i] = i;
+    }
+
+    print('run');
+    for (i = 0; i < 20; i++) {
+        void JSON.stringify(buf);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
Virtual index keys are enumerable, so result is e.g. `{"0":123,"1":10}`.