### PR TITLE
Add DUK_HOT() and DUK_COLD() function attributes

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2424,6 +2424,9 @@ Planned
 * Fix incorrect exponentiation operator behavior which happened at least on
   Linux gcc 4.8.4 with -O2 (not -Os) (GH-1272)
 
+* Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal
+  functions (GH-1297)
+
 * Internal change: duk_hstring now has a 'next' heap pointer for string table
   chaining; this affects string allocation sizes which may matter for manually
   tuned memory pools (GH-1277)

--- a/config/compilers/compiler_clang.h.in
+++ b/config/compilers/compiler_clang.h.in
@@ -29,6 +29,9 @@
 #define DUK_ALWAYS_INLINE   inline __attribute__((always_inline))
 #endif
 
+/* DUK_HOT */
+/* DUK_COLD */
+
 #if defined(DUK_F_DLL_BUILD) && defined(DUK_F_WINDOWS)
 #snippet "msvc_visibility.h.in"
 #else

--- a/config/compilers/compiler_gcc.h.in
+++ b/config/compilers/compiler_gcc.h.in
@@ -33,6 +33,12 @@
 #define DUK_ALWAYS_INLINE   inline __attribute__((always_inline))
 #endif
 
+#if (defined(DUK_F_C99) || defined(DUK_F_CPP11)) && \
+    defined(DUK_F_GCC_VERSION) && (DUK_F_GCC_VERSION >= 40300)
+#define DUK_HOT             __attribute__((hot))
+#define DUK_COLD            __attribute__((cold))
+#endif
+
 #if defined(DUK_F_DLL_BUILD) && defined(DUK_F_WINDOWS)
 #snippet "msvc_visibility.h.in"
 #elif defined(DUK_F_GCC_VERSION) && (DUK_F_GCC_VERSION >= 40000)

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -80,6 +80,13 @@
 #define DUK_ALWAYS_INLINE  /*nop*/
 #endif
 
+#if !defined(DUK_HOT)
+#define DUK_HOT            /*nop*/
+#endif
+#if !defined(DUK_COLD)
+#define DUK_COLD           /*nop*/
+#endif
+
 #if !defined(DUK_EXTERNAL_DECL)
 #define DUK_EXTERNAL_DECL  extern
 #endif

--- a/src-input/duk_error_macros.c
+++ b/src-input/duk_error_macros.c
@@ -8,7 +8,7 @@
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 
-DUK_INTERNAL void duk_err_handle_error_fmt(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *fmt, ...) {
+DUK_INTERNAL DUK_COLD void duk_err_handle_error_fmt(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *fmt, ...) {
 	va_list ap;
 	char msg[DUK__ERRFMT_BUFSIZE];
 	va_start(ap, fmt);
@@ -18,13 +18,13 @@ DUK_INTERNAL void duk_err_handle_error_fmt(duk_hthread *thr, const char *filenam
 	va_end(ap);  /* dead code, but ensures portability (see Linux man page notes) */
 }
 
-DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *msg) {
+DUK_INTERNAL DUK_COLD void duk_err_handle_error(duk_hthread *thr, const char *filename, duk_uint_t line_and_code, const char *msg) {
 	duk_err_create_and_throw(thr, (duk_errcode_t) (line_and_code >> 24), msg, filename, (duk_int_t) (line_and_code & 0x00ffffffL));
 }
 
 #else  /* DUK_USE_VERBOSE_ERRORS */
 
-DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, duk_errcode_t code) {
+DUK_INTERNAL DUK_COLD void duk_err_handle_error(duk_hthread *thr, duk_errcode_t code) {
 	duk_err_create_and_throw(thr, code);
 }
 
@@ -36,41 +36,41 @@ DUK_INTERNAL void duk_err_handle_error(duk_hthread *thr, duk_errcode_t code) {
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 #if defined(DUK_USE_PARANOID_ERRORS)
-DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
+DUK_INTERNAL DUK_COLD void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
 	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
 	                   expect_name, duk_get_type_name((duk_context *) thr, idx), (long) idx);
 }
 #else
-DUK_INTERNAL void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
+DUK_INTERNAL DUK_COLD void duk_err_require_type_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx, const char *expect_name) {
 	DUK_ERROR_RAW_FMT3(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, "%s required, found %s (stack index %ld)",
 	                   expect_name, duk_push_string_readable((duk_context *) thr, idx), (long) idx);
 }
 #endif
