### PR TITLE
Fix String.prototype.repeat() copy_size handling when not preferring footprint

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2366,6 +2366,9 @@ Planned
 1.7.0 (XXXX-XX-XX)
 ------------------
 
+2.0.1 (XXXX-XX-XX)
+------------------
+
 2.1.0 (XXXX-XX-XX)
 ------------------
 
@@ -2379,6 +2382,9 @@ Planned
   is constructed directly without needing the ArrayBuffer object (GH-1225)
 
 * Add a JSON.stringify() fast path for plain buffers (GH-1238)
+
+* Fix memory unsafe behavior in Duktape 2.0.0 String.prototype.repeat()
+  (GH-1270)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -1366,10 +1366,10 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_context *ctx) {
 		} else {
 			DUK_MEMCPY((void *) p, (const void *) src, copy_size);
 			p += copy_size;
-			copy_size *= 2;
 		}
 
 		src = (const duk_uint8_t *) buf;  /* Use buf as source for larger copies. */
+		copy_size = (duk_size_t) (p - buf);
 	}
 #endif  /* DUK_USE_PREFER_SIZE */
 


### PR DESCRIPTION
When DUK_USE_PREFER_SIZE is disabled, Duktape 2.0.0 String.prototype.repeat() mismanages the `copy_size` variable in the copy loop. This causes memory unsafe behavior and is visible both as valgrind warnings but also in actual repeat results. The error causes potentially uninitialized to be read during the copy, may corrupt the resulting string, but shouldn't cause the allocated result buffer to be overrun. Still tagged security because memory unsafe behavior is going on.