### PR TITLE
Fix missing duk_require_stack() in bound function call handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2828,6 +2828,10 @@ Planned
 * Add an internal type for representing Proxy instances (duk_hproxy) to
   simplify Proxy operations and improve performance (GH-1500, GH-1136)
 
+* Fix missing duk_require_stack() in bound function call handling which caused
+  calls to bound functions with a lot of bound arguments to fail with a value
+  stack limit error (GH-1504)
+
 * Internal change: set REACHABLE for all READONLY objects (relevant when
   using ROM built-ins) so that mark-and-sweep doesn't need an explicit
   READONLY check (GH-1502)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -564,6 +564,8 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 		duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_LENGTH);          /* -> [ ... func this arg1 ... argN _Args length ] */
 		len = (duk_idx_t) duk_require_int(ctx, -1);
 		duk_pop(ctx);
+
+		duk_require_stack(ctx, len);
 		for (i = 0; i < len; i++) {
 			/* XXX: very slow - better to bulk allocate a gap, and copy
 			 * from args_array directly (we know it has a compact array

--- a/tests/ecmascript/test-dev-bound-func-many-args.js
+++ b/tests/ecmascript/test-dev-bound-func-many-args.js
@@ -1,0 +1,22 @@
+/*===
+65535
+foo-0
+foo-65535
+undefined
+undefined
+===*/
+
+function target() {
+    print(arguments.length);
+    print(this);
+    print(arguments[65534]);
+    print(arguments[65535]);
+    print(arguments[65536]);
+}
+
+var args = [];
+while (args.length < 65536) {
+    args.push('foo-' + args.length);
+}
+var f = Function.prototype.bind.apply(target, args);
+f();


### PR DESCRIPTION
The missing duk_require_stack() call causes calls with a lot of bound arguments to fail due to current value stack limit.