### PR TITLE
Set REACHABLE for ROM objects to avoid a READONLY check in marking

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2828,6 +2828,10 @@ Planned
 * Add an internal type for representing Proxy instances (duk_hproxy) to
   simplify Proxy operations and improve performance (GH-1500, GH-1136)
 
+* Internal change: set REACHABLE for all READONLY objects (relevant when
+  using ROM built-ins) so that mark-and-sweep doesn't need an explicit
+  READONLY check (GH-1502)
+
 * Internal change: duk_activation structs are now in a single linked list
   attached to a duk_hthread instead of being a separate, monolithic
   thr->callstack (GH-1487)

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -169,21 +169,21 @@ DUK_LOCAL void duk__mark_heaphdr(duk_heap *heap, duk_heaphdr *h) {
 		return;
 	}
 
-	/* XXX: just mark all READONLY objects reachable so they can be skipped here? */
-#if defined(DUK_USE_ROM_OBJECTS)
-	if (DUK_HEAPHDR_HAS_READONLY(h)) {
-		DUK_DDD(DUK_DDDPRINT("readonly object %p, skip", (void *) h));
-		return;
-	}
-#endif
+	DUK_ASSERT(!DUK_HEAPHDR_HAS_READONLY(h) || DUK_HEAPHDR_HAS_REACHABLE(h));
+
 #if defined(DUK_USE_ASSERTIONS) && defined(DUK_USE_REFERENCE_COUNTING)
-	h->h_assert_refcount++;  /* Comparison refcount: bump even if already reachable. */
+	if (!DUK_HEAPHDR_HAS_READONLY(h)) {
+		h->h_assert_refcount++;  /* Comparison refcount: bump even if already reachable. */
+	}
 #endif
 	if (DUK_HEAPHDR_HAS_REACHABLE(h)) {
 		DUK_DDD(DUK_DDDPRINT("already marked reachable, skip"));
 		return;
 	}
 #if defined(DUK_USE_ROM_OBJECTS)
+	/* READONLY objects always have REACHABLE set, so the check above
+	 * will prevent READONLY objects from being marked here.
+	 */
 	DUK_ASSERT(!DUK_HEAPHDR_HAS_READONLY(h));
 #endif
 

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -157,12 +157,18 @@
 	DUK_ASSERT((duk_size_t) (((duk_hthread *) (ctx))->valstack_end - ((duk_hthread *) (ctx))->valstack) == \
 		((duk_hthread *) (ctx))->valstack_size)
 #endif
+/* Assertions for internals. */
+#define DUK_ASSERT_HTHREAD_VALID(thr) do { \
+		DUK_ASSERT((thr) != NULL); \
+		DUK_ASSERT(DUK_HEAPHDR_GET_TYPE((duk_heaphdr *) (thr)) == DUK_HTYPE_OBJECT); \
+		DUK_ASSERT(DUK_HOBJECT_IS_THREAD((duk_hobject *) (thr))); \
+		DUK_ASSERT((thr)->unused1 == 0); \
+		DUK_ASSERT((thr)->unused2 == 0); \
+	} while (0)
+/* Assertions for public API calls; a bit stronger. */
 #define DUK_ASSERT_CTX_VALID(ctx) do { \
 		DUK_ASSERT((ctx) != NULL); \
-		DUK_ASSERT(DUK_HEAPHDR_GET_TYPE((duk_heaphdr *) (ctx)) == DUK_HTYPE_OBJECT); \
-		DUK_ASSERT(DUK_HOBJECT_IS_THREAD((duk_hobject *) (ctx))); \
-		DUK_ASSERT(((duk_hthread *) (ctx))->unused1 == 0); \
-		DUK_ASSERT(((duk_hthread *) (ctx))->unused2 == 0); \
+		DUK_ASSERT_HTHREAD_VALID((duk_hthread *) (ctx)); \
 		DUK_ASSERT(((duk_hthread *) (ctx))->valstack != NULL); \
 		DUK_ASSERT(((duk_hthread *) (ctx))->valstack_end >= ((duk_hthread *) (ctx))->valstack); \
 		DUK_ASSERT(((duk_hthread *) (ctx))->valstack_top >= ((duk_hthread *) (ctx))->valstack); \
@@ -170,7 +176,6 @@
 		DUK_ASSERT(((duk_hthread *) (ctx))->valstack_end >= ((duk_hthread *) (ctx))->valstack_top); \
 		DUK_ASSERT_CTX_VSSIZE((ctx)); \
 	} while (0)
-#define DUK_ASSERT_HTHREAD_VALID(h) DUK_ASSERT_CTX_VALID((h))
 
 /*
  *  Assertion helpers.

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -2317,7 +2317,7 @@ def rom_emit_strings_source(genc, meta):
     for lst in romstr_hash:
         for v in reversed(lst):
             tmp = 'DUK_INTERNAL const duk_romstr_%d %s = {' % (len(v), bi_str_map[v])
-            flags = [ 'DUK_HTYPE_STRING', 'DUK_HEAPHDR_FLAG_READONLY' ]
+            flags = [ 'DUK_HTYPE_STRING', 'DUK_HEAPHDR_FLAG_READONLY', 'DUK_HEAPHDR_FLAG_REACHABLE' ]
             is_arridx = string_is_arridx(v)
 
             blen = len(v)
@@ -2741,7 +2741,7 @@ def rom_emit_objects(genc, meta, bi_str_map):
         else:
             tmp = 'DUK_EXTERNAL const duk_romobj duk_obj_%d = ' % idx
 
-        flags = [ 'DUK_HTYPE_OBJECT', 'DUK_HEAPHDR_FLAG_READONLY' ]
+        flags = [ 'DUK_HTYPE_OBJECT', 'DUK_HEAPHDR_FLAG_READONLY', 'DUK_HEAPHDR_FLAG_REACHABLE' ]
         if isfunc:
             flags.append('DUK_HOBJECT_FLAG_NATFUNC')
             flags.append('DUK_HOBJECT_FLAG_STRICT')


### PR DESCRIPTION
Minor optimization for mark-and-sweep when using ROM built-ins: set REACHABLE for ROM objects so that the REACHABLE check in marking a heap object is enough to also skip ROM objects without a separate READONLY check.

Tasks:

- [x] Make the change
- [x] Assertion run
- [x] Fix DUK_ASSERT_HTHREAD_VALID() assert for thr->valstack != NULL (introduced after 2.1.0 so not a released issue)
- [x] Releases entry