### PR TITLE
Removed references to io reliant duk_eval/compile APIs

### DIFF
--- a/website/api/duk_compile.yaml
+++ b/website/api/duk_compile.yaml
@@ -144,6 +144,5 @@ seealso:
   - duk_compile_string_filename
   - duk_compile_lstring
   - duk_compile_lstring_filename
-  - duk_compile_file
 
 introduced: 1.0.0

--- a/website/api/duk_eval.yaml
+++ b/website/api/duk_eval.yaml
@@ -49,7 +49,5 @@ seealso:
   - duk_eval_string_noresult
   - duk_eval_lstring
   - duk_eval_lstring_noresult
-  - duk_eval_file
-  - duk_eval_file_noresult
 
 introduced: 1.0.0

--- a/website/api/duk_eval_noresult.yaml
+++ b/website/api/duk_eval_noresult.yaml
@@ -21,6 +21,5 @@ tags:
 seealso:
   - duk_eval_string_noresult
   - duk_eval_lstring_noresult
-  - duk_eval_file_noresult
 
 introduced: 1.0.0

--- a/website/api/duk_pcompile.yaml
+++ b/website/api/duk_pcompile.yaml
@@ -34,6 +34,5 @@ seealso:
   - duk_pcompile_string_filename
   - duk_pcompile_lstring
   - duk_pcompile_lstring_filename
-  - duk_pcompile_file
 
 introduced: 1.0.0

--- a/website/api/duk_peval.yaml
+++ b/website/api/duk_peval.yaml
@@ -33,7 +33,5 @@ seealso:
   - duk_peval_string_noresult
   - duk_peval_lstring
   - duk_peval_lstring_noresult
-  - duk_peval_file
-  - duk_peval_file_noresult
 
 introduced: 1.0.0

--- a/website/api/duk_peval_noresult.yaml
+++ b/website/api/duk_peval_noresult.yaml
@@ -25,6 +25,5 @@ tags:
 seealso:
   - duk_peval_string_noresult
   - duk_peval_lstring_noresult
-  - duk_peval_file_noresult
 
 introduced: 1.0.0


### PR DESCRIPTION
Removed trailing references to `duk_compile_file`, `duk_peval_file`, `duk_eval_file` and `duk_peval_file_noresult` to the website's API, as per [changes to v2.0.0](https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-0.rst#file-io-duktape-c-api-calls-were-removed)