### PR TITLE
Fix Reflect.construct() handling of extra arguments (4 or more arguments)

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2858,6 +2858,9 @@ Planned
   "collapse" bound function chains so that the target of a duk_hboundfunc is
   always a non-bound function (GH-1503)
 
+* Fix Reflect.construct() handling for four or more arguments (GH-1517,
+  GH-1518)
+
 * Fix callstack limit bumping for errThrow augmentation calls, the limit might
   be bumped and unbumped for different Duktape threads if coroutines were
   resumed/yielded in the process; this is relatively harmless but might cause

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -202,6 +202,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_apply(duk_context *ctx) {
 			/* XXX: [[Construct]] newTarget currently unsupported */
 			DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
 		}
+		duk_set_top(ctx, 2);  /* chop off extra arguments: [ constructor argArray ] */
 		idx_args = 1;
 		break;
 	}

--- a/tests/ecmascript/test-bi-reflect-construct-extra-args.js
+++ b/tests/ecmascript/test-bi-reflect-construct-extra-args.js
@@ -1,0 +1,27 @@
+/*
+ *  Reflect.construct() arguments beyond newTarget are ignored.
+ */
+
+/*===
+object
+1970-01-01T00:00:00.123Z
+object
+1970-01-01T00:00:00.123Z
+===*/
+
+function test() {
+    var t = Reflect.construct(Date, [ 123 ], Date);
+    print(typeof t);
+    print(t.toISOString());
+
+    // This should work like Reflect.construct(Date, [ 123 ], Date).
+    var t = Reflect.construct(Date, [ 123 ], Date, 'extra');
+    print(typeof t);
+    print(t.toISOString());
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Fixes #1517.