### PR TITLE
Avoid harmless GC refcount assert during array abandonment

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2478,6 +2478,9 @@ Planned
   mark-and-sweep and assert for matching refcounts for objects surviving
   the sweep phase (GH-1406)
 
+* Avoid a harmless GC refcount assert when abandoning an object's array part
+  (GH-1408)
+
 * Fix a garbage collection bug where a finalizer triggered by mark-and-sweep
   could cause a recursive entry into mark-and-sweep (leading to memory unsafe
   behavior) if the voluntary GC trigger counter dropped to zero during

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -281,6 +281,8 @@ DUK_INTERNAL_DECL void duk_resolve_nonbound_function(duk_context *ctx);
 
 DUK_INTERNAL_DECL duk_idx_t duk_get_top_require_min(duk_context *ctx, duk_idx_t min_top);
 DUK_INTERNAL_DECL duk_idx_t duk_get_top_index_unsafe(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_pop_n_unsafe(duk_context *ctx, duk_idx_t count);
+DUK_INTERNAL_DECL void duk_pop_n_nodecref_unsafe(duk_context *ctx, duk_idx_t count);
 DUK_INTERNAL_DECL void duk_pop_unsafe(duk_context *ctx);
 
 DUK_INTERNAL_DECL void duk_compact_m1(duk_context *ctx);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4792,13 +4792,13 @@ DUK_EXTERNAL void duk_pop_n(duk_context *ctx, duk_idx_t count) {
 #endif
 
 	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 
 	if (DUK_UNLIKELY(count < 0)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
 		return;
 	}
 
-	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	if (DUK_UNLIKELY((duk_size_t) (thr->valstack_top - thr->valstack_bottom) < (duk_size_t) count)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
 	}
@@ -4836,7 +4836,8 @@ DUK_INTERNAL void duk_pop_n_unsafe(duk_context *ctx, duk_idx_t count) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(count >= 0);
-	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) < (duk_size_t) count);
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) >= (duk_size_t) count);
 
 #if defined(DUK_USE_REFERENCE_COUNTING)
 	tv = thr->valstack_top;
@@ -4870,7 +4871,8 @@ DUK_INTERNAL void duk_pop_n_nodecref_unsafe(duk_context *ctx, duk_idx_t count) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(count >= 0);
-	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) < (duk_size_t) count);
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) >= (duk_size_t) count);
 
 	tv = thr->valstack_top;
 	while (count > 0) {
@@ -4933,8 +4935,9 @@ DUK_INTERNAL void duk_pop_unsafe(duk_context *ctx) {
 	duk_tval *tv;
 
 	DUK_ASSERT_CTX_VALID(ctx);
-	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	DUK_ASSERT(thr->valstack_top != thr->valstack_bottom);
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) >= (duk_size_t) 1);
 
 	tv = --thr->valstack_top;  /* tv points to element just below prev top */
 	DUK_ASSERT(tv >= thr->valstack_bottom);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4803,17 +4803,40 @@ DUK_EXTERNAL void duk_pop_n(duk_context *ctx, duk_idx_t count) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
 	}
 
-	/*
-	 *  Must be very careful here, every DECREF may cause reallocation
-	 *  of our valstack.
-	 */
+#if defined(DUK_USE_REFERENCE_COUNTING)
+	tv = thr->valstack_top;
+	tv_end = tv - count;
+	while (tv != tv_end) {
+		tv--;
+		DUK_ASSERT(tv >= thr->valstack_bottom);
+		DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, tv);
+	}
+	thr->valstack_top = tv;
+	DUK_REFZERO_CHECK_FAST(thr);
+#else
+	tv = thr->valstack_top;
+	while (count > 0) {
+		count--;
+		tv--;
+		DUK_ASSERT(tv >= thr->valstack_bottom);
+		DUK_TVAL_SET_UNDEFINED(tv);
+	}
+	thr->valstack_top = tv;
+#endif
 
-	/* XXX: inlined DECREF macro would be nice here: no NULL check,
-	 * refzero queueing but no refzero algorithm run (= no pointer
-	 * instability), inline code.
-	 */
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+}
 
-	/* XXX: optimize loops */
+DUK_INTERNAL void duk_pop_n_unsafe(duk_context *ctx, duk_idx_t count) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_tval *tv;
+#if defined(DUK_USE_REFERENCE_COUNTING)
+	duk_tval *tv_end;
+#endif
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(count >= 0);
+	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) < (duk_size_t) count);
 
 #if defined(DUK_USE_REFERENCE_COUNTING)
 	tv = thr->valstack_top;
@@ -4838,6 +4861,33 @@ DUK_EXTERNAL void duk_pop_n(duk_context *ctx, duk_idx_t count) {
 
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 }
+
+/* Pop N elements without DECREF (in effect "stealing" the refcounts). */
+#if defined(DUK_USE_REFERENCE_COUNTING)
+DUK_INTERNAL void duk_pop_n_nodecref_unsafe(duk_context *ctx, duk_idx_t count) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_tval *tv;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(count >= 0);
+	DUK_ASSERT((duk_size_t) (thr->valstack_top - thr->valstack_bottom) < (duk_size_t) count);
+
+	tv = thr->valstack_top;
+	while (count > 0) {
+		count--;
+		tv--;
+		DUK_ASSERT(tv >= thr->valstack_bottom);
+		DUK_TVAL_SET_UNDEFINED(tv);
+	}
+	thr->valstack_top = tv;
+
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+}
+#else  /* DUK_USE_REFERENCE_COUNTING */
+DUK_INTERNAL void duk_pop_n_nodecref_unsafe(duk_context *ctx, duk_idx_t count) {
+	duk_pop_n_unsafe(ctx, count);
+}
+#endif  /* DUK_USE_REFERENCE_COUNTING */
 
 /* Popping one element is called so often that when footprint is not an issue,
  * compile a specialized function for it.
@@ -4875,14 +4925,14 @@ DUK_EXTERNAL void duk_pop(duk_context *ctx) {
 #if defined(DUK_USE_PREFER_SIZE)
 DUK_INTERNAL void duk_pop_unsafe(duk_context *ctx) {
 	DUK_ASSERT_CTX_VALID(ctx);
-	duk_pop_n(ctx, 1);
+	duk_pop_n_unsafe(ctx, 1);
 }
 #else
 DUK_INTERNAL void duk_pop_unsafe(duk_context *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv;
-	DUK_ASSERT_CTX_VALID(ctx);
 
+	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	DUK_ASSERT(thr->valstack_top != thr->valstack_bottom);
 
@@ -4893,6 +4943,7 @@ DUK_INTERNAL void duk_pop_unsafe(duk_context *ctx) {
 #else
 	DUK_TVAL_SET_UNDEFINED(tv);
 #endif
+
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 }
 #endif  /* !DUK_USE_PREFER_SIZE */


### PR DESCRIPTION
When abandoning an array part some string refcounts are temporarily (intentionally) out of sync and trigger the new GC refcount asserts. Rework the process so that refcounts remain in sync where GC refcount asserts may happen.