### PR TITLE
Minor tweaks to voluntary mark-and-sweep handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2460,10 +2460,14 @@ Planned
 * Improve lexical scope handling performance by adding internal duk_hdecenv
   and duk_hobjenv structures (previously generic objects were used) (GH-1310)
 
+* Remove voluntary GC check from refzero processing; the check is not really
+  necessary because all free operations decrement the voluntary GC counter and
+  all allocs/reallocs check for voluntary GC (GH-1355)
+
 * Fix a garbage collection bug where a finalizer triggered by mark-and-sweep
   could cause a recursive entry into mark-and-sweep (leading to memory unsafe
   behavior) if the voluntary GC trigger counter dropped to zero during
-  mark-and-sweep finalizer execution (GH-1347)
+  mark-and-sweep finalizer execution (GH-1347, GH-1355)
 
 * Fix a garbage collection bug where a call into duk_gc() from a mark-and-sweep
   triggered finalizer could cause recursive entry into mark-and-sweep (leading

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -940,8 +940,6 @@ The algorithm is as follows:
    e. Free any auxiliary references (such as object properties) contained
       in ``O``, and finally ``O`` itself.
 
-2. Check for a voluntary mark-and-sweep.
-
 Notes:
 
 * "Churning" the work list requires that the type of a heap element can be
@@ -1494,11 +1492,12 @@ point arithmetic)::
 
   // MULT and ADD are tuning parameters
 
-The trigger count is decreased on every memory (re)allocation, and for every
-object processed by the refzero algorithm.  If the trigger reaches zero when
-memory is about to be (re)allocated, a voluntary mark-and-sweep pass is done.
-When ``MULT`` is 1 and ``ADD`` is 0, a voluntary sweep is done when the number
-of "operations" matches the previous heap object/string count.
+The trigger count is decreased on every memory (re)allocation and free, to
+roughly measure allocation activity.  If the trigger count is below zero when
+memory is about to be (re)allocated, a a voluntary mark-and-sweep pass is
+done.  When ``MULT`` is 1 and ``ADD`` is 0, a voluntary sweep is done when
+the number of alloc/free operations matches the previous heap object/string
+count.
 
 When reference counting is enabled, ``MULT`` can be quite large (e.g. 10)
 because only circular references need to be swept.  When reference counting

--- a/src-input/duk_heap_memory.c
+++ b/src-input/duk_heap_memory.c
@@ -14,8 +14,7 @@
 
 #if defined(DUK_USE_VOLUNTARY_GC)
 #define DUK__VOLUNTARY_PERIODIC_GC(heap)  do { \
-		(heap)->mark_and_sweep_trigger_counter--; \
-		if ((heap)->mark_and_sweep_trigger_counter <= 0) { \
+		if (--(heap)->mark_and_sweep_trigger_counter < 0) { \
 			duk__run_voluntary_gc(heap); \
 		} \
 	} while (0)


### PR DESCRIPTION
- [x] Remove voluntary GC check entirely from refzero as unnecessary: free operations decrement the counter, and the first alloc operation will check for the counter in any case
- [x] Slightly better asm output for voluntary GC counter check in allocation code (at least on x64)
- [x] Releases entry