### PR TITLE
Fix textencoder uninitialized variable

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2418,6 +2418,9 @@ Planned
 * Fix memory unsafe behavior in Duktape 2.0.0 String.prototype.repeat()
   (GH-1270)
 
+* Fix memory unsafe behavior in new TextEncoder().encode('') (applied to an
+  empty string) which manifested at least on MSVC (GH-1293, GH-1294)
+
 * Fix incorrect exponentiation operator behavior which happened at least on
   Linux gcc 4.8.4 with -O2 (not -Os) (GH-1272)
 

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -362,7 +362,6 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 1);
 	if (duk_is_undefined(ctx, 0)) {
 		len = 0;
-		final_len = len;
 	} else {
 		duk_hstring *h_input;
 
@@ -420,6 +419,8 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_context *ctx) {
 		final_len = (duk_size_t) (enc_ctx.out - output);
 		duk_resize_buffer(ctx, -1, final_len);
 		/* 'output' and 'enc_ctx.out' are potentially invalidated by the resize. */
+	} else {
+		final_len = 0;
 	}
 
 	/* Standard WHATWG output is a Uint8Array.  Here the Uint8Array will


### PR DESCRIPTION
Final_len was uninitialized if input string was empty. Doesn't cause issues on Linux gcc or regression test coverage, but did cause issues with MSVC.

Fixes #1293.