### PR TITLE
Fix incorrect internal class number of Duktape.Thread.prototype

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2530,6 +2530,10 @@ Planned
 * Fix module-duktape and module-node handling of a module source which has
   a // comment on the last line without a trailing newline (GH-1394, GH-1395)
 
+* Fix incorrect internal class number of Duktape.Thread.prototype; this had a
+  cosmetic effect for Object.prototype.toString.call(Duktape.Thread.prototype)
+  (GH-1402)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)
 
 * Portability improvements for Solaris, HPUX, and AIX (GH-1356)

--- a/tests/ecmascript/test-bi-duktape-thread-prototype-class.js
+++ b/tests/ecmascript/test-bi-duktape-thread-prototype-class.js
@@ -1,0 +1,5 @@
+/*===
+[object Thread]
+===*/
+
+print(Object.prototype.toString.call(Duktape.Thread.prototype));

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1425,7 +1425,6 @@ class_names = [
     'Symbol',
     'ObjEnv',
     'DecEnv',
-    'Buffer',
     'Pointer',
     'Thread'
     # Remaining class names are not currently needed.


### PR DESCRIPTION
The class number was intended to be "Thread" but because of a class number list being out-of-sync in genbuiltins.py, came out as "ArrayBuffer". This has only a cosmetic effect, `Object.prototype.toString.call(Duktape.Thread.prototype)` would print `[object ArrayBuffer]` rather than `[object Thread]`. Present only in 2.0.x, not in 1.x.