### PR TITLE
Fix debugger Throw notify handling of empty callstack

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2515,6 +2515,9 @@ Planned
 
 * Fix duk_is_constructor_call() for an empty callstack (GH-1376)
 
+* Fix debugger Throw notify handling for an empty callstack (e.g. error
+  thrown by duk_throw() with nothing on the callstack) (GH-1377)
+
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1052,19 +1052,29 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 		duk__debug_write_hstring_safe_top(thr);
 		duk_get_prop_stridx_short(ctx, -2, DUK_STRIDX_LINE_NUMBER);
 		duk_debug_write_uint(thr, duk_get_uint(ctx, -1));
+		duk_pop_2(ctx);
 	} else {
-		/* For anything other than an Error instance, we calculate the error
-		 * location directly from the current activation.
+		/* For anything other than an Error instance, we calculate the
+		 * error location directly from the current activation if one
+		 * exists.
 		 */
-		act = thr->callstack + thr->callstack_top - 1;
-		duk_push_tval(ctx, &act->tv_func);
-		duk_get_prop_string(ctx, -1, "fileName");
-		duk__debug_write_hstring_safe_top(thr);
-		act = thr->callstack + thr->callstack_top - 1;
-		pc = duk_hthread_get_act_prev_pc(thr, act);
-		duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_pc2line_query(ctx, -2, pc));
+		if (thr->callstack_top > 0) {
+			act = thr->callstack + thr->callstack_top - 1;
+			duk_push_tval(ctx, &act->tv_func);
+			duk_get_prop_string(ctx, -1, "fileName");
+			duk__debug_write_hstring_safe_top(thr);
+			act = thr->callstack + thr->callstack_top - 1;
+			pc = duk_hthread_get_act_prev_pc(thr, act);
+			duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_pc2line_query(ctx, -2, pc));
+			duk_pop_2(ctx);
+		} else {
+			/* Can happen if duk_throw() is called on an empty
+			 * callstack.
+			 */
+			duk_debug_write_cstring(thr, "");
+			duk_debug_write_uint(thr, 0);
+		}
 	}
-	duk_pop_2(ctx);  /* shared pop */
 
 	duk_debug_write_eom(thr);
 }


### PR DESCRIPTION
If a Throw notify is sent when the callstack is empty (e.g. C code calls duk_throw() outside of any activation) and the error value tests false for `duk_is_error()`, existing code would try to access a stale activation pointer. Tagged security because memory unsafe behavior results. However, this can only be triggered by C code doing such a throw with debugger support enabled.

Also noted that `duk_debugger_send_throw()` will write to the debug connection regardless of whether a client is connected. This should be relatively harmless because the writes are ignored. But it'd be cleaner if it didn't do that at all. I'll address that in a separate pull.