### PR TITLE
Fix incorrect tail call assert

### DIFF
--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -2708,7 +2708,6 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		 */
 
 		/* Then reuse the unwound activation. */
-		DUK_ASSERT(act->parent == thr->callstack_curr);
 		act->cat = NULL;
 		act->var_env = NULL;
 		act->lex_env = NULL;


### PR DESCRIPTION
Fix incorrect assert in tail call handling. This was introduced after 2.1 release so no fix to backport.