### PR TITLE
Some cleanups for direct .call() and .apply() handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2850,7 +2850,8 @@ Planned
 
 * Handle Function.prototype.call(), Function.prototype.apply(), and
   Reflect.apply() inline in call handling; as a side effect .call() and
-  .apply() no longer appear in the call stack (tracebacks etc) (GH-1421)
+  .apply() no longer appear in the call stack (tracebacks etc) (GH-1421,
+  GH-1522)
 
 * Function.prototype.call(), Function.prototype.apply(), and Reflect.apply()
   can be used in tailcalls (e.g. 'return func.call(null, 123);'), don't grow


### PR DESCRIPTION
Cleanups for #1421:
- [x] Less code duplication in .call/.apply resolution
- [x] More assertion coverage for value stack shape during .call/.apply resolution
- [ ] num_stack_args, maybe remove entirely
- [x] Rename nonbound lookup helper as it now resolves bound and .call/.apply
- [x] Inline fast path for nonbound lookup: non-bound function, not .call/.apply