### PR TITLE
Allow duk_push_heapptr() for an unreachable but not yet finalized object

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2622,6 +2622,12 @@ Planned
   where an error would be thrown when handling a previously thrown error
   (GH-1427)
 
+* Allow duk_push_heapptr() for a heap object which has become unreachable,
+  has been queued to finalize_list, but hasn't yet been finalized; in this
+  case duk_push_heapptr() cancels the finalization and moves the object back
+  to the main heap_allocated list, in effect automatically rescuing the object
+  without finalizer interaction (GH-1442)
+
 * Use a 32-bit refcount field by default (even on 64-bit systems) which saves
   8 bytes for each heap object and can only wrap if the Duktape heap is
   larger than 64GB; disable DUK_USE_REFCOUNT32 to use size_t for refcounts

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4625,12 +4625,11 @@ DUK_LOCAL void duk__validate_push_heapptr(duk_context *ctx, void *ptr) {
 				DUK_ASSERT(found == 0);  /* Would indicate corrupted lists. */
 				found = 1;
 			} else {
-#if 1
-				DUK_ASSERT(0);
-#else  /* Enable when duk_push_heapptr() allowed for object on finalize_list. */
+				/* Not being finalized but on finalize_list,
+				 * allowed since Duktape 2.1.
+				 */
 				DUK_ASSERT(found == 0);  /* Would indicate corrupted lists. */
 				found = 1;
-#endif
 			}
 		}
 	}
@@ -4712,7 +4711,6 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 
 	DUK_ASSERT_HEAPHDR_VALID((duk_heaphdr *) ptr);
 
-#if 0
 	/* If the argument is on finalize_list it has technically been
 	 * unreachable before duk_push_heapptr() but it's still safe to
 	 * push it.  Starting from Duktape 2.1 allow application code to
@@ -4738,9 +4736,9 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 		curr = (duk_heaphdr *) ptr;
 		DUK_HEAPHDR_CLEAR_FINALIZABLE(curr);
 
-		/* Because FINALIZED is set prior to finalizer call, will be
-		 * set for the object being currently finalized, but not for
-		 * other objects on finalize_list.
+		/* Because FINALIZED is set prior to finalizer call, it will
+		 * be set for the object being currently finalized, but not
+		 * for other objects on finalize_list.
 		 */
 		DUK_HEAPHDR_CLEAR_FINALIZED(curr);
 
@@ -4756,7 +4754,6 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 
 		/* Continue with the rest. */
 	}
