### PR TITLE
Make duk_catchers a linked list in individual duk_activations

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2813,6 +2813,12 @@ Planned
 
 * TBD
 
+2.2.0 (XXXX-XX-XX)
+------------------
+
+* Internal change: duk_catcher structs are now in a single linked list attached
+  to a duk_activation instead of being a separate thr->catchstack (GH-1449)
+
 3.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -403,9 +403,10 @@ ownership relationships::
            |
            +-->  value stack
            |
-           +-->  call stack
+           +-->  call stack -->  duk_activations (array)
+           |                       |
+           |                       `--> duk_catchers (linked list)
            |
-           +-->  catch stack
            |                          +-------------+
            `-->  resumer -----------> | duk_hthread |
               (another duk_hthread    +-------------+
@@ -461,9 +462,7 @@ thread (if any).  All heap element references ultimately reside in:
 
 * Thread value stack
 
-* Thread call stack
-
-* Thread catch stack
+* Thread call stack (including catchers)
 
 * Thread resumer reference
 
@@ -553,8 +552,8 @@ The current specific heap element types are:
     further references to other heap elements.
 
   + For ``duk_hthread`` the heap header contains references to the
-    value stack, call stack, catch stack, etc, which provide references
-    to other heap elements.
+    value stack, call stack, etc, which provide references to other heap
+    elements.
 
 * ``duk_hbuffer`` (heap type ``DUK_HTYPE_BUFFER``):
 

--- a/doc/side-effects.rst
+++ b/doc/side-effects.rst
@@ -71,10 +71,11 @@ The most extensive type of side effect is arbitrary code execution, caused
 by e.g. a finalizer or a Proxy trap call (and a number of indirect causes).
 The potential side effects are very wide:
 
-* Because a call is made, value, call, and catch stacks may be grown (but
+* Because a call is made, value stacks and call stacks may be grown (but
   not shrunk) and their base pointers may change.  As a result, any duk_tval
-  pointers to the value stack, duk_activation pointers to the call stack, and
-  duk_catcher pointers to the catch stack are (potentially) invalidated.
+  pointers to the value stack and duk_activation pointers to the call stack
+  are (potentially) invalidated.  Since Duktape 2.2 duk_catchers are separately
+  allocated and have a stable pointer.
 
 * An error throw may happen, clobbering heap longjmp state.  This is a
   problem particularly in error handling where we're dealing with a previous
@@ -153,9 +154,9 @@ Other side effects don't happen with current mark-and-sweep implementation.
 For example, the following don't happen (but could, if mark-and-sweep scope
 and side effect lockouts are changed):
 
-* Thread value stack, call stack, and catch stack are never reallocated
-  and all pointers to duk_tvals, duk_activations, and duk_catchers remain
-  valid.  (This could easily change if mark-and-sweep were to "compact"
+* Thread value stack and call stack are never reallocated and all pointers to
+  duk_tvals and duk_activations remain valid; duk_catcher pointers are stable
+  in Duktape 2.2.  (This could easily change if mark-and-sweep were to "compact"
   the stacks in an emergency GC.)
 
 The mark-and-sweep side effects listed above are not fundamental to the

--- a/src-input/duk_api_memory.c
+++ b/src-input/duk_api_memory.c
@@ -41,7 +41,7 @@ DUK_EXTERNAL void duk_free(duk_context *ctx, void *ptr) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	DUK_FREE(thr->heap, ptr);
+	DUK_FREE_CHECKED(thr, ptr);
 }
 
 DUK_EXTERNAL void *duk_realloc(duk_context *ctx, void *ptr, duk_size_t size) {

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -534,21 +534,30 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 #endif
 	} else if (st->internal && DUK_HOBJECT_IS_THREAD(h)) {
 		duk_hthread *t = (duk_hthread *) h;
+		DUK__COMMA(); duk_fb_sprintf(fb, "__ptr_curr_pc:%p", (void *) t->ptr_curr_pc);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__heap:%p", (void *) t->heap);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__strict:%ld", (long) t->strict);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__state:%ld", (long) t->state);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__unused1:%ld", (long) t->unused1);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__unused2:%ld", (long) t->unused2);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_max:%ld", (long) t->valstack_max);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_max:%ld", (long) t->callstack_max);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__catchstack_max:%ld", (long) t->catchstack_max);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack:%p", (void *) t->valstack);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_end:%p/%ld", (void *) t->valstack_end, (long) (t->valstack_end - t->valstack));
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_bottom:%p/%ld", (void *) t->valstack_bottom, (long) (t->valstack_bottom - t->valstack));
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_top:%p/%ld", (void *) t->valstack_top, (long) (t->valstack_top - t->valstack));
-		DUK__COMMA(); duk_fb_sprintf(fb, "__catchstack:%p", (void *) t->catchstack);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__catchstack_size:%ld", (long) t->catchstack_size);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__catchstack_top:%ld", (long) t->catchstack_top);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack:%p", (void *) t->callstack);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_curr:%p", (void *) t->callstack_curr);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_size:%ld", (long) t->callstack_size);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_top:%ld", (long) t->callstack_top);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_preventcount:%ld", (long) t->callstack_preventcount);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__resumer:"); duk__print_hobject(st, (duk_hobject *) t->resumer);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__compile_ctx:%p", (void *) t->compile_ctx);
+#if defined(DUK_USE_INTERRUPT_COUNTER)
+		DUK__COMMA(); duk_fb_sprintf(fb, "__interrupt_counter:%ld", (long) t->interrupt_counter);
+		DUK__COMMA(); duk_fb_sprintf(fb, "__interrupt_init:%ld", (long) t->interrupt_init);
+#endif
+
 		/* XXX: print built-ins array? */
 
 	}

