### PR TITLE
Fix Symbol object .valueOf() which returned Symbol object instead of plain Symbol

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2744,6 +2744,9 @@ Planned
 * Fix potentially stale duk_tval pointer in duk_inspect_value(), also affects
   Duktape.info() (GH-1453)
 
+* Fix Symbol Object .valueOf() which returned the Symbol Object rather than
+  the underlying plain Symbol (GH-1459)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android and Atari MiNT
   (GH-1325, GH-1341, GH-1430, GH-1431)
 

--- a/src-input/duk_bi_symbol.c
+++ b/src-input/duk_bi_symbol.c
@@ -125,6 +125,7 @@ DUK_INTERNAL duk_ret_t duk_bi_symbol_tostring_shared(duk_context *ctx) {
 		duk_push_symbol_descriptive_string(ctx, h_str);
 	} else {
 		/* .valueOf() */
+		duk_push_hstring(ctx, h_str);
 	}
 	return 1;
 }

--- a/tests/ecmascript/test-bi-symbol-object-valueof.js
+++ b/tests/ecmascript/test-bi-symbol-object-valueof.js
@@ -1,0 +1,14 @@
+/*===
+symbol
+object
+symbol
+true
+===*/
+
+var symbol = Symbol('foo');
+print(typeof symbol);
+var object = Object(symbol);
+print(typeof object);
+var value = object.valueOf();
+print(typeof value);
+print(symbol === value);


### PR DESCRIPTION
- [x] Test case
- [x] Fix
- [x] Releases entry