### PR TITLE
Make internal duk_hobject (subclass) allocators checked by default

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2519,6 +2519,9 @@ Planned
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309)
 
+* Miscellaneous footprint improvements: more compact duk_hobject allocation
+  (GH-1357)
+
 * Internal change: duk_hstring now has a 'next' heap pointer for string table
   chaining; this affects string allocation sizes which may matter for manually
   tuned memory pools (GH-1277)

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -586,7 +586,7 @@ static duk_uint8_t *duk__load_func(duk_context *ctx, duk_uint8_t *p, duk_uint8_t
 		 */
 		duk_hdecenv *new_env;
 
-		new_env = duk_hdecenv_alloc(thr->heap,
+		new_env = duk_hdecenv_alloc(thr,
 		                            DUK_HOBJECT_FLAG_EXTENSIBLE |
 		                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV));
 		DUK_ASSERT(new_env != NULL);

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -161,7 +161,7 @@ DUK_EXTERNAL void duk_set_global_object(duk_context *ctx) {
 	 *  same (initial) built-ins.
 	 */
 
-	h_env = duk_hobjenv_alloc(thr->heap,
+	h_env = duk_hobjenv_alloc(thr,
 	                          DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                          DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV));
 	DUK_ASSERT(h_env != NULL);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3972,10 +3972,8 @@ DUK_INTERNAL duk_hobject *duk_push_object_helper(duk_context *ctx, duk_uint_t ho
 
 	DUK__CHECK_SPACE();
 
-	h = duk_hobject_alloc(thr->heap, hobject_flags_and_class);
-	if (DUK_UNLIKELY(h == NULL)) {
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
+	h = duk_hobject_alloc(thr, hobject_flags_and_class);
+	DUK_ASSERT(h != NULL);
 
 	DUK_DDD(DUK_DDDPRINT("created object with flags: 0x%08lx", (unsigned long) h->hdr.h_flags));
 
@@ -4033,10 +4031,8 @@ DUK_EXTERNAL duk_idx_t duk_push_array(duk_context *ctx) {
 	        DUK_HOBJECT_FLAG_EXOTIC_ARRAY |
 	        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_ARRAY);
 
-	obj = duk_harray_alloc(thr->heap, flags);
-	if (DUK_UNLIKELY(obj == NULL)) {
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
+	obj = duk_harray_alloc(thr, flags);
+	DUK_ASSERT(obj != NULL);
 
 	/* XXX: since prototype is NULL, could save a check */
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_ARRAY_PROTOTYPE]);
@@ -4092,13 +4088,11 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t flags) {
 
 	DUK__CHECK_SPACE();
 
-	obj = duk_hthread_alloc(thr->heap,
+	obj = duk_hthread_alloc(thr,
 	                        DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                        DUK_HOBJECT_FLAG_THREAD |
 	                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_THREAD));
-	if (DUK_UNLIKELY(obj == NULL)) {
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
+	DUK_ASSERT(obj != NULL);
 	obj->state = DUK_HTHREAD_STATE_INACTIVE;
 #if defined(DUK_USE_ROM_STRINGS)
 	/* Nothing to initialize, strs[] is in ROM. */
@@ -4157,7 +4151,7 @@ DUK_INTERNAL duk_hcompfunc *duk_push_hcompfunc(duk_context *ctx) {
 	 * DUK_HOBJECT_FLAG_CONSRUCTABLE flag cleared here.
 	 */
 
-	obj = duk_hcompfunc_alloc(thr->heap,
+	obj = duk_hcompfunc_alloc(thr,
 	                          DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                          DUK_HOBJECT_FLAG_COMPFUNC |
 	                          DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION));
@@ -4199,10 +4193,8 @@ DUK_LOCAL duk_idx_t duk__push_c_function_raw(duk_context *ctx, duk_c_function fu
 		goto api_error;
 	}
 
-	obj = duk_hnatfunc_alloc(thr->heap, flags);
-	if (DUK_UNLIKELY(obj == NULL)) {
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
+	obj = duk_hnatfunc_alloc(thr, flags);
+	DUK_ASSERT(obj != NULL);
 
 	obj->func = func;
 	obj->nargs = func_nargs;
@@ -4319,10 +4311,8 @@ DUK_INTERNAL duk_hbufobj *duk_push_bufobj_raw(duk_context *ctx, duk_uint_t hobje
 
 	DUK__CHECK_SPACE();
 
-	obj = duk_hbufobj_alloc(thr->heap, hobject_flags_and_class);
-	if (DUK_UNLIKELY(obj == NULL)) {
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
+	obj = duk_hbufobj_alloc(thr, hobject_flags_and_class);
+	DUK_ASSERT(obj != NULL);
 
 	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, (duk_hobject *) obj, thr->builtins[prototype_bidx]);
 	DUK_ASSERT_HBUFOBJ_VALID(obj);

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -522,7 +522,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			act_lex_env = act->lex_env;
 			act = NULL;  /* invalidated */
 
-			new_env = duk_hdecenv_alloc(thr->heap,
+			new_env = duk_hdecenv_alloc(thr,
 			                            DUK_HOBJECT_FLAG_EXTENSIBLE |
 			                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV));
 			DUK_ASSERT(new_env != NULL);

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -213,6 +213,13 @@ typedef void *(*duk_mem_getptr)(duk_heap *heap, void *ud);
 #define DUK_FREE(heap,ptr)                              duk_heap_mem_free((heap), (ptr))
 
 /*
+ *  Checked allocation, relative to a thread
+ */
+
+#define DUK_ALLOC_CHECKED(thr,size)                     duk_heap_mem_alloc_checked((thr), (size))
+#define DUK_ALLOC_CHECKED_ZEROED(thr,size)              duk_heap_mem_alloc_checked_zeroed((thr), (size))
+
+/*
  *  Memory constants
  */
 
@@ -522,6 +529,8 @@ DUK_INTERNAL_DECL void duk_default_free_function(void *udata, void *ptr);
 
 DUK_INTERNAL_DECL void *duk_heap_mem_alloc(duk_heap *heap, duk_size_t size);
 DUK_INTERNAL_DECL void *duk_heap_mem_alloc_zeroed(duk_heap *heap, duk_size_t size);
+DUK_INTERNAL_DECL void *duk_heap_mem_alloc_checked(duk_hthread *thr, duk_size_t size);
+DUK_INTERNAL_DECL void *duk_heap_mem_alloc_checked_zeroed(duk_hthread *thr, duk_size_t size);
 DUK_INTERNAL_DECL void *duk_heap_mem_realloc(duk_heap *heap, void *ptr, duk_size_t newsize);
 DUK_INTERNAL_DECL void *duk_heap_mem_realloc_indirect(duk_heap *heap, duk_mem_getptr cb, void *ud, duk_size_t newsize);
 DUK_INTERNAL_DECL void duk_heap_mem_free(duk_heap *heap, void *ptr);

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -436,11 +436,11 @@ DUK_LOCAL duk_bool_t duk__init_heap_thread(duk_heap *heap) {
 	duk_hthread *thr;
 
 	DUK_DD(DUK_DDPRINT("heap init: alloc heap thread"));
-	thr = duk_hthread_alloc(heap,
-	                        DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                        DUK_HOBJECT_FLAG_THREAD |
-	                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_THREAD));
-	if (!thr) {
+	thr = duk_hthread_alloc_unchecked(heap,
+	                                  DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                                  DUK_HOBJECT_FLAG_THREAD |
+	                                  DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_THREAD));
+	if (thr == NULL) {
 		DUK_D(DUK_DPRINT("failed to alloc heap_thread"));
 		return 0;
 	}
@@ -962,8 +962,8 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 
 	DUK_DD(DUK_DDPRINT("HEAP: INIT HEAP OBJECT"));
 	DUK_ASSERT(res->heap_thread != NULL);
-	res->heap_object = duk_hobject_alloc(res, DUK_HOBJECT_FLAG_EXTENSIBLE |
-	                                          DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT));
+	res->heap_object = duk_hobject_alloc_unchecked(res, DUK_HOBJECT_FLAG_EXTENSIBLE |
+	                                                    DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJECT));
 	if (res->heap_object == NULL) {
 		goto failed;
 	}

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -815,19 +815,18 @@ DUK_INTERNAL_DECL duk_uint8_t duk_class_number_to_stridx[32];
  */
 
 /* alloc and init */
-DUK_INTERNAL_DECL duk_hobject *duk_hobject_alloc(duk_heap *heap, duk_uint_t hobject_flags);
-#if 0  /* unused */
-DUK_INTERNAL_DECL duk_hobject *duk_hobject_alloc_checked(duk_hthread *thr, duk_uint_t hobject_flags);
-#endif
-DUK_INTERNAL_DECL duk_harray *duk_harray_alloc(duk_heap *heap, duk_uint_t hobject_flags);
-DUK_INTERNAL_DECL duk_hcompfunc *duk_hcompfunc_alloc(duk_heap *heap, duk_uint_t hobject_flags);
-DUK_INTERNAL_DECL duk_hnatfunc *duk_hnatfunc_alloc(duk_heap *heap, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hobject *duk_hobject_alloc_unchecked(duk_heap *heap, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hobject *duk_hobject_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_harray *duk_harray_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hcompfunc *duk_hcompfunc_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hnatfunc *duk_hnatfunc_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
-DUK_INTERNAL_DECL duk_hbufobj *duk_hbufobj_alloc(duk_heap *heap, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hbufobj *duk_hbufobj_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
 #endif
-DUK_INTERNAL_DECL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_flags);
-DUK_INTERNAL_DECL duk_hdecenv *duk_hdecenv_alloc(duk_heap *heap, duk_uint_t hobject_flags);
-DUK_INTERNAL_DECL duk_hobjenv *duk_hobjenv_alloc(duk_heap *heap, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hthread *duk_hthread_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hdecenv *duk_hdecenv_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
+DUK_INTERNAL_DECL duk_hobjenv *duk_hobjenv_alloc(duk_hthread *thr, duk_uint_t hobject_flags);
 
 /* resize */
 DUK_INTERNAL_DECL void duk_hobject_realloc_props(duk_hthread *thr,

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -12,18 +12,23 @@
 
 #include "duk_internal.h"
 
-DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_hobject *obj, duk_uint_t hobject_flags) {
+/*
+ *  Helpers.
+ */
+
+DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_uint_t hobject_flags, duk_hobject *obj) {
+	DUK_ASSERT(obj != NULL);
+	/* Zeroed by caller. */
+
+	obj->hdr.h_flags = hobject_flags | DUK_HTYPE_OBJECT;
+	DUK_ASSERT(DUK_HEAPHDR_GET_TYPE(&obj->hdr) == DUK_HTYPE_OBJECT);  /* Assume zero shift. */
+
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	DUK_HOBJECT_SET_PROTOTYPE(heap, obj, NULL);
 	DUK_HOBJECT_SET_PROPS(heap, obj, NULL);
 #endif
-
-	/* XXX: macro? sets both heaphdr and object flags */
-	obj->hdr.h_flags = hobject_flags;
-	DUK_HEAPHDR_SET_TYPE(&obj->hdr, DUK_HTYPE_OBJECT);  /* also goes into flags */
-
 #if defined(DUK_USE_HEAPPTR16)
-	/* Zero encoded pointer is required to match NULL */
+	/* Zero encoded pointer is required to match NULL. */
 	DUK_HEAPHDR_SET_NEXT(heap, &obj->hdr, NULL);
 #if defined(DUK_USE_DOUBLE_LINKED_HEAP)
 	DUK_HEAPHDR_SET_PREV(heap, &obj->hdr, NULL);
@@ -32,12 +37,20 @@ DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_hobject *obj, duk_uint
 	DUK_ASSERT_HEAPHDR_LINKS(heap, &obj->hdr);
 	DUK_HEAP_INSERT_INTO_HEAP_ALLOCATED(heap, &obj->hdr);
 
-	/*
-	 *  obj->props is intentionally left as NULL, and duk_hobject_props.c must deal
-	 *  with this properly.  This is intentional: empty objects consume a minimum
-	 *  amount of memory.  Further, an initial allocation might fail and cause
-	 *  'obj' to "leak" (require a mark-and-sweep) since it is not reachable yet.
+	/* obj->props is intentionally left as NULL, and duk_hobject_props.c must deal
+	 * with this properly.  This is intentional: empty objects consume a minimum
+	 * amount of memory.  Further, an initial allocation might fail and cause
+	 * 'obj' to "leak" (require a mark-and-sweep) since it is not reachable yet.
 	 */
+}
+
+DUK_LOCAL void *duk__hobject_alloc_init(duk_hthread *thr, duk_uint_t hobject_flags, duk_size_t size) {
+	void *res;
+
+	res = (void *) DUK_ALLOC_CHECKED_ZEROED(thr, size);
+	DUK_ASSERT(res != NULL);
+	duk__init_object_parts(thr->heap, hobject_flags, (duk_hobject *) res);
+	return res;
 }
 
 /*
@@ -51,7 +64,7 @@ DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_hobject *obj, duk_uint
  *  count before invoking any operation that might require memory allocation.
  */
 
-DUK_INTERNAL duk_hobject *duk_hobject_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hobject *duk_hobject_alloc_unchecked(duk_heap *heap, duk_uint_t hobject_flags) {
 	duk_hobject *res;
 
 	DUK_ASSERT(heap != NULL);
@@ -61,28 +74,27 @@ DUK_INTERNAL duk_hobject *duk_hobject_alloc(duk_heap *heap, duk_uint_t hobject_f
 	DUK_ASSERT((hobject_flags & DUK_HOBJECT_FLAG_NATFUNC) == 0);
 	DUK_ASSERT((hobject_flags & DUK_HOBJECT_FLAG_THREAD) == 0);
 
-	res = (duk_hobject *) DUK_ALLOC(heap, sizeof(duk_hobject));
+	res = (duk_hobject *) DUK_ALLOC_ZEROED(heap, sizeof(duk_hobject));
 	if (DUK_UNLIKELY(res == NULL)) {
 		return NULL;
 	}
-	DUK_MEMZERO(res, sizeof(duk_hobject));
 
-	duk__init_object_parts(heap, res, hobject_flags);
+	duk__init_object_parts(heap, hobject_flags, res);
 
 	return res;
 }
 
-DUK_INTERNAL duk_hcompfunc *duk_hcompfunc_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hobject *duk_hobject_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
+	duk_hobject *res;
+
+	res = (duk_hobject *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hobject));
+	return res;
+}
+
+DUK_INTERNAL duk_hcompfunc *duk_hcompfunc_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hcompfunc *res;
 
-	res = (duk_hcompfunc *) DUK_ALLOC(heap, sizeof(duk_hcompfunc));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_hcompfunc));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
-
+	res = (duk_hcompfunc *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hcompfunc));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 #if defined(DUK_USE_HEAPPTR16)
 	/* NULL pointer is required to encode to zero, so memset is enough. */
@@ -98,17 +110,10 @@ DUK_INTERNAL duk_hcompfunc *duk_hcompfunc_alloc(duk_heap *heap, duk_uint_t hobje
 	return res;
 }
 
-DUK_INTERNAL duk_hnatfunc *duk_hnatfunc_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hnatfunc *duk_hnatfunc_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hnatfunc *res;
 
-	res = (duk_hnatfunc *) DUK_ALLOC(heap, sizeof(duk_hnatfunc));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_hnatfunc));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
-
+	res = (duk_hnatfunc *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hnatfunc));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	res->func = NULL;
 #endif
@@ -117,17 +122,10 @@ DUK_INTERNAL duk_hnatfunc *duk_hnatfunc_alloc(duk_heap *heap, duk_uint_t hobject
 }
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
-DUK_INTERNAL duk_hbufobj *duk_hbufobj_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hbufobj *duk_hbufobj_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hbufobj *res;
 
-	res = (duk_hbufobj *) DUK_ALLOC(heap, sizeof(duk_hbufobj));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_hbufobj));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
-
+	res = (duk_hbufobj *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hbufobj));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	res->buf = NULL;
 	res->buf_prop = NULL;
