### PR TITLE
Fix forced writing of Duktape/C function .length

### DIFF
--- a/tests/api/test-dev-set-duktapec-func-length.c
+++ b/tests/api/test-dev-set-duktapec-func-length.c
@@ -1,0 +1,41 @@
+/*===
+===*/
+
+static duk_ret_t dummy_func(duk_context *ctx) {
+	(void) ctx;
+	return 0;
+}
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy_func, 1);
+	duk_push_string(ctx, "length");
+	duk_push_int(ctx, 3);
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE |
+	                      DUK_DEFPROP_CLEAR_WRITABLE |
+	                      DUK_DEFPROP_CLEAR_ENUMERABLE |
+	                      DUK_DEFPROP_SET_CONFIGURABLE |
+	                      DUK_DEFPROP_FORCE);
+
+	printf("added concrete .length\n");
+
+	duk_eval_string(ctx,
+		"(function (fn) {\n"
+		"    print(typeof fn);\n"
+		"    var desc = Object.getOwnPropertyDescriptor(fn, 'length');\n"
+		"    print(desc.writable);\n"
+		"    print(desc.enumerable);\n"
+		"    print(desc.configurable);\n"
+		"    print(desc.value);\n"
+		"})");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/api/test-dev-set-duktapec-func-name.c
+++ b/tests/api/test-dev-set-duktapec-func-name.c
@@ -1,0 +1,50 @@
+/*===
+*** test_basic (duk_safe_call)
+added concrete .name
+function
+false
+false
+true
+myFunc
+final top: 2
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t dummy_func(duk_context *ctx) {
+	(void) ctx;
+	return 0;
+}
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy_func, 1);
+	duk_push_string(ctx, "name");
+	duk_push_string(ctx, "myFunc");
+	duk_def_prop(ctx, -3, DUK_DEFPROP_HAVE_VALUE |
+	                      DUK_DEFPROP_CLEAR_WRITABLE |
+	                      DUK_DEFPROP_CLEAR_ENUMERABLE |
+	                      DUK_DEFPROP_SET_CONFIGURABLE |
+	                      DUK_DEFPROP_FORCE);
+
+	printf("added concrete .name\n");
+
+	duk_eval_string(ctx,
+		"(function (fn) {\n"
+		"    print(typeof fn);\n"
+		"    var desc = Object.getOwnPropertyDescriptor(fn, 'name');\n"
+		"    print(desc.writable);\n"
+		"    print(desc.enumerable);\n"
+		"    print(desc.configurable);\n"
+		"    print(desc.value);\n"
+		"})");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}


### PR DESCRIPTION
Duktape/C function .length is a "virtual" property so it's not an own property but also not inherited. The current handling prevents a DUK_DEFPROP_FORCE write to establish a .length own property for a Duktape/C function.

Nicest solution would be for Function.prototype.length to be an inherited accessor which could have special handling for Duktape/C functions, to provide a useful .length based on nargs count. However, that would violate the ES2015 property setup so the property needs to be virtual.

- [ ] Add testcase coverage
- [ ] Fix for virtual property writing, should allow one to establish a property in general even if a virtual property conflicts
- [ ] Releases entry
- [ ] Backports

The particular case for function .length might become moot with #1493 but other cases remain valid.