-DUK_INTERNAL void duk_err_error_internal(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_error_internal(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_ERROR, DUK_STR_INTERNAL_ERROR);
 }
-DUK_INTERNAL void duk_err_error_alloc_failed(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_error_alloc_failed(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_ERROR, DUK_STR_ALLOC_FAILED);
 }
-DUK_INTERNAL void duk_err_error(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+DUK_INTERNAL DUK_COLD void duk_err_error(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_ERROR, message);
 }
-DUK_INTERNAL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
+DUK_INTERNAL DUK_COLD void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_RANGE_ERROR, message);
 }
-DUK_INTERNAL void duk_err_range_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx) {
+DUK_INTERNAL DUK_COLD void duk_err_range_index(duk_hthread *thr, const char *filename, duk_int_t linenumber, duk_idx_t idx) {
 	DUK_ERROR_RAW_FMT1(thr, filename, linenumber, DUK_ERR_RANGE_ERROR, "invalid stack index %ld", (long) (idx));
 }
-DUK_INTERNAL void duk_err_range_push_beyond(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_range_push_beyond(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_RANGE_ERROR, DUK_STR_PUSH_BEYOND_ALLOC_STACK);
 }
-DUK_INTERNAL void duk_err_type_invalid_args(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_type_invalid_args(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_ARGS);
 }
-DUK_INTERNAL void duk_err_type_invalid_state(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_type_invalid_state(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_STATE);
 }
-DUK_INTERNAL void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+DUK_INTERNAL DUK_COLD void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_TRAP_RESULT);
 }
 #else
@@ -82,25 +82,25 @@ DUK_NORETURN(DUK_LOCAL_DECL void duk__err_shared(duk_hthread *thr, duk_uint_t co
 DUK_LOCAL void duk__err_shared(duk_hthread *thr, duk_uint_t code) {
 	DUK_ERROR_RAW(thr, NULL, 0, code, NULL);
 }
-DUK_INTERNAL void duk_err_error(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_error(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_ERROR);
 }
-DUK_INTERNAL void duk_err_range(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_range(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_RANGE_ERROR);
 }
-DUK_INTERNAL void duk_err_eval(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_eval(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_EVAL_ERROR);
 }
-DUK_INTERNAL void duk_err_reference(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_reference(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_REFERENCE_ERROR);
 }
-DUK_INTERNAL void duk_err_syntax(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_syntax(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_SYNTAX_ERROR);
 }
-DUK_INTERNAL void duk_err_type(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_type(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_TYPE_ERROR);
 }
-DUK_INTERNAL void duk_err_uri(duk_hthread *thr) {
+DUK_INTERNAL DUK_COLD void duk_err_uri(duk_hthread *thr) {
 	duk__err_shared(thr, DUK_ERR_URI_ERROR);
 }
 #endif
@@ -109,7 +109,7 @@ DUK_INTERNAL void duk_err_uri(duk_hthread *thr) {
  *  Default fatal error handler
  */
 
-DUK_INTERNAL void duk_default_fatal_handler(void *udata, const char *msg) {
+DUK_INTERNAL DUK_COLD void duk_default_fatal_handler(void *udata, const char *msg) {
 	DUK_UNREF(udata);
 	DUK_UNREF(msg);
 

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2410,7 +2410,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 }
 
 /* Inner executor, performance critical. */
-DUK_LOCAL DUK_NOINLINE void duk__js_execute_bytecode_inner(duk_hthread *entry_thread, duk_size_t entry_callstack_top) {
+DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *entry_thread, duk_size_t entry_callstack_top) {
 	/* Current PC, accessed by other functions through thr->ptr_to_curr_pc.
 	 * Critical for performance.  It would be safest to make this volatile,
 	 * but that eliminates performance benefits; aliasing guarantees


### PR DESCRIPTION
Add DUK_HOT() and DUK_COLD() mapped to `__attribute__((hot))` and `__attribute__((cold))` on GCC 4.3+. Try them out for bytecode executor inner function (hot) and error throwers (cold).