### PR TITLE
Faster on-the-fly arridx check when DUK_USE_HSTRING_ARRIDX is disabled

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2383,6 +2383,9 @@ Planned
 
 * Add a JSON.stringify() fast path for plain buffers (GH-1238)
 
+* Improve duk_hstring array index handling performance when
+  DUK_USE_HSTRING_ARRIDX is disabled (GH-1274)
+
 * Fix duk_hstring array index check integer overflow, which caused certain
   integer strings (such as '7394299990') to be incorrectly treated as array
   indices (GH-1273, GH-1276)

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -81,12 +81,16 @@ duk_hstring *duk__alloc_init_hstring(duk_heap *heap,
 
 	DUK_ASSERT(!DUK_HSTRING_HAS_ARRIDX(res));
 #if defined(DUK_USE_HSTRING_ARRIDX)
-	if (duk_js_to_arrayindex_raw_string(str, blen, &res->arridx)) {
-#else
-	if (duk_js_to_arrayindex_raw_string(str, blen, &dummy)) {
-#endif
+	res->arridx = duk_js_to_arrayindex_string(str, blen);
+	if (res->arridx != DUK_HSTRING_NO_ARRAY_INDEX) {
 		DUK_HSTRING_SET_ARRIDX(res);
 	}
+#else
+	dummy = duk_js_to_arrayindex_string(str, blen);
+	if (dummy != DUK_HSTRING_NO_ARRAY_INDEX) {
+		DUK_HSTRING_SET_ARRIDX(res);
+	}
+#endif
 
 	/* All strings beginning with specific (invalid UTF-8) byte prefixes
 	 * are treated as symbols.

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -146,11 +146,11 @@
  * avoids helper call if string has no array index value.
  */
 #define DUK_HSTRING_GET_ARRIDX_FAST(h)  \
-	(DUK_HSTRING_HAS_ARRIDX((h)) ? duk_js_to_arrayindex_string_helper((h)) : DUK_HSTRING_NO_ARRAY_INDEX)
+	(DUK_HSTRING_HAS_ARRIDX((h)) ? duk_js_to_arrayindex_hstring_fast_known((h)) : DUK_HSTRING_NO_ARRAY_INDEX)
 
 /* Slower but more compact variant. */
 #define DUK_HSTRING_GET_ARRIDX_SLOW(h)  \
-	(duk_js_to_arrayindex_string_helper((h)))
+	(duk_js_to_arrayindex_hstring_fast((h)))
 #endif
 
 /*

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -28,8 +28,11 @@ DUK_INTERNAL_DECL duk_double_t duk_js_tointeger(duk_hthread *thr, duk_tval *tv);
 DUK_INTERNAL_DECL duk_uint32_t duk_js_touint32(duk_hthread *thr, duk_tval *tv);
 DUK_INTERNAL_DECL duk_int32_t duk_js_toint32(duk_hthread *thr, duk_tval *tv);
 DUK_INTERNAL_DECL duk_uint16_t duk_js_touint16(duk_hthread *thr, duk_tval *tv);
-DUK_INTERNAL_DECL duk_small_int_t duk_js_to_arrayindex_raw_string(const duk_uint8_t *str, duk_uint32_t blen, duk_uarridx_t *out_idx);
-DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_string_helper(duk_hstring *h);
+DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_string(const duk_uint8_t *str, duk_uint32_t blen);
+#if !defined(DUK_USE_HSTRING_ARRIDX)
+DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_hstring_fast_known(duk_hstring *h);
+DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_hstring_fast(duk_hstring *h);
+#endif
 DUK_INTERNAL_DECL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_int_t flags);
 DUK_INTERNAL_DECL duk_small_int_t duk_js_data_compare(const duk_uint8_t *buf1, const duk_uint8_t *buf2, duk_size_t len1, duk_size_t len2);
 DUK_INTERNAL_DECL duk_small_int_t duk_js_string_compare(duk_hstring *h1, duk_hstring *h2);

--- a/tests/perf/test-string-arridx.js
+++ b/tests/perf/test-string-arridx.js
@@ -1,0 +1,32 @@
+/*
+ *  Test duk_hstring arridx parsing.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+    var tmp = '1234567';
+    var ref = tmp + '8';  // keep reachable so that no string is actually interned
+
+    // create string on-the-fly, intern check (= arridx)
+    for (i = 0; i < 1e6; i++) {
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+        void (tmp + '8');
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
`DUK_USE_HSTRING_ARRIDX` is often disabled for low memory targets. Make the runtime part of the arridx lookup (after interning) faster: if DUK_HSTRING_FLAG_ARRIDX is set, we already know the format is correct and can compute the arridx without actual parsing checks.

- [x] Actual change
- [x] Add a bit more regression coverage for arridx parsing (overflow)
- [x] Minimal perf test
- [x] Releases entry