### PR TITLE
Add explicit current activation pointer

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2536,7 +2536,8 @@ Planned
   flag (instead of a flag bit) (GH-1362)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
-  (GH-1357)
+  (GH-1357), explicit thr->callstack_curr field for current activation
+  (GH-1372)
 
 * Internal change: duk_hstring now has a 'next' heap pointer for string table
   chaining; this affects string allocation sizes which may matter for manually

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -472,7 +472,7 @@ DUK_EXTERNAL duk_bool_t duk_is_constructor_call(duk_context *ctx) {
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
-	act = duk_hthread_get_current_activation(thr);
+	act = thr->callstack_curr;
 	if (act != NULL) {
 		return ((act->flags & DUK_ACT_FLAG_CONSTRUCT) != 0 ? 1 : 0);
 	}
@@ -505,12 +505,13 @@ DUK_EXTERNAL duk_bool_t duk_is_strict_call(duk_context *ctx) {
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
-	act = duk_hthread_get_current_activation(thr);
-	if (act == NULL) {
+	act = thr->callstack_curr;
+	if (act != NULL) {
+		return ((act->flags & DUK_ACT_FLAG_STRICT) != 0 ? 1 : 0);
+	} else {
 		/* Strict by default. */
 		return 1;
 	}
-	return ((act->flags & DUK_ACT_FLAG_STRICT) != 0 ? 1 : 0);
 }
 
 /*
@@ -526,7 +527,7 @@ DUK_EXTERNAL duk_int_t duk_get_current_magic(duk_context *ctx) {
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
-	act = duk_hthread_get_current_activation(thr);
+	act = thr->callstack_curr;
 	if (act) {
 		func = DUK_ACT_GET_FUNC(act);
 		if (!func) {

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3781,6 +3781,7 @@ DUK_INTERNAL duk_tval *duk_get_borrowed_this_tval(duk_context *ctx) {
 	thr = (duk_hthread *) ctx;
 
 	DUK_ASSERT(thr->callstack_top > 0);  /* caller required to know */
+	DUK_ASSERT(thr->callstack_curr != NULL);
 	DUK_ASSERT(thr->valstack_bottom > thr->valstack);  /* consequence of above */
 	DUK_ASSERT(thr->valstack_bottom - 1 >= thr->valstack);  /* 'this' binding exists */
 
@@ -3796,8 +3797,8 @@ DUK_EXTERNAL void duk_push_current_function(duk_context *ctx) {
 	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 	DUK_ASSERT(thr->callstack_top <= thr->callstack_size);
 
-	act = duk_hthread_get_current_activation(thr);
-	if (act) {
+	act = thr->callstack_curr;
+	if (act != NULL) {
 		duk_push_tval(ctx, &act->tv_func);
 	} else {
 		duk_push_undefined(ctx);

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -431,7 +431,8 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 
 	DUK_ASSERT(duk_get_top(ctx) == 1 || duk_get_top(ctx) == 2);  /* 2 when called by debugger */
 	DUK_ASSERT(thr->callstack_top >= 1);  /* at least this function exists */
-	DUK_ASSERT(((thr->callstack + thr->callstack_top - 1)->flags & DUK_ACT_FLAG_DIRECT_EVAL) == 0 || /* indirect eval */
+	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT((thr->callstack_curr->flags & DUK_ACT_FLAG_DIRECT_EVAL) == 0 || /* indirect eval */
 	           (thr->callstack_top >= 2));  /* if direct eval, calling activation must exist */
 
 	/*
@@ -462,7 +463,8 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 	/* [ source ] */
 
 	comp_flags = DUK_JS_COMPILE_FLAG_EVAL;
-	act_eval = thr->callstack + thr->callstack_top - 1;    /* this function */
+	act_eval = thr->callstack_curr;  /* this function */
+	DUK_ASSERT(act_eval != NULL);
 	if (thr->callstack_top >= (duk_size_t) -level) {
 		/* Have a calling activation, check for direct eval (otherwise
 		 * assume indirect eval.
@@ -493,7 +495,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 
 	/* E5 Section 10.4.2 */
 	DUK_ASSERT(thr->callstack_top >= 1);
-	act = thr->callstack + thr->callstack_top - 1;  /* this function */
+	act = thr->callstack_curr;  /* this function */
 	if (act->flags & DUK_ACT_FLAG_DIRECT_EVAL) {
 		DUK_ASSERT(thr->callstack_top >= 2);
 		act = thr->callstack + thr->callstack_top + level;  /* caller */

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -79,11 +79,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 		DUK_DD(DUK_DDPRINT("resume state invalid: callstack should contain at least 2 entries (caller and Duktape.Thread.resume)"));
 		goto state_error;
 	}
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1) != NULL);  /* us */
-	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1)));
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 2) != NULL);  /* caller */
+	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);  /* us */
+	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr - 1) != NULL);  /* caller */
 
-	caller_func = DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 2);
+	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr - 1);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
 		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be Ecmascript code"));
 		goto state_error;
@@ -233,11 +234,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 		DUK_DD(DUK_DDPRINT("yield state invalid: callstack should contain at least 2 entries (caller and Duktape.Thread.yield)"));
 		goto state_error;
 	}
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1) != NULL);  /* us */
-	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1)));
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 2) != NULL);  /* caller */
+	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);  /* us */
+	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr - 1) != NULL);  /* caller */
 
-	caller_func = DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 2);
+	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr - 1);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
 		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be Ecmascript code"));
 		goto state_error;

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -161,6 +161,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t
 	res->valstack_bottom = NULL;
 	res->valstack_top = NULL;
 	res->callstack = NULL;
