### PR TITLE
Fix debugger GetHeapObjInfo property list

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2873,6 +2873,9 @@ Planned
 
 * Add a wrap check to duk_{check,require}_stack{_top}() (GH-1537)
 
+* Fix potential segfault in debugger GetHeapObjInfo command, caused by
+  key/mask list being out of sync (GH-1540)
+
 * Fix Reflect.construct() handling for four or more arguments (GH-1517,
   GH-1518)
 

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1914,7 +1914,7 @@ DUK_LOCAL const char * const duk__debug_getinfo_hobject_keys[] = {
 	"newenv",
 	"namebinding",
 	"createargs",
-	"have_finalizer"
+	"have_finalizer",
 	"exotic_array",
 	"exotic_stringobj",
 	"exotic_arguments",
@@ -1984,7 +1984,7 @@ DUK_LOCAL void duk__debug_getinfo_bitmask(duk_hthread *thr, const char * const *
 
 	for (;;) {
 		mask = *masks++;
-		if (!mask) {
+		if (mask == 0) {
 			break;
 		}
 		key = *keys++;
@@ -2065,6 +2065,10 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 
 	DUK_D(DUK_DPRINT("debug command GetHeapObjInfo"));
 	DUK_UNREF(heap);
+
+	DUK_ASSERT(sizeof(duk__debug_getinfo_hstring_keys) / sizeof(const char *) == sizeof(duk__debug_getinfo_hstring_masks) / sizeof(duk_uint_t) - 1);
+	DUK_ASSERT(sizeof(duk__debug_getinfo_hobject_keys) / sizeof(const char *) == sizeof(duk__debug_getinfo_hobject_masks) / sizeof(duk_uint_t) - 1);
+	DUK_ASSERT(sizeof(duk__debug_getinfo_hbuffer_keys) / sizeof(const char *) == sizeof(duk__debug_getinfo_hbuffer_masks) / sizeof(duk_uint_t) - 1);
 
 	h = duk_debug_read_any_ptr(thr);
 	if (!h) {


### PR DESCRIPTION
Property key list had a missing comma, which caused two key names to be concatenated. As a result GetHeapObjInfo might segfault. Also present in 2.1.0, but not 2.0.0 or prior.