### PR TITLE
Fix exponentiation operator behavior on Linux gcc 4.7+ -O2

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2386,5 +2386,8 @@ Planned
 * Fix memory unsafe behavior in Duktape 2.0.0 String.prototype.repeat()
   (GH-1270)
 
+* Fix incorrect exponentation operator behavior which happened at least on
+  Linux gcc 4.8.4 with -O2 (not -Os) (GH-1272)
+
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -276,7 +276,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tv
 			break;
 		}
 		default: {
-			DUK_UNREACHABLE();
+			/* Possible with DUK_OP_EXP. */
 			goto skip_fastint;
 		}
 		}


### PR DESCRIPTION
For some reason exponentation operator behaves incorrectly on Linux with gcc 4.8.4 -O2 (-Os used for commit regression tests is fine). Symptom example:

```
duk> 2 ** 10
= 1024
duk> x = 2
= 2
duk> x ** 10
= 1  // <-- ?
duk> Math.pow(2,10)
= 1024
```

Exp at compile time works while runtime results are incorrect. The mysterious thing is that in both cases the internal function used to compute the exponentiation is the same. Also other arithmetic operations, handled by the same arith helper, work.