### PR TITLE
Faster finalizer existence check in GC

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2537,7 +2537,8 @@ Planned
 
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309, GH-1312), integer
-  refzero-free-running flag (instead of a flag bit) (GH-1362)
+  refzero-free-running flag (instead of a flag bit) (GH-1362), faster GC
+  finalizer existence check using DUK_HOBJECT_FLAG_HAVE_FINALIZER (GH-1398)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
   (GH-1357), explicit thr->callstack_curr field for current activation

--- a/doc/bytecode.rst
+++ b/doc/bytecode.rst
@@ -280,6 +280,12 @@ Custom external prototype is lost
 A custom external prototype (``.prototype`` property) is lost, and a
 default empty prototype is created on bytecode load.
 
+Finalizer on the function is lost
+---------------------------------
+
+A finalizer on the function being serialized is lost, no finalizer will
+exist on bytecode load.
+
 Only specific function object properties are kept
 -------------------------------------------------
 

--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -2390,6 +2390,8 @@ The following list describes artificial keys included in Duktape 1.5.0, see
 +---------------------------------+---------------------------+---------------------------------------------------------+
 | ``createargs``                  | ``duk_hobject``           | DUK_HOBJECT_FLAG_CREATEARGS                             |
 +---------------------------------+---------------------------+---------------------------------------------------------+
