### PR TITLE
Expand duk_push_heapptr() pointer asserts

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2408,6 +2408,11 @@ Planned
 * Improve duk_hstring array index handling performance when
   DUK_USE_HSTRING_ARRIDX is disabled (GH-1274)
 
+* Improve duk_push_heapptr() assert validation to include checks that the
+  pointer is only allowed in finalize_list or refzero_list if currently being
+  finalized, and must otherwise be in either the string table (for strings)
+  or heap_allocated (non-strings) (GH-1317)
+
 * Fix a few incorrect asserts related to reference count triggered finalizer
   execution; the functionality itself was correct in these cases but a few
   asserts were too strict (GH-1318)

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -808,6 +808,10 @@ DUK_LOCAL void duk__run_object_finalizers(duk_heap *heap, duk_small_uint_t flags
 			 */
 			duk_hobject_run_finalizer(thr, (duk_hobject *) curr);  /* must never longjmp */
 			DUK_ASSERT(DUK_HEAPHDR_HAS_FINALIZED(curr));
+
+			/* XXX: could clear FINALIZED already here; now cleared in
+			 * next mark-and-sweep.
+			 */
 		} else {
 			/* Used during heap destruction: don't actually run finalizers
 			 * because we're heading into forced finalization.  Instead,


### PR DESCRIPTION
- Change the finalize_list check, see discussion below
- Add a refzero_list check, see discussion below
- Check that a string is present in the stringtable
- Check that a non-string is present in heap_allocated (or finalize_list/refzero_list)