### PR TITLE
Rework thr->callstack into a linked list of duk_activations

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2816,8 +2816,19 @@ Planned
 2.2.0 (XXXX-XX-XX)
 ------------------
 
+* Fix callstack limit bumping for errThrow augmentation calls, the limit might
+  be bumped and unbumped for different Duktape threads if coroutines were
+  resumed/yielded in the process; this is relatively harmless but might cause
+  an errThrow augmentation call to fail due to callstack limit being reached
+  (GH-1490)
+
+* Internal change: duk_activation structs are now in a single linked list
+  attached to a duk_hthread instead of being a separate, monolithic
+  thr->callstack (GH-1487)
+
 * Internal change: duk_catcher structs are now in a single linked list attached
-  to a duk_activation instead of being a separate thr->catchstack (GH-1449)
+  to a duk_activation instead of being a separate, monolithic
+  thr->catchstack (GH-1449)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -794,7 +794,7 @@ Released
 * Fix assignment evaluation order issue which affected expressions like
   "a[i] = b[i++]" (GH-118)
 
-* Fix incorrect parsing of zero escape in regexp class ("[\0]") (GH-122)
+* Fix incorrect parsing of zero escape in regexp class ("[\\0]") (GH-122)
 
 * Fix tail call issue in return comma expression when a function call
   in the comma expression was followed by a constant value or a register
@@ -886,7 +886,7 @@ Released
 * Fix value stack setup bug which caused a segfault with large number of
   arguments (GH-107)
 
-* Fix incorrect parsing of zero escape in regexp class ("[\0]") (GH-122)
+* Fix incorrect parsing of zero escape in regexp class ("[\\0]") (GH-122)
 
 * Fix assignment evaluation order issue which affected expressions like
   "a[i] = b[i++]" (GH-118)
@@ -2034,8 +2034,8 @@ Ecmascript 2015+ and real world compatibility:
   this aligns better with behavior of other engines (GH-1057)
 
 * Change parsing of octal escapes in string literals to better align with
-  ES2015 and other engines; "\078" is now accepted and is the same as
-  "\u00078", "\8" and "\9" are accepted as literal "8" and "9"  (GH-1057)
+  ES2015 and other engines; "\\078" is now accepted and is the same as
+  "\\u00078", "\\8" and "\\9" are accepted as literal "8" and "9"  (GH-1057)
 
 * Change bound function .name property handling to match ES2015 requirements;
   for a target function with name "foo", bound function name is "bound foo"
@@ -2539,8 +2539,8 @@ Miscellaneous:
 
 * Add ES2015 Annex B HTML comment syntax (GH-1435, GH-1436, GH-1438)
 
-* Allow ES2015 Annex B legacy octal escapes (\1 to \377) and literal digits
-  (\8 and \9) for RegExp character classes (GH-1275, GH-1483)
+* Allow ES2015 Annex B legacy octal escapes (\\1 to \\377) and literal digits
+  (\\8 and \\9) for RegExp character classes (GH-1275, GH-1483)
 
 * Add an experimental "global" property to the global object to provide easy
   access to the global object itself without needing idioms like

--- a/doc/execution.rst
+++ b/doc/execution.rst
@@ -63,8 +63,8 @@ changes:
 
 * A setjmp catchpoint is needed for protected calls.
 
-* The call stack is resized if necessary, and an activation record
-  (``duk_activation``) is set up for the new call.
+* An activation record, ``duk_activation``, is allocated and set up for the
+  new call.
 
 * The value stack is resized if necessary, and a fresh value stack frame
   is established for the call.  The calling value stack frame and the target
@@ -380,7 +380,7 @@ Misc notes
 
 * The value stack doesn't hold all the internal state relevant for an
   activation.  Some state, such as active environment records (``lex_env``
-  and ``var_env``) are held in the ``duk_activation`` call stack structure.
+  and ``var_env``) are held in the ``duk_activation`` activation structure.
 
 Value stack management
 ======================

--- a/doc/memory-management.rst
+++ b/doc/memory-management.rst
@@ -403,7 +403,7 @@ ownership relationships::
            |
            +-->  value stack
            |
