### PR TITLE
Make symbol checks unlikely

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2532,8 +2532,8 @@ Planned
 * Miscellaneous compiler warning fixes (GH-1358)
 
 * Miscellaneous performance improvements: more likely/unlike attributes and
-  hot/cold function splits (GH-1308, GH-1309), integer refzero-free-running
-  flag (instead of a flag bit) (GH-1362)
+  hot/cold function splits (GH-1308, GH-1309, GH-1312), integer
+  refzero-free-running flag (instead of a flag bit) (GH-1362)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
   (GH-1357), explicit thr->callstack_curr field for current activation

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1598,7 +1598,7 @@ DUK_INTERNAL duk_hstring *duk_get_hstring(duk_context *ctx, duk_idx_t idx) {
 
 DUK_INTERNAL duk_hstring *duk_get_hstring_notsymbol(duk_context *ctx, duk_idx_t idx) {
 	duk_hstring *res = (duk_hstring *) duk__get_tagged_heaphdr_raw(ctx, idx, DUK_TAG_STRING);
-	if (res && DUK_HSTRING_HAS_SYMBOL(res)) {
+	if (DUK_UNLIKELY(res && DUK_HSTRING_HAS_SYMBOL(res))) {
 		return NULL;
 	}
 	return res;
@@ -1920,7 +1920,7 @@ DUK_EXTERNAL duk_size_t duk_get_length(duk_context *ctx, duk_idx_t idx) {
 	case DUK_TAG_STRING: {
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			return 0;
 		}
 		return (duk_size_t) DUK_HSTRING_GET_CHARLEN(h);
@@ -2461,7 +2461,7 @@ DUK_INTERNAL void duk_push_class_string_tval(duk_context *ctx, duk_tval *tv) {
 		duk_hstring *h;
 		h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			stridx = DUK_STRIDX_UC_SYMBOL;
 		} else {
 			stridx = DUK_STRIDX_UC_STRING;
@@ -2699,7 +2699,7 @@ DUK_INTERNAL duk_hstring *duk_to_hstring_acceptsymbol(duk_context *ctx, duk_idx_
 	duk_hstring *ret;
 	DUK_ASSERT_CTX_VALID(ctx);
 	ret = duk_get_hstring(ctx, idx);
-	if (ret && DUK_HSTRING_HAS_SYMBOL(ret)) {
+	if (DUK_UNLIKELY(ret && DUK_HSTRING_HAS_SYMBOL(ret))) {
 		return ret;
 	}
 	return duk_to_hstring(ctx, idx);
@@ -2910,7 +2910,7 @@ DUK_EXTERNAL void duk_to_object(duk_context *ctx, duk_idx_t idx) {
 		duk_hstring *h;
 		h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			flags = DUK_HOBJECT_FLAG_EXTENSIBLE |
 			        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_SYMBOL);
 			proto = DUK_BIDX_SYMBOL_PROTOTYPE;
@@ -3317,7 +3317,10 @@ DUK_EXTERNAL duk_bool_t duk_is_symbol(duk_context *ctx, duk_idx_t idx) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	h = duk_get_hstring(ctx, idx);
-	if (h != NULL && DUK_HSTRING_HAS_SYMBOL(h)) {
+	/* Use DUK_LIKELY() here because caller may be more likely to type
+	 * check an expected symbol than not.
+	 */
+	if (DUK_LIKELY(h != NULL && DUK_HSTRING_HAS_SYMBOL(h))) {
 		return 1;
 	}
 	return 0;

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2164,7 +2164,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 	case DUK_TAG_STRING: {
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			goto pop2_undef;
 		}
 		duk__enc_quote_string(js_ctx, h);
@@ -2261,7 +2261,7 @@ DUK_LOCAL duk_bool_t duk__enc_allow_into_proplist(duk_tval *tv) {
 		duk_hstring *h;
 		h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			return 0;
 		}
 		return 1;
@@ -2330,7 +2330,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		duk_hstring *h;
 		h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			goto emit_undefined;
 		}
 		duk__enc_quote_string(js_ctx, h);
@@ -2495,7 +2495,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 					DUK_DD(DUK_DDPRINT("property is an accessor, abort fast path"));
 					goto abort_fastpath;
 				}
-				if (DUK_HSTRING_HAS_SYMBOL(k)) {
+				if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(k))) {
 					continue;
 				}
 

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -46,7 +46,7 @@ DUK_INTERNAL void duk_proxy_ownkeys_postprocess(duk_context *ctx, duk_hobject *h
 				goto skip_key;
 			}
 		}
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			if (!(flags & DUK_ENUM_INCLUDE_SYMBOLS)) {
 				DUK_DDD(DUK_DDDPRINT("ignore symbol property: %!T", duk_get_tval(ctx, -1)));
 				goto skip_key;

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -131,7 +131,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_constructor(duk_context *ctx) {
 		duk_push_hstring_empty(ctx);
 	} else {
 		h = duk_to_hstring_acceptsymbol(ctx, 0);
-		if (DUK_HSTRING_HAS_SYMBOL(h) && !duk_is_constructor_call(ctx)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h) && !duk_is_constructor_call(ctx))) {
 			duk_push_symbol_descriptive_string(ctx, h);
 			duk_replace(ctx, 0);
 		}

--- a/src-input/duk_bi_symbol.c
+++ b/src-input/duk_bi_symbol.c
@@ -104,7 +104,8 @@ DUK_LOCAL duk_hstring *duk__auto_unbox_symbol(duk_context *ctx, duk_tval *tv_arg
 	h_str = DUK_TVAL_GET_STRING(tv);
 	DUK_ASSERT(h_str != NULL);
 
-	if (!DUK_HSTRING_HAS_SYMBOL(h_str)) {
+	/* Here symbol is more expected than not. */
+	if (DUK_UNLIKELY(!DUK_HSTRING_HAS_SYMBOL(h_str))) {
 		return NULL;
 	}
 

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -509,7 +509,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_context *ctx, duk_small_uint
 			    !DUK_HOBJECT_E_SLOT_IS_ENUMERABLE(thr->heap, curr, i)) {
 				continue;
 			}
-			if (DUK_HSTRING_HAS_SYMBOL(k)) {
+			if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(k))) {
 				if (!(enum_flags & DUK_ENUM_INCLUDE_HIDDEN) &&
 				    DUK_HSTRING_HAS_HIDDEN(k)) {
 					continue;

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2362,7 +2362,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv_obj);
 		duk_int_t pop_count;
 
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			/* Symbols (ES2015 or hidden) don't have virtual properties. */
 			DUK_DDD(DUK_DDDPRINT("base object is a symbol, start lookup from symbol prototype"));
 			curr = thr->builtins[DUK_BIDX_SYMBOL_PROTOTYPE];
@@ -3387,7 +3387,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		arr_idx = duk__push_tval_to_property_key(ctx, tv_key, &key);
 		DUK_ASSERT(key != NULL);
 
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			/* Symbols (ES2015 or hidden) don't have virtual properties. */
 			curr = thr->builtins[DUK_BIDX_SYMBOL_PROTOTYPE];
 			goto lookup;

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -218,7 +218,7 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 	case DUK_TAG_STRING: {
 		/* For Symbols ToNumber() is always a TypeError. */
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv);
-		if (DUK_HSTRING_HAS_SYMBOL(h)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			DUK_ERROR_TYPE(thr, DUK_STR_CANNOT_NUMBER_COERCE_SYMBOL);
 		}
 		duk_push_hstring(ctx, h);
@@ -950,7 +950,7 @@ DUK_INTERNAL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, 
 		DUK_ASSERT(h1 != NULL);
 		DUK_ASSERT(h2 != NULL);
 
-		if (!DUK_HSTRING_HAS_SYMBOL(h1) && !DUK_HSTRING_HAS_SYMBOL(h2)) {
+		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h1) && !DUK_HSTRING_HAS_SYMBOL(h2))) {
 			rc = duk_js_string_compare(h1, h2);
 			duk_pop_2(ctx);
 			if (rc < 0) {
@@ -1267,7 +1267,7 @@ DUK_INTERNAL duk_small_uint_t duk_js_typeof_stridx(duk_tval *tv_x) {
 		/* All internal keys are identified as Symbols. */
 		str = DUK_TVAL_GET_STRING(tv_x);
 		DUK_ASSERT(str != NULL);
-		if (DUK_HSTRING_HAS_SYMBOL(str)) {
+		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(str))) {
 			stridx = DUK_STRIDX_LC_SYMBOL;
 		} else {
 			stridx = DUK_STRIDX_LC_STRING;


### PR DESCRIPTION
Usually symbol checks are in code paths expecting a string; make these unlikely.  For code paths where a symbol is expected, make the check likely.