### PR TITLE
Fix thread 'resumer' refcounts

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2542,6 +2542,10 @@ Planned
   cosmetic effect for Object.prototype.toString.call(Duktape.Thread.prototype)
   (GH-1402)
 
+* Fix missing INCREF/DECREF for a thread's .resumer field which caused a
+  mismatch between stored and computed refcounts (with assertions); the
+  mismatch doesn't have functional effects however (GH-1407)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)
 
 * Portability improvements for Solaris, HPUX, and AIX (GH-1356)

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1147,7 +1147,9 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 			 *  which we simply ignore.
 			 */
 
+			DUK_ASSERT(resumee->resumer == NULL);
 			resumee->resumer = thr;
+			DUK_HTHREAD_INCREF(thr, thr);
 			resumee->state = DUK_HTHREAD_STATE_RUNNING;
 			thr->state = DUK_HTHREAD_STATE_RESUMED;
 			DUK_HEAP_SWITCH_THREAD(thr->heap, resumee);
@@ -1177,7 +1179,9 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 
 			duk__reconfig_valstack_ecma_return(resumee, act_idx);
 
+			DUK_ASSERT(resumee->resumer == NULL);
 			resumee->resumer = thr;
+			DUK_HTHREAD_INCREF(thr, thr);
 			resumee->state = DUK_HTHREAD_STATE_RUNNING;
 			thr->state = DUK_HTHREAD_STATE_RESUMED;
 			DUK_HEAP_SWITCH_THREAD(thr->heap, resumee);
@@ -1213,7 +1217,9 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 				DUK_ERROR_INTERNAL(thr);
 			}
 
+			DUK_ASSERT(resumee->resumer == NULL);
 			resumee->resumer = thr;
+			DUK_HTHREAD_INCREF(thr, thr);
 			resumee->state = DUK_HTHREAD_STATE_RUNNING;
 			thr->state = DUK_HTHREAD_STATE_RESUMED;
 			DUK_HEAP_SWITCH_THREAD(thr->heap, resumee);
@@ -1270,6 +1276,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 		if (thr->heap->lj.iserror) {
 			thr->state = DUK_HTHREAD_STATE_YIELDED;
 			thr->resumer = NULL;
+			DUK_HTHREAD_DECREF_NORZ(thr, resumer);
 			resumer->state = DUK_HTHREAD_STATE_RUNNING;
 			DUK_HEAP_SWITCH_THREAD(thr->heap, resumer);
 			thr = resumer;
@@ -1285,6 +1292,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 
 			thr->state = DUK_HTHREAD_STATE_YIELDED;
 			thr->resumer = NULL;
+			DUK_HTHREAD_DECREF_NORZ(thr, resumer);
 			resumer->state = DUK_HTHREAD_STATE_RUNNING;
 			DUK_HEAP_SWITCH_THREAD(thr->heap, resumer);
 #if 0
@@ -1402,6 +1410,7 @@ duk_small_uint_t duk__handle_longjmp(duk_hthread *thr,
 		DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_TERMINATED);
 
 		thr->resumer = NULL;
+		DUK_HTHREAD_DECREF_NORZ(thr, resumer);
 		resumer->state = DUK_HTHREAD_STATE_RUNNING;
 		DUK_HEAP_SWITCH_THREAD(thr->heap, resumer);
 		thr = resumer;
@@ -1665,6 +1674,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr,
 	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_TERMINATED);
 
 	thr->resumer = NULL;
+	DUK_HTHREAD_DECREF(thr, resumer);
 	resumer->state = DUK_HTHREAD_STATE_RUNNING;
 	DUK_HEAP_SWITCH_THREAD(thr->heap, resumer);
 #if 0


### PR DESCRIPTION
Add INCREF/DECREF to thr->resumer when resuming and yielding coroutines.

Before this fix mark-and-sweep would consider thr->resumer a strong reference and marked it, but the refcount was not updated.  This caused mark-and-sweep's computed assert refcount to be off compared to the stored refcount.

This doesn't have a functional effect in practice: when a thread is resumed, its refcount remains > 0 for the duration of the resume because a reference exists in the caller's value stack.