### PR TITLE
Keep finalize_list up-to-date during its walk

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2413,6 +2413,11 @@ Planned
   finalized, and must otherwise be in either the string table (for strings)
   or heap_allocated (non-strings) (GH-1317)
 
+* Fix a duk_push_heapptr() finalize_list assertion issue caused by the
+  internal heap->finalize_list being (intentionally) out-of-sync during
+  mark-and-sweep finalizer execution; this has no functional impact but
+  breaks duk_push_heapptr() asserts in certain conditions (GH-1321)
+
 * Fix a few incorrect asserts related to reference count triggered finalizer
   execution; the functionality itself was correct in these cases but a few
   asserts were too strict (GH-1318)

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -800,6 +800,12 @@ DUK_LOCAL void duk__run_object_finalizers(duk_heap *heap, duk_small_uint_t flags
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_FINALIZED(curr));
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_READONLY(curr));  /* No finalizers for ROM objects */
 
+		/* Keep heap->finalize_list up-to-date during the list walk.
+		 * This has no functional impact, but does matter e.g. for
+		 * duk_push_heapptr() asserts when assertions are enabled.
+		 */
+		heap->finalize_list = curr;
+
 		if (DUK_LIKELY((flags & DUK_MS_FLAG_SKIP_FINALIZERS) == 0)) {
 			/* Run the finalizer, duk_hobject_run_finalizer() sets FINALIZED.
 			 * Next mark-and-sweep will collect the object unless it has


### PR DESCRIPTION
The mark-and-sweep finalizater execution code walks `heap->finalize_list` and calls finalizers for each object. The objects are unconditionally queued back to heap_allocated after the finalizer returns. Finally, `heap->finalize_list` is set to NULL, and the heap is back in a consistent set w.r.t. the object queues.

So during the process the heap object lists are not in sync; heap->finalize_list is essentially in an out-of-sync state. This works correctly because the `heap->finalize_list` pointer isn't needed by anything during finalization; in particular, nothing is queued into it during mark-and-sweep finalization.

However, `duk_push_heapptr()` has an assert that ensures the pointer argument is not an unreachable object which is in the finalize_list and that assertion is broken in certain conditions:
- When the first finalizer executes, everything goes correctly.
- When the finalizer returns, the object is queued into heap_allocated.
- However, heap->finalize_list *still* points to that first object.
- When the next finalizer executes, and the finalizer function calls duk_push_heapptr(), the heap->finalize_list asserts are walking heap objects starting from the first object -- which is now in heap_allocated. The asserts can then faily mysteriously.

See https://github.com/svaarala/duktape/issues/1311#issuecomment-274303648.

To be clear, this should have no functional impact with asserts disabled. With asserts enabled a bogus assertion failure can occur in the above conditions.