### PR TITLE
Add the Durango platform.

### DIFF
--- a/config/config-options/DUK_USE_DATE_TZO_WINDOWS_NO_DST.yaml
+++ b/config/config-options/DUK_USE_DATE_TZO_WINDOWS_NO_DST.yaml
@@ -1,0 +1,10 @@
+define: DUK_USE_DATE_TZO_WINDOWS_NO_DST
+introduced: 2.0.1
+default: false
+tags:
+  - date
+  - portability
+description: >
+  Use Win32 API calls to get local time offset at a certain time.
+  Does not take into account daylight savings time.  When enabled,
+  appropriate date/time headers must be included.

--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -22,10 +22,12 @@
 
 #if defined(DUK_USE_DATE_GET_LOCAL_TZOFFSET)
 /* External provider already defined. */
-#elif defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME)
+#elif defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME_S) || defined(DUK_USE_DATE_TZO_GMTIME)
 #define DUK_USE_DATE_GET_LOCAL_TZOFFSET(d)   duk_bi_date_get_local_tzoffset_gmtime((d))
 #elif defined(DUK_USE_DATE_TZO_WINDOWS)
 #define DUK_USE_DATE_GET_LOCAL_TZOFFSET(d)   duk_bi_date_get_local_tzoffset_windows((d))
+#elif defined(DUK_USE_DATE_TZO_WINDOWS_NO_DST)
+#define DUK_USE_DATE_GET_LOCAL_TZOFFSET(d)   duk_bi_date_get_local_tzoffset_windows_no_dst((d))
 #else
 #error no provider for DUK_USE_DATE_GET_LOCAL_TZOFFSET()
 #endif

--- a/config/helper-snippets/DUK_F_DURANGO.h.in
+++ b/config/helper-snippets/DUK_F_DURANGO.h.in
@@ -1,0 +1,4 @@
+/* Durango (Xbox One) */
+#if defined(_DURANGO) || defined(_XBOX_ONE)
+#define DUK_F_DURANGO
+#endif

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -28,6 +28,10 @@ autodetect:
     check: DUK_F_AMIGAOS
     include: platform_amigaos.h.in
   -
+    name: Durango
+    check: DUK_F_DURANGO
+    include: platform_durango.h.in
+  -
     name: Windows
     check: DUK_F_WINDOWS
     include: platform_windows.h.in

--- a/config/platforms/platform_durango.h.in
+++ b/config/platforms/platform_durango.h.in
@@ -1,0 +1,32 @@
+/* Durango = XboxOne
+ * Configuration is nearly identical to Windows, except for
+ * DUK_USE_DATE_TZO_WINDOWS.
+ */
+
+/* Initial fix: disable secure CRT related warnings when compiling Duktape
+ * itself (must be defined before including Windows headers).  Don't define
+ * for user code including duktape.h.
+ */
+#if defined(DUK_COMPILING_DUKTAPE) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+/* MSVC does not have sys/param.h */
+#define DUK_USE_DATE_NOW_WINDOWS
+#define DUK_USE_DATE_TZO_WINDOWS_NO_DST
+/* Note: PRS and FMT are intentionally left undefined for now.  This means
+ * there is no platform specific date parsing/formatting but there is still
+ * the ISO 8601 standard format.
+ */
+#if defined(DUK_COMPILING_DUKTAPE)
+/* Only include when compiling Duktape to avoid polluting application build
+ * with a lot of unnecessary defines.
+ */
+#include <windows.h>
+#endif
+
+#define DUK_USE_OS_STRING "durango"
+
+#if !defined(DUK_USE_BYTEORDER)
+#define DUK_USE_BYTEORDER 1
+#endif

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -96,3 +96,39 @@ DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t 
 	return (duk_int_t) (((LONGLONG) tmp3.QuadPart - (LONGLONG) tmp2.QuadPart) / 10000000LL);  /* seconds */
 }
 #endif  /* DUK_USE_DATE_TZO_WINDOWS */
+
+#if defined(DUK_USE_DATE_TZO_WINDOWS_NO_DST)
+DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows_no_dst(duk_double_t d) {
+	SYSTEMTIME st1;
+	SYSTEMTIME st2;
+	SYSTEMTIME st3;
+	ULARGE_INTEGER tmp1;
+	ULARGE_INTEGER tmp2;
+	ULARGE_INTEGER tmp3;
+	FILETIME ft1;
+	FILETIME ft2;
+
+	/* Do the same computation as duk_bi_date_get_local_tzoffset_windows
+	 * but without accounting for daylight savings time. Use this on
+	 * Windows platforms (like Durango) that don't support the
+	 * SystemTimeToTzSpecificLocalTime call.
+	 */
+
+	duk__set_systime_jan1970(&st1);
+	duk__convert_systime_to_ularge((const SYSTEMTIME *) &st1, &tmp1);
+	tmp2.QuadPart = (ULONGLONG) (d * 10000.0);  /* millisec -> 100ns units since jan 1, 1970 */
+	tmp2.QuadPart += tmp1.QuadPart;             /* input 'd' in Windows UTC, 100ns units */
+
+	ft1.dwLowDateTime = tmp2.LowPart;
+	ft1.dwHighDateTime = tmp2.HighPart;
+	FileTimeToSystemTime((const FILETIME *) &ft1, &st2);
+
+	FileTimeToLocalFileTime((const FILETIME *) &ft1, &ft2);
+	FileTimeToSystemTime((const FILETIME *) &ft2, &st3);
+
+	duk__convert_systime_to_ularge((const SYSTEMTIME *) &st3, &tmp3);
+
+	/* Positive if local time ahead of UTC. */
+	return (duk_int_t) (((LONGLONG) tmp3.QuadPart - (LONGLONG) tmp2.QuadPart) / 10000000LL);  /* seconds */
+}
+#endif  /* DUK_USE_DATE_TZO_WINDOWS_NO_DST */

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -37,6 +37,9 @@ DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d
 #if defined(DUK_USE_DATE_TZO_WINDOWS)
 DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t d);
 #endif
+#if defined(DUK_USE_DATE_TZO_WINDOWS_NO_DST)
+DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows_no_dst(duk_double_t d);
+#endif
 #if defined(DUK_USE_DATE_PRS_STRPTIME)
 DUK_INTERNAL_DECL duk_bool_t duk_bi_date_parse_string_strptime(duk_context *ctx, const char *str);
 #endif


### PR DESCRIPTION
The Durango platform is used by the Xbox One.
This platform currently differs from the Windows platform only in that
it does not support the SystemTimeToTzSpecificLocalTime API.