--- a/src-input/duk_error_misc.c
+++ b/src-input/duk_error_misc.c
@@ -12,22 +12,25 @@
 #if defined(DUK_USE_DEBUGGER_SUPPORT) && \
     (defined(DUK_USE_DEBUGGER_THROW_NOTIFY) || defined(DUK_USE_DEBUGGER_PAUSE_UNCAUGHT))
 DUK_LOCAL duk_bool_t duk__have_active_catcher(duk_hthread *thr) {
-	/*
-	 * XXX: As noted above, a protected API call won't be counted as a
-	 * catcher. This is usually convenient, e.g. in the case of a top-
-	 * level duk_pcall(), but may not always be desirable. Perhaps add an
-	 * argument to treat them as catchers?
+	/* As noted above, a protected API call won't be counted as a
+	 * catcher.  This is usually convenient, e.g. in the case of a top-
+	 * level duk_pcall(), but may not always be desirable.  Perhaps add
+	 * an argument to treat them as catchers?
 	 */
 
 	duk_size_t i;
+	duk_activation *act;
+	duk_catcher *cat;
 
 	DUK_ASSERT(thr != NULL);
 
 	while (thr != NULL) {
-		for (i = 0; i < thr->catchstack_top; i++) {
-			duk_catcher *cat = thr->catchstack + i;
-			if (DUK_CAT_HAS_CATCH_ENABLED(cat)) {
-				return 1;  /* all we need to know */
+		for (i = 0; i < thr->callstack_top; i++) {
+			act = thr->callstack + i;
+			for (cat = act->cat; cat != NULL; cat = cat->parent) {
+				if (DUK_CAT_HAS_CATCH_ENABLED(cat)) {
+					return 1;  /* all we need to know */
+				}
 			}
 		}
 		thr = thr->resumer;

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -220,10 +220,14 @@ typedef void *(*duk_mem_getptr)(duk_heap *heap, void *ud);
 
 /*
  *  Checked allocation, relative to a thread
+ *
+ *  DUK_FREE_CHECKED() doesn't actually throw, but accepts a 'thr' argument
+ *  for convenience.
  */
 
 #define DUK_ALLOC_CHECKED(thr,size)                     duk_heap_mem_alloc_checked((thr), (size))
 #define DUK_ALLOC_CHECKED_ZEROED(thr,size)              duk_heap_mem_alloc_checked_zeroed((thr), (size))
+#define DUK_FREE_CHECKED(thr,ptr)                       duk_heap_mem_free((thr)->heap, (ptr))
 
 /*
  *  Memory constants

--- a/src-input/duk_heap_finalize.c
+++ b/src-input/duk_heap_finalize.c
@@ -17,12 +17,11 @@ DUK_LOCAL duk_ret_t duk__fake_global_finalizer(duk_context *ctx) {
 	/* Require a lot of stack to force a value stack grow/shrink. */
 	duk_require_stack(ctx, 100000);
 
-	/* Force a reallocation with pointer change for value, call, and
-	 * catch stacks to maximize side effects.
+	/* Force a reallocation with pointer change for value and call
+	 * stacks to maximize side effects.
 	 */
 	duk_hthread_valstack_torture_realloc((duk_hthread *) ctx);
 	duk_hthread_callstack_torture_realloc((duk_hthread *) ctx);
-	duk_hthread_catchstack_torture_realloc((duk_hthread *) ctx);
 
 	/* Inner function call, error throw. */
 	duk_eval_string_noresult(ctx,
@@ -145,7 +144,6 @@ DUK_INTERNAL void duk_heap_process_finalize_list(duk_heap *heap) {
 	DUK_ASSERT(heap->heap_thread != NULL);
 	DUK_ASSERT(heap->heap_thread->valstack != NULL);
 	DUK_ASSERT(heap->heap_thread->callstack != NULL);
-	DUK_ASSERT(heap->heap_thread->catchstack != NULL);
 #if defined(DUK_USE_REFERENCE_COUNTING)
 	DUK_ASSERT(heap->refzero_list == NULL);
 #endif

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -125,13 +125,11 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
 			duk__mark_heaphdr(heap, (duk_heaphdr *) act->prev_caller);
 #endif
-		}
-
 #if 0  /* nothing now */
-		for (i = 0; i < (duk_uint_fast32_t) t->catchstack_top; i++) {
-			duk_catcher *cat = t->catchstack + i;
-		}
+			for (cat = act->cat; cat != NULL; cat = cat->parent) {
+			}
 #endif
+		}
 
 		duk__mark_heaphdr(heap, (duk_heaphdr *) t->resumer);
 
@@ -749,7 +747,7 @@ DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_int_t flags, duk_size_t *out_
 
 DUK_LOCAL int duk__protected_compact_object(duk_context *ctx, void *udata) {
 	duk_hobject *obj;
-	/* XXX: for threads, compact value stack, call stack, catch stack? */
+	/* XXX: for threads, compact stacks? */
 
 	DUK_UNREF(udata);
 	obj = duk_known_hobject(ctx, -1);
@@ -1018,7 +1016,6 @@ DUK_INTERNAL void duk_heap_mark_and_sweep(duk_heap *heap, duk_small_uint_t flags
 	DUK_ASSERT(heap->heap_thread != NULL);
 	DUK_ASSERT(heap->heap_thread->valstack != NULL);
 	DUK_ASSERT(heap->heap_thread->callstack != NULL);
-	DUK_ASSERT(heap->heap_thread->catchstack != NULL);
 
 	DUK_D(DUK_DPRINT("garbage collect (mark-and-sweep) starting, requested flags: 0x%08lx, effective flags: 0x%08lx",
 	                 (unsigned long) flags, (unsigned long) (flags | heap->ms_base_flags)));

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -174,13 +174,12 @@ DUK_INTERNAL void duk_hobject_refcount_finalize_norz(duk_heap *heap, duk_hobject
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) act->prev_caller);
 #endif
+#if 0  /* nothing now */
+			for (cat = act->cat; cat != NULL; cat = cat->parent) {
+			}
+#endif
 		}
 
-#if 0  /* nothing now */
-		for (i = 0; i < (duk_uint_fast32_t) t->catchstack_top; i++) {
-			duk_catcher *cat = t->catchstack + i;
-		}
-#endif
 
 		for (i = 0; i < DUK_NUM_BUILTINS; i++) {
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) t->builtins[i]);

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -163,7 +163,6 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t
 	res->valstack_top = NULL;
 	res->callstack = NULL;
 	res->callstack_curr = NULL;
-	res->catchstack = NULL;
 	res->resumer = NULL;
 	res->compile_ctx = NULL,
 #if defined(DUK_USE_HEAPPTR16)
@@ -184,7 +183,6 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t
 	res->heap = heap;
 	res->valstack_max = DUK_VALSTACK_DEFAULT_MAX;
 	res->callstack_max = DUK_CALLSTACK_DEFAULT_MAX;
-	res->catchstack_max = DUK_CATCHSTACK_DEFAULT_MAX;
 
 	return res;
 }

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -927,7 +927,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 	 *  All done, switch properties ('p') allocation to new one.
 	 */
 
-	DUK_FREE(thr->heap, DUK_HOBJECT_GET_PROPS(thr->heap, obj));  /* NULL obj->p is OK */
+	DUK_FREE_CHECKED(thr, DUK_HOBJECT_GET_PROPS(thr->heap, obj));  /* NULL obj->p is OK */
 	DUK_HOBJECT_SET_PROPS(thr->heap, obj, new_p);
 	DUK_HOBJECT_SET_ESIZE(obj, new_e_size_adjusted);
 	DUK_HOBJECT_SET_ENEXT(obj, new_e_next);
@@ -970,7 +970,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
  alloc_failed:
 	DUK_D(DUK_DPRINT("object property table resize failed"));
 
-	DUK_FREE(thr->heap, new_p);  /* OK for NULL. */
+	DUK_FREE_CHECKED(thr, new_p);  /* OK for NULL. */
 
 	thr->heap->pf_prevent_count--;
 	thr->heap->ms_base_flags = prev_ms_base_flags;

--- a/src-input/duk_hthread_alloc.c
+++ b/src-input/duk_hthread_alloc.c
@@ -22,7 +22,6 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	DUK_ASSERT(thr->valstack_top == NULL);
 	DUK_ASSERT(thr->callstack == NULL);
 	DUK_ASSERT(thr->callstack_curr == NULL);
-	DUK_ASSERT(thr->catchstack == NULL);
 
 	/* valstack */
 	alloc_size = sizeof(duk_tval) * DUK_VALSTACK_INITIAL_SIZE;
@@ -53,26 +52,14 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	DUK_ASSERT(thr->callstack_top == 0);
 	DUK_ASSERT(thr->callstack_curr == NULL);
 
-	/* catchstack */
-	alloc_size = sizeof(duk_catcher) * DUK_CATCHSTACK_INITIAL_SIZE;
-	thr->catchstack = (duk_catcher *) DUK_ALLOC(heap, alloc_size);
-	if (!thr->catchstack) {
-		goto fail;
-	}
-	DUK_MEMZERO(thr->catchstack, alloc_size);
-	thr->catchstack_size = DUK_CATCHSTACK_INITIAL_SIZE;
-	DUK_ASSERT(thr->catchstack_top == 0);
-
 	return 1;
 
  fail:
 	DUK_FREE(heap, thr->valstack);
 	DUK_FREE(heap, thr->callstack);
-	DUK_FREE(heap, thr->catchstack);
 
 	thr->valstack = NULL;
 	thr->callstack = NULL;
-	thr->catchstack = NULL;
 	return 0;
 }
 
@@ -88,10 +75,4 @@ DUK_INTERNAL void *duk_hthread_get_callstack_ptr(duk_heap *heap, void *ud) {
 	duk_hthread *thr = (duk_hthread *) ud;
 	DUK_UNREF(heap);
 	return (void *) thr->callstack;
-}
-
-DUK_INTERNAL void *duk_hthread_get_catchstack_ptr(duk_heap *heap, void *ud) {
-	duk_hthread *thr = (duk_hthread *) ud;
-	DUK_UNREF(heap);
-	return (void *) thr->catchstack;
 }

--- a/src-input/duk_hthread_misc.c
+++ b/src-input/duk_hthread_misc.c
@@ -7,9 +7,6 @@
 DUK_INTERNAL void duk_hthread_terminate(duk_hthread *thr) {
 	DUK_ASSERT(thr != NULL);
 
-	/* Order of unwinding is important */
-
-	duk_hthread_catchstack_unwind(thr, 0);
 	duk_hthread_callstack_unwind(thr, 0);  /* side effects, possibly errors */
 
 	thr->valstack_bottom = thr->valstack;

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -34,7 +34,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
                                       duk_size_t entry_valstack_bottom_index,
                                       duk_size_t entry_valstack_end,
-                                      duk_size_t entry_catchstack_top,
                                       duk_size_t entry_callstack_top,
                                       duk_int_t entry_call_recursion_depth,
                                       duk_hthread *entry_curr_thread,
@@ -48,14 +47,12 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
-                                           duk_size_t entry_callstack_top,
-                                           duk_size_t entry_catchstack_top);
+                                           duk_size_t entry_callstack_top);
 DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
                                            duk_size_t entry_callstack_top,
