### PR TITLE
Fix incorrect handling of duk_is_constructor_call() on empty callstack

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2513,6 +2513,8 @@ Planned
 * Fix some stale activation ('act') pointer handling which could lead to
   memory unsafe behavior in some cases (GH-1370, GH-1371, GH-1373)
 
+* Fix duk_is_constructor_call() for an empty callstack (GH-1376)
+
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -473,8 +473,10 @@ DUK_EXTERNAL duk_bool_t duk_is_constructor_call(duk_context *ctx) {
 	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
 	act = duk_hthread_get_current_activation(thr);
-	DUK_ASSERT(act != NULL);  /* because callstack_top > 0 */
-	return ((act->flags & DUK_ACT_FLAG_CONSTRUCT) != 0 ? 1 : 0);
+	if (act != NULL) {
+		return ((act->flags & DUK_ACT_FLAG_CONSTRUCT) != 0 ? 1 : 0);
+	}
+	return 0;
 }
 
 /* XXX: Make this obsolete by adding a function flag for rejecting a

--- a/tests/api/test-bug-is-constructor-call-empty-callstack.c
+++ b/tests/api/test-bug-is-constructor-call-empty-callstack.c
@@ -1,0 +1,8 @@
+/*===
+still here
+===*/
+
+void test(duk_context *ctx) {
+	(void) duk_is_constructor_call(ctx);
+	printf("still here\n");
+}


### PR DESCRIPTION
The call didn't handle an empty call stack correctly. Tagged security because memory unsafe behavior results - but in practice this only happens if C code specifically makes the API call outside of any Duktape/C function invocation.

Tasks:
- [x] Test case
- [x] Bug fix
- [x] Releases entry