### PR TITLE
Avoid duk_hbufobj validity assert trigger

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2832,6 +2832,8 @@ Planned
   calls to bound functions with a lot of bound arguments to fail with a value
   stack limit error (GH-1504)
 
+* Fix duk_hbufobj assert in shared slice() handling (GH-1506)
+
 * Internal change: set REACHABLE for all READONLY objects (relevant when
   using ROM built-ins) so that mark-and-sweep doesn't need an explicit
   READONLY check (GH-1502)

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -2046,7 +2046,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 	                               res_proto_bidx);
 	DUK_ASSERT(h_bufobj != NULL);
 
-	h_bufobj->length = slice_length;
+	DUK_ASSERT(h_bufobj->length == 0);
 	h_bufobj->shift = h_this->shift;  /* inherit */
 	h_bufobj->elem_type = h_this->elem_type;  /* inherit */
 	h_bufobj->is_typedarray = magic & 0x01;
@@ -2077,12 +2077,14 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_context *ctx) {
 
 		h_bufobj->buf = h_val;
 		DUK_HBUFFER_INCREF(thr, h_val);
+		h_bufobj->length = slice_length;
 		DUK_ASSERT(h_bufobj->offset == 0);
 
 		duk_pop(ctx);  /* reachable so pop OK */
 	} else {
 		h_bufobj->buf = h_val;
 		DUK_HBUFFER_INCREF(thr, h_val);
+		h_bufobj->length = slice_length;
 		h_bufobj->offset = (duk_uint_t) (h_this->offset + start_offset);
 
 		/* Copy the .buffer property, needed for TypedArray.prototype.subarray().


### PR DESCRIPTION
duk_hbufobj validity assertions require that if the buf pointer is NULL, the buffer length and offset are zero.  This is violated by the shared slice code because it sets ->length before allocating a buffer, and since an
allocation may trigger side effects, the assert may trigger in mark-and-sweep. I don't think this causes issues besides an assert failure.