### PR TITLE
Add __defineGetter__() and __defineSetter__()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2848,6 +2848,9 @@ Planned
   this change also allows .name and .length to be overridden using
   duk_def_prop() or Object.defineProperty() (GH-1493, GH-1494, GH-1515)
 
+* Add Object.prototype.{__defineGetter__,__defineSetter__} from ES7, they
+  are also used by a lot of existing legacy code (GH-1531)
+
 * Handle Function.prototype.call(), Function.prototype.apply(),
   Reflect.apply(), and Reflect.construct() inline in call handling; as a side
   effect .call(), .apply(), and .construct() no longer appear in the call stack

--- a/config/config-options/DUK_USE_ES7.yaml
+++ b/config/config-options/DUK_USE_ES7.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_ES7
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript2016
+description: >
+  Enable ES7 functionality not covered by other specific config options.

--- a/config/config-options/DUK_USE_ES8.yaml
+++ b/config/config-options/DUK_USE_ES8.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_ES8
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript2017
+description: >
+  Enable ES8 functionality not covered by other specific config options.

--- a/config/config-options/DUK_USE_ES9.yaml
+++ b/config/config-options/DUK_USE_ES9.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_ES9
+introduced: 2.0.0
+default: true
+tags:
+  - ecmascript2018
+description: >
+  Enable ES9 functionality not covered by other specific config options.

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -116,6 +116,10 @@ DUK_USE_FUNC_NAME_PROPERTY: true  # compliance
 DUK_USE_FUNC_FILENAME_PROPERTY: false  # non-standard, can be removed
 
 # Consider these; disabled by default because they don't impact E5 compliance.
+DUK_USE_ES6: false
+DUK_USE_ES7: false
+DUK_USE_ES8: false
+DUK_USE_ES9: false
 DUK_USE_COROUTINE_SUPPORT: false
 DUK_USE_SOURCE_NONBMP: false  # <300 bytes footprint
 DUK_USE_ES6_PROXY: false  # roughly 2kB footprint
@@ -125,5 +129,4 @@ DUK_USE_ES6_UNICODE_ESCAPE: false
 DUK_USE_HTML_COMMENTS: false
 DUK_USE_SHEBANG_COMMENTS: false
 DUK_USE_REFLECT_BUILTIN: false
-DUK_USE_ES6: false
 DUK_USE_SYMBOL_BUILTIN: false

--- a/config/tags.yaml
+++ b/config/tags.yaml
@@ -15,6 +15,9 @@ ecmascript2016:
 ecmascript2017:
   title: Ecmascript 2017 (ES8) options
 
+ecmascript2018:
+  title: Ecmascript 2018 (ES9) options
+
 duktape:
   title: Duktape specific options
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -699,6 +699,26 @@ objects:
           length: 1
         present_if: DUK_USE_OBJECT_BUILTIN
 
+      # __defineGetter, __defineSetter__: ES2018 draft Annex B
+      # https://tc39.github.io/ecma262/#sec-additional-properties-of-the-object.prototype-object
+      # https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__
+      # https://tc39.github.io/ecma262/#sec-object.prototype.__defineSetter__
+
+      - key: "__defineGetter__"
+        value:
+          type: function
+          native: duk_bi_object_prototype_defineaccessor
+          length: 2
+          magic: 0  # define getter
+        present_if: DUK_USE_ES8
+      - key: "__defineSetter__"
+        value:
+          type: function
+          native: duk_bi_object_prototype_defineaccessor
+          length: 2
+          magic: 1  # define setter
+        present_if: DUK_USE_ES8
+
   - id: bi_function_constructor
     class: Function
     internal_prototype: bi_function_prototype

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -805,3 +805,26 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_prevent_extensions(duk_context 
 	return 1;
 }
 #endif  /* DUK_USE_OBJECT_BUILTIN || DUK_USE_REFLECT_BUILTIN */
+
+/*
+ *  __defineGetter__, __defineSetter__
+ */
+
+#if defined(DUK_USE_ES8)
+DUK_INTERNAL duk_ret_t duk_bi_object_prototype_defineaccessor(duk_context *ctx) {
+	duk_push_this(ctx);
+	duk_insert(ctx, 0);
+	duk_to_object(ctx, 0);
+	if (!duk_is_callable(ctx, 2)) {
+		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
+	}
+
+	/* [ ToObject(this) key getter/setter ] */
+
+	/* ToPropertyKey() coercion is not needed, duk_def_prop() does it. */
+	duk_def_prop(ctx, 0, DUK_DEFPROP_SET_ENUMERABLE |
+	                     DUK_DEFPROP_SET_CONFIGURABLE |
+	                     (duk_get_current_magic(ctx) ? DUK_DEFPROP_HAVE_SETTER : DUK_DEFPROP_HAVE_GETTER));
+	return 0;
+}
+#endif  /* DUK_USE_ES8 */

--- a/tests/api/test-dev-lightfunc.c
+++ b/tests/api/test-dev-lightfunc.c
@@ -802,6 +802,8 @@ key: valueOf
 key: hasOwnProperty
 key: isPrototypeOf
 key: propertyIsEnumerable
+key: __defineGetter__
+key: __defineSetter__
 top: 1
 enum own
 top: 1