-                                           duk_size_t entry_catchstack_top,
                                            duk_jmpbuf *old_jmpbuf_ptr);
 DUK_LOCAL void duk__handle_safe_call_shared(duk_hthread *thr,
                                             duk_idx_t idx_retbase,
@@ -975,7 +972,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	duk_size_t entry_valstack_bottom_index;
 	duk_size_t entry_valstack_end;
 	duk_size_t entry_callstack_top;
-	duk_size_t entry_catchstack_top;
 	duk_int_t entry_call_recursion_depth;
 	duk_hthread *entry_curr_thread;
 	duk_uint_fast8_t entry_thread_state;
@@ -998,7 +994,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	/* XXX: currently NULL allocations are not supported; remove if later allowed */
 	DUK_ASSERT(thr->valstack != NULL);
 	DUK_ASSERT(thr->callstack != NULL);
-	DUK_ASSERT(thr->catchstack != NULL);
 
 	/* Argument validation and func/args offset. */
 	idx_func = duk__get_idx_func(thr, num_stack_args);
@@ -1015,7 +1010,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	entry_valstack_end = thr->valstack_size;
 #endif
 	entry_callstack_top = thr->callstack_top;
-	entry_catchstack_top = thr->catchstack_top;
 	entry_call_recursion_depth = thr->heap->call_recursion_depth;
 	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
 	entry_thread_state = thr->state;
@@ -1024,7 +1018,7 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	DUK_DD(DUK_DDPRINT("duk_handle_call_protected: thr=%p, num_stack_args=%ld, "
 	                   "call_flags=0x%08lx (ignorerec=%ld, constructor=%ld), "
 	                   "valstack_top=%ld, idx_func=%ld, idx_args=%ld, rec_depth=%ld/%ld, "
-	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, entry_catchstack_top=%ld, "
+	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, "
 	                   "entry_call_recursion_depth=%ld, entry_curr_thread=%p, entry_thread_state=%ld",
 	                   (void *) thr,
 	                   (long) num_stack_args,
@@ -1038,7 +1032,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 	                   (long) thr->heap->call_recursion_limit,
 	                   (long) entry_valstack_bottom_index,
 	                   (long) entry_callstack_top,
-	                   (long) entry_catchstack_top,
 	                   (long) entry_call_recursion_depth,
 	                   (void *) entry_curr_thread,
 	                   (long) entry_thread_state));
@@ -1074,7 +1067,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 		duk__handle_call_error(thr,
 		                       entry_valstack_bottom_index,
 		                       entry_valstack_end,
-		                       entry_catchstack_top,
 		                       entry_callstack_top,
 		                       entry_call_recursion_depth,
 		                       entry_curr_thread,
@@ -1100,7 +1092,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 			duk__handle_call_error(thr,
 			                       entry_valstack_bottom_index,
 			                       entry_valstack_end,
-			                       entry_catchstack_top,
 			                       entry_callstack_top,
 			                       entry_call_recursion_depth,
 			                       entry_curr_thread,
@@ -1121,7 +1112,6 @@ DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
 			duk__handle_call_error(thr,
 			                       entry_valstack_bottom_index,
 			                       entry_valstack_end,
-			                       entry_catchstack_top,
 			                       entry_callstack_top,
 			                       entry_call_recursion_depth,
 			                       entry_curr_thread,
@@ -1155,7 +1145,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	duk_size_t entry_valstack_bottom_index;
 	duk_size_t entry_valstack_end;
 	duk_size_t entry_callstack_top;
-	duk_size_t entry_catchstack_top;
 	duk_int_t entry_call_recursion_depth;
 	duk_hthread *entry_curr_thread;
 	duk_uint_fast8_t entry_thread_state;
@@ -1177,7 +1166,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	/* XXX: currently NULL allocations are not supported; remove if later allowed */
 	DUK_ASSERT(thr->valstack != NULL);
 	DUK_ASSERT(thr->callstack != NULL);
-	DUK_ASSERT(thr->catchstack != NULL);
 
 	DUK_DD(DUK_DDPRINT("duk__handle_call_inner: num_stack_args=%ld, call_flags=0x%08lx, top=%ld",
 	                   (long) num_stack_args, (long) call_flags, (long) duk_get_top(ctx)));
@@ -1194,7 +1182,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	entry_valstack_end = thr->valstack_size;
 #endif
 	entry_callstack_top = thr->callstack_top;
-	entry_catchstack_top = thr->catchstack_top;
 	entry_call_recursion_depth = thr->heap->call_recursion_depth;
 	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
 	entry_thread_state = thr->state;
@@ -1209,7 +1196,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	DUK_DD(DUK_DDPRINT("duk__handle_call_inner: thr=%p, num_stack_args=%ld, "
 	                   "call_flags=0x%08lx (ignorerec=%ld, constructor=%ld), "
 	                   "valstack_top=%ld, idx_func=%ld, idx_args=%ld, rec_depth=%ld/%ld, "
-	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, entry_catchstack_top=%ld, "
+	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, "
 	                   "entry_call_recursion_depth=%ld, entry_curr_thread=%p, entry_thread_state=%ld",
 	                   (void *) thr,
 	                   (long) num_stack_args,
@@ -1223,7 +1210,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	                   (long) thr->heap->call_recursion_limit,
 	                   (long) entry_valstack_bottom_index,
 	                   (long) entry_callstack_top,
-	                   (long) entry_catchstack_top,
 	                   (long) entry_call_recursion_depth,
 	                   (void *) entry_curr_thread,
 	                   (long) entry_thread_state));
@@ -1343,6 +1329,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	DUK_ASSERT(thr->valstack_top > thr->valstack_bottom);  /* at least effective 'this' */
 	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));
 
+	act->cat = NULL;
 	act->flags = 0;
 
 	/* For now all calls except Ecma-to-Ecma calls prevent a yield. */
@@ -1568,10 +1555,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 
 		/* Unwind. */
 
-		DUK_ASSERT(thr->catchstack_top >= entry_catchstack_top);  /* may need unwind */
 		DUK_ASSERT(thr->callstack_top == entry_callstack_top + 1);
-		duk_hthread_catchstack_unwind_norz(thr, entry_catchstack_top);
-		duk_hthread_catchstack_shrink_check(thr);
 		duk_hthread_callstack_unwind_norz(thr, entry_callstack_top);  /* XXX: may now fail */
 		duk_hthread_callstack_shrink_check(thr);
 
@@ -1632,7 +1616,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 
 		/* Unwind. */
 
-		DUK_ASSERT(thr->catchstack_top == entry_catchstack_top);  /* no need to unwind */
 		DUK_ASSERT(thr->callstack_top == entry_callstack_top + 1);
 		duk_hthread_callstack_unwind_norz(thr, entry_callstack_top);
 		duk_hthread_callstack_shrink_check(thr);
@@ -1739,7 +1722,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
                                       duk_size_t entry_valstack_bottom_index,
                                       duk_size_t entry_valstack_end,
-                                      duk_size_t entry_catchstack_top,
                                       duk_size_t entry_callstack_top,
                                       duk_int_t entry_call_recursion_depth,
                                       duk_hthread *entry_curr_thread,
@@ -1761,7 +1743,6 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
 	DUK_ASSERT(thr->heap->lj.type == DUK_LJ_TYPE_THROW);
 	DUK_ASSERT_LJSTATE_SET(thr->heap);
 	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
-	DUK_ASSERT(thr->catchstack_top >= entry_catchstack_top);
 
 	/* We don't need to sync back thr->ptr_curr_pc here because
 	 * the bytecode executor always has a setjmp catchpoint which
@@ -1781,8 +1762,6 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
 	 * scopes; this is a sandboxing issue, described in:
 	 * https://github.com/svaarala/duktape/issues/476
 	 */
-	duk_hthread_catchstack_unwind_norz(thr, entry_catchstack_top);
-	duk_hthread_catchstack_shrink_check(thr);
 	duk_hthread_callstack_unwind_norz(thr, entry_callstack_top);
 	duk_hthread_callstack_shrink_check(thr);
 
@@ -1902,7 +1881,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	duk_context *ctx = (duk_context *) thr;
 	duk_size_t entry_valstack_bottom_index;
 	duk_size_t entry_callstack_top;
-	duk_size_t entry_catchstack_top;
 	duk_int_t entry_call_recursion_depth;
 	duk_hthread *entry_curr_thread;
 	duk_uint_fast8_t entry_thread_state;
@@ -1918,7 +1896,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	/* Note: careful with indices like '-x'; if 'x' is zero, it refers to bottom */
 	entry_valstack_bottom_index = (duk_size_t) (thr->valstack_bottom - thr->valstack);
 	entry_callstack_top = thr->callstack_top;
-	entry_catchstack_top = thr->catchstack_top;
 	entry_call_recursion_depth = thr->heap->call_recursion_depth;
 	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
 	entry_thread_state = thr->state;
@@ -1928,7 +1905,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	/* Note: cannot portably debug print a function pointer, hence 'func' not printed! */
 	DUK_DD(DUK_DDPRINT("duk_handle_safe_call: thr=%p, num_stack_args=%ld, num_stack_rets=%ld, "
 	                   "valstack_top=%ld, idx_retbase=%ld, rec_depth=%ld/%ld, "
-	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, entry_catchstack_top=%ld, "
+	                   "entry_valstack_bottom_index=%ld, entry_callstack_top=%ld, "
 	                   "entry_call_recursion_depth=%ld, entry_curr_thread=%p, entry_thread_state=%ld",
 	                   (void *) thr,
 	                   (long) num_stack_args,
@@ -1939,7 +1916,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 	                   (long) thr->heap->call_recursion_limit,
 	                   (long) entry_valstack_bottom_index,
 	                   (long) entry_callstack_top,
-	                   (long) entry_catchstack_top,
 	                   (long) entry_call_recursion_depth,
 	                   (void *) entry_curr_thread,
 	                   (long) entry_thread_state));
@@ -1973,8 +1949,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 		                            idx_retbase,
 		                            num_stack_rets,
 		                            entry_valstack_bottom_index,
-		                            entry_callstack_top,
-		                            entry_catchstack_top);
+		                            entry_callstack_top);
 
 		/* Note: either pointer may be NULL (at entry), so don't assert */
 		thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
