### PR TITLE
Follow-ups to object property hash rework

### DIFF
--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -707,6 +707,8 @@ struct duk_propdesc {
 struct duk_hobject {
 	duk_heaphdr hdr;
 
+	/* FIXME: 16-bit hash part? */
+
 	/*
 	 *  'props' contains {key,value,flags} entries, optional array entries, and
 	 *  an optional hash lookup table for non-array entries in a single 'sliced'


### PR DESCRIPTION
- Keep probe step as 1?
- 16-bit hash part (works well with slot cache)?
- Drop hash parts on emergency GC?