@@ -138,15 +136,13 @@ DUK_INTERNAL duk_hbufobj *duk_hbufobj_alloc(duk_heap *heap, duk_uint_t hobject_f
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
-/*
- *  Allocate a new thread.
+/* Allocate a new thread.
  *
- *  Leaves the built-ins array uninitialized.  The caller must either
- *  initialize a new global context or share existing built-ins from
- *  another thread.
+ * Leaves the built-ins array uninitialized.  The caller must either
+ * initialize a new global context or share existing built-ins from
+ * another thread.
  */
-
-DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t hobject_flags) {
 	duk_hthread *res;
 
 	res = (duk_hthread *) DUK_ALLOC(heap, sizeof(duk_hthread));
@@ -155,7 +151,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_f
 	}
 	DUK_MEMZERO(res, sizeof(duk_hthread));
 
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
+	duk__init_object_parts(heap, hobject_flags, &res->obj);
 
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	res->ptr_curr_pc = NULL;
@@ -174,7 +170,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_f
 	res->strs = NULL;
 #endif
 	{
-		int i;
+		duk_small_uint_t i;
 		for (i = 0; i < DUK_NUM_BUILTINS; i++) {
 			res->builtins[i] = NULL;
 		}
@@ -191,51 +187,30 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_heap *heap, duk_uint_t hobject_f
 	return res;
 }
 
