### PR TITLE
Fix duk_api_inspect() stale 'tv' pointer

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2730,6 +2730,9 @@ Planned
 * Fix incorrect assert for RETCONSTN opcode when refcounting is disabled,
   actual behavior is correct however (GH-1432, GH-1433)
 
+* Fix potentially stale duk_tval pointer in duk_inspect_value(), also affects
+  Duktape.info() (GH-1453)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android and Atari MiNT
   (GH-1325, GH-1341, GH-1430, GH-1431)
 

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -66,17 +66,18 @@ DUK_EXTERNAL void duk_inspect_value(duk_context *ctx, duk_idx_t idx) {
 
 	DUK_UNREF(thr);
 
-	tv = duk_get_tval_or_unused(ctx, idx);
-	h = (DUK_TVAL_IS_HEAP_ALLOCATED(tv) ? DUK_TVAL_GET_HEAPHDR(tv) : NULL);
-
 	/* Assume two's complement and set everything to -1. */
 	DUK_MEMSET((void *) &vals, (int) 0xff, sizeof(vals));
 	DUK_ASSERT(vals[DUK__IDX_TYPE] == -1);  /* spot check one */
 
-	duk_push_bare_object(ctx);
+	tv = duk_get_tval_or_unused(ctx, idx);
+	h = (DUK_TVAL_IS_HEAP_ALLOCATED(tv) ? DUK_TVAL_GET_HEAPHDR(tv) : NULL);
 
 	vals[DUK__IDX_TYPE] = duk_get_type_tval(tv);
 	vals[DUK__IDX_ITAG] = (duk_uint_t) DUK_TVAL_GET_TAG(tv);
+
+	duk_push_bare_object(ctx);  /* Invalidates 'tv'. */
+	tv = NULL;
 
 	if (h == NULL) {
 		goto finish;


### PR DESCRIPTION
A pointer to the value stack was obtained before duk_push_bare_object() and used after the push.  If value stack resize happens as a side effect of the push (mark-and-sweep, finalizers, etc) the 'tv' pointer could be stale.  Found using torture tests.