+	res->callstack_curr = NULL;
 	res->catchstack = NULL;
 	res->resumer = NULL;
 	res->compile_ctx = NULL,

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -134,8 +134,6 @@
 #endif
 #endif  /* DUK_USE_ROM_STRINGS */
 
-#define DUK_HTHREAD_GET_CURRENT_ACTIVATION(thr)  (&(thr)->callstack[(thr)->callstack_top - 1])
-
 /* values for the state field */
 #define DUK_HTHREAD_STATE_INACTIVE     1   /* thread not currently running */
 #define DUK_HTHREAD_STATE_RUNNING      2   /* thread currently running (only one at a time) */
@@ -317,8 +315,9 @@ struct duk_hthread {
 
 	/* Call stack.  [0,callstack_top[ is GC reachable. */
 	duk_activation *callstack;
+	duk_activation *callstack_curr;         /* current activation (or NULL if none) */
 	duk_size_t callstack_size;              /* allocation size */
-	duk_size_t callstack_top;               /* next to use, highest used is top - 1 */
+	duk_size_t callstack_top;               /* next to use, highest used is top - 1 (or none if top == 0) */
 	duk_size_t callstack_preventcount;      /* number of activation records in callstack preventing a yield */
 
 	/* Catch stack.  [0,catchstack_top[ is GC reachable. */
@@ -385,7 +384,6 @@ DUK_INTERNAL_DECL void duk_hthread_catchstack_grow(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_hthread_catchstack_shrink_check(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_hthread_catchstack_unwind(duk_hthread *thr, duk_size_t new_top);
 
-DUK_INTERNAL_DECL duk_activation *duk_hthread_get_current_activation(duk_hthread *thr);
 DUK_INTERNAL_DECL void *duk_hthread_get_valstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */
 DUK_INTERNAL_DECL void *duk_hthread_get_callstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */
 DUK_INTERNAL_DECL void *duk_hthread_get_catchstack_ptr(duk_heap *heap, void *ud);  /* indirect allocs */

--- a/src-input/duk_hthread_alloc.c
+++ b/src-input/duk_hthread_alloc.c
@@ -21,6 +21,7 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	DUK_ASSERT(thr->valstack_bottom == NULL);
 	DUK_ASSERT(thr->valstack_top == NULL);
 	DUK_ASSERT(thr->callstack == NULL);
+	DUK_ASSERT(thr->callstack_curr == NULL);
 	DUK_ASSERT(thr->catchstack == NULL);
 
 	/* valstack */
@@ -50,6 +51,7 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	DUK_MEMZERO(thr->callstack, alloc_size);
 	thr->callstack_size = DUK_CALLSTACK_INITIAL_SIZE;
 	DUK_ASSERT(thr->callstack_top == 0);
+	DUK_ASSERT(thr->callstack_curr == NULL);
 
 	/* catchstack */
 	alloc_size = sizeof(duk_catcher) * DUK_CATCHSTACK_INITIAL_SIZE;

--- a/src-input/duk_hthread_misc.c
+++ b/src-input/duk_hthread_misc.c
@@ -33,16 +33,6 @@ DUK_INTERNAL void duk_hthread_terminate(duk_hthread *thr) {
 	 */
 }
 
-DUK_INTERNAL duk_activation *duk_hthread_get_current_activation(duk_hthread *thr) {
-	DUK_ASSERT(thr != NULL);
-
-	if (thr->callstack_top > 0) {
-		return thr->callstack + thr->callstack_top - 1;
-	} else {
-		return NULL;
-	}
-}
-
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 DUK_INTERNAL duk_uint_fast32_t duk_hthread_get_act_curr_pc(duk_hthread *thr, duk_activation *act) {
 	duk_instr_t *bcode;
@@ -88,7 +78,9 @@ DUK_INTERNAL void duk_hthread_sync_currpc(duk_hthread *thr) {
 	if (thr->ptr_curr_pc != NULL) {
 		/* ptr_curr_pc != NULL only when bytecode executor is active. */
 		DUK_ASSERT(thr->callstack_top > 0);
-		act = thr->callstack + thr->callstack_top - 1;
+		DUK_ASSERT(thr->callstack_curr != NULL);
+		act = thr->callstack_curr;
+		DUK_ASSERT(act != NULL);
 		act->curr_pc = *thr->ptr_curr_pc;
 	}
 }
@@ -101,7 +93,9 @@ DUK_INTERNAL void duk_hthread_sync_and_null_currpc(duk_hthread *thr) {
 	if (thr->ptr_curr_pc != NULL) {
 		/* ptr_curr_pc != NULL only when bytecode executor is active. */
 		DUK_ASSERT(thr->callstack_top > 0);
-		act = thr->callstack + thr->callstack_top - 1;
+		DUK_ASSERT(thr->callstack_curr != NULL);
+		act = thr->callstack_curr;
+		DUK_ASSERT(act != NULL);
 		act->curr_pc = *thr->ptr_curr_pc;
 		thr->ptr_curr_pc = NULL;
 	}


### PR DESCRIPTION
Add an explicit pointer to the current activation (or NULL) to shorten the common internal code idiom:

```c
act = thr->callstack + thr->callstack_top - 1
```

Footprint improvement is around 200-500 bytes depending on configuration and target.

Tasks:
- [x] Add internal callstack_curr field
- [x] Update callstack_curr whenever thr->callstack or thr->callstack_top is updated (must remain in sync)
- [x] Change call sites to use thr->callstack_curr
- [x] Review call sites for any unnecessary thr->callstack_top > 0 checks
- [x] Resolve FIXMEs
- [x] Check whether it's useful to remove thr->callstack_top which is computable from thr->callstack and thr->callstack_curr => separate change
- [x] Releases entry