### PR TITLE
Fix duk_tval_decref_norz() missing norz

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2549,6 +2549,10 @@ Planned
   mismatch between stored and computed refcounts (with assertions); the
   mismatch doesn't have functional effects however (GH-1407)
 
+* Fix incorrect duk_tval_decref_norz() handling (called duk_heaphdr_decref()
+  rather than duk_heaphdr_decref_norz()); however, this function is unused
+  unless fast refcount handling is disabled explicitly (GH-1410)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android (GH-1325, GH-1341)
 
 * Portability improvements for Solaris, HPUX, and AIX (GH-1356)

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -671,7 +671,7 @@ DUK_INTERNAL void duk_tval_decref_norz(duk_hthread *thr, duk_tval *tv) {
 		}
 		duk_heaphdr_refzero_norz(thr, h);
 #else
-		duk_heaphdr_decref(thr, h);
+		duk_heaphdr_decref_norz(thr, h);
 #endif
 	}
 }


### PR DESCRIPTION
duk_tval_decref_norz() was calling duk_heaphdr_decref() rather than duk_heaphdr_decref_norz(). This is unused code unless fast refcounts are disabled (they are enabled by default even on low memory targets now), so practical impact is very low.