+| ``have_finalizer``              | ``duk_hobject``           | DUK_HOBJECT_FLAG_HAVE_FINALIZER                         |
++---------------------------------+---------------------------+---------------------------------------------------------+
 | ``exotic_array``                | ``duk_hobject``           | DUK_HOBJECT_FLAG_EXOTIC_ARRAY                           |
 +---------------------------------+---------------------------+---------------------------------------------------------+
 | ``exotic_stringobj``            | ``duk_hobject``           | DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ                       |

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -279,6 +279,7 @@ static duk_uint8_t *duk__dump_func(duk_context *ctx, duk_hcompfunc *func, duk_bu
 	DUK_RAW_WRITE_U32_BE(p, 0);
 #endif
 	tmp32 = DUK_HEAPHDR_GET_FLAGS((duk_heaphdr *) func);  /* masks flags, only duk_hobject flags */
+	tmp32 &= ~(DUK_HOBJECT_FLAG_HAVE_FINALIZER);  /* finalizer flag is lost */
 	DUK_RAW_WRITE_U32_BE(p, tmp32);
 
 	/* Bytecode instructions: endian conversion needed unless

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -49,15 +49,16 @@ DUK_INTERNAL duk_ret_t duk_bi_duktape_object_fin(duk_context *ctx) {
 		 * undefined; this does not remove the property at the moment.
 		 * The value could be type checked to be either a function
 		 * or something else; if something else, the property could
-		 * be deleted.
+		 * be deleted.  Must use duk_set_finalizer() to keep
+		 * DUK_HOBJECT_FLAG_HAVE_FINALIZER in sync.
 		 */
 		duk_set_top(ctx, 2);
-		(void) duk_put_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_FINALIZER);
+		duk_set_finalizer(ctx, 0);
 		return 0;
 	} else {
 		/* Get. */
 		DUK_ASSERT(duk_get_top(ctx) == 1);
-		duk_get_prop_stridx_short(ctx, 0, DUK_STRIDX_INT_FINALIZER);
+		duk_get_finalizer(ctx, 0);
 		return 1;
 	}
 }

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1916,6 +1916,7 @@ DUK_LOCAL const char * const duk__debug_getinfo_hobject_keys[] = {
 	"newenv",
 	"namebinding",
 	"createargs",
+	"have_finalizer"
 	"exotic_array",
 	"exotic_stringobj",
 	"exotic_arguments",
@@ -1937,6 +1938,7 @@ DUK_LOCAL duk_uint_t duk__debug_getinfo_hobject_masks[] = {
 	DUK_HOBJECT_FLAG_NEWENV,
 	DUK_HOBJECT_FLAG_NAMEBINDING,
 	DUK_HOBJECT_FLAG_CREATEARGS,
+	DUK_HOBJECT_FLAG_HAVE_FINALIZER,
 	DUK_HOBJECT_FLAG_EXOTIC_ARRAY,
 	DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ,
 	DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS,

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -212,7 +212,7 @@ DUK_LOCAL void duk__free_run_finalizers(duk_heap *heap) {
 				DUK_ASSERT(thr != NULL);
 				DUK_ASSERT(curr != NULL);
 
-				if (duk_hobject_hasprop_raw(thr, (duk_hobject *) curr, DUK_HTHREAD_STRING_INT_FINALIZER(thr))) {
+				if (duk_hobject_has_finalizer_fast(thr, (duk_hobject *) curr)) {
 					if (!DUK_HEAPHDR_HAS_FINALIZED((duk_heaphdr *) curr)) {
 						DUK_ASSERT(DUK_HEAP_HAS_FINALIZER_NORESCUE(heap));  /* maps to finalizer 2nd argument */
 						duk_hobject_run_finalizer(thr, (duk_hobject *) curr);

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -293,16 +293,15 @@ DUK_LOCAL void duk__mark_finalizable(duk_heap *heap) {
 	hdr = heap->heap_allocated;
 	while (hdr) {
 		/* A finalizer is looked up from the object and up its prototype chain
-		 * (which allows inherited finalizers).  A prototype loop must not cause
-		 * an error to be thrown here; duk_hobject_hasprop_raw() will ignore a
-		 * prototype loop silently and indicate that the property doesn't exist.
+		 * (which allows inherited finalizers).  The finalizer is checked for
+		 * using a duk_hobject flag which is kept in sync with the presence and
+		 * callability of a _Finalizer hidden symbol.
 		 */
 
 		if (!DUK_HEAPHDR_HAS_REACHABLE(hdr) &&
 		    DUK_HEAPHDR_GET_TYPE(hdr) == DUK_HTYPE_OBJECT &&
 		    !DUK_HEAPHDR_HAS_FINALIZED(hdr) &&
-		    duk_hobject_hasprop_raw(thr, (duk_hobject *) hdr, DUK_HTHREAD_STRING_INT_FINALIZER(thr))) {
-
+		    duk_hobject_has_finalizer_fast(thr, (duk_hobject *) hdr)) {
 			/* heaphdr:
 			 *  - is not reachable
 			 *  - is an object

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -356,11 +356,12 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 		 *  finalizer again here.
 		 *
 		 *  A finalizer is looked up from the object and up its prototype chain
-		 *  (which allows inherited finalizers).
+		 *  (which allows inherited finalizers), but using a duk_hobject flag
+		 *  to avoid actual property table lookups.
 		 */
 
 #if defined(DUK_USE_FINALIZER_SUPPORT)
-		if (DUK_UNLIKELY(duk_hobject_hasprop_raw(thr, obj, DUK_HTHREAD_STRING_INT_FINALIZER(thr)))) {
+		if (DUK_UNLIKELY(duk_hobject_has_finalizer_fast(thr, obj))) {
 			DUK_DDD(DUK_DDDPRINT("object has a finalizer, run it"));
 
 			DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h1) == 0);

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -52,7 +52,7 @@
 #define DUK_HOBJECT_FLAG_NEWENV                DUK_HEAPHDR_USER_FLAG(11)  /* function: create new environment when called (see duk_hcompfunc) */
 #define DUK_HOBJECT_FLAG_NAMEBINDING           DUK_HEAPHDR_USER_FLAG(12)  /* function: create binding for func name (function templates only, used for named function expressions) */
 #define DUK_HOBJECT_FLAG_CREATEARGS            DUK_HEAPHDR_USER_FLAG(13)  /* function: create an arguments object on function call */
-#define DUK_HOBJECT_FLAG_ENVRECCLOSED          /* 14: unused */
+#define DUK_HOBJECT_FLAG_HAVE_FINALIZER        DUK_HEAPHDR_USER_FLAG(14)  /* object has a callable finalizer property */
 #define DUK_HOBJECT_FLAG_EXOTIC_ARRAY          DUK_HEAPHDR_USER_FLAG(15)  /* 'Array' object, array length and index exotic behavior */
 #define DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ      DUK_HEAPHDR_USER_FLAG(16)  /* 'String' object, array index exotic behavior */
 #define DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS      DUK_HEAPHDR_USER_FLAG(17)  /* 'Arguments' object and has arguments exotic behavior (non-strict callee) */
@@ -211,6 +211,7 @@
 #define DUK_HOBJECT_HAS_NEWENV(h)              DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NEWENV)
 #define DUK_HOBJECT_HAS_NAMEBINDING(h)         DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NAMEBINDING)
 #define DUK_HOBJECT_HAS_CREATEARGS(h)          DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_CREATEARGS)
+#define DUK_HOBJECT_HAS_HAVE_FINALIZER(h)      DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_HAVE_FINALIZER)
 #define DUK_HOBJECT_HAS_EXOTIC_ARRAY(h)        DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARRAY)
 #define DUK_HOBJECT_HAS_EXOTIC_STRINGOBJ(h)    DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ)
 #define DUK_HOBJECT_HAS_EXOTIC_ARGUMENTS(h)    DUK_HEAPHDR_CHECK_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS)
@@ -230,6 +231,7 @@
 #define DUK_HOBJECT_SET_NEWENV(h)              DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NEWENV)
 #define DUK_HOBJECT_SET_NAMEBINDING(h)         DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NAMEBINDING)
 #define DUK_HOBJECT_SET_CREATEARGS(h)          DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_CREATEARGS)
+#define DUK_HOBJECT_SET_HAVE_FINALIZER(h)      DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_HAVE_FINALIZER)
 #define DUK_HOBJECT_SET_EXOTIC_ARRAY(h)        DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARRAY)
 #define DUK_HOBJECT_SET_EXOTIC_STRINGOBJ(h)    DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ)
 #define DUK_HOBJECT_SET_EXOTIC_ARGUMENTS(h)    DUK_HEAPHDR_SET_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS)
@@ -249,6 +251,7 @@
 #define DUK_HOBJECT_CLEAR_NEWENV(h)            DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NEWENV)
 #define DUK_HOBJECT_CLEAR_NAMEBINDING(h)       DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_NAMEBINDING)
 #define DUK_HOBJECT_CLEAR_CREATEARGS(h)        DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_CREATEARGS)
+#define DUK_HOBJECT_CLEAR_HAVE_FINALIZER(h)    DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_HAVE_FINALIZER)
 #define DUK_HOBJECT_CLEAR_EXOTIC_ARRAY(h)      DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARRAY)
 #define DUK_HOBJECT_CLEAR_EXOTIC_STRINGOBJ(h)  DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_STRINGOBJ)
 #define DUK_HOBJECT_CLEAR_EXOTIC_ARGUMENTS(h)  DUK_HEAPHDR_CLEAR_FLAG_BITS(&(h)->hdr, DUK_HOBJECT_FLAG_EXOTIC_ARGUMENTS)
@@ -863,6 +866,7 @@ DUK_INTERNAL_DECL duk_bool_t duk_hobject_hasprop_raw(duk_hthread *thr, duk_hobje
 DUK_INTERNAL_DECL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_small_uint_t flags);
 DUK_INTERNAL_DECL void duk_hobject_define_property_internal_arridx(duk_hthread *thr, duk_hobject *obj, duk_uarridx_t arr_idx, duk_small_uint_t flags);
 DUK_INTERNAL_DECL duk_size_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *obj);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_has_finalizer_fast(duk_hthread *thr, duk_hobject *obj);
 
 /* helpers for defineProperty() and defineProperties() */
 DUK_INTERNAL_DECL

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -495,7 +495,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 		                     (long) num_stack_args, (long) idx_func, duk_get_tval(ctx, idx_func)));
 	} while (--sanity > 0);
 
-	if (sanity == 0) {
+	if (DUK_UNLIKELY(sanity == 0)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_BOUND_CHAIN_LIMIT);
 	}
 

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1080,7 +1080,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 		/* func support for [[HasInstance]] checked in the beginning of the loop */
 	} while (--sanity > 0);
 
-	if (sanity == 0) {
+	if (DUK_UNLIKELY(sanity == 0)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_BOUND_CHAIN_LIMIT);
 	}
 
@@ -1166,7 +1166,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 		val = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, val);
 	} while (--sanity > 0);
 
-	if (sanity == 0) {
+	if (DUK_UNLIKELY(sanity == 0)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
 	}
 	DUK_UNREACHABLE();

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -1059,11 +1059,11 @@ duk_bool_t duk__get_identifier_reference(duk_hthread *thr,
 			goto fail_not_found;
 		}
 
-                if (sanity-- == 0) {
+                if (DUK_UNLIKELY(sanity-- == 0)) {
                         DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
                 }
 		env = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, env);
-	};
+	}
 
 	/*
 	 *  Not found (even in global object)

--- a/tests/api/test-get-set-finalizer.c
+++ b/tests/api/test-get-set-finalizer.c
@@ -26,7 +26,7 @@ after explicit gc
 read finalizer: undefined
 ==> rc=0, result='undefined'
 *** test_set_nonobject (duk_safe_call)
-==> rc=1, result='TypeError: cannot write property '?Finalizer' of 123'
+==> rc=1, result='TypeError: object required, found 123 (stack index -2)'
 *** test_finalizer_loop (duk_safe_call)
 before pop
 after pop


### PR DESCRIPTION
One bottleneck in refzero and mark-and-sweep handling is checking whether an object has an own or inherited _Finalizer property. This check walks the prototype chain and does a property lookup for every object. Because most objects don't have a finalizer, the entire prototype chain is typically walked to confirm there's no inherited finalizer.

Improve this behavior by adding a `DUK_HOBJECT_FLAG_HAVE_FINALIZER` flag to `duk_hobject`. The flag is set/cleared when the internal `_Finalizer` property is changed using `duk_set_finalizer()`. Direct property changes won't update the flag, but that's OK because `_Finalizer` is an internal property with opaque semantics (IOW, application shouldn't change it manually).

The flag allows a fast finalizer check by walking the prototype chain and only checking one flag per object instead of doing an actual property lookup.

- [x] Add `DUK_HOBJECT_FLAG_HAVE_FINALIZER` and `duk_hobject_has_finalizer_fast()`
- [x] Use `duk_hobject_has_finalizer_fast()` in refcount and mark-and-sweep
- [x] Debugger artificial property for "have_finalizer"
- [x] Clear have finalizer flag when bytecode dumping a function
- [x] Testcase changes
- [x] Documentation changes
- [x] Releases entry