-           +-->  call stack -->  duk_activations (array)
+           +-->  call stack -->  duk_activations (linked list)
            |                       |
            |                       `--> duk_catchers (linked list)
            |

--- a/doc/side-effects.rst
+++ b/doc/side-effects.rst
@@ -71,11 +71,12 @@ The most extensive type of side effect is arbitrary code execution, caused
 by e.g. a finalizer or a Proxy trap call (and a number of indirect causes).
 The potential side effects are very wide:
 
-* Because a call is made, value stacks and call stacks may be grown (but
-  not shrunk) and their base pointers may change.  As a result, any duk_tval
-  pointers to the value stack and duk_activation pointers to the call stack
-  are (potentially) invalidated.  Since Duktape 2.2 duk_catchers are separately
-  allocated and have a stable pointer.
+* Because a call is made, the value stack may be grown (but not shrunk) and
+  its base pointer may change.  As a result, any duk_tval pointers to the
+  value stack are (potentially) invalidated.  Since Duktape 2.2 duk_activation
+  and duk_catcher structs are allocated separately and have a stable pointer.
+  Before Duktape 2.2 duk_activations were held in a call stack and duk_catchers
+  in a catch stack, and their pointers might be invalidated by side effects.
 
 * An error throw may happen, clobbering heap longjmp state.  This is a
   problem particularly in error handling where we're dealing with a previous
@@ -154,10 +155,10 @@ Other side effects don't happen with current mark-and-sweep implementation.
 For example, the following don't happen (but could, if mark-and-sweep scope
 and side effect lockouts are changed):
 
-* Thread value stack and call stack are never reallocated and all pointers to
-  duk_tvals and duk_activations remain valid; duk_catcher pointers are stable
-  in Duktape 2.2.  (This could easily change if mark-and-sweep were to "compact"
-  the stacks in an emergency GC.)
+* Thread value stack is never reallocated and all pointers to duk_tvals remain
+  valid; duk_activation and duk_catcher pointers are stable in Duktape 2.2.
+  (This could easily change if mark-and-sweep were to "compact" the value stack
+  in an emergency GC.)
 
 The mark-and-sweep side effects listed above are not fundamental to the
 engine and could be removed if they became inconvenient.  For example, it's

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -470,7 +470,6 @@ DUK_EXTERNAL duk_bool_t duk_is_constructor_call(duk_context *ctx) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
 	act = thr->callstack_curr;
 	if (act != NULL) {
@@ -503,7 +502,6 @@ DUK_EXTERNAL duk_bool_t duk_is_strict_call(duk_context *ctx) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
 	act = thr->callstack_curr;
 	if (act != NULL) {
@@ -525,7 +523,6 @@ DUK_EXTERNAL duk_int_t duk_get_current_magic(duk_context *ctx) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);
 
 	act = thr->callstack_curr;
 	if (act) {

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -87,8 +87,7 @@ DUK_EXTERNAL void duk_debugger_attach(duk_context *ctx,
 	heap->dbg_state_dirty = 0;
 	heap->dbg_force_restart = 0;
 	heap->dbg_step_type = DUK_STEP_TYPE_NONE;
-	heap->dbg_step_thread = NULL;
-	heap->dbg_step_csindex = 0;
+	heap->dbg_step_act = NULL;
 	heap->dbg_step_startline = 0;
 	heap->dbg_exec_counter = 0;
 	heap->dbg_last_counter = 0;
@@ -136,7 +135,7 @@ DUK_EXTERNAL void duk_debugger_cooperate(duk_context *ctx) {
 	if (!duk_debug_is_attached(thr->heap)) {
 		return;
 	}
-	if (thr->callstack_top > 0 || thr->heap->dbg_processing) {
+	if (thr->callstack_curr != NULL || thr->heap->dbg_processing) {
 		/* Calling duk_debugger_cooperate() while Duktape is being
 		 * called into is not supported.  This is not a 100% check
 		 * but prevents any damage in most cases.

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -192,17 +192,17 @@ DUK_EXTERNAL void duk_inspect_callstack_entry(duk_context *ctx, duk_int_t level)
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	/* -1             = top callstack entry, callstack[callstack_top - 1]
-	 * -callstack_top = bottom callstack entry, callstack[0]
+	/* -1   = top callstack entry
+	 * -2   = caller of level -1
+	 * etc
 	 */
-	if (level >= 0 || -level > (duk_int_t) thr->callstack_top) {
+	act = duk_hthread_get_activation_for_level(thr, level);
+	if (act == NULL) {
 		duk_push_undefined(ctx);
 		return;
 	}
 	duk_push_bare_object(ctx);
-	DUK_ASSERT(level >= -((duk_int_t) thr->callstack_top) && level <= -1);
 
-	act = thr->callstack + thr->callstack_top + level;
 	/* Relevant PC is just before current one because PC is
 	 * post-incremented.  This should match what error augment
 	 * code does.

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -80,11 +80,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_context *ctx) {
 		goto state_error;
 	}
 	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT(thr->callstack_curr->parent != NULL);
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);  /* us */
 	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr - 1) != NULL);  /* caller */
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr->parent) != NULL);  /* caller */
 
-	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr - 1);
+	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
 		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be Ecmascript code"));
 		goto state_error;
@@ -235,11 +236,12 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_context *ctx) {
 		goto state_error;
 	}
 	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT(thr->callstack_curr->parent != NULL);
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);  /* us */
 	DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
-	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr - 1) != NULL);  /* caller */
+	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr->parent) != NULL);  /* caller */
 
-	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr - 1);
+	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
 		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be Ecmascript code"));
 		goto state_error;

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -540,15 +540,11 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 		DUK__COMMA(); duk_fb_sprintf(fb, "__state:%ld", (long) t->state);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__unused1:%ld", (long) t->unused1);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__unused2:%ld", (long) t->unused2);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_max:%ld", (long) t->valstack_max);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_max:%ld", (long) t->callstack_max);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack:%p", (void *) t->valstack);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_end:%p/%ld", (void *) t->valstack_end, (long) (t->valstack_end - t->valstack));
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_bottom:%p/%ld", (void *) t->valstack_bottom, (long) (t->valstack_bottom - t->valstack));
 		DUK__COMMA(); duk_fb_sprintf(fb, "__valstack_top:%p/%ld", (void *) t->valstack_top, (long) (t->valstack_top - t->valstack));
-		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack:%p", (void *) t->callstack);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_curr:%p", (void *) t->callstack_curr);
-		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_size:%ld", (long) t->callstack_size);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_top:%ld", (long) t->callstack_top);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__callstack_preventcount:%ld", (long) t->callstack_preventcount);
 		DUK__COMMA(); duk_fb_sprintf(fb, "__resumer:"); duk__print_hobject(st, (duk_hobject *) t->resumer);

--- a/src-input/duk_error_misc.c
+++ b/src-input/duk_error_misc.c
@@ -18,22 +18,19 @@ DUK_LOCAL duk_bool_t duk__have_active_catcher(duk_hthread *thr) {
 	 * an argument to treat them as catchers?
 	 */
 
-	duk_size_t i;
 	duk_activation *act;
 	duk_catcher *cat;
 
 	DUK_ASSERT(thr != NULL);
 
-	while (thr != NULL) {
-		for (i = 0; i < thr->callstack_top; i++) {
-			act = thr->callstack + i;
+	for (; thr != NULL; thr = thr->resumer) {
+		for (act = thr->callstack_curr; act != NULL; act = act->parent) {
 			for (cat = act->cat; cat != NULL; cat = cat->parent) {
 				if (DUK_CAT_HAS_CATCH_ENABLED(cat)) {
 					return 1;  /* all we need to know */
 				}
 			}
 		}
-		thr = thr->resumer;
 	}
 	return 0;
 }

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -62,10 +62,6 @@ DUK_INTERNAL void duk_err_create_and_throw(duk_hthread *thr, duk_errcode_t code)
 		duk_tval tv_val;
 		duk_hobject *h_err;
 
-#if 0  /* XXX: not always true because the second throw may come from a different coroutine */
-		DUK_ASSERT(thr->callstack_max == DUK_CALLSTACK_DEFAULT_MAX + DUK_CALLSTACK_GROW_STEP + 11);
-#endif
-		thr->callstack_max = DUK_CALLSTACK_DEFAULT_MAX;
 		thr->heap->creating_error = 0;
 
 		h_err = thr->builtins[DUK_BIDX_DOUBLE_ERROR];
@@ -82,14 +78,11 @@ DUK_INTERNAL void duk_err_create_and_throw(duk_hthread *thr, duk_errcode_t code)
 
 		/* No augmentation to avoid any allocations or side effects. */
 	} else {
-		/* Allow headroom for calls during error handling (see GH-191).
-		 * We allow space for 10 additional recursions, with one extra
-		 * for, e.g. a print() call at the deepest level.
+		/* Prevent infinite recursion.  Extra call stack and C
+		 * recursion headroom (see GH-191) is added for augmentation.
+		 * That is now signalled by heap->augmenting error and taken
+		 * into account in call handling without an explicit limit bump.
 		 */
-#if 0  /* XXX: not always true, second throw may come from a different coroutine */
-		DUK_ASSERT(thr->callstack_max == DUK_CALLSTACK_DEFAULT_MAX);
-#endif
-		thr->callstack_max = DUK_CALLSTACK_DEFAULT_MAX + DUK_CALLSTACK_GROW_STEP + 11;
 		thr->heap->creating_error = 1;
 
 		duk_require_stack(ctx, 1);
@@ -125,7 +118,6 @@ DUK_INTERNAL void duk_err_create_and_throw(duk_hthread *thr, duk_errcode_t code)
 #endif
 
 		duk_err_setup_ljstate1(thr, DUK_LJ_TYPE_THROW, DUK_GET_TVAL_NEGIDX(ctx, -1));
-		thr->callstack_max = DUK_CALLSTACK_DEFAULT_MAX;
 		thr->heap->creating_error = 0;
 
 		/* Error is now created and we assume no errors can occur any

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -158,6 +158,7 @@ DUK_INTERNAL void duk_hobject_refcount_finalize_norz(duk_heap *heap, duk_hobject
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 	} else if (DUK_HOBJECT_IS_THREAD(h)) {
 		duk_hthread *t = (duk_hthread *) h;
+		duk_activation *act;
 		duk_tval *tv;
 
 		tv = t->valstack;
@@ -166,8 +167,7 @@ DUK_INTERNAL void duk_hobject_refcount_finalize_norz(duk_heap *heap, duk_hobject
 			tv++;
 		}
 
-		for (i = 0; i < (duk_uint_fast32_t) t->callstack_top; i++) {
-			duk_activation *act = t->callstack + i;
+		for (act = t->callstack_curr; act != NULL; act = act->parent) {
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) DUK_ACT_GET_FUNC(act));
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) act->var_env);
 			DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) act->lex_env);

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -177,13 +177,12 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t
 		}
 	}
 #endif
-	/* when nothing is running, API calls are in non-strict mode */
+	/* When nothing is running, API calls are in non-strict mode. */
 	DUK_ASSERT(res->strict == 0);
 
 	res->heap = heap;
-	res->valstack_max = DUK_VALSTACK_DEFAULT_MAX;
-	res->callstack_max = DUK_CALLSTACK_DEFAULT_MAX;
 
+	/* XXX: Any reason not to merge duk_hthread_alloc.c here? */
 	return res;
 }
 

--- a/src-input/duk_hthread_alloc.c
+++ b/src-input/duk_hthread_alloc.c
@@ -20,7 +20,6 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	DUK_ASSERT(thr->valstack_end == NULL);
 	DUK_ASSERT(thr->valstack_bottom == NULL);
 	DUK_ASSERT(thr->valstack_top == NULL);
-	DUK_ASSERT(thr->callstack == NULL);
 	DUK_ASSERT(thr->callstack_curr == NULL);
 
 	/* valstack */
@@ -41,25 +40,13 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 		DUK_TVAL_SET_UNDEFINED(&thr->valstack[i]);
 	}
 
-	/* callstack */
-	alloc_size = sizeof(duk_activation) * DUK_CALLSTACK_INITIAL_SIZE;
-	thr->callstack = (duk_activation *) DUK_ALLOC(heap, alloc_size);
-	if (!thr->callstack) {
-		goto fail;
-	}
-	DUK_MEMZERO(thr->callstack, alloc_size);
-	thr->callstack_size = DUK_CALLSTACK_INITIAL_SIZE;
-	DUK_ASSERT(thr->callstack_top == 0);
-	DUK_ASSERT(thr->callstack_curr == NULL);
-
 	return 1;
 
  fail:
 	DUK_FREE(heap, thr->valstack);
-	DUK_FREE(heap, thr->callstack);
+	DUK_ASSERT(thr->callstack_curr == NULL);
 
 	thr->valstack = NULL;
-	thr->callstack = NULL;
 	return 0;
 }
 
@@ -69,10 +56,4 @@ DUK_INTERNAL void *duk_hthread_get_valstack_ptr(duk_heap *heap, void *ud) {
 	duk_hthread *thr = (duk_hthread *) ud;
 	DUK_UNREF(heap);
 	return (void *) thr->valstack;
-}
-
-DUK_INTERNAL void *duk_hthread_get_callstack_ptr(duk_heap *heap, void *ud) {
-	duk_hthread *thr = (duk_hthread *) ud;
-	DUK_UNREF(heap);
-	return (void *) thr->callstack;
 }

--- a/src-input/duk_hthread_stacks.c
+++ b/src-input/duk_hthread_stacks.c
@@ -1,132 +1,15 @@
 /*
- *  Manipulation of thread stacks (valstack, callstack).
+ *  Thread stack (mainly call stack) primitives: allocation of activations,
+ *  unwinding catchers and activations, etc.
  *
- *  Ideally unwinding of stacks should have no side effects, which would
- *  then favor separate unwinding and shrink check primitives for each
- *  stack type.  A shrink check may realloc and thus have side effects.
- *
- *  However, currently callstack unwinding itself has side effects, as it
- *  needs to DECREF multiple objects, close environment records, etc.
- *  Stacks must thus be unwound in the correct order by the caller.
- *
- *  (XXX: This should be probably reworked so that there is a shared
- *  unwind primitive which handles all stacks as requested, and knows
- *  the proper order for unwinding.)
- *
- *  Valstack entries above 'top' are always kept initialized to "undefined".
- *  Callstack entries above 'top' are not zeroed and are left as garbage.
- *
- *  Value stack handling is mostly a part of the API implementation.
+ *  Value stack handling is a part of the API implementation.
  */
 
 #include "duk_internal.h"
 
-DUK_LOCAL DUK_COLD DUK_NOINLINE void duk__hthread_do_callstack_grow(duk_hthread *thr) {
-	duk_activation *new_ptr;
-	duk_size_t old_size;
-	duk_size_t new_size;
-
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);   /* avoid warning (unsigned) */
-	DUK_ASSERT(thr->callstack_size >= thr->callstack_top);
-
-	old_size = thr->callstack_size;
-	new_size = old_size + DUK_CALLSTACK_GROW_STEP;
-
-	/* this is a bit approximate (errors out before max is reached); this is OK */
-	if (new_size >= thr->callstack_max) {
-		DUK_ERROR_RANGE(thr, DUK_STR_CALLSTACK_LIMIT);
-	}
-
-	DUK_DD(DUK_DDPRINT("growing callstack %ld -> %ld", (long) old_size, (long) new_size));
-
-	/*
-	 *  Note: must use indirect variant of DUK_REALLOC() because underlying
-	 *  pointer may be changed by mark-and-sweep.
-	 */
-
-	DUK_ASSERT(new_size > 0);
-	new_ptr = (duk_activation *) DUK_REALLOC_INDIRECT(thr->heap, duk_hthread_get_callstack_ptr, (void *) thr, sizeof(duk_activation) * new_size);
-	if (!new_ptr) {
-		/* No need for a NULL/zero-size check because new_size > 0) */
-		DUK_ERROR_ALLOC_FAILED(thr);
-	}
-	thr->callstack = new_ptr;
-	thr->callstack_size = new_size;
-
-	if (thr->callstack_top > 0) {
-		thr->callstack_curr = thr->callstack + thr->callstack_top - 1;
-	} else {
-		thr->callstack_curr = NULL;
-	}
-
-	/* note: any entries above the callstack top are garbage and not zeroed */
-}
-
-/* check that there is space for at least one new entry */
-DUK_INTERNAL void duk_hthread_callstack_grow(duk_hthread *thr) {
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);   /* avoid warning (unsigned) */
-	DUK_ASSERT(thr->callstack_size >= thr->callstack_top);
-
-	if (DUK_LIKELY(thr->callstack_top < thr->callstack_size)) {
-		return;
-	}
-	duk__hthread_do_callstack_grow(thr);
-}
-
-DUK_LOCAL DUK_COLD DUK_NOINLINE void duk__hthread_do_callstack_shrink(duk_hthread *thr) {
-	duk_size_t new_size;
-	duk_activation *p;
-
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);  /* avoid warning (unsigned) */
-	DUK_ASSERT(thr->callstack_size >= thr->callstack_top);
-
-	new_size = thr->callstack_top + DUK_CALLSTACK_SHRINK_SPARE;
-	DUK_ASSERT(new_size >= thr->callstack_top);
-
-	DUK_DD(DUK_DDPRINT("shrinking callstack %ld -> %ld", (long) thr->callstack_size, (long) new_size));
-
-	/*
-	 *  Note: must use indirect variant of DUK_REALLOC() because underlying
-	 *  pointer may be changed by mark-and-sweep.
-	 */
-
-	/* shrink failure is not fatal */
-	p = (duk_activation *) DUK_REALLOC_INDIRECT(thr->heap, duk_hthread_get_callstack_ptr, (void *) thr, sizeof(duk_activation) * new_size);
-	if (p) {
-		thr->callstack = p;
-		thr->callstack_size = new_size;
-
-		if (thr->callstack_top > 0) {
-			thr->callstack_curr = thr->callstack + thr->callstack_top - 1;
-		} else {
-			thr->callstack_curr = NULL;
-		}
-	} else {
-		/* Because new_size != 0, if condition doesn't need to be
-		 * (p != NULL || new_size == 0).
-		 */
-		DUK_ASSERT(new_size != 0);
-		DUK_D(DUK_DPRINT("callstack shrink failed, ignoring"));
-	}
-
-	/* note: any entries above the callstack top are garbage and not zeroed */
-}
-
-DUK_INTERNAL void duk_hthread_callstack_shrink_check(duk_hthread *thr) {
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_DISABLE(thr->callstack_top >= 0);  /* avoid warning (unsigned) */
-	DUK_ASSERT(thr->callstack_size >= thr->callstack_top);
-
-	if (DUK_LIKELY(thr->callstack_size - thr->callstack_top < DUK_CALLSTACK_SHRINK_THRESHOLD)) {
-		return;
-	}
-
-	duk__hthread_do_callstack_shrink(thr);
-}
-
+/* Unwind the topmost catcher of the current activation (caller must check that
+ * both exist) without side effects.
+ */
 DUK_INTERNAL void duk_hthread_catcher_unwind_norz(duk_hthread *thr, duk_activation *act) {
 	duk_catcher *cat;
 
@@ -153,9 +36,10 @@ DUK_INTERNAL void duk_hthread_catcher_unwind_norz(duk_hthread *thr, duk_activati
 	}
 
 	act->cat = cat->parent;
-	DUK_FREE_CHECKED(thr, (void *) cat);
+	duk_hthread_catcher_free(thr, cat);
 }
 
+/* Same as above, but caller is certain no catcher-related lexenv may exist. */
 DUK_INTERNAL void duk_hthread_catcher_unwind_nolexenv_norz(duk_hthread *thr, duk_activation *act) {
 	duk_catcher *cat;
 
@@ -170,217 +54,264 @@ DUK_INTERNAL void duk_hthread_catcher_unwind_nolexenv_norz(duk_hthread *thr, duk
 	DUK_ASSERT(!DUK_CAT_HAS_LEXENV_ACTIVE(cat));
 
 	act->cat = cat->parent;
+	duk_hthread_catcher_free(thr, cat);
+}
+
+DUK_INTERNAL duk_catcher *duk_hthread_catcher_alloc(duk_hthread *thr) {
+	duk_catcher *cat;
+
+	DUK_ASSERT(thr != NULL);
+
+	cat = (duk_catcher *) DUK_ALLOC_CHECKED(thr, sizeof(duk_catcher));
+	DUK_ASSERT(cat != NULL);
+	return cat;
+}
+
+DUK_INTERNAL void duk_hthread_catcher_free(duk_hthread *thr, duk_catcher *cat) {
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(cat != NULL);
+
 	DUK_FREE_CHECKED(thr, (void *) cat);
 }
 
-DUK_INTERNAL void duk_hthread_callstack_unwind_norz(duk_hthread *thr, duk_size_t new_top) {
-	duk_size_t idx;
+DUK_INTERNAL duk_activation *duk_hthread_activation_alloc(duk_hthread *thr) {
+	duk_activation *act;
 
-	DUK_DDD(DUK_DDDPRINT("unwind callstack top of thread %p from %ld to %ld",
-	                     (void *) thr,
-	                     (thr != NULL ? (long) thr->callstack_top : (long) -1),
-	                     (long) new_top));
+	DUK_ASSERT(thr != NULL);
 
-	DUK_ASSERT(thr);
-	DUK_ASSERT(thr->heap);
-	DUK_ASSERT_DISABLE(new_top >= 0);  /* unsigned */
-	DUK_ASSERT((duk_size_t) new_top <= thr->callstack_top);  /* cannot grow */
-
-	/*
-	 *  The loop below must avoid issues with potential callstack
-	 *  reallocations.  A resize (and other side effects) may happen
-	 *  e.g. due to finalizer/errhandler calls caused by a refzero or
-	 *  mark-and-sweep.  Arbitrary finalizers may run, because when
-	 *  an environment record is refzero'd, it may refer to arbitrary
-	 *  values which also become refzero'd.
-	 *
-	 *  So, the pointer 'p' is re-looked-up below whenever a side effect
-	 *  might have changed it.
-	 */
-
-	idx = thr->callstack_top;
-	while (idx > new_top) {
-		duk_activation *act;
-		duk_hobject *func;
-		duk_hobject *tmp;
-#if defined(DUK_USE_DEBUGGER_SUPPORT)
-		duk_heap *heap;
+#if 0
+	/* XXX: inline the check part? */
+	act = thr->heap->activation_free;
+	if (DUK_LIKELY(act != NULL)) {
+		thr->heap->activation_free = act->parent;
+		return act;
+	}
 #endif
-		idx--;
-		DUK_ASSERT_DISABLE(idx >= 0);  /* unsigned */
-		DUK_ASSERT((duk_size_t) idx < thr->callstack_size);  /* true, despite side effect resizes */
 
-		act = thr->callstack + idx;
-		/* With lightfuncs, act 'func' may be NULL */
+	act = (duk_activation *) DUK_ALLOC_CHECKED(thr, sizeof(duk_activation));
+	DUK_ASSERT(act != NULL);
+	return act;
+}
+
+DUK_INTERNAL void duk_hthread_activation_free(duk_hthread *thr, duk_activation *act) {
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(act != NULL);
+
+#if 0
+	act->parent = thr->heap->activation_free;
+	thr->heap->activation_free = act;
+#else
+	DUK_FREE_CHECKED(thr, (void *) act);
+#endif
+}
+
+/* Internal helper: process the unwind for the topmost activation of a thread,
+ * but leave the duk_activation in place for possible tailcall reuse.
+ */
+DUK_LOCAL void duk__activation_unwind_nofree_norz(duk_hthread *thr) {
+#if defined(DUK_USE_DEBUGGER_SUPPORT)
+	duk_heap *heap;
+#endif
+	duk_activation *act;
+	duk_hobject *func;
+	duk_hobject *tmp;
+
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(thr->callstack_curr != NULL);  /* caller must check */
+	DUK_ASSERT(thr->callstack_top > 0);
+	act = thr->callstack_curr;
+	DUK_ASSERT(act != NULL);
+	/* With lightfuncs, act 'func' may be NULL. */
+
+	/* With duk_activation records allocated separately, 'act' is a stable
+	 * pointer and not affected by side effects.
+	 */
 
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
-		/*
-		 *  Restore 'caller' property for non-strict callee functions.
+	/*
+	 *  Restore 'caller' property for non-strict callee functions.
+	 */
+
+	func = DUK_ACT_GET_FUNC(act);
+	if (func != NULL && !DUK_HOBJECT_HAS_STRICT(func)) {
+		duk_tval *tv_caller;
+		duk_tval tv_tmp;
+		duk_hobject *h_tmp;
+
+		tv_caller = duk_hobject_find_existing_entry_tval_ptr(thr->heap, func, DUK_HTHREAD_STRING_CALLER(thr));
+
+		/* The act->prev_caller should only be set if the entry for 'caller'
+		 * exists (as it is only set in that case, and the property is not
+		 * configurable), but handle all the cases anyway.
 		 */
 
-		func = DUK_ACT_GET_FUNC(act);
-		if (func != NULL && !DUK_HOBJECT_HAS_STRICT(func)) {
-			duk_tval *tv_caller;
-			duk_tval tv_tmp;
-			duk_hobject *h_tmp;
-
-			tv_caller = duk_hobject_find_existing_entry_tval_ptr(thr->heap, func, DUK_HTHREAD_STRING_CALLER(thr));
-
-			/* The act->prev_caller should only be set if the entry for 'caller'
-			 * exists (as it is only set in that case, and the property is not
-			 * configurable), but handle all the cases anyway.
-			 */
-
-			if (tv_caller) {
-				DUK_TVAL_SET_TVAL(&tv_tmp, tv_caller);
-				if (act->prev_caller) {
-					/* Just transfer the refcount from act->prev_caller to tv_caller,
-					 * so no need for a refcount update.  This is the expected case.
-					 */
-					DUK_TVAL_SET_OBJECT(tv_caller, act->prev_caller);
-					act->prev_caller = NULL;
-				} else {
-					DUK_TVAL_SET_NULL(tv_caller);   /* no incref needed */
-					DUK_ASSERT(act->prev_caller == NULL);
-				}
-				DUK_TVAL_DECREF_NORZ(thr, &tv_tmp);
+		if (tv_caller) {
+			DUK_TVAL_SET_TVAL(&tv_tmp, tv_caller);
+			if (act->prev_caller) {
+				/* Just transfer the refcount from act->prev_caller to tv_caller,
+				 * so no need for a refcount update.  This is the expected case.
+				 */
+				DUK_TVAL_SET_OBJECT(tv_caller, act->prev_caller);
+				act->prev_caller = NULL;
 			} else {
-				h_tmp = act->prev_caller;
-				if (h_tmp) {
-					act->prev_caller = NULL;
-					DUK_HOBJECT_DECREF_NORZ(thr, h_tmp);
-				}
+				DUK_TVAL_SET_NULL(tv_caller);   /* no incref needed */
+				DUK_ASSERT(act->prev_caller == NULL);
 			}
-			DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-			DUK_ASSERT(act->prev_caller == NULL);
+			DUK_TVAL_DECREF_NORZ(thr, &tv_tmp);
+		} else {
+			h_tmp = act->prev_caller;
+			if (h_tmp) {
+				act->prev_caller = NULL;
+				DUK_HOBJECT_DECREF_NORZ(thr, h_tmp);
+			}
 		}
+		DUK_ASSERT(act->prev_caller == NULL);
+	}
 #endif
 
-		/*
-		 *  Unwind debugger state.  If we unwind while stepping
-		 *  (either step over or step into), pause execution.
-		 */
+	/*
+	 *  Unwind debugger state.  If we unwind while stepping
+	 *  (for any step type), pause execution.  This is the
+	 *  only place explicitly handling a step out.
+	 */
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-		heap = thr->heap;
-		if (heap->dbg_step_thread == thr &&
-		    heap->dbg_step_csindex == idx) {
-			/* Pause for all step types: step into, step over, step out.
-			 * This is the only place explicitly handling a step out.
-			 */
-			if (duk_debug_is_paused(heap)) {
-				DUK_D(DUK_DPRINT("step pause trigger but already paused, ignoring"));
-			} else {
-				duk_debug_set_paused(heap);
-				DUK_ASSERT(heap->dbg_step_thread == NULL);
-			}
+	heap = thr->heap;
+	if (heap->dbg_step_act == thr->callstack_curr) {
+		if (duk_debug_is_paused(heap)) {
+			DUK_D(DUK_DPRINT("step pause trigger but already paused, ignoring"));
+		} else {
+			duk_debug_set_paused(heap);
+			DUK_ASSERT(heap->dbg_step_act == NULL);
 		}
+	}
 #endif
 
-		/*
-		 *  Unwind catchers.
-		 *
-		 *  Since there are no references in the catcher structure,
-		 *  unwinding is quite simple.  The only thing we need to
-		 *  look out for is popping a possible lexical environment
-		 *  established for an active catch clause.
-		 */
-
-		DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-		while (act->cat != NULL) {
-			DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-			duk_hthread_catcher_unwind_norz(thr, act);
-		}
-
-		/*
-		 *  Close environment record(s) if they exist.
-		 *
-		 *  Only variable environments are closed.  If lex_env != var_env, it
-		 *  cannot currently contain any register bound declarations.
-		 *
-		 *  Only environments created for a NEWENV function are closed.  If an
-		 *  environment is created for e.g. an eval call, it must not be closed.
-		 */
-
-		DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-		func = DUK_ACT_GET_FUNC(act);
-		if (func != NULL && !DUK_HOBJECT_HAS_NEWENV(func)) {
-			DUK_DDD(DUK_DDDPRINT("skip closing environments, envs not owned by this activation"));
-			goto skip_env_close;
-		}
-		/* func is NULL for lightfunc */
-
-		/* Catch sites are required to clean up their environments
-		 * in FINALLY part before propagating, so this should
-		 * always hold here.
-		 */
-		DUK_ASSERT(act->lex_env == act->var_env);
-
-		DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-		if (act->var_env != NULL) {
-			DUK_DDD(DUK_DDDPRINT("closing var_env record %p -> %!O",
-			                     (void *) act->var_env, (duk_heaphdr *) act->var_env));
-			duk_js_close_environment_record(thr, act->var_env);
-			act = thr->callstack + idx;  /* avoid side effect issues */
-		}
-
-	 skip_env_close:
-
-		/*
-		 *  Update preventcount
-		 */
-
-		DUK_ASSERT(act == thr->callstack + idx);  /* no side effects */
-		if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
-			DUK_ASSERT(thr->callstack_preventcount >= 1);
-			thr->callstack_preventcount--;
-		}
-
-		/*
-		 *  Reference count updates, using NORZ macros so we don't
-		 *  need to handle side effects.
-		 */
-
-		DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, act->var_env);
-		act->var_env = NULL;
-		DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, act->lex_env);
-		act->lex_env = NULL;
-
-		/* Note: this may cause a corner case situation where a finalizer
-		 * may see a currently reachable activation whose 'func' is NULL.
-		 */
-		tmp = DUK_ACT_GET_FUNC(act);
-		DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, tmp);
-		DUK_UNREF(tmp);
-		act->func = NULL;
-	}
-
-	thr->callstack_top = new_top;
-	if (new_top > 0) {
-		thr->callstack_curr = thr->callstack + new_top - 1;
-	} else {
-		thr->callstack_curr = NULL;
-	}
-
-	/* We could clear the book-keeping variables for the topmost activation,
-	 * but don't do so now.
+	/*
+	 *  Unwind catchers.
+	 *
+	 *  Since there are no references in the catcher structure,
+	 *  unwinding is quite simple.  The only thing we need to
+	 *  look out for is popping a possible lexical environment
+	 *  established for an active catch clause.
 	 */
-#if 0
-	if (thr->callstack_curr != NULL) {
-		duk_activation *act = thr->callstack_curr;
-		act->idx_retval = 0;
-	}
-#endif
 
-	/* Note: any entries above the callstack top are garbage and not zeroed.
-	 * Also topmost activation idx_retval is garbage (not zeroed), and must
-	 * be ignored.
+	while (act->cat != NULL) {
+		duk_hthread_catcher_unwind_norz(thr, act);
+	}
+
+	/*
+	 *  Close environment record(s) if they exist.
+	 *
+	 *  Only variable environments are closed.  If lex_env != var_env, it
+	 *  cannot currently contain any register bound declarations.
+	 *
+	 *  Only environments created for a NEWENV function are closed.  If an
+	 *  environment is created for e.g. an eval call, it must not be closed.
+	 */
+
+	func = DUK_ACT_GET_FUNC(act);
+	if (func != NULL && !DUK_HOBJECT_HAS_NEWENV(func)) {
+		DUK_DDD(DUK_DDDPRINT("skip closing environments, envs not owned by this activation"));
+		goto skip_env_close;
+	}
+	/* func is NULL for lightfunc */
+
+	/* Catch sites are required to clean up their environments
+	 * in FINALLY part before propagating, so this should
+	 * always hold here.
+	 */
+	DUK_ASSERT(act->lex_env == act->var_env);
+
+	/* XXX: Closing the environment record copies values from registers
+	 * into the scope object.  It's side effect free as such, but may
+	 * currently run out of memory which causes an error throw.  This is
+	 * an actual sandboxing problem for error unwinds, and needs to be
+	 * fixed e.g. by preallocating the scope property slots.
+	 */
+	if (act->var_env != NULL) {
+		DUK_DDD(DUK_DDDPRINT("closing var_env record %p -> %!O",
+		                     (void *) act->var_env, (duk_heaphdr *) act->var_env));
+		duk_js_close_environment_record(thr, act->var_env);
+	}
+
+ skip_env_close:
+
+	/*
+	 *  Update preventcount
+	 */
+
+	if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
+		DUK_ASSERT(thr->callstack_preventcount >= 1);
+		thr->callstack_preventcount--;
+	}
+
+	/*
+	 *  Reference count updates, using NORZ macros so we don't
+	 *  need to handle side effects.
+	 *
+	 *  duk_activation pointers like act->var_env are intentionally
+	 *  left as garbage and not NULLed.  Without side effects they
+	 *  can't be used when the values are dangling/garbage.
+	 */
+
+	DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, act->var_env);
+	DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, act->lex_env);
+	tmp = DUK_ACT_GET_FUNC(act);
+	DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, tmp);
+	DUK_UNREF(tmp);
+}
+
+/* Unwind topmost duk_activation of a thread, caller must ensure that an
+ * activation exists.  The call is side effect free, except that scope
+ * closure may currently throw an out-of-memory error.
+ */
+DUK_INTERNAL void duk_hthread_activation_unwind_norz(duk_hthread *thr) {
+	duk_activation *act;
+
+	duk__activation_unwind_nofree_norz(thr);
+
+	DUK_ASSERT(thr->callstack_curr != NULL);
+	DUK_ASSERT(thr->callstack_top > 0);
+	act = thr->callstack_curr;
+	thr->callstack_curr = act->parent;
+	thr->callstack_top--;
+
+	/* XXX: inline for performance builds? */
+	duk_hthread_activation_free(thr, act);
+
+	/* We could clear the book-keeping variables like idx_retval for the
+	 * topmost activation, but don't do so now as it's not necessary.
 	 */
 }
 
-DUK_INTERNAL void duk_hthread_callstack_unwind(duk_hthread *thr, duk_size_t new_top) {
-	duk_hthread_callstack_unwind_norz(thr, new_top);
-	DUK_REFZERO_CHECK_FAST(thr);
+DUK_INTERNAL void duk_hthread_activation_unwind_reuse_norz(duk_hthread *thr) {
+	duk__activation_unwind_nofree_norz(thr);
+}
+
+/* Get duk_activation for given callstack level or NULL if level is invalid
+ * or deeper than the call stack.  Level -1 refers to current activation, -2
+ * to its caller, etc.  Starting from Duktape 2.2 finding the activation is
+ * a linked list scan which gets more expensive the deeper the lookup is.
+ */
+DUK_INTERNAL duk_activation *duk_hthread_get_activation_for_level(duk_hthread *thr, duk_int_t level) {
+	duk_activation *act;
+
+	if (level >= 0) {
+		return NULL;
+	}
+	act = thr->callstack_curr;
+	for (;;) {
+		if (act == NULL) {
+			return act;
+		}
+		if (level == -1) {
+			return act;
+		}
+		level++;
+		act = act->parent;
+	}
+	/* never here */
 }
 
 #if defined(DUK_USE_FINALIZER_TORTURE)
@@ -415,34 +346,6 @@ DUK_INTERNAL void duk_hthread_valstack_torture_realloc(duk_hthread *thr) {
 		/* No change in size. */
 	} else {
 		DUK_D(DUK_DPRINT("failed to realloc valstack for torture, ignore"));
-	}
-}
-
-DUK_INTERNAL void duk_hthread_callstack_torture_realloc(duk_hthread *thr) {
-	duk_size_t alloc_size;
-	duk_activation *new_ptr;
-	duk_ptrdiff_t curr_off;
-
-	if (thr->callstack == NULL) {
-		return;
-	}
-
-	curr_off = (duk_ptrdiff_t) ((duk_uint8_t *) thr->callstack_curr - (duk_uint8_t *) thr->callstack);
-	alloc_size = sizeof(duk_activation) * thr->callstack_size;
-	if (alloc_size == 0) {
-		return;
-	}
-
-	new_ptr = (duk_activation *) DUK_ALLOC(thr->heap, alloc_size);
-	if (new_ptr != NULL) {
-		DUK_MEMCPY((void *) new_ptr, (const void *) thr->callstack, alloc_size);
-		DUK_MEMSET((void *) thr->callstack, 0x55, alloc_size);
-		DUK_FREE_CHECKED(thr, (void *) thr->callstack);
-		thr->callstack = new_ptr;
-		thr->callstack_curr = (duk_activation *) ((duk_uint8_t *) new_ptr + curr_off);
-		/* No change in size. */
-	} else {
-		DUK_D(DUK_DPRINT("failed to realloc callstack for torture, ignore"));
 	}
 }
 #endif  /* DUK_USE_FINALIZER_TORTURE */

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -6,11 +6,10 @@
 #define DUK_JS_H_INCLUDED
 
 /* Flags for call handling. */
-#define DUK_CALL_FLAG_IGNORE_RECLIMIT        (1 << 0)  /* duk_handle_call_xxx: call ignores C recursion limit (for errhandler calls) */
-#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 1)  /* duk_handle_call_xxx: constructor call (i.e. called as 'new Foo()') */
-#define DUK_CALL_FLAG_IS_RESUME              (1 << 2)  /* duk_handle_ecma_call_setup: setup for a resume() */
-#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 3)  /* duk_handle_ecma_call_setup: setup for a tail call */
-#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 4)  /* call is a direct eval call */
+#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 0)  /* duk_handle_call_xxx: constructor call (i.e. called as 'new Foo()') */
+#define DUK_CALL_FLAG_IS_RESUME              (1 << 1)  /* duk_handle_ecma_call_setup: setup for a resume() */
+#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 2)  /* duk_handle_ecma_call_setup: setup for a tail call */
+#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 3)  /* call is a direct eval call */
 
 /* Flags for duk_js_equals_helper(). */
 #define DUK_EQUALS_FLAG_SAMEVALUE            (1 << 0)  /* use SameValue instead of non-strict equality */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -68,12 +68,12 @@
 
 #define DUK__RECURSION_INCREASE(comp_ctx,thr)  do { \
 		DUK_DDD(DUK_DDDPRINT("RECURSION INCREASE: %s:%ld", (const char *) DUK_FILE_MACRO, (long) DUK_LINE_MACRO)); \
-		duk__recursion_increase((comp_ctx)); \
+		duk__comp_recursion_increase((comp_ctx)); \
 	} while (0)
 
 #define DUK__RECURSION_DECREASE(comp_ctx,thr)  do { \
 		DUK_DDD(DUK_DDDPRINT("RECURSION DECREASE: %s:%ld", (const char *) DUK_FILE_MACRO, (long) DUK_LINE_MACRO)); \
-		duk__recursion_decrease((comp_ctx)); \
+		duk__comp_recursion_decrease((comp_ctx)); \
 	} while (0)
 
 /* Value stack slot limits: these are quite approximate right now, and
@@ -403,7 +403,7 @@ DUK_LOCAL const duk_uint8_t duk__token_lbp[] = {
  *  Misc helpers
  */
 
-DUK_LOCAL void duk__recursion_increase(duk_compiler_ctx *comp_ctx) {
+DUK_LOCAL void duk__comp_recursion_increase(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(comp_ctx != NULL);
 	DUK_ASSERT(comp_ctx->recursion_depth >= 0);
 	if (comp_ctx->recursion_depth >= comp_ctx->recursion_limit) {
@@ -412,7 +412,7 @@ DUK_LOCAL void duk__recursion_increase(duk_compiler_ctx *comp_ctx) {
 	comp_ctx->recursion_depth++;
 }
 
-DUK_LOCAL void duk__recursion_decrease(duk_compiler_ctx *comp_ctx) {
+DUK_LOCAL void duk__comp_recursion_decrease(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(comp_ctx != NULL);
 	DUK_ASSERT(comp_ctx->recursion_depth > 0);
 	comp_ctx->recursion_depth--;

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -562,10 +562,7 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr,
 	duk_context *ctx = (duk_context *) thr;
 	duk_hobject *func;
 	duk_hobject *env;
-	duk_size_t act_off;
 
-	DUK_ASSERT(act != NULL);
-	act_off = (duk_size_t) ((duk_uint8_t *) act - (duk_uint8_t *) thr->callstack);
 	func = DUK_ACT_GET_FUNC(act);
 	DUK_ASSERT(func != NULL);
 	DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));  /* bound functions are never in act 'func' */
@@ -580,7 +577,7 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr,
 
 	env = duk_create_activation_environment_record(thr, func, act->idx_bottom);
 	DUK_ASSERT(env != NULL);
-	act = (duk_activation *) (void *) ((duk_uint8_t *) thr->callstack + act_off);
+	/* 'act' is a stable pointer, so still OK. */
 
 	DUK_DDD(DUK_DDDPRINT("created delayed fresh env: %!ipO", (duk_heaphdr *) env));
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
@@ -1724,10 +1721,8 @@ duk_bool_t duk_js_declvar_activation(duk_hthread *thr,
                                      duk_bool_t is_func_decl) {
 	duk_hobject *env;
 	duk_tval tv_val_copy;
-	duk_size_t act_off;
 
 	DUK_ASSERT(act != NULL);
-	act_off = (duk_size_t) ((duk_uint8_t *) act - (duk_uint8_t *) thr->callstack);
 
 	/*
 	 *  Make a value copy of the input val.  This ensures that
@@ -1744,7 +1739,7 @@ duk_bool_t duk_js_declvar_activation(duk_hthread *thr,
 	if (!act->var_env) {
 		DUK_ASSERT(act->lex_env == NULL);
 		duk_js_init_activation_environment_records_delayed(thr, act);
-		act = (duk_activation *) (void *) ((duk_uint8_t *) thr->callstack + act_off);
+		/* 'act' is a stable pointer, so still OK. */
 	}
 	DUK_ASSERT(act->lex_env != NULL);
 	DUK_ASSERT(act->var_env != NULL);

--- a/tests/ecmascript/test-err-callstack-headroom-1.js
+++ b/tests/ecmascript/test-err-callstack-headroom-1.js
@@ -41,7 +41,6 @@ try {
 
     function f() { f(); }
     f();
-}
-catch(e) {
+} catch(e) {
     print(e);
 }

--- a/tests/ecmascript/test-err-callstack-headroom-2.js
+++ b/tests/ecmascript/test-err-callstack-headroom-2.js
@@ -1,0 +1,35 @@
+/*
+ *  Error handling callstack headroom (GH-191)
+ *
+ *  Check that relaxed callstack limit during error creation is still bounded
+ *  so that an errCreate callback doing unbounded recursion is caught.  The
+ *  result is a DoubleError.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+DoubleError: error in error handling
+===*/
+
+try {
+    function recurse() {
+        var dummy;
+        recurse();
+        dummy = 1;
+    }
+
+    Duktape.errCreate = function(e) {
+        recurse();
+        return e;
+    };
+
+    function f() { f(); }
+    f();
+} catch(e) {
+    print(e);
+}

--- a/tests/ecmascript/test-err-errcreate-error.js
+++ b/tests/ecmascript/test-err-errcreate-error.js
@@ -1,0 +1,37 @@
+/*
+ *  Errors thrown by Duktape internals during an errCreate() will work
+ *  normally except they won't be augmented to avoid recursion.
+ */
+
+/*===
+errCreate: RangeError
+internal error: URIError
+internal error: EvalError
+errThrow: RangeError
+RangeError
+===*/
+
+try {
+    Duktape.errCreate = function (e) {
+        print('errCreate:', e.name);
+        try {
+            decodeURIComponent('%ff%ff');
+        } catch (e2) {
+            print('internal error:', e2.name);
+        }
+        try {
+            throw new EvalError('user error');  // created but not augmented
+        } catch (e2) {
+            print('internal error:', e2.name);
+        }
+        return e;
+    };
+    Duktape.errThrow = function (e) {
+        print('errThrow:', e.name);
+        return e;
+    };
+
+    throw new RangeError('aiee');
+} catch (e) {
+    print(e.name);
+}

--- a/tests/ecmascript/test-err-errthrow-error.js
+++ b/tests/ecmascript/test-err-errthrow-error.js
@@ -1,0 +1,37 @@
+/*
+ *  Errors thrown by Duktape internals during an errThrow() will work
+ *  normally except they won't be augmented to avoid recursion.
+ */
+
+/*===
+errCreate: RangeError
+errThrow: RangeError
+internal error: URIError
+internal error: EvalError
+RangeError
+===*/
+
+try {
+    Duktape.errCreate = function (e) {
+        print('errCreate:', e.name);
+        return e;
+    };
+    Duktape.errThrow = function (e) {
+        print('errThrow:', e.name);
+        try {
+            decodeURIComponent('%ff%ff');
+        } catch (e2) {
+            print('internal error:', e2.name);
+        }
+        try {
+            throw new EvalError('user error');  // created but not augmented
+        } catch (e2) {
+            print('internal error:', e2.name);
+        }
+        return e;
+    };
+
+    throw new RangeError('aiee');
+} catch (e) {
+    print(e.name);
+}


### PR DESCRIPTION
Remove thr->callstack array of duk_activations and replace it with a linked list, with thr->callstack_curr holding the currently active entry and act->parent chaining upwards in the call chain.

The upside of the change is that there is one fewer large monolithic allocations which are problematic for low memory targets. Instead, there are a lot of smaller allocations maintained as a linked list. Another upside is that 'act' pointers are now stable, so a lot of side effect questions are eliminated.

One downside is that random access is no longer possible (though it can be accelerated later if necessary); however, very few call sites actually need the random access capability. Another downside is that there are a lot of small allocations when calling and returning; this can be mitigated by duk_activation pooling (to be implemented separately).

Tasks:
- [x] Initial draft of changes
- [x] Clean up FIXMEs, compile warnings, etc
- [x] Callstack limit check, to be kept
- [x] Go through 'act = ...' re-lookups; no longer needed because 'act' is now stable, but keep if they make footprint better (they may, because re-lookup may be smaller/faster than store/restore past function call(s))
- [x] Rework thr->callstack_max headroom when creating error: the previous solution wasn't 100% when coroutines were involved (setting and restoring the limit might happen in different threads!); new solution is to add headroom in call handling (without a store/restore) when heap->augmenting_error is set
- [x] Remove internal IGNORE_RECLIMIT flag and rework it to be conditional on heap->augmenting_error dynamically without an explicit store/restore (much easier to handle correctly)
- [x] Remove ERRHANDLER_RUNNING flag and use heap->augmenting_error instead
- [x] Testcase fixes
- [x] Internal documentation changes
- [x] Perf test
- [x] Torture tests
- [x] Releases entry

Fixes #1490.