### PR TITLE
Fix a non-fastint _Varmap index for a redeclared global

### DIFF
--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -2222,6 +2222,16 @@ DUK_LOCAL duk_double_t duk__to_int_uint_helper(duk_context *ctx, duk_idx_t idx, 
 
 	tv = duk_require_tval(ctx, idx);
 	DUK_ASSERT(tv != NULL);
+
+#if defined(DUK_USE_FASTINT)
+	/* If argument is a fastint, guarantee that it remains one.
+	 * There's no downgrade check for other cases.
+	 */
+	if (DUK_TVAL_IS_FASTINT(tv)) {
+		/* XXX: Unnecessary conversion back and forth. */
+		return (duk_double_t) DUK_TVAL_GET_FASTINT(tv);
+	}
+#endif
 	d = coerce_func(thr, tv);
 
 	/* XXX: fastint? */
@@ -2233,8 +2243,8 @@ DUK_LOCAL duk_double_t duk__to_int_uint_helper(duk_context *ctx, duk_idx_t idx, 
 }
 
 DUK_EXTERNAL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t idx) {
-	/* Value coercion (in stack): ToInteger(), E5 Section 9.4
-	 * API return value coercion: custom
+	/* Value coercion (in stack): ToInteger(), E5 Section 9.4,
+	 * API return value coercion: custom.
 	 */
 	DUK_ASSERT_CTX_VALID(ctx);
 	(void) duk__to_int_uint_helper(ctx, idx, duk_js_tointeger);
@@ -2242,8 +2252,8 @@ DUK_EXTERNAL duk_int_t duk_to_int(duk_context *ctx, duk_idx_t idx) {
 }
 
 DUK_EXTERNAL duk_uint_t duk_to_uint(duk_context *ctx, duk_idx_t idx) {
-	/* Value coercion (in stack): ToInteger(), E5 Section 9.4
-	 * API return value coercion: custom
+	/* Value coercion (in stack): ToInteger(), E5 Section 9.4,
+	 * API return value coercion: custom.
 	 */
 	DUK_ASSERT_CTX_VALID(ctx);
 	(void) duk__to_int_uint_helper(ctx, idx, duk_js_tointeger);

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -750,6 +750,10 @@ DUK_LOCAL void duk__print_tval(duk__dprint_state *st, duk_tval *tv) {
 	}
 #if defined(DUK_USE_FASTINT)
 	case DUK_TAG_FASTINT:
+		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
+		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
+		duk_fb_sprintf(fb, "%.18gF", (double) DUK_TVAL_GET_NUMBER(tv));
+		break;
 #endif
 	default: {
 		/* IEEE double is approximately 16 decimal digits; print a couple extra */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -6957,6 +6957,9 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 		                     (duk_tval *) duk_get_tval(ctx, -2),
 		                     (duk_tval *) duk_get_tval(ctx, -1)));
 
+#if defined(DUK_USE_FASTINT)
+		DUK_ASSERT(DUK_TVAL_IS_NULL(duk_get_tval(ctx, -1)) || DUK_TVAL_IS_FASTINT(duk_get_tval(ctx, -1)));
+#endif
 		duk_put_prop(ctx, comp_ctx->curr_func.varmap_idx);  /* [ ... name reg/null ] -> [ ... ] */
 	}
 


### PR DESCRIPTION
The issue was introduced in master when adding explicit scope objects and is unreleased, so no releases entry.