### PR TITLE
Add a 'global' binding

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2369,6 +2369,11 @@ Planned
 2.1.0 (XXXX-XX-XX)
 ------------------
 
+* Add a "global" property to the global object to provide easy access to the
+  global object itself without needing idioms like
+  "new Function('return this')()"; implemented based on
+  https://github.com/tc39/proposal-global (GH-1259, GH-1260)
+
 * Spawn the ArrayBuffer object backing a typed array lazily when its .buffer
   property is first read, reducing memory usage in common cases where the view
   is constructed directly without needing the ArrayBuffer object (GH-1225)

--- a/polyfills/global.js
+++ b/polyfills/global.js
@@ -1,0 +1,15 @@
+/*
+ *  Duktape 2.1.0 adds a 'global' binding.  Polyfill for earlier versions.
+ */
+
+if (typeof global === 'undefined') {
+    (function () {
+        var global = new Function('return this;')();
+        Object.defineProperty(global, 'global', {
+            value: global,
+            writable: true,
+            enumerable: false,
+            configurable: true
+        });
+    })();
+}

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -168,6 +168,16 @@ objects:
     bidx: true
 
     properties:
+      # 'global' binding giving easy to access to the global object.
+      # Not yet standard, see https://github.com/tc39/proposal-global.
+      - key: "global"
+        value:
+          type: object
+          id: bi_global
+        attributes: "wc"
+        # This could be stripped when DUK_USE_GLOBAL_BUILTIN is disabled
+        # but keep for now (the property is quite fundamental).
+
       - key: "NaN"
         value:
           type: double

--- a/tests/ecmascript/test-bi-global-global-binding.js
+++ b/tests/ecmascript/test-bi-global-global-binding.js
@@ -1,0 +1,40 @@
+/*
+ *  'global' binding based on https://github.com/tc39/proposal-global
+ */
+
+/*===
+object
+true
+object
+true
+true
+false
+true
+===*/
+
+function test() {
+    var pd, g;
+
+    // Standard trick to access global object.
+    g = new Function('return this')();
+
+    // proposal-global provides 'global' for cleaner standard access.
+    print(typeof global);
+    print(g === global);
+
+    // Attributes in current proposal.
+    pd = Object.getOwnPropertyDescriptor(g, 'global');
+    print(typeof pd);
+    if (pd) {
+        print(pd.value === g);
+        print(pd.writable);
+        print(pd.enumerable);
+        print(pd.configurable);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/util/dist.py
+++ b/util/dist.py
@@ -499,6 +499,7 @@ def main():
 
     copy_files([
         'console-minimal.js',
+        'global.js',
         'object-prototype-definegetter.js',
         'object-prototype-definesetter.js',
         'object-assign.js',

--- a/website/guide/duktapebuiltins.html
+++ b/website/guide/duktapebuiltins.html
@@ -14,6 +14,11 @@ objects, methods, and values.</p>
 </thead>
 <tbody>
 <tr>
+<td class="propname">global</td>
+<td>References the global object itself.
+    See <a href="https://github.com/tc39/proposal-global">proposal-global</a>.</td>
+</tr>
+<tr>
 <td class="propname"><a href="#builtin-duktape">Duktape</a></td>
 <td>The Duktape built-in object.  Contains miscellaneous implementation specific stuff.</td>
 </tr>


### PR DESCRIPTION
Fixes #1259.

- [x] Add the binding
- [x] Config option? => No option for now.
- [x] Polyfill
- [x] Test coverage
- [x] Website documentation update (non-standard built-ins)
- [x] Search repo for 'new Function("return this")()' occurrences and see if they should reference 'global'
- [x] Wiki post-ES5+ features - https://github.com/svaarala/duktape-wiki/pull/160
- [x] Releases entry