### PR TITLE
Fix typedarray .set(undefined) assert failure and incorrect behavior

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2390,6 +2390,9 @@ Planned
 * Improve duk_hstring array index handling performance when
   DUK_USE_HSTRING_ARRIDX is disabled (GH-1274)
 
+* Fix argument validation bug in typedarray .set() which would cause a segfault
+  for e.g. new Float64Array(2).set(undefined) (GH-1285, GH-1286)
+
 * Fix duk_hstring array index check integer overflow, which caused certain
   integer strings (such as '7394299990') to be incorrectly treated as array
   indices (GH-1273, GH-1276)

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -1656,7 +1656,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_context *ctx) {
 	}
 
 	duk_hbufobj_promote_plain(ctx, 0);
-	h_obj = duk_known_hobject(ctx, 0);
+	h_obj = duk_require_hobject(ctx, 0);
 
 	/* XXX: V8 throws a TypeError for negative values.  Would it
 	 * be more useful to interpret negative offsets here from the

--- a/tests/ecmascript/test-bug-typedarray-set-undefined.js
+++ b/tests/ecmascript/test-bug-typedarray-set-undefined.js
@@ -1,0 +1,12 @@
+/*===
+TypeError
+still here
+===*/
+
+var x = new Float64Array(2)
+try {
+    x.set(undefined)
+} catch (e) {
+    print(e.name);
+}
+print('still here');


### PR DESCRIPTION
Present in 2.0.0 but not in 1.x; incorrect behavior causes a segfault so tagged security.

Fixes #1285.