-#endif
 
 	switch (DUK_HEAPHDR_GET_TYPE((duk_heaphdr *) ptr)) {
 	case DUK_HTYPE_STRING:

--- a/tests/api/test-push-heapptr-finalize-list.c
+++ b/tests/api/test-push-heapptr-finalize-list.c
@@ -1,0 +1,217 @@
+/*
+ *  Duktape 2.0 and prior required that duk_push_heapptr() argument was fully
+ *  reachable all the way between duk_get_heapptr() and duk_push_heapptr().
+ *  This also meant that if an object became unreachable but its finalizer had
+ *  not yet executed, it was an assertion violation to use duk_push_heapptr()
+ *  for it.  Such a push also caused incorrect, memory unsafe behavior besides
+ *  just assertion errors.
+ *
+ *  Duktape 2.1 allows the duk_push_heapptr() argument to be an object on the
+ *  finalize_list, provided that the finalizer has not yet executed (it's OK
+ *  for the finalizer to be executing, but not finished) without rescue.
+ *
+ *  There are a few separate cases here:
+ *
+ *  - Refzero collection: duk_push_heapptr() within the finalizer for the
+ *    object itself.
+ *
+ *  - Refzero collection: duk_push_heapptr() in a finalizer for another
+ *    object not yet finalized (but on finalize_list).
+ *
+ *  - Mark-and-sweep: duk_push_heapptr() for object being finalized.
+ *
+ *  - Mark-and-sweep: duk_push_heapptr() for another object on finalize_list.
+ */
+
+/*===
+*** test_refcount (duk_safe_call)
+trigger refzero
+fin1 called
+fin2 called
+fin2 rescues ptr3
+refzero done
+fin3 called
+fin1 called
+null writes done
+final top: 0
+==> rc=0, result='undefined'
+*** test_mark_and_sweep (duk_safe_call)
+make unreachable
+call duk_gc()
+fin1 called
+fin2 called
+fin2 rescues ptr3
+duk_gc returned()
+null writes done
+call duk_gc()
+fin3 called
+duk_gc returned()
+final top: 0
+==> rc=0, result='undefined'
+*** test_mark_and_sweep_2 (duk_safe_call)
+make unreachable
+call duk_gc()
+fin_norescue called
+fin_norescue called
+duk_gc returned()
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static void *ptr1 = NULL;
+static void *ptr2 = NULL;
+static void *ptr3 = NULL;
+
+static duk_ret_t fin1(duk_context *ctx) {
+	printf("fin1 called\n");
+
+	duk_push_heapptr(ctx, ptr1);
+	duk_put_global_string(ctx, "rescue1");
+
+	ptr1 = NULL;
+	return 0;
+}
+
+static duk_ret_t fin2(duk_context *ctx) {
+	printf("fin2 called\n");
+
+	if (ptr3 != NULL) {
+		printf("fin2 rescues ptr3\n");
+
+		duk_push_heapptr(ctx, ptr3);
+		duk_put_global_string(ctx, "rescue3");
+	}
+
+	ptr2 = NULL;
+	return 0;
+}
+
+static duk_ret_t fin3(duk_context *ctx) {
+	printf("fin3 called\n");
+
+	if (ptr2 != NULL) {
+		printf("fin3 rescues ptr2\n");
+
+		duk_push_heapptr(ctx, ptr2);
+		duk_put_global_string(ctx, "rescue2");
+	}
+
+	ptr3 = NULL;
+	return 0;
+}
+
+static duk_ret_t fin_norescue(duk_context *ctx) {
+	printf("fin_norescue called\n");
+
+	duk_del_prop_string(ctx, 0, "ref");
+	return 0;
+}
+
+static duk_ret_t test_refcount(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Refcount case:
+	 *   - Object 1 rescues itself.
+	 *   - Object 2 rescues object 3 or vice versa.  This depends on
+	 *     the finalization order which is not guaranteed, so the test
+	 *     is a bit fragile for this part.
+	 */
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, fin1, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr1 = duk_get_heapptr(ctx, -1);
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, fin2, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr2 = duk_get_heapptr(ctx, -1);
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, fin3, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr3 = duk_get_heapptr(ctx, -1);
+
+	printf("trigger refzero\n");
+	duk_set_top(ctx, 0);  /* REFZERO for all objects at the same time. */
+	printf("refzero done\n");
+
+	duk_eval_string_noresult(ctx, "rescue1 = rescue2 = rescue3 = null;");
+
+	printf("null writes done\n");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_mark_and_sweep(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_eval_string(ctx, "(function () { var obj = {}; obj.ref = {}; obj.ref.ref = obj; return obj; })()");
+	duk_push_c_function(ctx, fin1, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr1 = duk_get_heapptr(ctx, -1);
+
+	duk_eval_string(ctx, "(function () { var obj = {}; obj.ref = {}; obj.ref.ref = obj; return obj; })()");
+	duk_push_c_function(ctx, fin2, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr2 = duk_get_heapptr(ctx, -1);
+
+	duk_eval_string(ctx, "(function () { var obj = {}; obj.ref = {}; obj.ref.ref = obj; return obj; })()");
+	duk_push_c_function(ctx, fin3, 1);
+	duk_set_finalizer(ctx, -2);
+	ptr3 = duk_get_heapptr(ctx, -1);
+
+	printf("make unreachable\n");
+	duk_set_top(ctx, 0);  /* Now unreachable. */
+	printf("call duk_gc()\n");
+	duk_gc(ctx, 0);
+	printf("duk_gc returned()\n");
+
+	duk_eval_string_noresult(ctx, "rescue1 = rescue2 = rescue3 = null;");
+
+	printf("null writes done\n");
+
+	printf("call duk_gc()\n");
+	duk_gc(ctx, 0);
+	printf("duk_gc returned()\n");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_mark_and_sweep_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Mark-and-sweep case: two objects with finalizers point to each
+	 * other using '.ref'.  When an object is finalized, the other
+	 * object gets refzero'ed.
+	 */
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, fin_norescue, 1);
+	duk_set_finalizer(ctx, -2);
+
+	duk_push_object(ctx);
+	duk_push_c_function(ctx, fin_norescue, 1);
+	duk_set_finalizer(ctx, -2);
+
+	duk_dup(ctx, 1);
+	duk_put_prop_string(ctx, 0, "ref");
+	duk_dup(ctx, 0);
+	duk_put_prop_string(ctx, 1, "ref");
+
+	printf("make unreachable\n");
+	duk_set_top(ctx, 0);  /* Now unreachable. */
+	printf("call duk_gc()\n");
+	duk_gc(ctx, 0);
+	printf("duk_gc returned()\n");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_refcount);
+	TEST_SAFE_CALL(test_mark_and_sweep);
+	TEST_SAFE_CALL(test_mark_and_sweep_2);
+}

--- a/website/api/duk_push_heapptr.yaml
+++ b/website/api/duk_push_heapptr.yaml
@@ -4,32 +4,52 @@ proto: |
   duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr);
 
 stack: |
-  [ ... ] -> [ ... obj! ]
+  [ ... ] -> [ ... obj! ]  (if ptr != NULL)
+  [ ... ] -> [ ... undefined! ]  (if ptr == NULL)
 
 summary: |
