### PR TITLE
Fix duk_hstring arridx computation overflow check bug

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2383,6 +2383,10 @@ Planned
 
 * Add a JSON.stringify() fast path for plain buffers (GH-1238)
 
+* Fix duk_hstring array index check integer overflow, which caused certain
+  integer strings (such as '7394299990') to be incorrectly treated as array
+  indices (GH-1273)
+
 * Fix memory unsafe behavior in Duktape 2.0.0 String.prototype.repeat()
   (GH-1270)
 

--- a/tests/ecmascript/test-bug-string-arridx-overflow.js
+++ b/tests/ecmascript/test-bug-string-arridx-overflow.js
@@ -1,0 +1,20 @@
+/*
+ *  Bug testcase for duk_hstring arridx overflow handling.
+ */
+
+/*===
+0
+===*/
+
+function test() {
+    var arr = [];
+    arr['7394299990'] = 1;  // not in 32-bit range, should not affect arr.length
+
+    print(arr.length);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
When computing a potential array index for a string input, the string intern code checks for overflow by computing `res * 10 + char_val` and then detects overflow if the result is smaller than previous `res`. The check is incorrect and allows certain >32-bit integer strings to be accepted as array indices; this behavior is limited to strings with exactly 10 integer digits.

An example string is `"7394299990"` (see bug testcase). For such strings when an overflow happens the new result is still larger than in the previous step. For the example string:
- Intermediate result with 9 digits parsed: 0x2c12ce6f
- Result with 10 digits parsed, without truncation: 0x1b8bc1056
- Result with 10 digits parsed, but with truncation caused by overflow: 0xb8bc1056; this is still larger than the previous value 0x2c12ce6f

Fix by using a different overflow check based on addition overflow.

This bug has been present since 1.0.0, and I'll backport the fix to 1.6.1, 1.7.0, and 2.0.1.