### PR TITLE
Faster refzero queueing / free pending check

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2529,11 +2529,15 @@ Planned
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal
   functions (GH-1297)
 
+* Don't decrease voluntary GC trigger counter for internal memory free
+  operations (only allocations) (GH-1361)
+
 * Miscellaneous compiler warning fixes (GH-1358)
 
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309, GH-1312), integer
-  refzero-free-running flag (instead of a flag bit) (GH-1362)
+  refzero-free-running flag (instead of a flag bit) (GH-1362), faster refzero
+  queueing / free pending check (GH-1361)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
   (GH-1357), explicit thr->callstack_curr field for current activation

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -1492,9 +1492,9 @@ point arithmetic)::
 
   // MULT and ADD are tuning parameters
 
-The trigger count is decreased on every memory (re)allocation and free, to
-roughly measure allocation activity.  If the trigger count is below zero when
-memory is about to be (re)allocated, a a voluntary mark-and-sweep pass is
+The trigger count is decreased on every memory (re)allocation (but not free),
+to roughly measure allocation activity.  If the trigger count is below zero
+when memory is about to be (re)allocated, a a voluntary mark-and-sweep pass is
 done.  When ``MULT`` is 1 and ``ADD`` is 0, a voluntary sweep is done when
 the number of alloc/free operations matches the previous heap object/string
 count.

--- a/src-input/duk_error_longjmp.c
+++ b/src-input/duk_error_longjmp.c
@@ -47,7 +47,7 @@ DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 	 * some internal code uses no-refzero (NORZ) macro variants but an
 	 * error occurs before it has the chance to DUK_REFZERO_CHECK_xxx()
 	 * explicitly.  Refzero'ed objects would otherwise remain pending
-	 * until the next refzero (which is not a big issue but still).
+	 * until the next forced DUK_REFZERO_CHECK_xxx().
 	 */
 	DUK_REFZERO_CHECK_SLOW(thr);
 

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -114,8 +114,7 @@
 /* Mark-and-sweep interval is relative to combined count of objects and
  * strings kept in the heap during the latest mark-and-sweep pass.
  * Fixed point .8 multiplier and .0 adder.  Trigger count (interval) is
- * decreased by each (re)allocation attempt (regardless of size), and each
- * refzero processed object.
+ * decreased by each (re)allocation attempt (regardless of size).
  *
  * 'SKIP' indicates how many (re)allocations to wait until a retry if
  * GC is skipped because there is no thread do it with yet (happens

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -492,6 +492,10 @@ DUK_LOCAL void duk__finalize_refcounts(duk_heap *heap) {
 
 		hdr = DUK_HEAPHDR_GET_NEXT(heap, hdr);
 	}
+
+	/* We don't DUK_REFZERO_CHECK_xxx() here because refzero queueing is
+	 * disabled while mark-and-sweep runs.
+	 */
 }
 #endif  /* DUK_USE_REFERENCE_COUNTING */
 

--- a/src-input/duk_heap_memory.c
+++ b/src-input/duk_heap_memory.c
@@ -352,12 +352,9 @@ DUK_INTERNAL void duk_heap_mem_free(duk_heap *heap, void *ptr) {
 	 */
 	heap->free_func(heap->heap_udata, ptr);
 
-	/* Count free operations toward triggering a GC but never actually trigger
-	 * a GC from a free.  Otherwise code which frees internal structures would
-	 * need to put in NULLs at every turn to ensure the object is always in
-	 * consistent state for a mark-and-sweep.
+	/* Don't update the voluntary GC counter or trigger a GC from a free.
+	 * This ensures that code freeing internal structures can be made side
+	 * effect free.  Also DECREF_NORZ macros, which free strings and buffers
+	 * immediately, are then side effect free.
 	 */
-#if defined(DUK_USE_VOLUNTARY_GC)
-	heap->mark_and_sweep_trigger_counter--;
-#endif
 }

--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -290,6 +290,14 @@ struct duk_heaphdr_string {
  *  Note that 'raw' macros such as DUK_HEAPHDR_GET_REFCOUNT() are not
  *  defined without DUK_USE_REFERENCE_COUNTING, so caller must #if defined()
  *  around them.
+ *
+ *  NORZ variants perform refcount operations and may queue an object to be
+ *  refcount finalized (heap->refzero_list), but won't actually process the
+ *  queue.  Calling code must always call DUK_REFZERO_CHECK_xxx() after a
+ *  sequence of NORZ macro calls, otherwise the queue may be left unprocessed
+ *  until the next such call.  If an error thrown, DUK_REFZERO_CHECK_xxx()
+ *  is always called so that NORZ/DUK_REFZERO_CHECK_xxx() can be used without
+ *  a catch point.
  */
 
 #if defined(DUK_USE_REFERENCE_COUNTING)

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -5883,6 +5883,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_context *ctx,
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_EXTENSIBLE);
 	}
+	DUK_REFZERO_CHECK_SLOW(thr);
 	return 0;
 
  fail_virtual:  /* just use the same "not configurable" error message" */
@@ -5890,6 +5891,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_context *ctx,
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
 	}
+	DUK_REFZERO_CHECK_SLOW(thr);
 	return 0;
 }
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -701,6 +701,10 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 	((duk_hdecenv *) env)->thread = NULL;
 	((duk_hdecenv *) env)->varmap = NULL;
 
+	/* No DUK_REFZERO_CHECK_xxx() on purpose, caller is responsible for
+	 * doing it.
+	 */
+
 	DUK_DDD(DUK_DDDPRINT("env after closing: %!O", (duk_heaphdr *) env));
 }
 


### PR DESCRIPTION
When a refzero event occurs, assume that we only need to check for `duk_refzero_free_pending()` when refzero_list is NULL prior to refzero_list queueing. This is always the case except when NORZ macros prevent "free pending" execution.

In the NORZ macro case refzero_list may accumulate objects which are currently processed either via a forced DUK_REFZERO_CHECK_xxx() call, or any other refzero event. The change in this pull changes this so that a refzero event will no longer process the queue because the whole check is skipped if refzero_list != NULL. It's thus more critical that a DUK_REFZERO_CHECK_xxx() call is made after every NORZ macro sequence; longjmp handling also does a forced refzero check so that if errors are thrown between a NORZ and a forced refzero the queue gets processed promptly.

Tasks:
- [x] First draft
- [x] Remove "refzero running" checks from the initial entry: if refzero_list == NULL prior to insert, the check is always unnecessary (just assert for it)
- [x] Include a "refzero running" check for a forced DUK_REFZERO_CHECK_xxx() call however, and the flag does need to be set and cleared
- [x] Make "refzero running" a `duk_bool_t` flag for faster checking (merge separately?)
- [x] Remove voluntary GC counter update from internal "free" operation
- [x] Go through all NORZ code paths and ensure an explicit refzero check follows
- [ ] Delprop NORZ check
- [ ] Manual massif test
- [x] Releases entry