### PR TITLE
Define _XOPEN_SOURCE for Nspire (needed for strptime)

### DIFF
--- a/config/platforms/platform_tinspire.h.in
+++ b/config/platforms/platform_tinspire.h.in
@@ -1,3 +1,7 @@
+#if defined(DUK_COMPILING_DUKTAPE) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE    /* e.g. strptime */
+#endif
+
 #define DUK_USE_DATE_NOW_GETTIMEOFDAY
 #define DUK_USE_DATE_TZO_GMTIME_R
 #define DUK_USE_DATE_PRS_STRPTIME


### PR DESCRIPTION
The strptime declaration isn't exposed unless _XOPEN_SOURCE is defined.