### PR TITLE
Use _snprintf() for pre-MSVC 2015 in extras/module-duktape

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2531,6 +2531,9 @@ Planned
 
 * Miscellaneous compiler warning fixes (GH-1358)
 
+* Use _snprintf() prior to MSVC 2015 in extras/module-duktape (GH-1369,
+  GH-1385)
+
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309, GH-1312), integer
   refzero-free-running flag (instead of a flag bit) (GH-1362)

--- a/extras/module-duktape/duk_module_duktape.c
+++ b/extras/module-duktape/duk_module_duktape.c
@@ -5,6 +5,14 @@
 #include "duktape.h"
 #include "duk_module_duktape.h"
 
+/* (v)snprintf() is missing before MSVC 2015.  Note that _(v)snprintf() does
+ * NOT NUL terminate on truncation, but that's OK here.
+ * http://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
+ */
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf _snprintf
+#endif
+
 #if 0  /* Enable manually */
 #define DUK__ASSERT(x) do { \
 		if (!(x)) { \


### PR DESCRIPTION
Fixes #1369.