### PR TITLE
Fix stale activation pointer in pre/post inc/dec handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2510,6 +2510,10 @@ Planned
   overwrite the existing binding rather than being treated as a no-op
   (GH-1351, GH-1354)
 
+* Fix stale activation ('act') pointer in pre/post inc/dec handling which could
+  lead to memory unsafe behavior if the argument ToNumber() coercion had side
+  effects causing a callstack resize (GH-1370, GH-1371)
+
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -748,11 +748,13 @@ DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr,
 
 	if (op & 0x02) {
 		duk_push_number(ctx, y);  /* -> [ ... x this y ] */
+		act = thr->callstack + thr->callstack_top - 1;
 		duk_js_putvar_activation(thr, act, name, DUK_GET_TVAL_NEGIDX(ctx, -1), is_strict);
 		duk_pop_2(ctx);  /* -> [ ... x ] */
 	} else {
 		duk_pop_2(ctx);  /* -> [ ... ] */
 		duk_push_number(ctx, y);  /* -> [ ... y ] */
+		act = thr->callstack + thr->callstack_top - 1;
 		duk_js_putvar_activation(thr, act, name, DUK_GET_TVAL_NEGIDX(ctx, -1), is_strict);
 	}
 

--- a/tests/ecmascript/test-bug-incdec-stale-act-gh1370.js
+++ b/tests/ecmascript/test-bug-incdec-stale-act-gh1370.js
@@ -1,0 +1,16 @@
+/*
+ *  Stale 'act' pointer in pre/post inc/dec handling.
+ *  https://github.com/svaarala/duktape/issues/1370
+ *
+
+/*===
+RangeError
+===*/
+
+try {
+    (function foo() {
+       foo--; foo();
+    })();
+} catch (e) {
+    print(e.name);  // eventual RangeError
+}


### PR DESCRIPTION
Pre/post inc/dec handling might use a stale 'act' pointer if side effects cause a callstack resize during the operation. This caused #1370 and can lead to memory unsafe behavior (thus tagged security).

Fixes #1370.