### PR TITLE
Fix incorrect !FINALIZED asserts for refzero_list

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2408,6 +2408,10 @@ Planned
 * Improve duk_hstring array index handling performance when
   DUK_USE_HSTRING_ARRIDX is disabled (GH-1274)
 
+* Fix a few incorrect asserts related to reference count triggered finalizer
+  execution; the functionality itself was correct in these cases but a few
+  asserts were too strict (GH-1318)
+
 * Fix argument validation bug in typedarray .set() which would cause a segfault
   for e.g. new Float64Array(2).set(undefined) (GH-1285, GH-1286)
 

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -500,7 +500,7 @@ DUK_LOCAL void duk__clear_refzero_list_flags(duk_heap *heap) {
 	while (hdr) {
 		DUK_HEAPHDR_CLEAR_REACHABLE(hdr);
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZABLE(hdr));
-		DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZED(hdr));
+		/* DUK_HEAPHDR_HAS_FINALIZED may or may not be set. */
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_TEMPROOT(hdr));
 		hdr = DUK_HEAPHDR_GET_NEXT(heap, hdr);
 	}
@@ -961,7 +961,11 @@ DUK_LOCAL void duk__assert_heaphdr_flags(duk_heap *heap) {
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_REACHABLE(hdr));
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_TEMPROOT(hdr));
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZABLE(hdr));
-		DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZED(hdr));
+		/* DUK_HEAPHDR_HAS_FINALIZED may be set if we're doing a
+		 * refzero finalization and mark-and-sweep gets triggered
+		 * during the finalizer.
+		 */
+		/* DUK_HEAPHDR_HAS_FINALIZED may or may not be set. */
 		hdr = DUK_HEAPHDR_GET_NEXT(heap, hdr);
 	}
 #endif  /* DUK_USE_REFERENCE_COUNTING */


### PR DESCRIPTION
When mark-and-sweep runs, objects in refzero_list may have a FINALIZED flag if:
- Refzero processing runs a finalizer.
- The flag gets set before running the finalizer (the finalization helper does that).
- The finalizer triggers mark-and-sweep.

In that sequence refzero_list may contain a single object with FINALIZED set; that object is freed or queued back into heap_allocated after the finalizer returns.