### PR TITLE
V2.0.0 release post cleanups

### DIFF
--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -110,7 +110,7 @@ struct duk_time_components {
  * development snapshots have 99 for patch level (e.g. 0.10.99 would be a
  * development version after 0.10.0 but before the next official release).
  */
-#define DUK_VERSION                       20000L
+#define DUK_VERSION                       20099L
 
 /* Git commit, describe, and branch for Duktape build.  Useful for
  * non-official snapshot builds so that application code can easily log

--- a/website/guide/gettingstarted.html
+++ b/website/guide/gettingstarted.html
@@ -53,7 +53,7 @@ by editing the Makefile:
 <p>You can now run Ecmascript code interactively:</p>
 <pre>
 $ ./duk
-((o) Duktape 1.5.0 (v1.5.0)
+((o) Duktape 2.0.0 (v2.0.0)
 duk&gt; print('Hello world!')
 Hello world!
 = undefined


### PR DESCRIPTION
- Fix Duktape version in Guide getting started
- Bump DUK_VERSION to 2.0.99