### PR TITLE
Use an integer flag for refzero_free_running

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2522,7 +2522,8 @@ Planned
 * Miscellaneous compiler warning fixes (GH-1358)
 
 * Miscellaneous performance improvements: more likely/unlike attributes and
-  hot/cold function splits (GH-1308, GH-1309)
+  hot/cold function splits (GH-1308, GH-1309), integer refzero-free-running
+  flag (instead of a flag bit) (GH-1362)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
   (GH-1357)

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -16,11 +16,10 @@
 
 #define DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING                     (1 << 0)  /* mark-and-sweep is currently running */
 #define DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED            (1 << 1)  /* mark-and-sweep marking reached a recursion limit and must use multi-pass marking */
-#define DUK_HEAP_FLAG_REFZERO_FREE_RUNNING                     (1 << 2)  /* refcount code is processing refzero list */
-#define DUK_HEAP_FLAG_ERRHANDLER_RUNNING                       (1 << 3)  /* an error handler (user callback to augment/replace error) is running */
-#define DUK_HEAP_FLAG_INTERRUPT_RUNNING                        (1 << 4)  /* executor interrupt running (used to avoid nested interrupts) */
-#define DUK_HEAP_FLAG_FINALIZER_NORESCUE                       (1 << 5)  /* heap destruction ongoing, finalizer rescue no longer possible */
-#define DUK_HEAP_FLAG_DEBUGGER_PAUSED                          (1 << 6)  /* debugger is paused: talk with debug client until step/resume */
+#define DUK_HEAP_FLAG_ERRHANDLER_RUNNING                       (1 << 2)  /* an error handler (user callback to augment/replace error) is running */
+#define DUK_HEAP_FLAG_INTERRUPT_RUNNING                        (1 << 3)  /* executor interrupt running (used to avoid nested interrupts) */
+#define DUK_HEAP_FLAG_FINALIZER_NORESCUE                       (1 << 4)  /* heap destruction ongoing, finalizer rescue no longer possible */
+#define DUK_HEAP_FLAG_DEBUGGER_PAUSED                          (1 << 5)  /* debugger is paused: talk with debug client until step/resume */
 
 #define DUK__HEAP_HAS_FLAGS(heap,bits)               ((heap)->flags & (bits))
 #define DUK__HEAP_SET_FLAGS(heap,bits)  do { \
@@ -32,7 +31,6 @@
 
 #define DUK_HEAP_HAS_MARKANDSWEEP_RUNNING(heap)            DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING)
 #define DUK_HEAP_HAS_MARKANDSWEEP_RECLIMIT_REACHED(heap)   DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED)
-#define DUK_HEAP_HAS_REFZERO_FREE_RUNNING(heap)            DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_HAS_ERRHANDLER_RUNNING(heap)              DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_HAS_INTERRUPT_RUNNING(heap)               DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
 #define DUK_HEAP_HAS_FINALIZER_NORESCUE(heap)              DUK__HEAP_HAS_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
@@ -40,7 +38,6 @@
 
 #define DUK_HEAP_SET_MARKANDSWEEP_RUNNING(heap)            DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING)
 #define DUK_HEAP_SET_MARKANDSWEEP_RECLIMIT_REACHED(heap)   DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED)
-#define DUK_HEAP_SET_REFZERO_FREE_RUNNING(heap)            DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_SET_ERRHANDLER_RUNNING(heap)              DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_SET_INTERRUPT_RUNNING(heap)               DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
 #define DUK_HEAP_SET_FINALIZER_NORESCUE(heap)              DUK__HEAP_SET_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
@@ -48,7 +45,6 @@
 
 #define DUK_HEAP_CLEAR_MARKANDSWEEP_RUNNING(heap)          DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RUNNING)
 #define DUK_HEAP_CLEAR_MARKANDSWEEP_RECLIMIT_REACHED(heap) DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED)
-#define DUK_HEAP_CLEAR_REFZERO_FREE_RUNNING(heap)          DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_REFZERO_FREE_RUNNING)
 #define DUK_HEAP_CLEAR_ERRHANDLER_RUNNING(heap)            DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_ERRHANDLER_RUNNING)
 #define DUK_HEAP_CLEAR_INTERRUPT_RUNNING(heap)             DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_INTERRUPT_RUNNING)
 #define DUK_HEAP_CLEAR_FINALIZER_NORESCUE(heap)            DUK__HEAP_CLEAR_FLAGS((heap), DUK_HEAP_FLAG_FINALIZER_NORESCUE)
@@ -352,6 +348,7 @@ struct duk_heap {
 #if defined(DUK_USE_REFERENCE_COUNTING)
 	duk_heaphdr *refzero_list;
 	duk_heaphdr *refzero_list_tail;
+	duk_bool_t refzero_free_running;
 #endif
 
 	/* mark-and-sweep control */

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -1144,7 +1144,7 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 	DUK_ASSERT(heap->mark_and_sweep_recursion_depth == 0);
 	duk__assert_heaphdr_flags(heap);
 #if defined(DUK_USE_REFERENCE_COUNTING)
-	/* Note: DUK_HEAP_HAS_REFZERO_FREE_RUNNING(heap) may be true; a refcount
+	/* Note: heap->refzero_free_running may be true; a refcount
 	 * finalizer may trigger a mark-and-sweep.
 	 */
 	duk__assert_valid_refcounts(heap);
@@ -1318,7 +1318,7 @@ DUK_INTERNAL duk_bool_t duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t
 	DUK_ASSERT(heap->mark_and_sweep_recursion_depth == 0);
 	duk__assert_heaphdr_flags(heap);
 #if defined(DUK_USE_REFERENCE_COUNTING)
-	/* Note: DUK_HEAP_HAS_REFZERO_FREE_RUNNING(heap) may be true; a refcount
+	/* Note: heap->refzero_free_running may be true; a refcount
 	 * finalizer may trigger a mark-and-sweep.
 	 */
 	duk__assert_valid_refcounts(heap);

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -297,7 +297,7 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 	 *  Detect recursive invocation
 	 */
 
-	if (DUK_HEAP_HAS_REFZERO_FREE_RUNNING(heap)) {
+	if (heap->refzero_free_running) {
 		DUK_DDD(DUK_DDDPRINT("refzero free running, skip run"));
 		return;
 	}
@@ -306,7 +306,9 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 	 *  Churn refzero_list until empty
 	 */
 
-	DUK_HEAP_SET_REFZERO_FREE_RUNNING(heap);
+	DUK_ASSERT(heap->refzero_free_running == 0);
+	heap->refzero_free_running = 1;
+
 	while (heap->refzero_list) {
 		duk_hobject *obj;
 #if defined(DUK_USE_FINALIZER_SUPPORT)
@@ -434,7 +436,9 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 		count++;
 #endif
 	}
-	DUK_HEAP_CLEAR_REFZERO_FREE_RUNNING(heap);
+
+	DUK_ASSERT(heap->refzero_free_running == 1);
+	heap->refzero_free_running = 0;
 
 	DUK_DDD(DUK_DDDPRINT("refzero processed %ld objects", (long) count));
 }


### PR DESCRIPTION
This is a hot flag so it's probably better as an integer field rather than a flag in a heap bitfield.