### PR TITLE
Add shebang support to module-node

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2555,6 +2555,8 @@ Planned
   source if DUK_COMPILE_SHEBANG option is given to duk_compile() (GH-1380,
   GH-1346)
 
+* Add shebang support to module-node (GH-1452)
+
 * Spawn the ArrayBuffer object backing a typed array lazily when its .buffer
   property is first read, reducing memory usage in common cases where the view
   is constructed directly without needing the ArrayBuffer object (GH-1225)

--- a/extras/module-node/Makefile
+++ b/extras/module-node/Makefile
@@ -16,3 +16,4 @@ test:
 	./test 'var ape = require("ape"); assert(ape.__filename === "ape.js", "__filename");'
 	./test 'var badger = require("badger"); assert(badger.foo === 123 && badger.bar === 234, "exports.foo assignment");'
 	./test 'var comment = require("comment"); assert(comment.foo === 123 && comment.bar === 234, "last line with // comment");'
+	./test 'var shebang = require("shebang"); assert(shebang.foo === 123 && shebang.bar === 234, "shebang");'

--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -204,6 +204,8 @@ static duk_int_t duk__eval_module_source(duk_context *ctx, void *udata) {
 #else
 static duk_int_t duk__eval_module_source(duk_context *ctx) {
 #endif
+	const char *src;
+
 	/*
 	 *  Stack: [ ... module source ]
 	 */
@@ -217,9 +219,11 @@ static duk_int_t duk__eval_module_source(duk_context *ctx) {
 	 * e.g. Node.js.
 	 */
 	duk_push_string(ctx, "(function(exports,require,module,__filename,__dirname){");
-	duk_dup(ctx, -2);  /* source */
+	src = duk_require_string(ctx, -2);
+	duk_push_string(ctx, (src[0] == '#' && src[1] == '!') ? "//" : "");  /* Shebang support. */
+	duk_dup(ctx, -3);  /* source */
 	duk_push_string(ctx, "\n})");  /* Newline allows module last line to contain a // comment. */
-	duk_concat(ctx, 3);
+	duk_concat(ctx, 4);
 
 	/* [ ... module source func_src ] */
 

--- a/extras/module-node/test.c
+++ b/extras/module-node/test.c
@@ -38,6 +38,8 @@ static duk_ret_t cb_load_module(duk_context *ctx) {
 		duk_push_string(ctx, "exports.foo = 123; exports.bar = 234;");
 	} else if (strcmp(module_id, "comment.js") == 0) {
 		duk_push_string(ctx, "exports.foo = 123; exports.bar = 234; // comment");
+	} else if (strcmp(module_id, "shebang.js") == 0) {
+		duk_push_string(ctx, "#!ignored\nexports.foo = 123; exports.bar = 234;");
 	} else {
 		duk_error(ctx, DUK_ERR_TYPE_ERROR, "cannot find module: %s", module_id);
 	}


### PR DESCRIPTION
duk_compile() + DUK_COMPILE_SHEBANG is not enough for modules because there is a module function wrapper which offsets the shebang in the module source when Duktape actually sees it.