### PR TITLE
Fix DUK_UNREF() warning for volatile

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2424,6 +2424,8 @@ Planned
 * Fix incorrect exponentiation operator behavior which happened at least on
   Linux gcc 4.8.4 with -O2 (not -Os) (GH-1272)
 
+* Compiler warning fix for using DUK_UNREF() on a volatile argument (GH-1282)
+
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal
   functions (GH-1297)
 

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -38,7 +38,8 @@
 /* Macro for suppressing warnings for potentially unreferenced variables.
  * The variables can be actually unreferenced or unreferenced in some
  * specific cases only; for instance, if a variable is only debug printed,
- * it is unreferenced when debug printing is disabled.
+ * it is unreferenced when debug printing is disabled.  May cause warnings
+ * for volatile arguments.
  */
 #define DUK_UNREF(x)  do { (void) (x); } while (0)
 #endif

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4996,22 +4996,18 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 		case DUK_OP_UNUSED252:
 		case DUK_OP_UNUSED253:
 		case DUK_OP_UNUSED254:
-		case DUK_OP_UNUSED255: {
-			/* Force all case clauses to map to an actual handler
-			 * so that the compiler can emit a jump without a bounds
-			 * check: the switch argument is a duk_uint8_t so that
-			 * the compiler may be able to figure it out.  This is
-			 * a small detail and obviously compiler dependent.
-			 */
-			volatile duk_small_int_t dummy_volatile;
-			dummy_volatile = 0;
-			DUK_UNREF(dummy_volatile);
-			DUK_D(DUK_DPRINT("invalid opcode: %ld - %!I", (long) op, ins));
-			DUK__INTERNAL_ERROR("invalid opcode");
-			break;
-		}
+		case DUK_OP_UNUSED255:
+		/* Force all case clauses to map to an actual handler
+		 * so that the compiler can emit a jump without a bounds
+		 * check: the switch argument is a duk_uint8_t so that
+		 * the compiler may be able to figure it out.  This is
+		 * a small detail and obviously compiler dependent.
+		 */
+		/* default: clause omitted on purpose */
+#else
+		default:
 #endif  /* DUK_USE_EXEC_PREFER_SIZE */
-		default: {
+		{
 			/* Default case catches invalid/unsupported opcodes. */
 			DUK_D(DUK_DPRINT("invalid opcode: %ld - %!I", (long) op, ins));
 			DUK__INTERNAL_ERROR("invalid opcode");


### PR DESCRIPTION
Reported by @markand:

```
duk_js_executor.c:5008:14: warning: conversion to void will not access object of type ‘volatile duk_small_int_t {aka 
                 volatile int}’
duk_config.h:2436:36: note: in definition of macro ‘DUK_UNREF’
#define DUK_UNREF(x)  do { (void) (x); } while (0)
```