### PR TITLE
Change header used for byteorder detection for modern Solaris

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * James Swift (https://github.com/phraemer)
 * Luis de Bethencourt (https://github.com/luisbg)
 * Ian Whyman (https://github.com/v00d00)
+* Rick Sayre (https://github.com/whorfin)
 
 Other contributions
 ===================

--- a/config/platforms/platform_solaris.h.in
+++ b/config/platforms/platform_solaris.h.in
@@ -11,7 +11,7 @@
 #define DUK_USE_BYTEORDER 3
 #endif
 #else  /* DUK_F_OLD_SOLARIS */
-#include <ast/endian.h>
+#include <sys/param.h>
 #endif  /* DUK_F_OLD_SOLARIS */
 
 #include <sys/param.h>


### PR DESCRIPTION
sys/param.h is the new hotness
the old <ast/endian.h> fails on OmniOS as it trys to include ast/bytesex.h as <bytesex.h>;
one would need to add -Iast to include path to fix, but sys/param.h works fine and ast
is "unstable"