### PR TITLE
Fix duk_error_raw() warning with -Wmissing-prototypes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ CCOPTS_SHARED += -Wall -Wextra -Wunused-result -Wdeclaration-after-statement -Wu
 CCOPTS_SHARED += -Wcast-qual
 CCOPTS_SHARED += -Wshadow
 CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an error
+CCOPTS_SHARED += -Wmissing-prototypes
 # -Wfloat-equal is too picky, there's no apparent way to compare floats
 # (even when you know it's safe) without triggering warnings
 CCOPTS_SHARED += -I./linenoise

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2520,6 +2520,8 @@ Planned
 
 * Fix 'duk' command line bytecode load error (GH-1333, GH-1334)
 
+* Fix duk_error_raw() compile warning with -Wmissing-prototypes (GH-1390)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)
 
 * Portability improvements for Solaris, HPUX, and AIX (GH-1356)

--- a/examples/alloc-hybrid/duk_alloc_hybrid.c
+++ b/examples/alloc-hybrid/duk_alloc_hybrid.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "duk_alloc_hybrid.h"
 
 /* Define to enable some debug printfs. */
 /* #define DUK_ALLOC_HYBRID_DEBUG */

--- a/examples/alloc-logging/duk_alloc_logging.c
+++ b/examples/alloc-logging/duk_alloc_logging.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "duk_alloc_logging.h"
 
 #define  ALLOC_LOG_FILE  "/tmp/duk-alloc-log.txt"
 

--- a/examples/alloc-torture/duk_alloc_torture.c
+++ b/examples/alloc-torture/duk_alloc_torture.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "duk_alloc_torture.h"
 
 #define  RED_ZONE_SIZE  16
 #define  RED_ZONE_BYTE  0x5a

--- a/examples/debug-trans-socket/duk_trans_socket_unix.c
+++ b/examples/debug-trans-socket/duk_trans_socket_unix.c
@@ -19,6 +19,7 @@
 #endif  /* !USE_SELECT */
 #include <errno.h>
 #include "duktape.h"
+#include "duk_trans_socket.h"
 
 #if !defined(DUK_DEBUG_PORT)
 #define DUK_DEBUG_PORT 9091

--- a/examples/debug-trans-socket/duk_trans_socket_windows.c
+++ b/examples/debug-trans-socket/duk_trans_socket_windows.c
@@ -51,6 +51,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "duktape.h"
+#include "duk_trans_socket.h"
 
 #if defined(_MSC_VER)
 #pragma comment (lib, "Ws2_32.lib")

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -302,9 +302,9 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_throw_raw(duk_context *ctx));
 DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_fatal_raw(duk_context *ctx, const char *err_msg));
 #define duk_fatal(ctx,err_msg) \
 	(duk_fatal_raw((ctx), (err_msg)), (duk_ret_t) 0)
+DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
 
 #if defined(DUK_API_VARIADIC_MACROS)
-DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...));
 #define duk_error(ctx,err_code,...)  \
 	(duk_error_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), __VA_ARGS__), (duk_ret_t) 0)
 #define duk_generic_error(ctx,...)  \
@@ -373,6 +373,7 @@ DUK_API_NORETURN(DUK_EXTERNAL_DECL duk_ret_t duk_uri_error_stash(duk_context *ct
 #endif  /* DUK_API_VARIADIC_MACROS */
 
 DUK_API_NORETURN(DUK_EXTERNAL_DECL void duk_error_va_raw(duk_context *ctx, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, va_list ap));
+
 #define duk_error_va(ctx,err_code,fmt,ap)  \
 	(duk_error_va_raw((ctx), (duk_errcode_t) (err_code), (const char *) (DUK_FILE_MACRO), (duk_int_t) (DUK_LINE_MACRO), (fmt), (ap)), (duk_ret_t) 0)
 #define duk_generic_error_va(ctx,fmt,ap)  \


### PR DESCRIPTION
`duk_error_raw()` was defined and called without a prototype when variadic macros were not supported.

Fix by declaring and defining `duk_error_raw()` even when variadic macros are not supported. There's one internal call site which uses duk_error_raw() (even without variadic macros) to allow an error thrown to be omitted from a stack trace.