@@ -1992,7 +1967,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 		                            num_stack_rets,
 		                            entry_valstack_bottom_index,
 		                            entry_callstack_top,
-		                            entry_catchstack_top,
 		                            old_jmpbuf_ptr);
 
 		retval = DUK_EXEC_ERROR;
@@ -2014,7 +1988,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 			                            num_stack_rets,
 			                            entry_valstack_bottom_index,
 			                            entry_callstack_top,
-			                            entry_catchstack_top,
 			                            old_jmpbuf_ptr);
 			retval = DUK_EXEC_ERROR;
 		}
@@ -2030,7 +2003,6 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 			                            num_stack_rets,
 			                            entry_valstack_bottom_index,
 			                            entry_callstack_top,
-			                            entry_catchstack_top,
 			                            old_jmpbuf_ptr);
 			retval = DUK_EXEC_ERROR;
 		}
@@ -2058,8 +2030,7 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
-                                           duk_size_t entry_callstack_top,
-                                           duk_size_t entry_catchstack_top) {
+                                           duk_size_t entry_callstack_top) {
 	duk_context *ctx;
 	duk_ret_t rc;
 
@@ -2068,7 +2039,6 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_UNREF(entry_valstack_bottom_index);
 	DUK_UNREF(entry_callstack_top);
-	DUK_UNREF(entry_catchstack_top);
 
 	/*
 	 *  Thread state check and book-keeping.
@@ -2136,7 +2106,6 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 
 	/* we're running inside the caller's activation, so no change in call/catch stack or valstack bottom */
 	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
-	DUK_ASSERT(thr->catchstack_top == entry_catchstack_top);
 	DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
 	DUK_ASSERT((duk_size_t) (thr->valstack_bottom - thr->valstack) == entry_valstack_bottom_index);
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
@@ -2151,7 +2120,6 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 		DUK_ERROR_RANGE(thr, "not enough stack values for safe_call rc");
 	}
 
