### PR TITLE
Handle constructor call semantics inline, allow yield from constructor

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2858,6 +2858,12 @@ Planned
   the native C stack when doing an Ecmascript-to-Ecmascript call, and no
   longer prevent coroutine yielding (GH-1421)
 
+* Constructor calls (new Func()) can be used in tailcalls, don't grow
+  the native C stack when doing an Ecmascript-to-Ecmascript call, and no
+  longer prevent coroutine yielding (GH-1523)
+
+* Add duk_is_constructable() API call (GH-1523)
+
 * Add duk_push_proxy() API call which allows a Proxy to be created from C
   code (GH-1500, GH-837)
 

--- a/doc/release-notes-v2-2.rst
+++ b/doc/release-notes-v2-2.rst
@@ -28,6 +28,10 @@ from Duktape v2.1.x.  Note the following:
   and can now be used in tailcall positions, e.g. in
   'return func.call(null, 1, 2);'.
 
+* Constructor calls, i.e. 'new Xyz()' or duk_new(), no longer prevent a yield,
+  don't consume native stack for Ecmascript-to-Ecmascript calls, and can now
+  be used in tailcalls.
+
 * Functions pushed using duk_push_c_function() and duk_push_c_lightfunc() now
   inherit from an intermediate prototype (func -> %NativeFunctionPrototype%
   -> Function.prototype) which provides ``.name`` and ``.length`` getters.
@@ -42,3 +46,10 @@ from Duktape v2.1.x.  Note the following:
   binding, target, and bound argument count are now visible as artificial
   properties; the bound argument values are not visible in the debugger
   protocol for now.
