### PR TITLE
Add wrap asserts for INCREF

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2536,6 +2536,8 @@ Planned
 * Add DUK_HOT() and DUK_COLD() macros, and use them for a few internal
   functions (GH-1297)
 
+* Add assertion coverage for INCREF refcount wrapping (GH-1400)
+
 * Miscellaneous compiler warning fixes (GH-1358)
 
 * Miscellaneous performance improvements: more likely/unlike attributes and

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -335,6 +335,7 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 		DUK_DD(DUK_DDPRINT("refzero torture enabled, fake finalizer"));
 		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h1) == 0);
 		DUK_HEAPHDR_PREINC_REFCOUNT(h1);  /* bump refcount to prevent refzero during finalizer processing */
+		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h1) != 0);  /* No wrapping; always true because initial refcount was 0. */
 		duk__refcount_run_torture_finalizer(thr, obj);  /* must never longjmp */
 		DUK_HEAPHDR_PREDEC_REFCOUNT(h1);  /* remove artificial bump */
 		DUK_ASSERT_DISABLE(h1->h_refcount >= 0);  /* refcount is unsigned, so always true */
@@ -366,6 +367,7 @@ DUK_INTERNAL void duk_refzero_free_pending(duk_hthread *thr) {
 
 			DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h1) == 0);
 			DUK_HEAPHDR_PREINC_REFCOUNT(h1);  /* bump refcount to prevent refzero during finalizer processing */
+			DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h1) != 0);  /* No wrapping; always true because initial refcount was 0. */
 
 			duk_hobject_run_finalizer(thr, obj);  /* must never longjmp */
 			DUK_ASSERT(DUK_HEAPHDR_HAS_FINALIZED(h1));  /* duk_hobject_run_finalizer() sets */
@@ -619,6 +621,7 @@ DUK_INTERNAL void duk_tval_incref(duk_tval *tv) {
 		DUK_ASSERT(DUK_HEAPHDR_HTYPE_VALID(h));
 		DUK_ASSERT_DISABLE(h->h_refcount >= 0);
 		DUK_HEAPHDR_PREINC_REFCOUNT(h);
+		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(h) != 0);  /* No wrapping. */
 	}
 }
 
@@ -676,6 +679,7 @@ DUK_INTERNAL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv) {
 			return; \
 		} \
 		DUK_HEAPHDR_PREINC_REFCOUNT((duk_heaphdr *) h); \
+		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT((duk_heaphdr *) h) != 0);  /* No wrapping. */ \
 	} while (0)
 #define DUK__DECREF_SHARED() do { \
 		if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h)) { \
@@ -688,6 +692,7 @@ DUK_INTERNAL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv) {
 #else
 #define DUK__INCREF_SHARED() do { \
 		DUK_HEAPHDR_PREINC_REFCOUNT((duk_heaphdr *) h); \
+		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT((duk_heaphdr *) h) != 0);  /* No wrapping. */ \
 	} while (0)
 #define DUK__DECREF_SHARED() do { \
 		if (DUK_HEAPHDR_PREDEC_REFCOUNT((duk_heaphdr *) h) != 0) { \

--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -321,6 +321,7 @@ struct duk_heaphdr_string {
 			DUK_ASSERT(duk__h != NULL); \
 			DUK_ASSERT(DUK_HEAPHDR_HTYPE_VALID(duk__h)); \
 			DUK_HEAPHDR_PREINC_REFCOUNT(duk__h); \
+			DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(duk__h) != 0);  /* No wrapping. */ \
 		} \
 	} while (0)
 #define DUK_TVAL_DECREF_FAST(thr,tv) do { \
@@ -355,6 +356,7 @@ struct duk_heaphdr_string {
 		DUK_ASSERT(DUK_HEAPHDR_HTYPE_VALID(duk__h)); \
 		if (DUK_HEAPHDR_NEEDS_REFCOUNT_UPDATE(duk__h)) { \
 			DUK_HEAPHDR_PREINC_REFCOUNT(duk__h); \
+			DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(duk__h) != 0);  /* No wrapping. */ \
 		} \
 	} while (0)
 #define DUK_HEAPHDR_DECREF_FAST_RAW(thr,h,rzcall,rzcast) do { \


### PR DESCRIPTION
The refcount field must be chosen so that there's never any wrapping, otherwise memory unsafe behavior will happen. For the default configuration a size_t is used for refcount; it's guaranteed not to wrap because there can't be enough references to wrap it, even in the worst case.  For low memory targets it's possible to configure 16-bit refcounts.  This is fine as long as memory pools are small enough to never contain more than 2^16-1 references.

This pull adds refcount wrap asserts: making the refcount field smaller than technically necessary may be fine in many cases, but it's good to have assertion coverage for it.