-	DUK_ASSERT(thr->catchstack_top == entry_catchstack_top);  /* no need to unwind */
 	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
 
 	duk__safe_call_adjust_valstack(thr, idx_retbase, num_stack_rets, rc);
@@ -2171,7 +2139,6 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_index,
                                            duk_size_t entry_callstack_top,
-                                           duk_size_t entry_catchstack_top,
                                            duk_jmpbuf *old_jmpbuf_ptr) {
 	duk_context *ctx;
 
@@ -2195,15 +2162,11 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
 	DUK_ASSERT(thr->heap->lj.type == DUK_LJ_TYPE_THROW);
 	DUK_ASSERT_LJSTATE_SET(thr->heap);
 	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
-	DUK_ASSERT(thr->catchstack_top >= entry_catchstack_top);
 
 	/* Note: either pointer may be NULL (at entry), so don't assert. */
 	thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
 
-	DUK_ASSERT(thr->catchstack_top >= entry_catchstack_top);
 	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
-	duk_hthread_catchstack_unwind_norz(thr, entry_catchstack_top);
-	duk_hthread_catchstack_shrink_check(thr);
 	duk_hthread_callstack_unwind_norz(thr, entry_callstack_top);
 	duk_hthread_callstack_shrink_check(thr);
 	thr->valstack_bottom = thr->valstack + entry_valstack_bottom_index;
@@ -2350,7 +2313,6 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 	/* XXX: assume these? */
 	DUK_ASSERT(thr->valstack != NULL);
 	DUK_ASSERT(thr->callstack != NULL);
-	DUK_ASSERT(thr->catchstack != NULL);
 
 	/* no need to handle thread state book-keeping here */
 	DUK_ASSERT((call_flags & DUK_CALL_FLAG_IS_RESUME) != 0 ||
@@ -2365,31 +2327,29 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 	entry_ptr_curr_pc = thr->ptr_curr_pc;
 	duk_hthread_sync_and_null_currpc(thr);
 
-	/* if a tail call:
+	/* If a tail call:
 	 *   - an Ecmascript activation must be on top of the callstack
-	 *   - there cannot be any active catchstack entries
+	 *   - there cannot be any catch stack entries that would catch
+	 *     a return
 	 */
 #if defined(DUK_USE_ASSERTIONS)
 	if (call_flags & DUK_CALL_FLAG_IS_TAILCALL) {
-		duk_size_t our_callstack_index;
-		duk_size_t i;
+		duk_activation *tmp_act;
+		duk_catcher *tmp_cat;
 
 		DUK_ASSERT(thr->callstack_top >= 1);
-		our_callstack_index = thr->callstack_top - 1;
-		DUK_ASSERT_DISABLE(our_callstack_index >= 0);
-		DUK_ASSERT(our_callstack_index < thr->callstack_size);
-		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + our_callstack_index) != NULL);
-		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack + our_callstack_index)));
+		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1) != NULL);
+		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack + thr->callstack_top - 1)));
 
