### PR TITLE
Minor cleanups for explicit scope objects

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2458,7 +2458,8 @@ Planned
   read (GH-1303, GH-1358)
 
 * Improve lexical scope handling performance by adding internal duk_hdecenv
-  and duk_hobjenv structures (previously generic objects were used) (GH-1310)
+  and duk_hobjenv structures (previously generic objects were used) (GH-1310,
+  GH-1339)
 
 * Remove voluntary GC check from refzero processing; the check is not really
   necessary because all free operations decrement the voluntary GC counter and
@@ -2518,7 +2519,7 @@ Planned
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal
   functions (GH-1297)
 
-* Miscellaneous compiler warning fices (GH-1358)
+* Miscellaneous compiler warning fixes (GH-1358)
 
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309)

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -73,12 +73,8 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	 */
 	alloc_size = DUK_HOBJECT_P_ALLOC_SIZE(h_oldglobal);
 	DUK_ASSERT(alloc_size > 0);
-	props = DUK_ALLOC(thr->heap, alloc_size);
-	if (DUK_UNLIKELY(props == NULL)) {
-		/* XXX: just use DUK_ALLOC_CHECKED()? */
-		DUK_ERROR_ALLOC_FAILED(thr);
-		return;
-	}
+	props = DUK_ALLOC_CHECKED(thr, alloc_size);
+	DUK_ASSERT(props != NULL);
 	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal) != NULL);
 	DUK_MEMCPY((void *) props, (const void *) DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal), alloc_size);
 


### PR DESCRIPTION
Minor cleanups after merging main functionality:

- [x] Checked alloc where possible
- [x] Executor objenv push -> see if it's possible to avoid pushing to stabilize the env