### PR TITLE
Preincrement refcount on finalize_list insert to avoid refzero for pending objects

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2610,7 +2610,7 @@ Planned
 * Rework finalizer handling: finalizer execution is now outside of refzero
   processing and mark-and-sweep; however, mark-and-sweep is still disabled
   while finalizers are being executed to avoid incorrect rescue decisions
-  caused by a partially processed finalize_list (GH-1427)
+  caused by a partially processed finalize_list (GH-1427, GH-1451)
 
 * Improve side effect protections: prevent finalizer execution between an
   error throw point and its catch point; add asserts for catching any cases

--- a/doc/side-effects.rst
+++ b/doc/side-effects.rst
@@ -390,6 +390,10 @@ DECREF
 * When mark-and-sweep is running, DECREF adjusts target refcount but won't
   do anything else.
 
+* All objects on finalize_list have an artificial +1 refcount bump, so that
+  they can never trigger refzero processing (assuming refcounts are correct).
+  This allows refzero code to assume a refzero object is on heap_allocated.
+
 duk__refcount_free_pending()
 
 * As of Duktape 2.1 no side effects, just frees objects without a finalizer

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4747,6 +4747,10 @@ DUK_EXTERNAL duk_idx_t duk_push_heapptr(duk_context *ctx, void *ptr) {
 		/* Dequeue object from finalize_list and queue it back to
 		 * heap_allocated.
 		 */
+#if defined(DUK_USE_REFERENCE_COUNTING)
+		DUK_ASSERT(DUK_HEAPHDR_GET_REFCOUNT(curr) >= 1);  /* Preincremented on finalize_list insert. */
+		DUK_HEAPHDR_PREDEC_REFCOUNT(curr);
+#endif
 		DUK_HEAP_REMOVE_FROM_FINALIZE_LIST(thr->heap, curr);
 		DUK_HEAP_INSERT_INTO_HEAP_ALLOCATED(thr->heap, curr);
 

--- a/tests/ecmascript/test-dev-finalizer-refzero-for-pending.js
+++ b/tests/ecmascript/test-dev-finalizer-refzero-for-pending.js
@@ -1,0 +1,41 @@
+/*
+ *  Two objects in a reference loop on finalize_list, both having finalizers.
+ *  Each finalizer will break the reference to the other object.
+ *
+ *  Assume X's finalizer executes first.  It deletes X.ref, so that Y's refcount
+ *  drops to zero and Y gets refzero processed while still on finalize_list.
+ *  This causes heap list corruption because refzero should only happen for
+ *  objects on heap_allocated.
+ *
+ *  This is avoided by preincrementing refcounts when an object is inserted to
+ *  finalize_list (cf. how mark-and-sweep considers finalize_list objects
+ *  reachability roots).  This ensures that the refcount remains >= 1 at all
+ *  times, and can only drop to zero once the finalizer for the object is
+ *  complete.
+ */
+
+/*===
+gc 1
+lose refs
+gc 2
+fin x
+fin y
+still here
+===*/
+
+var x = {};
+var y = {};
+x.ref = y;
+y.ref = x;
+
+Duktape.fin(x, function (v) { print('fin x'); v.ref = null; });
+Duktape.fin(y, function (v) { print('fin y'); v.ref = null; });
+
+print('gc 1');
+Duktape.gc();
+print('lose refs');
+x = y = null;
+print('gc 2');
+Duktape.gc();
+
+print('still here');


### PR DESCRIPTION
- [x] Repro from https://github.com/svaarala/duktape/pull/1442#issuecomment-290209502
- [x] Preincrement refcounts on finalize_list insert, and decrement after finalizer execution only (refcount is >= 1 until finalizer exits)
- [x] Refcount asserts for finalize_list?
- [x] Check if this is an issue in 1.x => no, there's no early free in 1.x for this case because "mark-and-sweep running" protects against refzero actions (besides refcount update)
- [x] Internal docs re: refcount bump and finalize_list reachability
- [x] Releases entry