-#if 0  /* unused now */
-DUK_INTERNAL duk_hobject *duk_hobject_alloc_checked(duk_hthread *thr, duk_uint_t hobject_flags) {
-	duk_hobject *res = duk_hobject_alloc(thr->heap, hobject_flags);
-	if (!res) {
+DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
+	duk_hthread *res;
+
+	res = duk_hthread_alloc_unchecked(thr->heap, hobject_flags);
+	if (res == NULL) {
 		DUK_ERROR_ALLOC_FAILED(thr);
 	}
 	return res;
 }
-#endif
 
-/*
- *  Allocate a new array.
- */
-
-DUK_INTERNAL duk_harray *duk_harray_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_harray *duk_harray_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_harray *res;
 
-	res = (duk_harray *) DUK_ALLOC(heap, sizeof(duk_harray));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_harray));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
+	res = (duk_harray *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_harray));
 
 	DUK_ASSERT(res->length == 0);
 
 	return res;
 }
 
-/*
- *  Allocate a new environment
- */
-
-DUK_INTERNAL duk_hdecenv *duk_hdecenv_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hdecenv *duk_hdecenv_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hdecenv *res;
 
-	res = (duk_hdecenv *) DUK_ALLOC(heap, sizeof(duk_hdecenv));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_hdecenv));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
-
+	res = (duk_hdecenv *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hdecenv));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	res->thread = NULL;
 	res->varmap = NULL;
