### PR TITLE
Move large and rare opcodes into NOINLINE helpers

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2858,6 +2858,9 @@ Planned
 * Internal change: simple freelists for duk_activation and duk_catcher
   (GH-1491)
 
+* Miscellaneous performance improvements: move rare/large opcodes into
+  NOINLINE helpers (GH-1510)
+
 3.0.0 (XXXX-XX-XX)
 ------------------
 


### PR DESCRIPTION
Move handling of the following opcodes into NOINLINE helpers to make the main dispatch function smaller and a bit better performing:

- INITSET and INITGET
- TRYCATCH
- ENDTRY
- ENDCATCH
- ENDFIN
- INITENUM and NEXTENUM

There are more potential opcodes for similar treatment, but these are quite clear cases.

Tasks:
- [x] Move opcodes to helpers
- [x] Check if a conditional NOINLINE improves footprint
- [x] Releases entry