### PR TITLE
Implement Symbol sorting for Reflect.ownKeys() order

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2886,6 +2886,9 @@ Planned
   explicit newTarget not yet supported and handling of new.target in eval()
   code is not yet fully correct (GH-1544, GH-1572)
 
+* Add proper string vs. symbol sorting to Reflect.ownKeys() and other
+  enumeration call sites (GH-1460)
+
 * Add an internal type for representing Proxy instances (duk_hproxy) to
   simplify Proxy operations and improve performance (GH-1500, GH-1136)
 

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -217,7 +217,8 @@ struct duk_time_components {
 #define DUK_ENUM_EXCLUDE_STRINGS          (1 << 3)    /* exclude strings */
 #define DUK_ENUM_OWN_PROPERTIES_ONLY      (1 << 4)    /* don't walk prototype chain, only check own properties */
 #define DUK_ENUM_ARRAY_INDICES_ONLY       (1 << 5)    /* only enumerate array indices */
-#define DUK_ENUM_SORT_ARRAY_INDICES       (1 << 6)    /* sort array indices (applied to full enumeration result, including inherited array indices) */
+/* XXX: misleading name */
+#define DUK_ENUM_SORT_ARRAY_INDICES       (1 << 6)    /* sort array indices (applied to full enumeration result, including inherited array indices); XXX: misleading name */
 #define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 << 7)    /* enumerate a proxy object itself without invoking proxy behavior */
 
 /* Compilation flags for duk_compile() and duk_eval() */

--- a/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order-2.js
+++ b/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order-2.js
@@ -1,0 +1,37 @@
+/*===
+0
+1
+2
+3
+7
+foo
+bar
+quux
+S2
+S3
+S1
+===*/
+
+var S1 = Symbol('s1');
+var S2 = Symbol('s2');
+var S3 = Symbol('s3');
+
+var obj = {};
+obj[1] = 'one';
+obj['foo'] = 'foo';
+obj[0] = 'zero';
+obj[3] = 'three';
+obj[S2] = 's2';
+obj[2] = 'two';
+obj[S3] = 's3';
+obj['bar'] = 'bar';
+obj[S1] = 's1';
+obj['quux'] = 'quux';
+obj[7] = 'seven';
+
+Reflect.ownKeys(obj).forEach(function (v) {
+    if (v === S1) { print('S1'); }
+    else if (v === S2) { print('S2'); }
+    else if (v === S3) { print('S3'); }
+    else { print(v); }
+});

--- a/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order-3.js
+++ b/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order-3.js
@@ -1,0 +1,27 @@
+/*===
+foo
+bar
+quux
+S2
+S3
+S1
+===*/
+
+var S1 = Symbol('s1');
+var S2 = Symbol('s2');
+var S3 = Symbol('s3');
+
+var obj = {};
+obj['foo'] = 'foo';
+obj[S2] = 's2';
+obj[S3] = 's3';
+obj['bar'] = 'bar';
+obj[S1] = 's1';
+obj['quux'] = 'quux';
+
+Reflect.ownKeys(obj).forEach(function (v) {
+    if (v === S1) { print('S1'); }
+    else if (v === S2) { print('S2'); }
+    else if (v === S3) { print('S3'); }
+    else { print(v); }
+});

--- a/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order.js
+++ b/tests/ecmascript/test-bi-reflect-ownkeys-symbol-order.js
@@ -1,0 +1,28 @@
+/*===
+7
+300
+100
+500
+700
+200
+400
+600
+===*/
+
+var sym1 = Symbol();
+var sym2 = Symbol();
+var sym3 = Symbol();
+var obj = {};
+obj.foo = 100;
+obj[sym1] = 200;
+obj[3] = 300;
+obj[sym2] = 400;
+obj.quux = 500;
+obj[sym3] = 600;
+obj.baz = 700;
+
+var keys = Reflect.ownKeys(obj);
+print(keys.length);
+keys.forEach(function (v) {
+    print(obj[v]);
+});

--- a/tests/perf/test-reflect-ownkeys-sorted.js
+++ b/tests/perf/test-reflect-ownkeys-sorted.js
@@ -1,0 +1,36 @@
+function test() {
+    var S1 = Symbol('s1');
+    var S2 = Symbol('s2');
+    var S3 = Symbol('s3');
+    var S4 = Symbol('s4');
+    var S5 = Symbol('s5');
+    var i;
+    var obj = {};
+    obj[0] = 'zero';
+    obj[1] = 'one';
+    obj[2] = 'two';
+    obj[3] = 'three';
+    obj['foo'] = 'foo';
+    obj['bar'] = 'bar';
+    obj['quux'] = 'quux';
+    obj['baz'] = 'baz';
+    obj[S2] = 's2';
+    obj[S3] = 's3';
+    obj[S1] = 's1';
+    obj[S5] = 's5';
+    obj[S4] = 's4';
+
+    for (i = 0; i < 1e5; i++) {
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+    }
+}
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-reflect-ownkeys-unsorted.js
+++ b/tests/perf/test-reflect-ownkeys-unsorted.js
@@ -1,0 +1,36 @@
+function test() {
+    var S1 = Symbol('s1');
+    var S2 = Symbol('s2');
+    var S3 = Symbol('s3');
+    var S4 = Symbol('s4');
+    var S5 = Symbol('s5');
+    var i;
+    var obj = {};
+    obj[3] = 'three';
+    obj['foo'] = 'foo';
+    obj[S2] = 's2';
+    obj[S3] = 's3';
+    obj[2] = 'two';
+    obj['bar'] = 'bar';
+    obj[0] = 'zero';
+    obj[S1] = 's1';
+    obj['quux'] = 'quux';
+    obj[1] = 'one';
+    obj[S5] = 's5';
+    obj['baz'] = 'baz';
+    obj[S4] = 's4';
+
+    for (i = 0; i < 1e5; i++) {
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+        void Reflect.ownKeys(obj);
+    }
+}
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/website/api/duk_enum.yaml
+++ b/website/api/duk_enum.yaml
@@ -16,7 +16,7 @@ summary: |
   <tr>
   <td>DUK_ENUM_INCLUDE_NONENUMERABLE</td>
   <td>Enumerate also non-enumerable properties, by default only enumerable
-      properties are enumerated</td>
+      properties are enumerated.</td>
   </tr>
   <tr>
   <td>DUK_ENUM_INCLUDE_HIDDEN</td>
@@ -37,18 +37,19 @@ summary: |
   <tr>
   <td>DUK_ENUM_OWN_PROPERTIES_ONLY</td>
   <td>Enumerate only an object's "own" properties, by default also inherited
-      properties are enumerated</td>
+      properties are enumerated.</td>
   </tr>
   <tr>
   <td>DUK_ENUM_ARRAY_INDICES_ONLY</td>
   <td>Enumerate only array indices, i.e. property names of the form "0", "1",
-      "2", etc</td>
+      "2", etc.</td>
   </tr>
   <tr>
   <td>DUK_ENUM_SORT_ARRAY_INDICES</td>
   <td>Apply the ES2015 [[OwnPropertyKeys]] enumeration order over the whole
       enumeration result rather than per inheritance level, this has the
-      effect of sorting array indices (even when inherited)</td>
+      effect of sorting array indices (even when inherited).  Also symbols
+      are sorted after ordinary string keys (both in insertion order).</td>
   </tr>
   <tr>
   <td>DUK_ENUM_NO_PROXY_BEHAVIOR</td>


### PR DESCRIPTION
Currently array indices and strings are sorted to the ES2015 ownKeys order, but symbols and strings keep their place (symbols should be last): http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys.

This is easy to fix in the insertion sort of duk_hobject_enum.c

- [x] Test coverage
- [x] Fix enum order
- [x] Fix need_sort
- [x] Optimizations when symbol support disabled
- [x] Releases entry