### PR TITLE
Avoid log2(), log10(), cbrt(), trunc() on Android

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2502,6 +2502,8 @@ Planned
 
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
+* Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)
+
 * Compiler warning fix for using DUK_UNREF() on a volatile argument (GH-1282)
 
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal

--- a/config/header-snippets/platform_fillins.h.in
+++ b/config/header-snippets/platform_fillins.h.in
@@ -266,9 +266,9 @@
 /* The functions below exist only in C99/C++11 or later and need a workaround
  * for platforms that don't include them.  MSVC isn't detected as C99, but
  * these functions also exist in MSVC 2013 and later so include a clause for
- * that too.
+ * that too.  Android doesn't have log2; disable all of these for Android.
  */
-#if defined(DUK_F_C99) || defined(DUK_F_CPP11) || (defined(_MSC_VER) && (_MSC_VER >= 1800))
+#if (defined(DUK_F_C99) || defined(DUK_F_CPP11) || (defined(_MSC_VER) && (_MSC_VER >= 1800))) && !defined(DUK_F_ANDROID)
 #if !defined(DUK_CBRT)
 #define DUK_CBRT             cbrt
 #endif
@@ -281,7 +281,7 @@
 #if !defined(DUK_TRUNC)
 #define DUK_TRUNC            trunc
 #endif
-#endif  /* DUK_F_C99 */
+#endif  /* DUK_F_C99 etc */
 
 /* NetBSD 6.0 x86 (at least) has a few problems with pow() semantics,
  * see test-bug-netbsd-math-pow.js.  MinGW has similar (but different)

--- a/config/helper-snippets/DUK_F_ANDROID.h.in
+++ b/config/helper-snippets/DUK_F_ANDROID.h.in
@@ -1,0 +1,3 @@
+#if defined(ANDROID) || defined(__ANDROID__)
+#define DUK_F_ANDROID
+#endif


### PR DESCRIPTION
Fixes #1325.