+
+Other minor differences:
+
+* When an Error instance is being constructed and Duktape.errCreate() is
+  called for the constructor return value, the call stack seen by errCreate()
+  now includes the constructor call (previously it was unwound before calling
+  errCreate()).  This affects e.g. any Duktape.act() calls in errCreate().

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -39,7 +39,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_constructor_shared(duk_context *ctx) {
 
 #if defined(DUK_USE_AUGMENT_ERROR_CREATE)
 	if (!duk_is_constructor_call(ctx)) {
-		duk_err_augment_error_create(thr, thr, NULL, 0, 1 /*noblame_fileline*/);
+		duk_err_augment_error_create(thr, thr, NULL, 0, DUK_AUGMENT_FLAG_NOBLAME_FILELINE);
 	}
 #endif
 

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -764,7 +764,7 @@ DUK_LOCAL void duk__print_tval(duk__dprint_state *st, duk_tval *tv) {
 	case DUK_TAG_FASTINT:
 		DUK_ASSERT(!DUK_TVAL_IS_UNUSED(tv));
 		DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
-		duk_fb_sprintf(fb, "%.18gF", (double) DUK_TVAL_GET_NUMBER(tv));
+		duk_fb_sprintf(fb, "%.18g_F", (double) DUK_TVAL_GET_NUMBER(tv));
 		break;
 #endif
 	default: {

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -455,8 +455,11 @@ DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_create_and_throw(duk_hthread *thr, d
 
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_error_throw_from_negative_rc(duk_hthread *thr, duk_ret_t rc));
 
+#define DUK_AUGMENT_FLAG_NOBLAME_FILELINE  (1U << 0)  /* if set, don't blame C file/line for .fileName and .lineNumber */
+#define DUK_AUGMENT_FLAG_SKIP_ONE          (1U << 1)  /* if set, skip topmost activation in traceback construction */
+
 #if defined(DUK_USE_AUGMENT_ERROR_CREATE)
-DUK_INTERNAL_DECL void duk_err_augment_error_create(duk_hthread *thr, duk_hthread *thr_callstack, const char *filename, duk_int_t line, duk_bool_t noblame_fileline);
+DUK_INTERNAL_DECL void duk_err_augment_error_create(duk_hthread *thr, duk_hthread *thr_callstack, const char *filename, duk_int_t line, duk_small_uint_t flags);
 #endif
 #if defined(DUK_USE_AUGMENT_ERROR_THROW)
 DUK_INTERNAL_DECL void duk_err_augment_error_throw(duk_hthread *thr);

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -97,6 +97,7 @@ DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_
 DUK_INTERNAL_DECL void duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, void *udata, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
 DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL void duk_call_construct_postprocess(duk_context *ctx);
 
 /* bytecode execution */
 DUK_INTERNAL_DECL void duk_js_execute_bytecode(duk_hthread *exec_thr);

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -622,6 +622,8 @@ DUK_EXTERNAL_DECL duk_bool_t duk_is_thread(duk_context *ctx, duk_idx_t idx);
 
 #define duk_is_callable(ctx,idx) \
 	duk_is_function((ctx), (idx))
+DUK_EXTERNAL_DECL duk_bool_t duk_is_constructable(duk_context *ctx, duk_idx_t idx);
+
 DUK_EXTERNAL_DECL duk_bool_t duk_is_dynamic_buffer(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_fixed_buffer(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_external_buffer(duk_context *ctx, duk_idx_t idx);

--- a/tests/api/test-dev-constructor-augment.c
+++ b/tests/api/test-dev-constructor-augment.c
@@ -1,0 +1,39 @@
+/*
+ *  Error augmentation in duk_new().
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+err.augmented: true
+err._Tracedata exists: 1
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_eval_string_noresult(ctx,
+		"(function () {\n"
+		"    Duktape.errCreate = function (v) { v.augmented = true; return v; };\n"
+		"})()\n");
+
+	duk_eval_string(ctx, "RangeError");
+	duk_push_string(ctx, "aiee");
+	duk_new(ctx, 1);
+
+	duk_get_prop_string(ctx, -1, "augmented");
+	printf("err.augmented: %s\n", duk_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	duk_get_prop_string(ctx, -1, "\xff" "Tracedata");
+	printf("err._Tracedata exists: %ld\n", (long) duk_is_object(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/tests/api/test-new.c
+++ b/tests/api/test-new.c
@@ -14,7 +14,7 @@ final top: 0
 ==> rc=0, result='undefined'
 *** test_pnew_2 (duk_safe_call)
 pnew returned: 1
-result: TypeError: function required, found null (stack index -1)
+result: TypeError: null not callable
 final top: 0
 ==> rc=0, result='undefined'
 ===*/

--- a/tests/ecmascript/test-dev-constructor-augment.js
+++ b/tests/ecmascript/test-dev-constructor-augment.js
@@ -1,0 +1,34 @@
+/*
+ *  Error augmentation for constructor calls.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+string
+true
+string
+true
+===*/
+
+function test() {
+    var t;
+
+    t = new Error('aiee');
+    print(typeof t.stack);
+    print(t.lineNumber > 0);
+
+    t = Reflect.construct(Error, [ 'aiee' ]);
+    print(typeof t.stack);
+    print(t.lineNumber > 0);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-constructor-bound.js
+++ b/tests/ecmascript/test-dev-constructor-bound.js
@@ -1,0 +1,42 @@
+/*
+ *  Constructor call (new) for a bound constructor.
+ */
+
+/*===
+object
+true
+false
+this: object undefined
+object
+foo,bar,quux,baz,quuux
+===*/
+
+function MyConstructor(a, b, c, d, e) {
+    print('this:', typeof this, this.foo);
+    this.list = [ a, b, c, d, e ];
+}
+
+function test() {
+    var bound;
+    var t;
+
+    // Native constructor function, bound argument.  The 'this' binding
+    // is ignored.
+    bound = RegExp.bind({ foo: 123, ignored: true }, '^(foo){2}$');
+    t = new bound('i');
+    print(typeof t);
+    print(t.test('fooFOO'));
+    print(t.test('foobar'));
+
+    // Ecmascript constructor function, bound arguments.
+    bound = MyConstructor.bind({ foo: 123, ignored: true }, 'foo', 'bar', 'quux');
+    t = new bound('baz', 'quuux');
+    print(typeof t);
+    print(t.list);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-constructor-tailcall.js
+++ b/tests/ecmascript/test-dev-constructor-tailcall.js
@@ -1,0 +1,33 @@
+/*
+ *  Since Duktape 2.2 constructor calls can be tailcalled.
+ */
+
+/*===
+object
+0
+5001
+===*/
+
+var count = 0;
+
+function MyConstructor(arg) {
+    count++;
+    if (arg === 0) {
+        this.arg = arg;
+        return;
+    }
+    return new MyConstructor(arg - 1);
+}
+
+function test() {
+    var res = new MyConstructor(5000);
+    print(typeof res);
+    print(res.arg);
+    print(count);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-yield-from-constructor.js
+++ b/tests/ecmascript/test-dev-yield-from-constructor.js
@@ -1,11 +1,14 @@
 /*
- *  Constructor calls currently prevent a yield.
+ *  Constructor calls prevent a yield until Duktape 2.2.
+ *  Test for Duktape 2.2 behavior.
  */
 
 /*===
 coroutine start
 123
-TypeError
+123
+coroutine end
+321
 ===*/
 
 var thr;
@@ -16,12 +19,15 @@ function Foo() {
 
 function coroutine() {
     print('coroutine start');
-    Foo();      // works, not a constructor call
-    new Foo();  // not allowed currently -> TypeError
+    Foo();
+    new Foo();
+    print('coroutine end');
+    return 321;
 }
 
 try {
     thr = new Duktape.Thread(coroutine);
+    print(Duktape.Thread.resume(thr));
     print(Duktape.Thread.resume(thr));
     print(Duktape.Thread.resume(thr));
 } catch (e) {

--- a/tests/knownissues/test-dev-16bit-overflows-2.txt
+++ b/tests/knownissues/test-dev-16bit-overflows-2.txt
@@ -1,0 +1,9 @@
+summary: requires lowmem 16-bit field options
+---
+32768
+32767
+65535
+65536
+TypeError: undefined not callable
+TypeError: undefined not callable
+Reached: 65535

--- a/website/api/duk_is_constructable.yaml
+++ b/website/api/duk_is_constructable.yaml
@@ -1,0 +1,21 @@
+name: duk_is_constructable
+
+proto: |
+  duk_bool_t duk_is_constructable(duk_context *ctx, duk_idx_t idx);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Return 1 if value at <code>idx</code> is constructable, otherwise returns 0.
+  Also returns 0 if <code>idx</code> is invalid.</p>
+
+example: |
+  if (duk_is_constructable(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+
+introduced: 2.2.0

--- a/website/guide/coroutines.html
+++ b/website/guide/coroutines.html
@@ -38,15 +38,15 @@ of plain Ecmascript-to-Ecmascript calls.  The following prevent a yield if
 they are present anywhere in the yielding coroutine's call stack:</p>
 <ul>
 <li>a Duktape/C function call</li>
-<li>a constructor call</li>
 <li>a getter/setter call</li>
 <li>a proxy trap call</li>
+<li>a <code>Reflect.construct()</code> call</li>
 <li>an <code>eval()</code> call</li>
 <li>a finalizer call</li>
 </ul>
 
 <div class="note">
-Since Duktape 2.2 <code>Function.prototype.call()</code>,
+Since Duktape 2.2 constructor calls, <code>Function.prototype.call()</code>,
 <code>Function.prototype.apply()</code>, and <code>Reflect.apply()</code>
 no longer prevent a yield.
 </div>


### PR DESCRIPTION
- [x] Move constructor call preparations into a shared helper
- [x] Handle constructor call post-processing inline in duk_js_call.c and duk_js_executor.c
- [x] Handle Ecma-to-Ecma constructor calls specially to avoid native recursion and allow yield from constructor
- [x] Add public duk_is_constructable() API call
- [x] API docs for duk_is_constructable()
- [x] Testcase: yield from Ecma-to-Ecma constructor call
- [x] Testcase: native recursion limit not consumed by Ecma-to-Ecma constructor calls
- [x] Testcase: try-finally handling in constructor call, check that replacement object works (not replaced in 'finally', replaced on exit)
- [x] Testcase: error augmentation for constructed errors (C code, Ecmascript code, Reflect.construct)
- [x] Testcase: bound constructor call
- [x] Testcase: bound constructor call (with bound args), final function is native
- [x] Website: yield limitations
- [x] Releases entry
- [ ] Follow-up: yield from Reflect.construct() call (handle Reflect.construct inline)