### PR TITLE
Fix recursive mark-and-sweep entry

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2460,6 +2460,15 @@ Planned
 * Improve lexical scope handling performance by adding internal duk_hdecenv
   and duk_hobjenv structures (previously generic objects were used) (GH-1310)
 
+* Fix a garbage collection bug where a finalizer triggered by mark-and-sweep
+  could cause a recursive entry into mark-and-sweep (leading to memory unsafe
+  behavior) if the voluntary GC trigger counter dropped to zero during
+  mark-and-sweep finalizer execution (GH-1347)
+
+* Fix a garbage collection bug where a call into duk_gc() from a mark-and-sweep
+  triggered finalizer could cause recursive entry into mark-and-sweep (leading
+  memory unsafe behavior) (GH-1347)
+
 * Fix a duk_push_heapptr() finalize_list assertion issue caused by the
   internal heap->finalize_list being (intentionally) out-of-sync during
   mark-and-sweep finalizer execution; this has no functional impact but

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -1088,6 +1088,11 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 	duk_size_t tmp;
 #endif
 
+	if (DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap)) {
+		DUK_D(DUK_DPRINT("refuse to do a recursive mark-and-sweep"));
+		return 0;
+	}
+
 	/* XXX: thread selection for mark-and-sweep is currently a hack.
 	 * If we don't have a thread, the entire mark-and-sweep is now
 	 * skipped (although we could just skip finalizations).

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -445,12 +445,17 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 	 */
 	heap->mark_and_sweep_trigger_counter -= count;
 	if (DUK_UNLIKELY(heap->mark_and_sweep_trigger_counter <= 0)) {
-		duk_bool_t rc;
-		duk_small_uint_t flags = 0;  /* not emergency */
-		DUK_D(DUK_DPRINT("refcount triggering mark-and-sweep"));
-		rc = duk_heap_mark_and_sweep(heap, flags);
-		DUK_UNREF(rc);
-		DUK_D(DUK_DPRINT("refcount triggered mark-and-sweep => rc %ld", (long) rc));
+		if (DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap)) {
+			DUK_D(DUK_DPRINT("mark-and-sweep in progress -> skip voluntary mark-and-sweep now"));
+		} else {
+			duk_bool_t rc;
+			duk_small_uint_t flags = 0;  /* not emergency */
+
+			DUK_D(DUK_DPRINT("refcount triggering mark-and-sweep"));
+			rc = duk_heap_mark_and_sweep(heap, flags);
+			DUK_UNREF(rc);
+			DUK_D(DUK_DPRINT("refcount triggered mark-and-sweep => rc %ld", (long) rc));
+		}
 	}
 #endif  /* DUK_USE_VOLUNTARY_GC */
 }

--- a/tests/ecmascript/test-bug-recursive-voluntary-markandsweep.js
+++ b/tests/ecmascript/test-bug-recursive-voluntary-markandsweep.js
@@ -1,0 +1,69 @@
+/*
+ *  Bug testcase for recursive mark-and-sweep entry from refzero triggered
+ *  voluntary GC, https://github.com/svaarala/duktape/pull/1347.
+ */
+
+/*===
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+done
+===*/
+
+function myFinalizer(obj) {
+    var t;
+    var i, j;
+
+    for (i = 0; i < 10; i++) {
+        // We need to cause a lot of allocation activity without running
+        // out of memory (which is possible because GC cannot currently run
+        // inside a finalizer).  Use property table resizes to create the
+        // activity, and then trigger a voluntary GC from refzero.
+
+        t = {};
+
+        for (j = 1; j < 1e3; j++) {
+            t['prop' + j] = true;
+        }
+        for (j = 0; j < 1e3; j++) {
+            delete t['prop' + j];
+        }
+
+        t = null;
+    }
+}
+
+function test() {
+    var i;
+    var obj;
+
+    for (i = 0; i < 10; i++) {
+        print(i);
+
+        obj = {};
+        obj.ref = {};
+        obj.ref.back = obj;  // circular refs
+
+        Duktape.fin(obj, myFinalizer);
+        Duktape.fin(obj.ref, myFinalizer);
+
+        obj = null;
+        Duktape.gc();
+        Duktape.gc();
+    }
+
+    print('done');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
- [x] Repro testcase
- [x] Fix recursive mark-and-sweep entry from refzero triggered voluntary GC, see https://github.com/svaarala/duktape/issues/1311#issuecomment-277299860
- [x] Reject recursive mark-and-sweep explicitly rather than just asserting for it
- [x] Schedule fixes for 1.7.0 and 2.0.2
- [x] Releases entry

The latter change is necessary so that, for example, if a native finalizer calls duk_gc(), that won't cause recursive entry into mark-and-sweep.