### PR TITLE
Direct support for Reflect.construct in call handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,13 @@ clean:
 	@rm -rf prep/
 	@rm -rf site/
 	@rm -f duk duk-rom dukd dukd-rom duk.O2 duk.O3 duk.O4
-	@rm -f duk-clang duk-g++ dukd-g++
+	@rm -f duk-pgo duk-pgo.O2
+	@rm -f duk-perf duk-perf.O2 duk-perf.O3 duk-perf.O4
+	@rm -f duk-perf-pgo duk-perf-pgo.O2 duk-perf-pgo.O3 duk-perf-pgo.O4
+	@rm -f duk-size
+	@rm -f duk-rom dukd-rom
+	@rm -f duk-clang duk-perf-clang
+	@rm -f duk-g++ dukd-g++ duk-perf-g++
 	@rm -f ajduk ajduk-rom ajdukd
 	@rm -f emduk emduk.js
 	@rm -f libduktape*.so*

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2848,15 +2848,16 @@ Planned
   this change also allows .name and .length to be overridden using
   duk_def_prop() or Object.defineProperty() (GH-1493, GH-1494, GH-1515)
 
-* Handle Function.prototype.call(), Function.prototype.apply(), and
-  Reflect.apply() inline in call handling; as a side effect .call() and
-  .apply() no longer appear in the call stack (tracebacks etc) (GH-1421,
-  GH-1522)
+* Handle Function.prototype.call(), Function.prototype.apply(),
+  Reflect.apply(), and Reflect.construct() inline in call handling; as a side
+  effect .call(), .apply(), and .construct() no longer appear in the call stack
+  (tracebacks etc) (GH-1421, GH-1522, GH-1545)
 
-* Function.prototype.call(), Function.prototype.apply(), and Reflect.apply()
-  can be used in tailcalls (e.g. 'return func.call(null, 123);'), don't grow
-  the native C stack when doing an Ecmascript-to-Ecmascript call, and no
-  longer prevent coroutine yielding (GH-1421)
+* Function.prototype.call(), Function.prototype.apply(), Reflect.apply(),
+  and Reflect.construct() can now be used in tailcalls (e.g.
+  'return func.call(null, 123);'), don't grow the native C stack when doing an
+  Ecmascript-to-Ecmascript call, and no longer prevent coroutine yielding
+  (GH-1421, GH-1545)
 
 * Constructor calls (new Func()) can be used in tailcalls, don't grow
   the native C stack when doing an Ecmascript-to-Ecmascript call, and no

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -3000,7 +3000,9 @@ objects:
           type: function
           native: duk_bi_reflect_construct
           length: 2
