### PR TITLE
Document profile guided optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.o
 *.strip
 *.pyc
+/*.gcda
 /_*
 /duk.*
 /duk

--- a/doc/performance-sensitive.rst
+++ b/doc/performance-sensitive.rst
@@ -33,6 +33,30 @@ several reasons:
   is better.  Note that ``-O3`` is not always better because the code is
   larger and may not fit in caches as well as with ``-O2``.
 
+Profile guided optimization (PGO)
+=================================
+
+Duktape source files contain some performance attributes like forced inline
+forced noinline, and hot/cold attributes.
+
+A better alternative is to use profile guided optimization (PGO) which is
+highly recommended for performance sensitive environments.  For example,
+GCC -O2 with PGO can be around 20% faster than GCC -O2 without PGO.
+
+See for example the following:
+
+* http://stackoverflow.com/questions/13881292/gcc-profile-guided-optimization-pgo
+
+* https://msdn.microsoft.com/en-us/library/e7k32f4k.aspx
+
+With GCC PGO is relatively simple:
+
+* Use ``-fprofile-generate`` to compile Duktape and your application.
+
+* Execute the result with representative (this is important) source files.
+
+* Use ``-fprofile-use`` to recompile Duktape and your application.
+
 Suggested feature options
 =========================
 

--- a/website/guide/performance.html
+++ b/website/guide/performance.html
@@ -11,3 +11,7 @@ languages.</p>
 <p>See <a href="http://wiki.duktape.org/Performance.html">How to optimize performance</a>
 for discussion of Duktape performance characteristics and hints to optimize code
 for performance.</p>
+
+<p>Profile guided optimization (PGO) is strongly recommended if performance is
+a major concern.  For example, GCC -O2 with PGO can be around 20% faster than
+GCC -O2 without PGO.</p>


### PR DESCRIPTION
For performance sensitive environments using profile guided optimization (PGO) is very useful, so reference it from the website and performance sensitive environment documentation.

Also add `duk-pgo.O2` and `duk-perf-pgo.O2` test targets to the Makefile. The difference to plain GCC -O2 is almost 20% on `tests/perf/test-mandel.js`:

```
# -O2 without PGO.
$ time ./duk.O2 tests/perf/test-mandel.js
[...]

real    0m3.061s
user    0m3.059s
sys     0m0.000s

# -O2 with PGO.
$ time ./duk-pgo.O2 tests/perf/test-mandel.js
[...]

real    0m2.488s
user    0m2.487s
sys     0m0.000s
```

On Google V8 benchmark the plain -O2 result is around 305, while -O2 + PGO is around 376.

The training set for duk-pgo.O2 is quite dummy and doesn't involve e.g. regexps, so these results are probably possible to improve on by using a better profile generation test set.