-		/* No entry in the catchstack which would actually catch a
+		/* No entry in the catch stack which would actually catch a
 		 * throw can refer to the callstack entry being reused.
-		 * There *can* be catchstack entries referring to the current
+		 * There *can* be catch stack entries referring to the current
 		 * callstack entry as long as they don't catch (e.g. label sites).
 		 */
 
-		for (i = 0; i < thr->catchstack_top; i++) {
-			DUK_ASSERT(thr->catchstack[i].callstack_index < our_callstack_index ||  /* refer to callstack entries below current */
-			           DUK_CAT_GET_TYPE(thr->catchstack + i) == DUK_CAT_TYPE_LABEL); /* or a non-catching entry */
+		tmp_act = thr->callstack + thr->callstack_top - 1;
+		for (tmp_cat = tmp_act->cat; tmp_cat != NULL; tmp_cat = tmp_cat->parent) {
+			DUK_ASSERT(DUK_CAT_GET_TYPE(tmp_cat) == DUK_CAT_TYPE_LABEL); /* a non-catching entry */
 		}
 	}
 #endif  /* DUK_USE_ASSERTIONS */
@@ -2500,8 +2460,6 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 
 	if (use_tailcall) {
 		duk_tval *tv1, *tv2;
-		duk_size_t cs_index;
-		duk_int_t i_stk;  /* must be signed for loop structure */
 		duk_idx_t i_arg;
 
 		/*
@@ -2510,7 +2468,7 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		 *  Although the callstack entry is reused, we need to explicitly unwind
 		 *  the current activation (or simulate an unwind).  In particular, the
 		 *  current activation must be closed, otherwise something like
-		 *  test-bug-reduce-judofyr.js results.  Also catchstack needs be unwound
+		 *  test-bug-reduce-judofyr.js results.  Also catchers need to be unwound
 		 *  because there may be non-error-catching label entries in valid tail calls.
 		 */
 
@@ -2524,19 +2482,9 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
 		DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
 
-		/* Unwind catchstack entries referring to the callstack entry we're reusing */
-		cs_index = thr->callstack_top - 1;
-		DUK_ASSERT(thr->catchstack_top <= DUK_INT_MAX);  /* catchstack limits */
-		for (i_stk = (duk_int_t) (thr->catchstack_top - 1); i_stk >= 0; i_stk--) {
-			duk_catcher *cat = thr->catchstack + i_stk;
-			if (cat->callstack_index != cs_index) {
-				/* 'i' is the first entry we'll keep */
-				break;
-			}
-		}
-		duk_hthread_catchstack_unwind_norz(thr, i_stk + 1);
-
-		/* Unwind the topmost callstack entry before reusing it */
+		/* Unwind the topmost callstack entry before reusing it.  This
+		 * also unwinds the catchers related to the topmost entry.
+		 */
 		DUK_ASSERT(thr->callstack_top > 0);
 		duk_hthread_callstack_unwind_norz(thr, thr->callstack_top - 1);
 
@@ -2547,6 +2495,7 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		thr->callstack_curr = act;
 
 		/* Start filling in the activation */
+		act->cat = NULL;
 		act->func = func;  /* don't want an intermediate exposed state with func == NULL */
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
 		act->prev_caller = NULL;
@@ -2646,6 +2595,7 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(func));
 		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
 
