### PR TITLE
Compatibility fixes for several platforms.

### DIFF
--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -22,7 +22,7 @@
 
 #if defined(DUK_USE_DATE_GET_LOCAL_TZOFFSET)
 /* External provider already defined. */
-#elif defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME)
+#elif defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME_S) || defined(DUK_USE_DATE_TZO_GMTIME)
 #define DUK_USE_DATE_GET_LOCAL_TZOFFSET(d)   duk_bi_date_get_local_tzoffset_gmtime((d))
 #elif defined(DUK_USE_DATE_TZO_WINDOWS)
 #define DUK_USE_DATE_GET_LOCAL_TZOFFSET(d)   duk_bi_date_get_local_tzoffset_windows((d))

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -86,10 +86,15 @@ DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t 
 	ft1.dwLowDateTime = tmp2.LowPart;
 	ft1.dwHighDateTime = tmp2.HighPart;
 	FileTimeToSystemTime((const FILETIME *) &ft1, &st2);
+#if defined(_DURANGO) || defined(_XBOX_ONE)
+	// XboxOne doesn't have 'SystemTimeToTzSpecificLocalTime' API
+	st3 = st2;
+#else
 	if (SystemTimeToTzSpecificLocalTime((LPTIME_ZONE_INFORMATION) NULL, &st2, &st3) == 0) {
 		DUK_D(DUK_DPRINT("SystemTimeToTzSpecificLocalTime() failed, return tzoffset 0"));
 		return 0;
 	}
+#endif
 	duk__convert_systime_to_ularge((const SYSTEMTIME *) &st3, &tmp3);
 
 	/* Positive if local time ahead of UTC. */

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1423,7 +1423,11 @@ DUK_LOCAL void duk__enc_fastint_tval(duk_json_enc_ctx *js_ctx, duk_tval *tv) {
 	 * "long long" type exists.  Could also rely on C99 directly but that
 	 * won't work for older MSVC.
 	 */
+#if defined(__MINGW32__) || defined(__MINGW64__)
+	DUK_SPRINTF((char *) buf, "%I64d", (long long) v);
+#else
 	DUK_SPRINTF((char *) buf, "%lld", (long long) v);
+#endif
 	DUK__EMIT_CSTR(js_ctx, (const char *) buf);
 }
 #endif

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -5663,7 +5663,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_context *ctx,
 			a = (duk_harray *) obj;
 			DUK_DD(DUK_DDPRINT("Object.defineProperty() attribute update for duk_harray .length -> %02lx", (unsigned long) new_flags));
 			DUK_ASSERT_HARRAY_VALID(a);
-			if ((new_flags & DUK_PROPDESC_FLAGS_EC) != (curr.flags & DUK_PROPDESC_FLAGS_EC)) {
+			if ((new_flags & DUK_PROPDESC_FLAGS_EC) != ((duk_small_uint_t)curr.flags & DUK_PROPDESC_FLAGS_EC)) {
 				DUK_D(DUK_DPRINT("Object.defineProperty() attempt to change virtual array .length enumerable or configurable attribute, fail"));
 				goto fail_virtual;
 			}


### PR DESCRIPTION
XboxOne/Durango: Missing SystemTimeToTzSpecificLocalTime API.
MinGW: Doesn't support sprintf with %lld. Requires %I64d.
Compiler warning fixed in duk_hobject_props.c