@@ -248,17 +223,10 @@ DUK_INTERNAL duk_hdecenv *duk_hdecenv_alloc(duk_heap *heap, duk_uint_t hobject_f
 	return res;
 }
 
-DUK_INTERNAL duk_hobjenv *duk_hobjenv_alloc(duk_heap *heap, duk_uint_t hobject_flags) {
+DUK_INTERNAL duk_hobjenv *duk_hobjenv_alloc(duk_hthread *thr, duk_uint_t hobject_flags) {
 	duk_hobjenv *res;
 
-	res = (duk_hobjenv *) DUK_ALLOC(heap, sizeof(duk_hobjenv));
-	if (DUK_UNLIKELY(res == NULL)) {
-		return NULL;
-	}
-	DUK_MEMZERO(res, sizeof(duk_hobjenv));
-
-	duk__init_object_parts(heap, &res->obj, hobject_flags);
-
+	res = (duk_hobjenv *) duk__hobject_alloc_init(thr, hobject_flags, sizeof(duk_hobjenv));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	res->target = NULL;
 #endif

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -108,7 +108,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	 * needed so that the global scope points to the newly created RAM-based
 	 * global object.
 	 */
-	h_objenv = (duk_hobject *) duk_hobjenv_alloc(thr->heap,
+	h_objenv = (duk_hobject *) duk_hobjenv_alloc(thr,
 	                                             DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                                             DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV));
 	DUK_ASSERT(h_objenv != NULL);
@@ -300,7 +300,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			DUK_ASSERT(i == DUK_BIDX_GLOBAL_ENV);
 			DUK_ASSERT(DUK_BIDX_GLOBAL_ENV > DUK_BIDX_GLOBAL);
 
-			env = duk_hobjenv_alloc(thr->heap,
+			env = duk_hobjenv_alloc(thr,
 	                                        DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV));
 			DUK_ASSERT(env->target == NULL);

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -935,7 +935,7 @@ DUK_LOCAL void duk__handle_catch(duk_hthread *thr, duk_size_t cat_idx, duk_tval 
 		act_lex_env = act->lex_env;
 		act = NULL;  /* invalidated */
 
-		new_env = duk_hdecenv_alloc(thr->heap,
+		new_env = duk_hdecenv_alloc(thr,
 		                            DUK_HOBJECT_FLAG_EXTENSIBLE |
 		                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV));
 		DUK_ASSERT(new_env != NULL);
@@ -4051,9 +4051,10 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 				DUK_ASSERT(act->lex_env != NULL);
 				DUK_ASSERT(act->var_env != NULL);
 
-				env = duk_hobjenv_alloc(thr->heap,
+				env = duk_hobjenv_alloc(thr,
 				                        DUK_HOBJECT_FLAG_EXTENSIBLE |
 				                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_OBJENV));
+				DUK_ASSERT(env != NULL);
 				DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(thr->heap, (duk_hobject *) env) == NULL);
 				duk_push_hobject(ctx, (duk_hobject *) env);  /* Push to stabilize against side effects. */
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -247,7 +247,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			}
 
 			/* -> [ ... closure template env ] */
-			new_env = duk_hdecenv_alloc(thr->heap,
+			new_env = duk_hdecenv_alloc(thr,
 			                            DUK_HOBJECT_FLAG_EXTENSIBLE |
 			                            DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV));
 			DUK_ASSERT(new_env != NULL);
@@ -516,7 +516,7 @@ duk_hobject *duk_create_activation_environment_record(duk_hthread *thr,
 		parent = thr->builtins[DUK_BIDX_GLOBAL_ENV];
 	}
 
-	env = duk_hdecenv_alloc(thr->heap,
+	env = duk_hdecenv_alloc(thr,
 	                        DUK_HOBJECT_FLAG_EXTENSIBLE |
 	                        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_DECENV));
 	DUK_ASSERT(env != NULL);


### PR DESCRIPTION
Small internal rework: since almost all call sites expect checked behavior (throw on alloc error) change allocator functions for e.g. `duk_hdecenv_alloc()` to be checked by default. Two unchecked calls are needed during heap init when no thread yet exists.

Other minor footprint rework too (shared helper calls). Fixes unreleased `duk_hdecenv` and `duk_hobjenv` alloc bugs: the call sites used unchecked allocations but just asserted for a non-NULL result; now fixed to use a checked call.