### PR TITLE
Allow mark-and-sweep during finalize_list processing

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2608,9 +2608,9 @@ Planned
   for mark-and-sweep to confirm its status (GH-1427)
 
 * Rework finalizer handling: finalizer execution is now outside of refzero
-  processing and mark-and-sweep; however, mark-and-sweep is still disabled
-  while finalizers are being executed to avoid incorrect rescue decisions
-  caused by a partially processed finalize_list (GH-1427, GH-1451)
+  processing and mark-and-sweep, and mark-and-sweep (but not recursive
+  finalizer handling) is allowed during finalizer execution (GH-1427, GH-1451,
+  GH-1457)
 
 * Rework mark-and-sweep: include finalize_list in TEMPROOT marking; with
   duk_push_heapptr() allowed it's possible for application code to create

--- a/doc/objects-in-code-section.rst
+++ b/doc/objects-in-code-section.rst
@@ -59,7 +59,8 @@ duk_heaphdr
   - Mark-and-sweep: cannot mark object reachable, temproot, etc.  Built-in
     strings/objects must not be marked "visited".
 
-  - No finalizer support: cannot mark finalizable, finalized.
+  - No finalizer support: cannot mark finalizable, finalized.  Also no need
+    for finalization because ROM objects don't need to be freed.
 
 * Can't update refcount.
 

--- a/doc/side-effects.rst
+++ b/doc/side-effects.rst
@@ -418,9 +418,12 @@ Mark-and-sweep
 
 * Executes finalizers after mark-and-sweep is complete (unless prevented),
   which has arbitrary code execution side effects.  Finalizer execution
-  happens outside of mark-and-sweep protection, but currently finalizer
-  execution explicitly prevents mark-and-sweep to avoid incorrect rescue/free
-  decisions when the finalize_list is only partially processed.
+  happens outside of mark-and-sweep protection, and may trigger mark-and-sweep.
+  However, when mark-and-sweep runs with finalize_list != NULL, rescue
+  decisions are postponed to avoid incorrect rescue decisions caused by
+  finalize_list being (artificially) treated as a reachability root; in
+  concrete terms, FINALIZED flags are not cleared so they'll be rechecked
+  later.
 
 Error throw
 

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -75,6 +75,12 @@
 /* Voluntary mark-and-sweep: triggered periodically. */
 #define DUK_MS_FLAG_VOLUNTARY                (1 << 1)
 
+/* Postpone rescue decisions for reachable objects with FINALIZED set.
+ * Used during finalize_list processing to avoid incorrect rescue
+ * decisions due to finalize_list being a reachability root.
+ */
+#define DUK_MS_FLAG_POSTPONE_RESCUE          (1 << 2)
+
 /* Don't compact objects; needed during object property table resize
  * to prevent a recursive resize.  It would suffice to protect only the
  * current object being resized, but this is not yet implemented.
@@ -344,9 +350,13 @@ struct duk_heap {
 	duk_heaphdr *refzero_list;
 #endif
 
-	/* Work list for objects to be finalized (by mark-and-sweep). */
 #if defined(DUK_USE_FINALIZER_SUPPORT)
+	/* Work list for objects to be finalized. */
 	duk_heaphdr *finalize_list;
+#if defined(DUK_USE_ASSERTIONS)
+	/* Object whose finalizer is executing right now (no nesting). */
+	duk_heaphdr *currently_finalizing;
+#endif
 #endif
 
 	/* Voluntary mark-and-sweep trigger counter.  Intentionally signed

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -823,6 +823,9 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 #endif
 #if defined(DUK_USE_FINALIZER_SUPPORT)
 	res->finalize_list = NULL;
+#if defined(DUK_USE_ASSERTIONS)
+	res->currently_finalizing = NULL;
+#endif
 #endif
 	res->heap_thread = NULL;
 	res->curr_thread = NULL;

--- a/tests/ecmascript/test-dev-markandsweep-during-finalization.js
+++ b/tests/ecmascript/test-dev-markandsweep-during-finalization.js
@@ -1,0 +1,95 @@
+/*
+ *  In Duktape 2.1 mark-and-sweep can run while we process finalize_list.
+ *
+ *  Exercise the feature by running GC during finalization and seeing that
+ *  finalizer decisions still come out correctly.  In particular, an object
+ *  must not be rescued if it's unreachable except for references coming
+ *  from finalize_list.
+ */
+
+/*===
+gc 1
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+finalizer called
+finalizer exiting
+gc 1 returned
+gc 2
+gc 2 returned
+finCount: 10
+===*/
+
+var finCount = 0;
+
+function fin(o) {
+    finCount++;
+    print('finalizer called');
+    Duktape.gc();
+    Duktape.gc();
+    print('finalizer exiting');
+
+    // Create a lot of collectable circular garbage with explicit GC.
+    // This has no outward effect as such, but can be seen in memory
+    // behavior with massif.  In Duktape 2.1 memory usage will be flat,
+    // in Duktape 2.0 and prior it will increase during finalizer
+    // execution.
+
+    for (var i = 0; i < 1e5; i++) {
+        var obj = { foo: 123 };
+        obj.ref = {};
+        obj.ref.ref = obj;
+
+        obj = null;
+        Duktape.gc();
+    }
+}
+
+function createObjects() {
+    // Create a set of finalizable objects.
+    var arr = [];
+    while (arr.length < 10) {
+        var obj = {};
+        Duktape.fin(obj, fin);
+        arr.push(obj);
+    }
+
+    // Place the objects into a circular reference relation.
+    for (var i = 0; i < arr.length; i++) {
+        arr[i].ref = arr[(i + 1) % arr.length];
+    }
+
+    return arr;
+}
+
+var arr = createObjects();
+Duktape.gc();
+
+// Make the whole set unreachable at the same time.  Because of
+// the circular references, finalization only happens after an
+// explicit GC.
+arr = null;
+
+print('gc 1');
+Duktape.gc();
+print('gc 1 returned');
+print('gc 2');
+Duktape.gc();  // rescue/free
+print('gc 2 returned');
+
+print('finCount:', finCount);

