### PR TITLE
Complain if configure.py is given plain arguments

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2592,6 +2592,10 @@ Planned
   happened during handling of a previous error); this is cleaner but relying
   on value stack space should also be OK (GH-1415)
 
+* Reject plain arguments to configure.py, they were previously ignored which
+  allowed typos like "-DFOO bar" to be accepted silently (here as "-DFOO" and
+  an ignored pain "bar" argument) (GH-1425)
+
 * Fix a garbage collection bug where a finalizer triggered by mark-and-sweep
   could cause a recursive entry into mark-and-sweep (leading to memory unsafe
   behavior) if the voluntary GC trigger counter dropped to zero during

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -255,6 +255,8 @@ def main():
     parser.add_option('--verbose', dest='verbose', action='store_true', default=False, help='Show verbose debug messages')
 
     (opts, args) = parser.parse_args()
+    if len(args) > 0:
+        raise Exception('unexpected arguments: %r' % args)
 
     if opts.obsolete_builtin_metadata is not None:
         raise Exception('--user-builtin-metadata has been removed, use --builtin-file instead')


### PR DESCRIPTION
This avoids some confusing cases; for example, if one gave "-DFOO bar" instead of "-DFOO=bar", the 'bar' part would be a plain argument and get ignored.