--- a/tests/api/test-dev-plain-buffer.c
+++ b/tests/api/test-dev-plain-buffer.c
@@ -187,6 +187,8 @@ flag index: 2, top: 2
 - hasOwnProperty: function hasOwnProperty() { [native code] }
 - isPrototypeOf: function isPrototypeOf() { [native code] }
 - propertyIsEnumerable: function propertyIsEnumerable() { [native code] }
+- __defineGetter__: function __defineGetter__() { [native code] }
+- __defineSetter__: function __defineSetter__() { [native code] }
 flag index: 3, top: 2
 - 0: 100
 - 1: 101

--- a/tests/ecmascript/test-bi-error-instance-custom.js
+++ b/tests/ecmascript/test-bi-error-instance-custom.js
@@ -39,6 +39,8 @@ all properties (including non-enumerable and inherited)
 "hasOwnProperty"
 "isPrototypeOf"
 "propertyIsEnumerable"
+"__defineGetter__"
+"__defineSetter__"
 ---
 function function false true
 function function false true

--- a/tests/ecmascript/test-bi-object-proto-definegetter.js
+++ b/tests/ecmascript/test-bi-object-proto-definegetter.js
@@ -1,0 +1,76 @@
+/*
+ *  ES2017 Annex B __defineGetter__
+ */
+
+/*===
+BAR
+undefined
+QUUX
+QUUX
+BAR
+BAR
+BAR
+TypeError
+TypeError
+TypeError
+2
+__defineGetter__
+===*/
+
+function testDefineGetter() {
+    var obj = {};
+
+    // Basic case.
+    obj.__defineGetter__('foo', function returnBar() { return 'BAR'; });
+    print(obj.foo);
+    print(Object.prototype.foo);
+
+    // Key is ToPropertyKey() coerced.
+    Object.prototype.__defineGetter__(123, function returnQuux() { return 'QUUX'; });
+    print(obj['123']);
+    print(Object.prototype['123']);
+    obj.__defineGetter__(void 0, function returnBar() { return 'BAR'; });
+    print(obj.undefined);
+    obj.__defineGetter__(null, function returnBar() { return 'BAR'; });
+    print(obj.null);
+    obj.__defineGetter__({}, function returnBar() { return 'BAR'; });
+    print(obj['[object Object]']);
+
+    // Non-callable function is rejected with TypeError.
+    try {
+        obj.__defineGetter__('abc', {});
+    } catch (e) {
+        print(e.name);
+    }
+
+    // Failure to establish the own property is a TypeError; ES7 uses
+    // DefinePropertyOrThrow which provides this throwing behavior
+    // regardless of function strictness.  NodeJs 4.2.6 will silently
+    // ignore failed attempts, Firefox 53.0.3 throws.
+    obj = {};
+    Object.preventExtensions(obj);
+    try {
+        obj.__defineGetter__('abc', function returnBar() { return 'BAR'; });
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+    obj = {};
+    Object.defineProperty(obj, 'abc', { value: 123, writable: false, enumerable: false, configurable: false });
+    try {
+        obj.__defineGetter__('abc', function returnBar() { return 'BAR'; });
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+
+    // .length and .name
+    print(Object.prototype.__defineGetter__.length);
+    print(Object.prototype.__defineGetter__.name);
+}
+
+try {
+    testDefineGetter();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-object-proto-definesetter.js
+++ b/tests/ecmascript/test-bi-object-proto-definesetter.js
@@ -1,0 +1,76 @@
+/*
+ *  ES2017 Annex B: __defineSetter__
+ */
+
+/*===
+set: 123
+set: foo
+set: bar
+set: quux
+set: baz
+set: quuux
+TypeError
+TypeError
+TypeError
+2
+__defineSetter__
+===*/
+
+function setter(v) {
+    print('set:', v);
+}
+
+function testDefineSetter() {
+    var obj = {};
+
+    // Basic case.
+    obj.__defineSetter__('foo', setter);
+    obj.foo = 123;
+    Object.prototype.foo = 123;
+
+    // Key is ToPropertyKey() coerced.
+    Object.prototype.__defineSetter__(123, setter);
+    obj['123'] = 'foo';
+    Object.prototype['123'] = 'bar';
+    obj.__defineSetter__(void 0, setter);
+    obj.undefined = 'quux';
+    obj.__defineSetter__(null, setter);
+    obj.null = 'baz';
+    obj.__defineSetter__({}, setter);
+    obj['[object Object]'] = 'quuux';
+
+    // Non-callable function is rejected with TypeError.
+    try {
+        obj.__defineSetter__('abc', {});
+    } catch (e) {
+        print(e.name);
+    }
+
+    // Failure to establish the own property is a TypeError. ES7 uses
+    obj = {};
+    Object.preventExtensions(obj);
+    try {
+        obj.__defineSetter__('abc', setter);
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+    obj = {};
+    Object.defineProperty(obj, 'abc', { value: 123, writable: false, enumerable: false, configurable: false });
+    try {
+        obj.__defineSetter__('abc', setter);
+        print('never here');
+    } catch (e) {
+        print(e.name);
+    }
+
+    // .length and .name
+    print(Object.prototype.__defineSetter__.length);
+    print(Object.prototype.__defineSetter__.name);
+}
+
+try {
+    testDefineSetter();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Fixes #1529.

Tasks:
- [x] Add `__defineGetter__()` and `__defineSetter()__` to Object.prototype based on ES2017 draft
- [x] Conditional (low memory targets)
- [x] Testcases
- [x] Documentation
- [x] Wiki post-ES5
- [x] Releases entry