### PR TITLE
Add a duk_harray fast path to the internal duk_unpack_array_like() helper

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2910,7 +2910,8 @@ Planned
   (GH-1491)
 
 * Miscellaneous performance improvements: move rare/large opcodes into
-  NOINLINE helpers (GH-1510)
+  NOINLINE helpers (GH-1510), duk_harray fast path for internal array
+  unpack for bound functions, .call, and .apply (GH-1525)
 
 3.0.0 (XXXX-XX-XX)
 ------------------


### PR DESCRIPTION
The helper is used by bound function and .apply() handling. Tasks:

- [x] Add the basic fast path
- [x] Conditional: doesn't do Array.prototype index lookups (technically noncompliant); low memory
- [x] Releases