### PR TITLE
Remove duk_compile() flag translation

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2752,12 +2752,12 @@ Planned
 * Miscellaneous performance improvements: more likely/unlike attributes and
   hot/cold function splits (GH-1308, GH-1309, GH-1312), integer
   refzero-free-running flag (instead of a flag bit) (GH-1362), faster GC
-  finalizer existence check using DUK_HOBJECT_FLAG_HAVE_FINALIZER (GH-1398);
+  finalizer existence check using DUK_HOBJECT_FLAG_HAVE_FINALIZER (GH-1398),
   faster skipping of sub-struct checks in DECREF/mark-and-sweep (GH-1403)
 
 * Miscellaneous footprint improvements: more compact duk_hobject allocation
   (GH-1357), explicit thr->callstack_curr field for current activation
-  (GH-1372)
+  (GH-1372), avoid DUK_COMPILE_xxx flag translation internally (GH-1450)
 
 * Internal change: duk_hstring now has a 'next' heap pointer for string table
   chaining; this affects string allocation sizes which may matter for manually

--- a/src-input/duk_api_compile.c
+++ b/src-input/duk_api_compile.c
@@ -13,7 +13,6 @@ struct duk__compile_raw_args {
 
 /* Eval is just a wrapper now. */
 DUK_EXTERNAL duk_int_t duk_eval_raw(duk_context *ctx, const char *src_buffer, duk_size_t src_length, duk_uint_t flags) {
-	duk_uint_t comp_flags;
 	duk_int_t rc;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -27,9 +26,7 @@ DUK_EXTERNAL duk_int_t duk_eval_raw(duk_context *ctx, const char *src_buffer, du
 
 	/* [ ... source? filename? ] (depends on flags) */
 
-	comp_flags = flags;
-	comp_flags |= DUK_COMPILE_EVAL;
-	rc = duk_compile_raw(ctx, src_buffer, src_length, comp_flags);  /* may be safe, or non-safe depending on flags */
+	rc = duk_compile_raw(ctx, src_buffer, src_length, flags | DUK_COMPILE_EVAL);  /* may be safe, or non-safe depending on flags */
 
 	/* [ ... closure/error ] */
 
@@ -62,7 +59,6 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx, void *udata) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk__compile_raw_args *comp_args;
 	duk_uint_t flags;
-	duk_small_uint_t comp_flags;
 	duk_hcompfunc *h_templ;
 
 	DUK_ASSERT_CTX_VALID(ctx);
@@ -101,25 +97,13 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_context *ctx, void *udata) {
 	}
 	DUK_ASSERT(comp_args->src_buffer != NULL);
 
-	/* XXX: unnecessary translation of flags */
-	comp_flags = 0;
-	if (flags & DUK_COMPILE_EVAL) {
-		comp_flags |= DUK_JS_COMPILE_FLAG_EVAL;
-	}
 	if (flags & DUK_COMPILE_FUNCTION) {
-		comp_flags |= DUK_JS_COMPILE_FLAG_EVAL |
-		              DUK_JS_COMPILE_FLAG_FUNCEXPR;
-	}
-	if (flags & DUK_COMPILE_STRICT) {
-		comp_flags |= DUK_JS_COMPILE_FLAG_STRICT;
-	}
-	if (flags & DUK_COMPILE_SHEBANG) {
-		comp_flags |= DUK_JS_COMPILE_FLAG_SHEBANG;
+		flags |= DUK_COMPILE_EVAL | DUK_COMPILE_FUNCEXPR;
 	}
 
 	/* [ ... source? filename ] */
 
-	duk_js_compile(thr, comp_args->src_buffer, comp_args->src_length, comp_flags);
+	duk_js_compile(thr, comp_args->src_buffer, comp_args->src_length, flags);
 
 	/* [ ... source? func_template ] */
 

--- a/src-input/duk_api_public.h.in
+++ b/src-input/duk_api_public.h.in
@@ -191,12 +191,13 @@ struct duk_time_components {
 #define DUK_COMPILE_EVAL                  (1 << 3)    /* compile eval code (instead of global code) */
 #define DUK_COMPILE_FUNCTION              (1 << 4)    /* compile function code (instead of global code) */
 #define DUK_COMPILE_STRICT                (1 << 5)    /* use strict (outer) context for global, eval, or function code */
-#define DUK_COMPILE_SAFE                  (1 << 6)    /* (internal) catch compilation errors */
-#define DUK_COMPILE_NORESULT              (1 << 7)    /* (internal) omit eval result */
-#define DUK_COMPILE_NOSOURCE              (1 << 8)    /* (internal) no source string on stack */
-#define DUK_COMPILE_STRLEN                (1 << 9)    /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
-#define DUK_COMPILE_NOFILENAME            (1 << 10)   /* (internal) no filename on stack */
-#define DUK_COMPILE_SHEBANG               (1 << 11)   /* allow shebang ('#! ...') comment on first line of source */
+#define DUK_COMPILE_SHEBANG               (1 << 6)    /* allow shebang ('#! ...') comment on first line of source */
+#define DUK_COMPILE_SAFE                  (1 << 7)    /* (internal) catch compilation errors */
+#define DUK_COMPILE_NORESULT              (1 << 8)    /* (internal) omit eval result */
+#define DUK_COMPILE_NOSOURCE              (1 << 9)    /* (internal) no source string on stack */
+#define DUK_COMPILE_STRLEN                (1 << 10)   /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
+#define DUK_COMPILE_NOFILENAME            (1 << 11)   /* (internal) no filename on stack */
+#define DUK_COMPILE_FUNCEXPR              (1 << 12)   /* (internal) source is a function expression (used for Function constructor) */
 
 /* Flags for duk_def_prop() and its variants */
 #define DUK_DEFPROP_WRITABLE              (1 << 0)    /* set writable (effective if DUK_DEFPROP_HAVE_WRITABLE set) */

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -61,7 +61,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 3);
 
 	/* strictness is not inherited, intentional */
-	comp_flags = DUK_JS_COMPILE_FLAG_FUNCEXPR;
+	comp_flags = DUK_COMPILE_FUNCEXPR;
 
 	duk_push_hstring_stridx(ctx, DUK_STRIDX_COMPILE);  /* XXX: copy from caller? */  /* XXX: ignored now */
 	h_sourcecode = duk_require_hstring(ctx, -2);  /* no symbol check needed; -2 is concat'd code */

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -462,7 +462,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 
 	/* [ source ] */
 
-	comp_flags = DUK_JS_COMPILE_FLAG_EVAL;
+	comp_flags = DUK_COMPILE_EVAL;
 	act_eval = thr->callstack_curr;  /* this function */
 	DUK_ASSERT(act_eval != NULL);
 	if (thr->callstack_top >= (duk_size_t) -level) {
@@ -475,7 +475,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 			/* Only direct eval inherits strictness from calling code
 			 * (E5.1 Section 10.1.1).
 			 */
-			comp_flags |= DUK_JS_COMPILE_FLAG_STRICT;
+			comp_flags |= DUK_COMPILE_STRICT;
 		}
 	} else {
 		DUK_ASSERT((act_eval->flags & DUK_ACT_FLAG_DIRECT_EVAL) == 0);

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -7720,9 +7720,9 @@ DUK_LOCAL duk_ret_t duk__js_compile_raw(duk_context *ctx, void *udata) {
 	DUK_ASSERT(lex_pt != NULL);
 
 	flags = comp_stk->flags;
-	is_eval = (flags & DUK_JS_COMPILE_FLAG_EVAL ? 1 : 0);
-	is_strict = (flags & DUK_JS_COMPILE_FLAG_STRICT ? 1 : 0);
-	is_funcexpr = (flags & DUK_JS_COMPILE_FLAG_FUNCEXPR ? 1 : 0);
+	is_eval = (flags & DUK_COMPILE_EVAL ? 1 : 0);
+	is_strict = (flags & DUK_COMPILE_STRICT ? 1 : 0);
+	is_funcexpr = (flags & DUK_COMPILE_FUNCEXPR ? 1 : 0);
 
 	h_filename = duk_get_hstring(ctx, -1);  /* may be undefined */
 

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -222,11 +222,6 @@ struct duk_compiler_ctx {
  *  Prototypes
  */
 
-#define DUK_JS_COMPILE_FLAG_EVAL      (1 << 0)  /* source is eval code (not global) */
-#define DUK_JS_COMPILE_FLAG_STRICT    (1 << 1)  /* strict outer context */
-#define DUK_JS_COMPILE_FLAG_FUNCEXPR  (1 << 2)  /* source is a function expression (used for Function constructor) */
-#define DUK_JS_COMPILE_FLAG_SHEBANG   (1 << 3)  /* allow shebang comment on first line */
-
 DUK_INTERNAL_DECL void duk_js_compile(duk_hthread *thr, const duk_uint8_t *src_buffer, duk_size_t src_length, duk_small_uint_t flags);
 
 #endif  /* DUK_JS_COMPILER_H_INCLUDED */

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -1073,7 +1073,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 #if defined(DUK_USE_SHEBANG_COMMENTS)
 	case DUK_ASC_HASH:  /* '#' */
 		if (DUK__L1() == DUK_ASC_EXCLAMATION && lex_ctx->window[0].offset == 0 &&
-		    (lex_ctx->flags & DUK_JS_COMPILE_FLAG_SHEBANG)) {
+		    (lex_ctx->flags & DUK_COMPILE_SHEBANG)) {
 			/* "Shebang" comment ('#! ...') on first line. */
 			/* DUK__ADVANCECHARS(lex_ctx, 2) would be correct here, but not necessary */
 			duk__lexer_skip_to_endofline(lex_ctx);


### PR DESCRIPTION
Unify the internal and external flags; mark actually internal flags as such in the API header.

- [x] Rebase once #1380 is merged
- [x] Rework compilation flags
- [x] Releases entry