--- a/website/guide/finalization.html
+++ b/website/guide/finalization.html
@@ -78,7 +78,7 @@ finalizer are also silently ignored.</p>
 
 <p>Together these guarantee that a finalizer gets executed at some point
 before a heap is destroyed, which allows native resources (such as sockets
-and files) to be freed reliably.  There are two exceptions to this guarantee,
+and files) to be freed reliably.  There are a few exceptions to this guarantee,
 see below for more discussion:</p>
 <ul>
 <li>Heap destruction finalizer sanity limit may cause a finalizer not to
@@ -86,6 +86,12 @@ see below for more discussion:</p>
 <li>When a script timeout is being propagated out of the current callstack,
     Ecmascript finalizers will immediately rethrow the script timeout error.
     Duktape/C finalizers will execute normally.</li>
+<li>If Duktape runs out of memory (despite emergency GC) when trying to call a
+    finalizer, the call error is silently ignored and the finalizer will be
+    skipped.</li>
+<li>When an object is finalized by mark-and-sweep but becomes unreachable
+    before the next mark-and-sweep round has a change to detect the rescue,
+    the object's finalizer will not be executed.</li>
 </ul>
 
 <p>When the Duktape heap is being destroyed there are a few limitations for


### PR DESCRIPTION
When finalizers are executed from finalize_list, master (and Duktape 2.0 and prior) prevent mark-and-sweep in the middle of the process. The main reason to do so is to avoid incorrect rescue decisions:
- An object X is queued for finalization by mark-and-sweep.
- X gets finalized and is queued back to heap_allocated with FINALIZED set.
- Another finalizer runs while finalize_list is still not empty, and mark-and-sweep is triggered.
- If X is unreachable except for references from the objects still on finalize_list (which are considered reachability roots to prevent collection), mark-and-sweep decides to rescue the object.

This decision is incorrect: had the finalize_list been fully processed, and mark-and-sweep executed afterwards, the object would be freed as unreachable. User code also cannot change the outcome by calling duk_push_heapptr(); even with relaxed rules it's not allowed to call duk_push_heapptr() after the finalizer for that object has been executed *and* the object is no longer reachable.

The harm from an incorrect rescue decision is that FINALIZED gets cleared and the object is thus eligible for another finalization. This may happen multiple times, with the object getting unnecessarily finalized an arbitrary number of times.

This pull allows mark-and-sweep during finalize_list processing with a small tweak:
- When mark-and-sweep starts with heap->finalize_list != NULL, an automatic flag "don't rescue objects" is set.
- When a rescue decision is about to be made, the object is queued to heap_allocated (as if rescued); however, FINALIZED is kept. So the object remains in the "pending rescue/free decision" state until next mark-and-sweep.

Tasks:
- [x] Rebase once #1442 is merged
- [x] Mark-and-sweep and finalizer processing basic changes
- [x] Fix mark-and-sweep assertions: FINALIZED is no longer set for an object currently being finalized (detect the specific object with an assert-only heap field)
- [x] Test coverage for mark-and-sweep running while finalizers processed
- [x] Test coverage for an object that would get incorrectly rescued without the tweak
- [x] Internal documentation changes
- [x] External documentation changes
- [x] Document mark-and-sweep rescue limitation in Finalization page
- [x] Releases entry