### PR TITLE
Fix ROM object incref with slow refcount default

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2428,6 +2428,9 @@ Planned
 * Fix incorrect exponentiation operator behavior which happened at least on
   Linux gcc 4.8.4 with -O2 (not -Os) (GH-1272)
 
+* Fix ROM pointer duk_heaphdr_incref() handling when slow refcount default
+  was enabled (GH-1320)
+
 * Compiler warning fix for using DUK_UNREF() on a volatile argument (GH-1282)
 
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -671,6 +671,12 @@ DUK_INTERNAL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv) {
 		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT((duk_heaphdr *) h) >= 1); \
 	} while (0)
 #if defined(DUK_USE_ROM_OBJECTS)
+#define DUK__INCREF_SHARED() do { \
+		if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h)) { \
+			return; \
+		} \
+		DUK_HEAPHDR_PREINC_REFCOUNT((duk_heaphdr *) h); \
+	} while (0)
 #define DUK__DECREF_SHARED() do { \
 		if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h)) { \
 			return; \
@@ -680,6 +686,9 @@ DUK_INTERNAL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv) {
 		} \
 	} while (0)
 #else
+#define DUK__INCREF_SHARED() do { \
+		DUK_HEAPHDR_PREINC_REFCOUNT((duk_heaphdr *) h); \
+	} while (0)
 #define DUK__DECREF_SHARED() do { \
 		if (DUK_HEAPHDR_PREDEC_REFCOUNT((duk_heaphdr *) h) != 0) { \
 			return; \
@@ -696,7 +705,7 @@ DUK_INTERNAL void duk_heaphdr_incref(duk_heaphdr *h) {
 	DUK_ASSERT(DUK_HEAPHDR_HTYPE_VALID(h));
 	DUK_ASSERT_DISABLE(DUK_HEAPHDR_GET_REFCOUNT(h) >= 0);
 
-	DUK_HEAPHDR_PREINC_REFCOUNT(h);
+	DUK__INCREF_SHARED();
 }
 
 DUK_INTERNAL void duk_heaphdr_decref(duk_hthread *thr, duk_heaphdr *h) {


### PR DESCRIPTION
With slow refcount default, duk_heaphdr_incref() didn't include a "readonly" check as intended.

Reported by @nkolban.