+		act->cat = NULL;
 		act->flags = (DUK_HOBJECT_HAS_STRICT(func) ?
 		              DUK_ACT_FLAG_STRICT :
 		              0);

--- a/src-input/duk_refcount.h
+++ b/src-input/duk_refcount.h
@@ -661,6 +661,33 @@
 
 #endif  /* DUK_USE_REFERENCE_COUNTING */
 
+/*
+ *  Some convenience macros that don't have optimized implementations now.
+ */
+
+#define DUK_TVAL_SET_TVAL_UPDREF_NORZ(thr,tv_dst,tv_src) do { \
+		duk_hthread *duk__thr = (thr); \
+		duk_tval *duk__dst = (tv_dst); \
+		duk_tval *duk__src = (tv_src); \
+		DUK_UNREF(duk__thr); \
+		DUK_TVAL_DECREF_NORZ(thr, duk__dst); \
+		DUK_TVAL_SET_TVAL(duk__dst, duk__src); \
+		DUK_TVAL_INCREF(thr, duk__dst); \
+	} while (0)
+
+#define DUK_TVAL_SET_U32_UPDREF_NORZ(thr,tv_dst,val) do { \
+		duk_hthread *duk__thr = (thr); \
+		duk_tval *duk__dst = (tv_dst); \
+		duk_uint32_t duk__val = (duk_uint32_t) (val); \
+		DUK_UNREF(duk__thr); \
+		DUK_TVAL_DECREF_NORZ(thr, duk__dst); \
+		DUK_TVAL_SET_U32(duk__dst, duk__val); \
+	} while (0)
+
+/*
+ *  Prototypes
+ */
+
 #if defined(DUK_USE_REFERENCE_COUNTING)
 #if defined(DUK_USE_FINALIZER_SUPPORT)
 DUK_INTERNAL_DECL void duk_refzero_check_slow(duk_hthread *thr);

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -143,7 +143,6 @@
 /* Limits */
 #define DUK_STR_VALSTACK_LIMIT                   "valstack limit"
 #define DUK_STR_CALLSTACK_LIMIT                  "callstack limit"