-          varargs: true
+          magic: 3  # see duk_js_call.c
+          special_call: true
+        auto_lightfunc: false  # automatic lightfunc conversion clashes with internal implementation
         es6: true
       - key: "defineProperty"
         value:

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -188,27 +188,9 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_apply(duk_context *ctx) {
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_reflect_construct(duk_context *ctx) {
-	duk_idx_t nargs;
-	duk_idx_t len;
-
-	duk_require_constructable(ctx, 0);
-
-	nargs = duk_get_top(ctx);
-	if (nargs < 2) {
-		DUK_DCERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
-	}
-	if (nargs >= 3 && !duk_strict_equals(ctx, 0, 2)) {
-		/* XXX: [[Construct]] newTarget currently unsupported */
-		DUK_ERROR_UNSUPPORTED((duk_hthread *) ctx);
-	}
-	duk_set_top(ctx, 2);
-
-	len = duk_unpack_array_like(ctx, 1 /*idx_args*/);
-	duk_remove(ctx, 1);
-	DUK_ASSERT_TOP(ctx, len + 1);
-
-	duk_new(ctx, len);
-	return 1;
+	/* Like .call(), never actually called. */
+	DUK_UNREF(ctx);
+	return DUK_RET_TYPE_ERROR;
 }
 
 #if defined(DUK_USE_FUNCTION_BUILTIN)

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -597,7 +597,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 #endif
 			if (c_func == duk_bi_function_prototype_call ||
 			    c_func == duk_bi_function_prototype_apply ||
-			    c_func == duk_bi_reflect_apply) {
+			    c_func == duk_bi_reflect_apply ||
+			    c_func == duk_bi_reflect_construct) {
 				lightfunc_eligible = 0;
 			}
 
@@ -620,10 +621,12 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			h_func = duk_known_hnatfunc(ctx, -1);
 			DUK_UNREF(h_func);
 
+			/* XXX: add into init data? */
 			/* Special call handling, not described in init data. */
 			if (c_func == duk_bi_function_prototype_call ||
 			    c_func == duk_bi_function_prototype_apply ||
-			    c_func == duk_bi_reflect_apply) {
+			    c_func == duk_bi_reflect_apply ||
+			    c_func == duk_bi_reflect_construct) {
 				DUK_HOBJECT_SET_SPECIAL_CALL((duk_hobject *) h_func);
 			}
 

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -96,7 +96,7 @@ DUK_INTERNAL_DECL void duk_js_push_closure(duk_hthread *thr,
 DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL void duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, void *udata, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
-DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags, duk_small_uint_t *out_call_flags);
 DUK_INTERNAL_DECL void duk_call_construct_postprocess(duk_context *ctx);
 
 /* bytecode execution */

--- a/tests/ecmascript/test-bi-function-proto-apply-side-effects.js
+++ b/tests/ecmascript/test-bi-function-proto-apply-side-effects.js
@@ -1,0 +1,43 @@
+/*===
+get 0
+get 1
+get 2
+103
+TypeError
+===*/
+
+function test() {
+    var notCallable = 123;
+    var args = {
+        length: 3
+    };
+    Object.defineProperty(args, '0', {
+        get: function () { print('get 0'); return 109; }
+    });
+    Object.defineProperty(args, '1', {
+        get: function () { print('get 1'); return 103; }
+    });
+    Object.defineProperty(args, '2', {
+        get: function () { print('get 2'); return 107; }
+    });
+    Object.defineProperty(args, '3', {
+        get: function () { print('get 3'); return -100; }  // not read because .length == 3
+    });
+
+    try {
+        // Target is callable, args are read and trigger side effects.
+        print(Function.prototype.apply.call(Math.min, null, args));
+
+        // Target is not callable, args are not read and there should be
+        // no side effects.
+        print(Function.prototype.apply.call(notCallable, null, args));
+    } catch (e) {
+        print(e.name);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-reflect-construct-bound.js
+++ b/tests/ecmascript/test-bi-reflect-construct-bound.js
@@ -1,0 +1,62 @@
+/*
+ *  If Reflect.construct() is used on a bound target, the bound function
+ *  arguments are handled normally but the 'this' binding is ignored for
+ *  constructor calls.
+ */
+
+/*===
+object [object Object]
+bindThis
+number 100
+number 200
+number 1
+number 2
+object [object Object]
+bindThis
+number 100
+number 200
+number 1
+number 2
+object [object Object]
+protoThis
+number 100
+number 200
+number 1
+number 2
+object [object Object]
+protoThis
+number 100
+number 200
+number 1
+number 2
+===*/
+
+function MyConstructor(a, b, c, d) {
+    print(typeof this, this);
+    print(this.name);
+    print(typeof a, a);
+    print(typeof b, b);
+    print(typeof c, c);
+    print(typeof d, d);
+}
+
+MyConstructor.prototype.name = 'protoThis';
+
+function test() {
+    var bound = MyConstructor.bind({ name: 'bindThis' }, 100, 200);
+
+    // For normal calls, the "closest" 'this' binding wins.
+    bound(1, 2, 3);
+    bound.apply({ name: 'applyThis' }, [ 1, 2, 3 ]);
+
+    // For constructor calls the default instance created is never
+    // overwritten during bound function resolution.
+    new bound(1, 2, 3);
+    Reflect.construct(bound, [ 1, 2, 3 ]);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-reflect-construct-callstack.js
+++ b/tests/ecmascript/test-bi-reflect-construct-callstack.js
@@ -1,0 +1,39 @@
+/*
+ *  In Duktape 2.2 Reflect.construct() is handled inline in call handling and
+ *  is no longer visible in the callstack.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+MyConstructor
+-1 act
+-2 MyConstructor
+-3 test
+-4 global
+===*/
+
+function MyConstructor(a, b, c) {
+    var idx;
+
+    print('MyConstructor');
+    for (idx = -1; ; idx--) {
+        var t = Duktape.act(idx);
+        if (!t) { break; }
+        print(idx, (t.function || {}).name);
+    }
+}
+
+function test() {
+    Reflect.construct(MyConstructor, [ 1, 2, 3 ]);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-reflect-construct-tail.js
+++ b/tests/ecmascript/test-bi-reflect-construct-tail.js
@@ -1,0 +1,64 @@
+/*
+ *  In Duktape 2.2 Reflect.construct() is handled inline in call handling and
+ *  doesn't involve a native call.  Ecmascript-to-Ecmascript Reflect.construct()
+ *  calls are thus only limited by callstack limit (not recursion C limit).
+ *  Reflect.construct() can be used in tailcall position.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+count: 5001
+RangeError
+count: 1000001
+===*/
+
+var count;
+
+function MyConstructor(n) {
+    count++;
+    if (n <= 0) {
+        return;
+    }
+    var tmp = Reflect.construct(MyConstructor, [ n - 1 ]);
+    return tmp;
+}
+
+function MyConstructorTailcall(n) {
+    count++;
+    if (n <= 0) {
+        return;
+    }
+    return Reflect.construct(MyConstructorTailcall, [ n - 1 ]);
+}
+
+function test() {
+    // Ecma-to-Ecma Reflect.construct() call: limited by call stack.
+    count = 0;
+    new MyConstructor(5000);
+    print('count:', count);
+
+    // Here the count is too large and call stack limit is reached.
+    count = 0;
+    try {
+        new MyConstructor(1e6);
+        print('count:', count);
+    } catch (e) {
+        print(e.name);
+    }
+
+    // No limit for tailcall variant.
+    count = 0;
+    new MyConstructorTailcall(1e6);
+    print('count:', count);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-call-special-misc.js
+++ b/tests/ecmascript/test-dev-call-special-misc.js
@@ -1,0 +1,84 @@
+/*
+ *  Misc tests related to Reflect.construct() and other special call handling.
+ */
+
+/*===
+TypeError: [object Function] not constructable
+TypeError: [object Function] not constructable
+TypeError: [object Function] not constructable
+TypeError: [object Function] not constructable
+TypeError: undefined not callable
+TypeError: [object Function] not constructable
+TypeError: [object Function] not constructable
+TypeError: [object Function] not constructable
+===*/
+
+function test() {
+    function foo() {
+        print('foo called');
+    }
+
+    // Reflect.construct for foo.call() fails because Function.prototype.call()
+    // is not constructable.
+    try {
+        print(Reflect.construct(foo.call, [ 1, 2, 3 ]));
+    } catch (e) {
+        print(e);
+    }
+
+    // Same test, argArray is an Ecmascript function (this makes no sense,
+    // but covers a development time bug).
+    try {
+        print(Reflect.construct(foo.call, foo));
+    } catch (e) {
+        print(e);
+    }
+
+    // Same for foo.apply().
+    try {
+        print(Reflect.construct(foo.apply, [ 1, 2, 3 ]));
+    } catch (e) {
+        print(e);
+    }
+
+    // Reflect.construct(), non-constructable target and missing argArray.
+    // Should fail in the non-constructable check before considering
+    // argArray.
+    try {
+        print(Reflect.construct(foo.call));
+    } catch (e) {
+        print(e);
+    }
+
+    // Reflect.construct() without arguments (covers a specific internal path):
+    try {
+        print(Reflect.construct());
+    } catch (e) {
+        print(e);
+    }
+
+    // new Reflect.construct() fails, not constructable.
+    try {
+        print(new Reflect.construct(foo, [ 1, 2, 3 ]));
+    } catch (e) {
+        print(e);
+    }
+
+    // Same for foo.call() and foo.apply().
+    try {
+        print(new foo.call());
+    } catch (e) {
+        print(e);
+    }
+    try {
+        print(new foo.apply());
+    } catch (e) {
+        print(e);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-constructor-tryfinally.js
+++ b/tests/ecmascript/test-dev-constructor-tryfinally.js
@@ -1,0 +1,70 @@
+/*
+ *  Return and replacement value handling in try-finally of a constructor call.
+ */
+
+/*===
+finally
+object undefined
+finally
+object true
+finally
+object true
+finally
+object true
+===*/
+
+function MyConstructor1() {
+    try {
+        return 123;  // return non-object value -> won't replace default instance
+    } finally {
+        print('finally');
+    }
+}
+
+function MyConstructor2() {
+    try {
+        return 123;  // return non-object value -> won't replace default instance
+    } finally {
+        print('finally');
+        return { replaced: true };  // replace with object value
+    }
+}
+
+function MyConstructor3() {
+    try {
+        return { replaced: true };
+    } finally {
+        print('finally');
+    }
+}
+
+function MyConstructor4() {
+    try {
+        return { foo: 123 };
+    } finally {
+        print('finally');
+        return { replaced: true };
+    }
+}
+
+function test() {
+    var t;
+
+    t = new MyConstructor1();
+    print(typeof t, t.replaced);
+
+    t = new MyConstructor2();
+    print(typeof t, t.replaced);
+
+    t = new MyConstructor3();
+    print(typeof t, t.replaced);
+
+    t = new MyConstructor4();
+    print(typeof t, t.replaced);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/website/guide/coroutines.html
+++ b/website/guide/coroutines.html
@@ -40,15 +40,14 @@ they are present anywhere in the yielding coroutine's call stack:</p>
 <li>a Duktape/C function call</li>
 <li>a getter/setter call</li>
 <li>a proxy trap call</li>
-<li>a <code>Reflect.construct()</code> call</li>
 <li>an <code>eval()</code> call</li>
 <li>a finalizer call</li>
 </ul>
 
 <div class="note">
-Since Duktape 2.2 constructor calls, <code>Function.prototype.call()</code>,
-<code>Function.prototype.apply()</code>, and <code>Reflect.apply()</code>
-no longer prevent a yield.
+Since Duktape 2.2 constructor calls (<code>new Func()</code>), <code>Function.prototype.call()</code>,
+<code>Function.prototype.apply()</code>, <code>Reflect.apply()</code>, and
+<code>Reflect.construct()</code> no longer prevent a yield.
 </div>
 
 <p>See <a href="http://wiki.duktape.org/HowtoCoroutines.html">How to use coroutines</a>


### PR DESCRIPTION
Change Reflect.construct() to be handled in call handling directly without involving a native function call. As a result Reflect.construct itself won't appear in callstacks, won't prevent tailcalls, and won't prevent a yield.

Tasks:
- [x] Rework Reflect.construct() into call handling
- [x] Reflect.apply() and Reflect.construct() conditional to config
- [x] Clean up changes
- [x] Testcases: not visible in callstack
- [x] Testcases: doesn't consume native stack for Ecma-to-Ecma Reflect.construct() calls
- [x] Testcases: allows tailcalls
- [x] Testcases: Reflect.construct() with a bound constructor target, check that 'this' binding not modified (constructor mode)
- [x] Testcases: Reflect.construct() for func.apply() or func.call(); fails due to target being non-constructable
- [x] Testcases: new Reflect.construct(), new foo.call(), etc
- [x] Testcases: unpack side effects for non-callable .apply/.call target
- [x] Website guide update
- [x] Releases entry