### PR TITLE
Make duk_hstring charlen lazy

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2453,6 +2453,10 @@ Planned
 * Minor improvements to heap object queue handling code: improve pointer
   compression performance a little, more assertion coverage (GH-1323)
 
+* Make duk_hstring character length (clen) lazily computed to improve string
+  handling performance for the majority of strings whose .length is never
+  read (GH-1303)
+
 * Fix a duk_push_heapptr() finalize_list assertion issue caused by the
   internal heap->finalize_list being (intentionally) out-of-sync during
   mark-and-sweep finalizer execution; this has no functional impact but

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -194,6 +194,7 @@ DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t idx, duk_size_t star
 	duk_hstring *res;
 	duk_size_t start_byte_offset;
 	duk_size_t end_byte_offset;
+	duk_size_t charlen;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -201,8 +202,9 @@ DUK_EXTERNAL void duk_substring(duk_context *ctx, duk_idx_t idx, duk_size_t star
 	h = duk_require_hstring(ctx, idx);
 	DUK_ASSERT(h != NULL);
 
-	if (end_offset >= DUK_HSTRING_GET_CHARLEN(h)) {
-		end_offset = DUK_HSTRING_GET_CHARLEN(h);
+	charlen = DUK_HSTRING_GET_CHARLEN(h);
+	if (end_offset >= charlen) {
+		end_offset = charlen;
 	}
 	if (start_offset > end_offset) {
 		start_offset = end_offset;

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -3095,8 +3095,11 @@ void duk_bi_json_stringify_helper(duk_context *ctx,
 	}
 
 	if (js_ctx->h_gap != NULL) {
-		/* if gap is empty, behave as if not given at all */
-		if (DUK_HSTRING_GET_CHARLEN(js_ctx->h_gap) == 0) {
+		/* If gap is empty, behave as if not given at all.  Check
+		 * against byte length because character length is more
+		 * expensive.
+		 */
+		if (DUK_HSTRING_GET_BYTELEN(js_ctx->h_gap) == 0) {
 			js_ctx->h_gap = NULL;
 		}
 	}

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -776,6 +776,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_context *ctx) {
 					/* Use match charlen instead of bytelen, just in case the input and
 					 * match codepoint encodings would have different lengths.
 					 */
+					/* XXX: charlen computed here, and also in char2byte helper. */
 					match_end_boff = duk_heap_strcache_offset_char2byte(thr,
 					                                                    h_input,
 					                                                    match_start_coff + DUK_HSTRING_GET_CHARLEN(h_match));
@@ -1128,7 +1129,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_context *ctx) {
 	DUK_DDD(DUK_DDDPRINT("split trailer; prev_end b=%ld,c=%ld",
 	                     (long) prev_match_end_boff, (long) prev_match_end_coff));
 
-	if (DUK_HSTRING_GET_CHARLEN(h_input) > 0 || !matched) {
+	if (DUK_HSTRING_GET_BYTELEN(h_input) > 0 || !matched) {
 		/* Add trailer if:
 		 *   a) non-empty input
 		 *   b) empty input and no (zero size) match found (step 11)

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -153,7 +153,6 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 #if !defined(DUK_USE_HSTRING_ARRIDX)
 	duk_uarridx_t dummy;
 #endif
-	duk_uint32_t clen;
 
 	DUK_ASSERT(heap != NULL);
 	DUK_UNREF(extdata);
@@ -225,7 +224,6 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 		DUK_HSTRING_SET_ARRIDX(res);
 		DUK_HSTRING_SET_ASCII(res);
 		DUK_ASSERT(duk_unicode_unvalidated_utf8_length(data, (duk_size_t) blen) == blen);
-		clen = blen;
 	} else {
 		/* Because 'data' is NUL-terminated, we don't need a
 		 * blen > 0 check here.  For NUL (0x00) the symbol
@@ -241,27 +239,18 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 			}
 		}
 
-		clen = (duk_uint32_t) duk_unicode_unvalidated_utf8_length(data, (duk_size_t) blen);
-		DUK_ASSERT(clen <= blen);
-
 		/* Using an explicit 'ASCII' flag has larger footprint (one call site
 		 * only) but is quite useful for the case when there's no explicit
 		 * 'clen' in duk_hstring.
+		 *
+		 * The flag is set lazily for RAM strings.
 		 */
 		DUK_ASSERT(!DUK_HSTRING_HAS_ASCII(res));
-		if (DUK_LIKELY(clen == blen)) {
-			/* ASCII strings can't be symbol strings. */
-			DUK_HSTRING_SET_ASCII(res);
-		}
 	}
-#if defined(DUK_USE_HSTRING_CLEN)
-	DUK_HSTRING_SET_CHARLEN(res, clen);
-#endif
 
-	DUK_DDD(DUK_DDDPRINT("interned string, hash=0x%08lx, blen=%ld, clen=%ld, has_arridx=%ld, has_extdata=%ld",
+	DUK_DDD(DUK_DDDPRINT("interned string, hash=0x%08lx, blen=%ld, has_arridx=%ld, has_extdata=%ld",
 	                     (unsigned long) DUK_HSTRING_GET_HASH(res),
 	                     (long) DUK_HSTRING_GET_BYTELEN(res),
-	                     (long) DUK_HSTRING_GET_CHARLEN(res),
 	                     (long) (DUK_HSTRING_HAS_ARRIDX(res) ? 1 : 0),
 	                     (long) (DUK_HSTRING_HAS_EXTDATA(res) ? 1 : 0)));
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -1761,6 +1761,8 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 		DUK_DDD(DUK_DDDPRINT("string object exotic property get for key: %!O, arr_idx: %ld",
 		                     (duk_heaphdr *) key, (long) arr_idx));
 
+		/* XXX: charlen; avoid multiple lookups? */
+
 		if (arr_idx != DUK__NO_ARRAY_INDEX) {
 			duk_hstring *h_val;
 

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -79,7 +79,7 @@
         */
 #define DUK_HSTRING_IS_ASCII(x)                     (DUK_HSTRING_GET_BYTELEN((x)) == DUK_HSTRING_GET_CHARLEN((x)))
 #endif
-#define DUK_HSTRING_IS_ASCII(x)                     DUK_HSTRING_HAS_ASCII((x))
+#define DUK_HSTRING_IS_ASCII(x)                     DUK_HSTRING_HAS_ASCII((x))  /* lazily set! */
 #define DUK_HSTRING_IS_EMPTY(x)                     (DUK_HSTRING_GET_BYTELEN((x)) == 0)
 
 #if defined(DUK_USE_STRHASH16)
@@ -100,7 +100,7 @@
 		(x)->hdr.h_strextra16 = (v); \
 	} while (0)
 #if defined(DUK_USE_HSTRING_CLEN)
-#define DUK_HSTRING_GET_CHARLEN(x)                  ((x)->clen16)
+#define DUK_HSTRING_GET_CHARLEN(x)                  duk_hstring_get_charlen((x))
 #define DUK_HSTRING_SET_CHARLEN(x,v) do { \
 		(x)->clen16 = (v); \
 	} while (0)
@@ -115,7 +115,7 @@
 #define DUK_HSTRING_SET_BYTELEN(x,v) do { \
 		(x)->blen = (v); \
 	} while (0)
-#define DUK_HSTRING_GET_CHARLEN(x)                  ((x)->clen)
+#define DUK_HSTRING_GET_CHARLEN(x)                  duk_hstring_get_charlen((x))
 #define DUK_HSTRING_SET_CHARLEN(x,v) do { \
 		(x)->clen = (v); \
 	} while (0)
@@ -221,9 +221,6 @@ struct duk_hstring_external {
  */
 
 DUK_INTERNAL_DECL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr, duk_hstring *h, duk_uint_t pos, duk_bool_t surrogate_aware);
-
-#if !defined(DUK_USE_HSTRING_CLEN)
 DUK_INTERNAL_DECL duk_size_t duk_hstring_get_charlen(duk_hstring *h);
-#endif
 
 #endif  /* DUK_HSTRING_H_INCLUDED */

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1870,7 +1870,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 }
 #endif  /* DUK_USE_DEBUGGER_SUPPORT */
 
-DUK_LOCAL duk_small_uint_t duk__executor_interrupt(duk_hthread *thr) {
+DUK_LOCAL DUK_NOINLINE DUK_COLD duk_small_uint_t duk__executor_interrupt(duk_hthread *thr) {
 	duk_int_t ctr;
 	duk_activation *act;
 	duk_hcompfunc *fun;

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -818,6 +818,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		char_offset = (duk_uint32_t) 0;
 	}
 
+	DUK_ASSERT(char_offset <= DUK_HSTRING_GET_CHARLEN(h_input));
 	sp = re_ctx.input + duk_heap_strcache_offset_char2byte(thr, h_input, char_offset);
 
 	/*

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -766,8 +766,6 @@ strings:
     duktape: true
     internal: true
 
-  # FIXME...
-
   # internal properties for enumerator objects
   - str: "\u00ffTarget"
     duktape: true

--- a/tests/perf/test-string-scan-nonascii.js
+++ b/tests/perf/test-string-scan-nonascii.js
@@ -1,0 +1,47 @@
+function test() {
+    var str = [];
+    var i;
+
+    for (i = 0; i < 1024; i++) {
+        str.push(String.fromCharCode(i & 0xffff));
+    }
+    str = str.join('');
+
+    /* Because this testcase is not about interning, intern the substrings
+     * to avoid string table traffic in this particular test.
+     */
+    var dummy = [
+        str.charCodeAt(0),
+        str.charCodeAt(1023),
+        str.charCodeAt(100),
+        str.charCodeAt(200),
+        str.charCodeAt(300),
+        str.charCodeAt(400),
+        str.charCodeAt(900),
+        str.charCodeAt(800),
+        str.charCodeAt(700),
+        str.charCodeAt(600),
+        str.charCodeAt(500)
+    ];
+
+    for (i = 0; i < 1e6; i++) {
+        void str.charCodeAt(0);
+        void str.charCodeAt(1023);
+        void str.charCodeAt(100);
+        void str.charCodeAt(200);
+        void str.charCodeAt(300);
+        void str.charCodeAt(400);
+        void str.charCodeAt(900);
+        void str.charCodeAt(800);
+        void str.charCodeAt(700);
+        void str.charCodeAt(600);
+        void str.charCodeAt(500);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
For most strings the character length (`.length`) is not accessed. It's currently precomputed which slows down every string intern operation. Change that behavior so that the character length is computed lazily when it is first needed.

Tasks:
- [x] Change charlen and intern handling
- [x] Test effect in practice
- [x] Because of footprint impact, maybe make lazy/strict behavior optional => follow-up
- [x] Releases entry