-#define DUK_STR_CATCHSTACK_LIMIT                 "catchstack limit"
 #define DUK_STR_PROTOTYPE_CHAIN_LIMIT            "prototype chain limit"
 #define DUK_STR_BOUND_CHAIN_LIMIT                "function call bound chain limit"
 #define DUK_STR_C_CALLSTACK_LIMIT                "C call stack depth limit"

--- a/tests/ecmascript/test-dev-cont-catchstack.js
+++ b/tests/ecmascript/test-dev-cont-catchstack.js
@@ -1,15 +1,22 @@
 /*
  *  Test that we can continue after a catchstack limit error.
+ *
+ *  Since Duktape 2.2.0 there isn't an explicit catch stack limit: catchers
+ *  are allocated normally and an out-of-memory may occur when trying to
+ *  allocate a catcher.  This test would now fail with callstack limit and
+ *  is disabled.
  */
 
+// Skipped since Duktape 2.2.0: no explicit catchstack limits.
 /*---
 {
-    "custom": true
+    "custom": true,
+    "skip": true
 }
 ---*/
 
 /*===
-RangeError: catchstack limit
+RangeError: callstack limit
 true
 still here
 ===*/


### PR DESCRIPTION
- [x] Remove the catch stack from duk_hthread
- [x] Store current duk_catcher in each duk_activation, with each duk_catcher pointing to the surrounding catcher or NULL
- [x] Change catcher unwind to happen when call stack entries are unwound
- [x] For now, allocate duk_catchers individually without pooling/caching (future work to keep a small spare, with GC integration)
- [x] Review and finalize changes
- [x] Review code comments referencing catchstack
- [x] Testing and test case fixes
- [x] GC torture+assert run
- [x] Internal documentation
- [x] Releases entry

Footprint improvement varies, on x86 around 0.5kB while on x64 around 1.5kB (minsize).