### PR TITLE
Fix a few more sites where activation pointer may be stale

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2510,9 +2510,8 @@ Planned
   overwrite the existing binding rather than being treated as a no-op
   (GH-1351, GH-1354)
 
-* Fix stale activation ('act') pointer in pre/post inc/dec handling which could
-  lead to memory unsafe behavior if the argument ToNumber() coercion had side
-  effects causing a callstack resize (GH-1370, GH-1371)
+* Fix some stale activation ('act') pointer handling which could lead to
+  memory unsafe behavior in some cases (GH-1370, GH-1371, GH-1373)
 
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -518,7 +518,6 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			                     "var_env and lex_env to a fresh env, "
 			                     "this_binding to caller's this_binding"));
 
-			act = thr->callstack + thr->callstack_top + level;  /* caller */
 			act_lex_env = act->lex_env;
 			act = NULL;  /* invalidated */
 

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1019,6 +1019,7 @@ DUK_INTERNAL void duk_debug_send_status(duk_hthread *thr) {
 		duk_pop_3(ctx);
 		/* Report next pc/line to be executed. */
 		duk_debug_write_uint(thr, (duk_uint32_t) duk_debug_curr_line(thr));
+		act = thr->callstack + thr->callstack_top - 1;
 		duk_debug_write_uint(thr, (duk_uint32_t) duk_hthread_get_act_curr_pc(thr, act));
 	}
 
@@ -1059,6 +1060,7 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 		duk_push_tval(ctx, &act->tv_func);
 		duk_get_prop_string(ctx, -1, "fileName");
 		duk__debug_write_hstring_safe_top(thr);
+		act = thr->callstack + thr->callstack_top - 1;
 		pc = duk_hthread_get_act_prev_pc(thr, act);
 		duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_pc2line_query(ctx, -2, pc));
 	}

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1433,8 +1433,8 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
 	if (func) {
 		duk__update_func_caller_prop(thr, func);
+		act = thr->callstack + thr->callstack_top - 1;
 	}
-	act = thr->callstack + thr->callstack_top - 1;
 #endif
 
 	/* [ ... func this arg1 ... argN ] */
@@ -1494,6 +1494,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			DUK_ASSERT(!DUK_HOBJECT_HAS_CREATEARGS(func));
 
 			duk__handle_oldenv_for_call(thr, func, act);
+			/* No need to re-lookup 'act' at present: no side effects. */
 
 			DUK_ASSERT(act->lex_env != NULL);
 			DUK_ASSERT(act->var_env != NULL);
@@ -1530,6 +1531,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	 *  new value stack bottom, and call the target.
 	 */
 
+	act = thr->callstack + thr->callstack_top - 1;
 	if (func != NULL && DUK_HOBJECT_IS_COMPFUNC(func)) {
 		/*
 		 *  Ecmascript call
@@ -2659,6 +2661,7 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		 */
 
 		duk__handle_oldenv_for_call(thr, func, act);
+		/* No need to re-lookup 'act' at present: no side effects. */
 
 		DUK_ASSERT(act->lex_env != NULL);
 		DUK_ASSERT(act->var_env != NULL);

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -3762,6 +3762,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			if (act->lex_env == NULL) {
 				DUK_ASSERT(act->var_env == NULL);
 				duk_js_init_activation_environment_records_delayed(thr, act);
+				act = thr->callstack + thr->callstack_top - 1;
 			}
 			DUK_ASSERT(act->lex_env != NULL);
 			DUK_ASSERT(act->var_env != NULL);
@@ -4086,8 +4087,8 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 				duk_hobject *target;
 
 				/* Delayed env initialization for activation (if needed). */
-				act = thr->callstack + thr->callstack_top - 1;
 				DUK_ASSERT(thr->callstack_top >= 1);
+				act = thr->callstack + thr->callstack_top - 1;
 				if (act->lex_env == NULL) {
 					DUK_DDD(DUK_DDDPRINT("delayed environment initialization"));
 					DUK_ASSERT(act->var_env == NULL);

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -562,7 +562,10 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr,
 	duk_context *ctx = (duk_context *) thr;
 	duk_hobject *func;
 	duk_hobject *env;
+	duk_size_t act_off;
 
+	DUK_ASSERT(act != NULL);
+	act_off = (duk_size_t) ((duk_uint8_t *) act - (duk_uint8_t *) thr->callstack);
 	func = DUK_ACT_GET_FUNC(act);
 	DUK_ASSERT(func != NULL);
 	DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));  /* bound functions are never in act 'func' */
@@ -577,6 +580,7 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr,
 
 	env = duk_create_activation_environment_record(thr, func, act->idx_bottom);
 	DUK_ASSERT(env != NULL);
+	act = (duk_activation *) ((duk_uint8_t *) thr->callstack + act_off);
 
 	DUK_DDD(DUK_DDDPRINT("created delayed fresh env: %!ipO", (duk_heaphdr *) env));
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
@@ -1720,6 +1724,10 @@ duk_bool_t duk_js_declvar_activation(duk_hthread *thr,
                                      duk_bool_t is_func_decl) {
 	duk_hobject *env;
 	duk_tval tv_val_copy;
+	duk_size_t act_off;
+
+	DUK_ASSERT(act != NULL);
+	act_off = (duk_size_t) ((duk_uint8_t *) act - (duk_uint8_t *) thr->callstack);
 
 	/*
 	 *  Make a value copy of the input val.  This ensures that
@@ -1736,6 +1744,7 @@ duk_bool_t duk_js_declvar_activation(duk_hthread *thr,
 	if (!act->var_env) {
 		DUK_ASSERT(act->lex_env == NULL);
 		duk_js_init_activation_environment_records_delayed(thr, act);
+		act = (duk_activation *) ((duk_uint8_t *) thr->callstack + act_off);
 	}
 	DUK_ASSERT(act->lex_env != NULL);
 	DUK_ASSERT(act->var_env != NULL);


### PR DESCRIPTION
One sequence which may invalidate an `act` pointer is that a voluntary GC gets triggered when e.g. allocating a new environment record, that GC runs a finalizer, and a callstack resize invalidates the 'act' pointer. There are at least two sites like this reported by @andoma: https://github.com/svaarala/duktape/pull/1371#issuecomment-283022380.

Tasks:
- [x] Fix andoma's reported sites
- [x] Figure out a better fix for the duk_js_var.c case: 'act' doesn't point to topmost activation when Eval debugger command used
- [x] Check all 'act' sites in code for any similar issues
- [x] Releases entry