-  <p>Push a Duktape heap allocated object into the value stack based on a borrowed
-  void pointer reference.
-  The argument <code>ptr</code> must be obtained using
-  <code><a href="#duk_get_heapptr">duk_get_heapptr()</a></code> (or its variants)
-  and must have been reachable for Duktape garbage collection up to this call.
-  If <code>ptr</code> is <code>NULL</code>, <code>undefined</code> is pushed.</p>
+  <p>Push a Duktape heap object into the value stack using a borrowed pointer
+  reference from <code><a href="#duk_get_heapptr">duk_get_heapptr()</a></code>
+  or its variants.  If <code>ptr</code> is <code>NULL</code>,
+  <code>undefined</code> is pushed.</p>
+
+  <p>The caller is responsible for ensuring that the argument <code>ptr</code>
+  is still valid (not freed by Duktape garbage collection) when it is pushed.
+  There are two basic ways to ensure this:</p>
+  <ul>
+  <li><b>Strong backing reference:</b> ensure that the related heap object is
+      always reachable for Duktape garbage collection between duk_get_heapptr()
+      and duk_push_heapptr().  For example, ensure that the related object has
+      been written to a stash while the borrowed void pointer is being used.
+      In essence, the application is holding a borrowed reference which is
+      backed by a strongly referenced value.  This was the only supported
+      approach before Duktape 2.1.</li>
+  <li><b>Weak reference + finalizer</b>: add a (preferably native) finalizer
+      for the related heap object and stop using the void pointer at the latest
+      when the finalizer is called (assuming the object is not rescued by the
+      finalizer).  Starting from Duktape 2.1 duk_push_heapptr() is allowed for
+      unreachable objects pending finalization, all the way up to the actual
+      finalizer call; the object will be rescued and the finalizer call
+      automatically cancelled.  This approach allows an application to hold
+      weak references to the related objects.  However, see limitations below.</li>
+  </ul>
 
   <div class="note">
-  It's not safe to rely on finalizer calls to indicate that an object has become
-  unreachable.  When an object becomes unreachable, it is queued to be finalized,
-  and it takes some time before the finalization happens.  In this state it's no
-  longer safe to call duk_push_heapptr() for the object waiting for finalization.
-  The application must ensure on its own that the object is reachable all the way
-  between duk_get_heapptr() and duk_push_heapptr().
+  Finalizer calls may silently fail e.g. due to out-of-memory.  When relying on
+  finalizer calls to indicate an end of pointer validity, a missed finalizer
+  call may cause a dangling pointer to be given to duk_push_heapptr().
+  There's currently no workaround for this situation, so if out-of-memory
+  conditions are to be expected, the finalizer-based approach may not work
+  reliably.  Future work is to ensure that an object is not freed without
+  at least a successful entry into a native finalizer function, see
+  <a href="https://github.com/svaarala/duktape/issues/1456">https://github.com/svaarala/duktape/issues/1456</a>.
   </div>
 
 example: |
   void *ptr;
   duk_idx_t idx;
 
-  /* 'ptr' originally obtained using duk_get_heapptr() earlier, with the original
-   * value reachable by Duktape GC all the way to here:
-   */
+  /* 'ptr' originally obtained using duk_get_heapptr() earlier: */
 
   idx = duk_push_heapptr(ctx, ptr);
 


### PR DESCRIPTION
Up to Duktape 2.0 the API contract for duk_push_heapptr() is strict:
- The argument must be strongly referenced (= reachable for Duktape, refcount > 0) all the way between duk_get_heapptr() and duk_push_heapptr().

In particular, calling duk_push_heapptr() for an object in its finalizer is not allowed, and causes both assertion errors and actual memory safety issues.

There are quite common application use cases where this is limiting, and it would be very useful to allow duk_push_heapptr() to rescue an object in a finalizer call -- i.e. when the object has become unreachable, but has not yet been finalized and freed. In essence the application uses a finalizer to rescue a weakly referenced object.

This pull allows that use case:
- [x] Requires #1427; prototype code is already in that pull but commented out
- [x] Update duk_push_heapptr() asserts
- [x] Detect an object on finalize_list based on FINALIZABLE flag and "auto rescue" it in duk_push_heapptr()
- [x] Issue for finalizer call guarantees (e.g. keep object on finalize_list until we can successfully call it) #1456
- [x] Test coverage
- [x] Documentation changes
- [x] Revise API documentation changes for better clarity
- [x] Releases entry

This use case may still not work 100% correctly in out-of-memory situations, e.g. if a finalizer call fails due to out-of-memory. Guaranteeing that native finalizer calls are always possible would fix the issue. That could be achieved by ensuring there's always enough value stack and call stack spare to call a finalizer. A finalizer call could work with a smaller spare than an ordinary function. But, this should be covered in a follow-up.