### PR TITLE
Add Octane benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@
 /references/ECMA-262 5th edition December 2009.pdf
 /references/ECMA-262 5.1 edition June 2011.pdf
 /references/ECMA-262.pdf
+/tests/octane/octane

--- a/tests/octane/Makefile
+++ b/tests/octane/Makefile
@@ -1,0 +1,31 @@
+# octane/mandreel.js: exceeds const limit at present.
+# octane/run.js: not needed, duktape_harness.js handles
+# octane/typescript-compiler.js: I/O to be stubbed
+# octane/typescript-input.js: -""-
+# octane/typescript.js: -""-
+# octane/zlib.js: read() dependency
+# octane/zlib-data.js: -""-
+# octane/regexp.js: checksum error
+
+TESTS= \
+	octane/base.js \
+	octane/box2d.js \
+	octane/code-load.js \
+	octane/crypto.js \
+	octane/deltablue.js \
+	octane/earley-boyer.js \
+	octane/gbemu-part1.js \
+	octane/gbemu-part2.js \
+	octane/navier-stokes.js \
+	octane/pdfjs.js \
+	octane/raytrace.js \
+	octane/richards.js \
+	octane/splay.js
+
+.PHONY: test
+test: octane
+	if [ ! -f "../../duk.O2" ]; then echo "*** Expected ../../duk.O2 to exist"; exit 1; fi
+	../../duk.O2 $(TESTS) duktape_harness.js
+
+octane:
+	git clone https://github.com/chromium/octane.git

--- a/tests/octane/README.rst
+++ b/tests/octane/README.rst
@@ -1,0 +1,10 @@
+================
+Octane benchmark
+================
+
+Example of running manually:
+
+```
+$ git clone https://github.com/chromium/octane.git
+$ cd octane
+$ ../duk.O2 base.js splay.js ../tests/octane/duktape_harness.js

--- a/tests/octane/duktape_harness.js
+++ b/tests/octane/duktape_harness.js
@@ -1,0 +1,45 @@
+var globalObject = new Function('return this')();
+
+if (typeof globalObject.print !== 'function') {
+  globalObject.print = globalObject.console.log;
+}
+
+function Run() {
+  BenchmarkSuite.RunSuites({ NotifyStep: ShowProgress,
+                             NotifyError: AddError,
+                             NotifyResult: AddResult,
+                             NotifyScore: AddScore });
+}
+
+var harnessErrorCount = 0;
+
+function ShowProgress(name) {
+  print('PROGRESS', name);
+}
+
+function AddError(name, error) {
+  print('ERROR', name, error);
+  print(error.stack);
+  harnessErrorCount++;
+}
+
+function AddResult(name, result) {
+  print('RESULT', name, result);
+}
+
+function AddScore(score) {
+  print('SCORE', score);
+}
+
+try {
+  Run();
+} catch (e) {
+  print('*** Run() failed');
+  print(e.stack || e);
+}
+
+if (harnessErrorCount > 0) {
+  // Throw an error so that 'duk' has a non-zero exit code which helps
+  // automatic testing.
+  throw new Error('Benchmark had ' + harnessErrorCount + ' errors');
+}


### PR DESCRIPTION
Add a Makefile and the necessary harness code to run Octane 2.0 benchmark. A few tests need to be stubbed out for now for various reasons (missing stub functions, const limits).

This should replace `tests/google-v8-benchmark-v7` as being larger in scope. I'll update the commit tests so that the Octane benchmark is executed on a fixed physical host.