### PR TITLE
Clarify finalizer rescue behavior in Guide

### DIFF
--- a/website/guide/finalization.html
+++ b/website/guide/finalization.html
@@ -60,12 +60,17 @@ finalizer are also silently ignored.</p>
 <li>Finalizers are also executed for all remaining objects, regardless of
     their reachability status, when a Duktape heap is destroyed.</li>
 <li>A finalizer is called exactly once, at the latest when the heap is
-    destroyed, unless the object is rescued by the finalizer by making
-    it reachable again.  An object may be rescued an arbitrary number of
-    times; the finalizer is called exactly once for each "rescue cycle".
-    Even with this guarantee in place, it's best practice for a finalizer
-    to be re-entrant and carefully avoid e.g. freeing a native resource
-    multiple times if re-entered.</li>
+    destroyed, unless the object is rescued by making it reachable again.
+    An object may be rescued by its own finalizer, or by another object's
+    finalizer when mark-and-sweep finalizes an object.  For example, if
+    <code>X.ref = Y</code>, and both X and Y become unreachable, it's
+    possible for Y's finalizer to run, and later on X's finalizer to rescue
+    both X and Y.</li>
+<li>An object may be rescued an arbitrary number of times; the finalizer
+    is called exactly once for each "rescue cycle".  Even with this
+    guarantee in place, it's best practice for a finalizer to be re-entrant
+    and carefully avoid e.g. freeing a native resource multiple times if
+    re-entered.</li>
 <li>A finalizer is not executed for a Proxy object, but is executed for
     the plain target object.  This ensures that a finalizer isn't executed
     multiple times when Proxy objects are created.</li>


### PR DESCRIPTION
When mark-and-sweep runs finalizers, it may involve a set of finalizable objects in an arbitrary graph. Duktape calls finalizers for each object in the finalizable set in an unspecified order, and rescuing an object X may rescue other objects -- even if the finalizers for those objects has already executed.

Clarify the Guide summary which implied that only the object's own finalizer could rescue an object (which is the typical case but not always true).