### PR TITLE
Fix use of potentially unstable duk_tval ptr in Proxy deleteProperty handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2764,6 +2764,9 @@ Planned
 * Fix RegExp group parsing to reject invalid groups like /(?Xabc)/, previously
   they were accepted silently (GH-1463)
 
+* Fix potentially stale duk_tval pointer in Proxy deleteProperty handling
+  (GH-1482)
+
 * Avoid log2(), log10(), cbrt(), and trunc() on Android and Atari MiNT
   (GH-1325, GH-1341, GH-1430, GH-1431)
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -4430,10 +4430,10 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 			/* Note: proxy handling must happen before key is string coerced. */
 
 			if (duk__proxy_check_prop(thr, obj, DUK_STRIDX_DELETE_PROPERTY, tv_key, &h_target)) {
-				/* -> [ ... trap handler ] */
+				/* -> [ ... obj key trap handler ] */
 				DUK_DDD(DUK_DDDPRINT("-> proxy object 'deleteProperty' for key %!T", (duk_tval *) tv_key));
 				duk_push_hobject(ctx, h_target);  /* target */
-				duk_push_tval(ctx, tv_key);       /* P */
+				duk_dup_m4(ctx);  /* P */
 				duk_call_method(ctx, 2 /*nargs*/);
 				tmp_bool = duk_to_boolean(ctx, -1);
 				duk_pop(ctx);
@@ -4444,6 +4444,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 				/* Target object must be checked for a conflicting
 				 * non-configurable property.
 				 */
+				tv_key = DUK_GET_TVAL_NEGIDX(ctx, -1);
 				arr_idx = duk__push_tval_to_property_key(ctx, tv_key, &key);
 				DUK_ASSERT(key != NULL);
 


### PR DESCRIPTION
To reproduce, enable DUK_USE_ASSERTIONS, DUK_USE_GC_TORTURE, and DUK_USE_FINALIZER_TORTURE. Then run:

```
$ python util/runtest.py --clip-lines 100 --duk ./duk tests/ecmascript/test-bi-proxy-get-set-deleteproperty.js
FAILURE test-bi-proxy-get-set-deleteproperty.js            [25.2 s] [30 diff lines] [errors: expect-mismatch]
- Diff to expected result:
    @@ -120,18 +120,18 @@
     deleteProperty hook
     property1: success, result: true
     property2: success, result: true
    -property3: TypeError
    -property4: TypeError
    -property5: TypeError
    -property6: TypeError
    -property7: TypeError
    +property3: success, result: true
    +property4: success, result: true
    +property5: success, result: true
    +property6: success, result: true
    +property7: success, result: true
     accessor1: success, result: true
     accessor2: success, result: true
    -accessor3: TypeError
    +accessor3: success, result: true
     accessor4: success, result: true
    -accessor5: TypeError
    -accessor6: TypeError
    -accessor7: TypeError
    +accessor5: success, result: true
    +accessor6: success, result: true
    +accessor7: success, result: true
     recursive proxies
     TypeError
     TypeError
```

The cause is a duk_tval pointer being used after a memory allocation which may invalidate the duk_tval pointer if a voluntary GC happens and a finalizer runs. Labelled 'security' because might result in memory unsafe behavior (though I could only cause incorrect Proxy handling even with torture tests).

Other Proxy operations are not affected because the get, set, etc. calls explicitly stabilize their argument key/object pointers by making a copy.

Tasks:
- [x] Fix deleteProperty issue, verify with torture test
- [x] Check other Proxy paths for similar issues
- [x] Releases entry
- [x] Backports to 2.0.x and 1.x