### PR TITLE
Fix global/eval variable redeclaration handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2500,6 +2500,11 @@ Planned
 * Fix bug in global object environment "provideThis" attribute when using ROM
   objects and DUK_USE_ROM_GLOBAL_INHERIT (GH-1340, GH-1310)
 
+* Fix bug in global/eval code variable redeclaration handling where a
+  plain 'var X;' redeclaration for an existing binding caused 'undefined' to
+  overwrite the existing binding rather than being treated as a no-op
+  (GH-1351, GH-1354)
+
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
 * Compiler warning fix for using DUK_UNREF() on a volatile argument (GH-1282)

--- a/debugger/duk_opcodes.yaml
+++ b/debugger/duk_opcodes.yaml
@@ -705,8 +705,6 @@ opcodes:
       - mask: 0x800
         name: accessor
       - mask: 0x1000
-        name: undef_value
-      - mask: 0x2000
         name: func_decl
   - name: DECLVAR_CR
     args:
@@ -723,8 +721,6 @@ opcodes:
       - mask: 0x800
         name: accessor
       - mask: 0x1000
-        name: undef_value
-      - mask: 0x2000
         name: func_decl
   - name: DECLVAR_RC
     args:
@@ -741,8 +737,6 @@ opcodes:
       - mask: 0x800
         name: accessor
       - mask: 0x1000
-        name: undef_value
-      - mask: 0x2000
         name: func_decl
   - name: DECLVAR_CC
     args:
@@ -759,8 +753,6 @@ opcodes:
       - mask: 0x800
         name: accessor
       - mask: 0x1000
-        name: undef_value
-      - mask: 0x2000
         name: func_decl
   - name: REGEXP_RR
     args:

--- a/src-input/duk_js_bytecode.h
+++ b/src-input/duk_js_bytecode.h
@@ -461,8 +461,7 @@ typedef duk_uint32_t duk_instr_t;
 #define DUK_BC_TRYCATCH_FLAG_WITH_BINDING   (1 << 3)
 
 /* DUK_OP_DECLVAR flags in A; bottom bits are reserved for propdesc flags (DUK_PROPDESC_FLAG_XXX) */
-#define DUK_BC_DECLVAR_FLAG_UNDEF_VALUE     (1 << 4)  /* use 'undefined' for value automatically */
-#define DUK_BC_DECLVAR_FLAG_FUNC_DECL       (1 << 5)  /* function declaration */
+#define DUK_BC_DECLVAR_FLAG_FUNC_DECL       (1 << 4)  /* function declaration */
 
 /* Misc constants and helper macros. */
 #define DUK_BC_LDINT_BIAS           (1L << 15)

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -7025,8 +7025,7 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 				duk_push_null(ctx);
 
 				declvar_flags = DUK_PROPDESC_FLAG_WRITABLE |
-			                        DUK_PROPDESC_FLAG_ENUMERABLE |
-				                DUK_BC_DECLVAR_FLAG_UNDEF_VALUE;
+			                        DUK_PROPDESC_FLAG_ENUMERABLE;
 				if (configurable_bindings) {
 					declvar_flags |= DUK_PROPDESC_FLAG_CONFIGURABLE;
 				}

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -3665,9 +3665,15 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 
 			act = thr->callstack + thr->callstack_top - 1;
 			if (duk_js_declvar_activation(thr, act, name, tv1, prop_flags, is_func_decl)) {
-				/* already declared, must update binding value */
-				tv1 = DUK_GET_TVAL_NEGIDX(ctx, -1);
-				duk_js_putvar_activation(thr, act, name, tv1, DUK__STRICT());
+				if (is_undef_value) {
+					/* Already declared but no initializer value
+					 * (e.g. 'var xyz;'), no-op.
+					 */
+				} else {
+					/* Already declared, update value. */
+					tv1 = DUK_GET_TVAL_NEGIDX(ctx, -1);
+					duk_js_putvar_activation(thr, act, name, tv1, DUK__STRICT());
+				}
 			}
 
 			duk_pop(ctx);

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -3636,14 +3636,12 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			duk_hstring *name;
 			duk_small_uint_t prop_flags;
 			duk_bool_t is_func_decl;
-			duk_bool_t is_undef_value;
 
 			tv1 = DUK__REGCONSTP_B(ins);
 			DUK_ASSERT(DUK_TVAL_IS_STRING(tv1));
 			name = DUK_TVAL_GET_STRING(tv1);
 			DUK_ASSERT(name != NULL);
 
-			is_undef_value = ((a & DUK_BC_DECLVAR_FLAG_UNDEF_VALUE) != 0);
 			is_func_decl = ((a & DUK_BC_DECLVAR_FLAG_FUNC_DECL) != 0);
 
 			/* XXX: declvar takes an duk_tval pointer, which is awkward and
@@ -3655,24 +3653,24 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			 */
 			prop_flags = a & DUK_PROPDESC_FLAGS_MASK;
 
-			if (is_undef_value) {
+			if (is_func_decl) {
+				duk_push_tval(ctx, DUK__REGCONSTP_C(ins));
+			} else {
 				DUK_ASSERT(DUK_TVAL_IS_UNDEFINED(thr->valstack_top));  /* valstack policy */
 				thr->valstack_top++;
-			} else {
-				duk_push_tval(ctx, DUK__REGCONSTP_C(ins));
 			}
 			tv1 = DUK_GET_TVAL_NEGIDX(ctx, -1);
 
 			act = thr->callstack + thr->callstack_top - 1;
 			if (duk_js_declvar_activation(thr, act, name, tv1, prop_flags, is_func_decl)) {
-				if (is_undef_value) {
-					/* Already declared but no initializer value
-					 * (e.g. 'var xyz;'), no-op.
-					 */
-				} else {
+				if (is_func_decl) {
 					/* Already declared, update value. */
 					tv1 = DUK_GET_TVAL_NEGIDX(ctx, -1);
 					duk_js_putvar_activation(thr, act, name, tv1, DUK__STRICT());
+				} else {
+					/* Already declared but no initializer value
+					 * (e.g. 'var xyz;'), no-op.
+					 */
 				}
 			}
 

--- a/tests/ecmascript/test-bug-global-eval-redeclare.js
+++ b/tests/ecmascript/test-bug-global-eval-redeclare.js
@@ -1,0 +1,38 @@
+/*
+ *  Bug in handling of variable redeclaration from eval/global code.
+ *  The redeclaration must happen in a separate compilation unit for
+ *  the bug to manifest, e.g. eval code must redeclare a global variable.
+ */
+
+/*===
+function
+fn called
+[object Math]
+[object Math]
+done
+===*/
+
+var global = new Function('return this')();
+
+// Redeclare from eval without initializer, should be no-op.
+
+global.fn = function () {
+    print('fn called');
+};
+
+(0, eval)('var fn;');
+
+print(typeof fn);
+try {
+    fn();
+} catch (e) {
+    print(e.stack || e);
+}
+
+// Related issue: redeclare Math from global code, should be no-op.
+
+print(Math);
+var Math;
+print(Math);
+
+print('done');


### PR DESCRIPTION
- [x] Bug testcase
- [x] Implement minimal fix
- [x] Check if DECLVAR flags can be simplified because there are only really two cases: function declaration and var declaration now
- [x] Releases entry
- [ ] Backport to at least 2.0.x, maybe 1.7.0

Fixes #1351.