### PR TITLE
Use a ROM string table for ROM string intern lookup

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2388,7 +2388,8 @@ Planned
 
 * Replace heap string table algorithms (chain and probe) with a single
   algorithm based on single linked chaining of duk_hstrings, with the same
-  algorithm serving both default and low memory environments (GH-1277)
+  algorithm serving both default and low memory environments; improve ROM
+  string intern check (GH-1277, GH-1327)
 
 * Replace object property table hash algorithm with a faster algorithm
   which uses a 2^N size and a bit mask instead of a prime size and a MOD;

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -348,15 +348,19 @@ DUK_LOCAL duk_bool_t duk__init_heap_strings(duk_heap *heap) {
 	 */
 
 #if defined(DUK_USE_ASSERTIONS)
-	for (i = 0; i < sizeof(duk_rom_strings) / sizeof(const duk_hstring *); i++) {
-		duk_uint32_t hash;
+	for (i = 0; i < sizeof(duk_rom_strings_lookup) / sizeof(const duk_hstring *); i++) {
 		const duk_hstring *h;
-		h = duk_rom_strings[i];
-		DUK_ASSERT(h != NULL);
-		hash = duk_heap_hashstring(heap, (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
-		DUK_DD(DUK_DDPRINT("duk_rom_strings[%d] -> hash 0x%08lx, computed 0x%08lx",
-		                   (int) i, (unsigned long) DUK_HSTRING_GET_HASH(h), (unsigned long) hash));
-		DUK_ASSERT(hash == (duk_uint32_t) DUK_HSTRING_GET_HASH(h));
+		duk_uint32_t hash;
+
+		h = duk_rom_strings_lookup[i];
+		while (h != NULL) {
+			hash = duk_heap_hashstring(heap, (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+			DUK_DD(DUK_DDPRINT("duk_rom_strings_lookup[%d] -> hash 0x%08lx, computed 0x%08lx",
+			                   (int) i, (unsigned long) DUK_HSTRING_GET_HASH(h), (unsigned long) hash));
+			DUK_ASSERT(hash == (duk_uint32_t) DUK_HSTRING_GET_HASH(h));
+
+			h = (const duk_hstring *) h->hdr.h_next;
+		}
 	}
 #endif
 	return 1;


### PR DESCRIPTION
Replace previous linear lookup placeholder with a ROM string table. The top level of the table is a 256-byte lookup whose key is much simpler than the corresponding RAM hash to avoid dealing with different string hashes (depending on config options). The value is a `duk_hstring *` and ROM strings are chained using their `h_next` field, which also means there's no longer a need to figure out what to do with the field.