### PR TITLE
Better default for MinGW setjmp/longjmp

### DIFF
--- a/config/platforms/platform_cygwin.h.in
+++ b/config/platforms/platform_cygwin.h.in
@@ -8,6 +8,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+/*FIXME*/
+
 #define DUK_JMPBUF_TYPE       jmp_buf
 #define DUK_SETJMP(jb)        _setjmp((jb))
 #define DUK_LONGJMP(jb)       _longjmp((jb), 1)


### PR DESCRIPTION
Proposal from IRC: https://github.com/mamod/JavaScript-Duktape/pull/23/commits/91f0ef29096f19991186a27a268d92521ff7d983.