### PR TITLE
Add a more useful profile guided optimization test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ CONFIGOPTS_EMDUK=-UDUK_USE_FASTINT -UDUK_USE_PACKED_TVAL
 CONFIGOPTS_DUKWEB=--option-file util/dukweb_base.yaml --fixup-file util/dukweb_fixup.h
 
 # Profile guided optimization test set.
+# FIXME
 PGO_TEST_SET=\
 	tests/ecmascript/test-dev-mandel2-func.js \
 	tests/ecmascript/test-dev-totp.js \


### PR DESCRIPTION
The test script should exercise usual code paths for all built-ins so that the performance profiling data accurately reflects the relative frequency of most practical code paths. Current PGO test set in the Makefile is a dummy placeholder.

- [ ] Come up with a test set as a separate test file or as sequence of individual tests
- [ ] The full tests/ecmascript test run could be useful (execute with runtest.py), but might be too heavy for practical Makefiles
- [ ] Document that `duktape.c` can be profile optimized with a dummy main (e.g. "duk") and the profile then used in an application build
- [ ] Consider bundling the PGO test file into the distributable along with a PGO example