### PR TITLE
Add __lookupGetter__ and __lookupSetter__

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2848,8 +2848,9 @@ Planned
   this change also allows .name and .length to be overridden using
   duk_def_prop() or Object.defineProperty() (GH-1493, GH-1494, GH-1515)
 
-* Add Object.prototype.{__defineGetter__,__defineSetter__} from ES7, they
-  are also used by a lot of existing legacy code (GH-1531)
+* Add Object.prototype.{__defineGetter__,__defineSetter__} and
+  Object.prototype.{__lookupGetter__,__lookupSetter__} from ES2017 Annex B,
+  they are also used by a lot of existing legacy code (GH-1531, GH-1551)
 
 * Handle Function.prototype.call(), Function.prototype.apply(),
   Reflect.apply(), and Reflect.construct() inline in call handling; as a side

--- a/polyfills/object-prototype-definegetter.js
+++ b/polyfills/object-prototype-definegetter.js
@@ -2,10 +2,13 @@
  *  Object.prototype.__defineGetter__ polyfill
  */
 
-if (typeof Object.prototype.__defineGetter__ === 'undefined') {
-    Object.defineProperty(Object.prototype, '__defineGetter__', {
-        value: function (n, f) {
-            Object.defineProperty(this, n, { enumerable: true, configurable: true, get: f });
-        }, writable: true, enumerable: false, configurable: true
-    });
-}
+(function () {
+    if (typeof Object.prototype.__defineGetter__ === 'undefined') {
+        var DP = Object.defineProperty;
+        DP(Object.prototype, '__defineGetter__', {
+            value: function (n, f) {
+                DP(this, n, { enumerable: true, configurable: true, get: f });
+            }, writable: true, enumerable: false, configurable: true
+        });
+    }
+})();

--- a/polyfills/object-prototype-definesetter.js
+++ b/polyfills/object-prototype-definesetter.js
@@ -2,10 +2,13 @@
  *  Object.prototype.__defineSetter__ polyfill
  */
 
-if (typeof Object.prototype.__defineSetter__ === 'undefined') {
-    Object.defineProperty(Object.prototype, '__defineSetter__', {
-        value: function (n, f) {
-            Object.defineProperty(this, n, { enumerable: true, configurable: true, set: f });
-        }, writable: true, enumerable: false, configurable: true
-    });
-}
+(function () {
+    if (typeof Object.prototype.__defineSetter__ === 'undefined') {
+        var DP = Object.defineProperty;
+        DP(Object.prototype, '__defineSetter__', {
+            value: function (n, f) {
+                DP(this, n, { enumerable: true, configurable: true, set: f });
+            }, writable: true, enumerable: false, configurable: true
+        });
+    }
+})();

--- a/polyfills/object-prototype-lookupgetter.js
+++ b/polyfills/object-prototype-lookupgetter.js
@@ -1,0 +1,21 @@
+/*
+ *  Object.prototype.__lookupGetter__ polyfill
+ */
+
+(function () {
+    if (typeof Object.prototype.__lookupGetter__ === 'undefined') {
+        var DP = Object.defineProperty;
+        var GPO = Object.getPrototypeOf;
+        var GOPD = Object.getOwnPropertyDescriptor;
+        DP(Object.prototype, '__lookupGetter__', {
+            value: function (n) {
+                for (var o = this; o; o = GPO(o)) {
+                    var p = GOPD(o, n);
+                    if (p) {
+                        return p.get;
+                    }
+                }
+            }, writable: true, enumerable: false, configurable: true
+        });
+    }
+})();

--- a/polyfills/object-prototype-lookupsetter.js
+++ b/polyfills/object-prototype-lookupsetter.js
@@ -1,0 +1,21 @@
+/*
+ *  Object.prototype.__lookupSetter__ polyfill
+ */
+
+(function () {
+    if (typeof Object.prototype.__lookupSetter__ === 'undefined') {
+        var DP = Object.defineProperty;
+        var GPO = Object.getPrototypeOf;
+        var GOPD = Object.getOwnPropertyDescriptor;
+        DP(Object.prototype, '__lookupSetter__', {
+            value: function (n, f) {
+                for (var o = this; o; o = GPO(o)) {
+                    var p = GOPD(o, n);
+                    if (p) {
+                        return p.set;
+                    }
+                }
+            }, writable: true, enumerable: false, configurable: true
+        });
+    }
+})();

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -699,10 +699,8 @@ objects:
           length: 1
         present_if: DUK_USE_OBJECT_BUILTIN
 
-      # __defineGetter, __defineSetter__: ES2018 draft Annex B
+      # __defineGetter, __defineSetter__, __lookupGetter__, __lookupSetter__: ES2017 Annex B
       # https://tc39.github.io/ecma262/#sec-additional-properties-of-the-object.prototype-object
-      # https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__
-      # https://tc39.github.io/ecma262/#sec-object.prototype.__defineSetter__
 
       - key: "__defineGetter__"
         value:
@@ -717,6 +715,20 @@ objects:
           native: duk_bi_object_prototype_defineaccessor
           length: 2
           magic: 1  # define setter
+        present_if: DUK_USE_ES8
+      - key: "__lookupGetter__"
+        value:
+          type: function
+          native: duk_bi_object_prototype_lookupaccessor
+          length: 1
+          magic: 0  # lookup getter
+        present_if: DUK_USE_ES8
+      - key: "__lookupSetter__"
+        value:
+          type: function
+          native: duk_bi_object_prototype_lookupaccessor
+          length: 1
+          magic: 1  # lookup setter
         present_if: DUK_USE_ES8
 
   - id: bi_function_constructor

--- a/tests/api/test-dev-lightfunc.c
+++ b/tests/api/test-dev-lightfunc.c
@@ -804,6 +804,8 @@ key: isPrototypeOf
 key: propertyIsEnumerable
 key: __defineGetter__
 key: __defineSetter__
+key: __lookupGetter__
+key: __lookupSetter__
 top: 1
 enum own
 top: 1

--- a/tests/api/test-dev-plain-buffer.c
+++ b/tests/api/test-dev-plain-buffer.c
@@ -189,6 +189,8 @@ flag index: 2, top: 2
 - propertyIsEnumerable: function propertyIsEnumerable() { [native code] }
 - __defineGetter__: function __defineGetter__() { [native code] }
 - __defineSetter__: function __defineSetter__() { [native code] }
+- __lookupGetter__: function __lookupGetter__() { [native code] }
+- __lookupSetter__: function __lookupSetter__() { [native code] }
 flag index: 3, top: 2
 - 0: 100
 - 1: 101

--- a/tests/ecmascript/test-bi-error-instance-custom.js
+++ b/tests/ecmascript/test-bi-error-instance-custom.js
@@ -41,6 +41,8 @@ all properties (including non-enumerable and inherited)
 "propertyIsEnumerable"
 "__defineGetter__"
 "__defineSetter__"
+"__lookupGetter__"
+"__lookupSetter__"
 ---
 function function false true
 function function false true

--- a/tests/ecmascript/test-bi-object-proto-lookupgetter.js
+++ b/tests/ecmascript/test-bi-object-proto-lookupgetter.js
@@ -1,0 +1,61 @@
+/*
+ *  ES2017 Annex B __lookupGetter__
+ */
+
+/*===
+ownGetter
+inheritedGetter
+undefined
+undefined
+undefined
+undefined
+1
+__lookupGetter__
+===*/
+
+function testLookupGetter() {
+    var obj = {};
+
+    // Getter lookup traverses internal prototype chain.
+    Object.defineProperty(Object.prototype, 'inherited', {
+        get: function inheritedGetter() {}
+    });
+    Object.defineProperty(obj, 'own', {
+        get: function ownGetter() {}
+    });
+    print(obj.__lookupGetter__('own').name);
+    print(obj.__lookupGetter__('inherited').name);
+
+    // An accessor lacking a 'get' masks an inherited getter.
+    Object.defineProperty(Object.prototype, 'masking', {
+        get: function inheritedGetter() {}
+    });
+    Object.defineProperty(obj, 'masking', {
+        set: function ownGetter() {}
+        // no getter
+    });
+    print(obj.__lookupGetter__('masking'));
+
+    // A data property causes undefined to be returned.
+    Object.defineProperty(Object.prototype, 'inheritedData', {
+        value: 123
+    });
+    Object.defineProperty(obj, 'ownData', {
+        value: 321
+    });
+    print(obj.__lookupGetter__('ownData'));
+    print(obj.__lookupGetter__('inheritedData'));
+
+    // Same for missing property.
+    print(obj.__lookupGetter__('noSuch'));
+
+    // .length and .name
+    print(Object.prototype.__lookupGetter__.length);
+    print(Object.prototype.__lookupGetter__.name);
+}
+
+try {
+    testLookupGetter();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-object-proto-lookupsetter.js
+++ b/tests/ecmascript/test-bi-object-proto-lookupsetter.js
@@ -1,0 +1,61 @@
+/*
+ *  ES2017 Annex B __lookupSetter__
+ */
+
+/*===
+ownSetter
+inheritedSetter
+undefined
+undefined
+undefined
+undefined
+1
+__lookupSetter__
+===*/
+
+function testLookupSetter() {
+    var obj = {};
+
+    // Setter lookup traverses internal prototype chain.
+    Object.defineProperty(Object.prototype, 'inherited', {
+        set: function inheritedSetter() {}
+    });
+    Object.defineProperty(obj, 'own', {
+        set: function ownSetter() {}
+    });
+    print(obj.__lookupSetter__('own').name);
+    print(obj.__lookupSetter__('inherited').name);
+
+    // An accessor lacking a 'get' masks an inherited setter.
+    Object.defineProperty(Object.prototype, 'masking', {
+        set: function inheritedSetter() {}
+    });
+    Object.defineProperty(obj, 'masking', {
+        get: function ownGetter() {}
+        // no setter
+    });
+    print(obj.__lookupSetter__('masking'));
+
+    // A data property causes undefined to be returned.
+    Object.defineProperty(Object.prototype, 'inheritedData', {
+        value: 123
+    });
+    Object.defineProperty(obj, 'ownData', {
+        value: 321
+    });
+    print(obj.__lookupSetter__('ownData'));
+    print(obj.__lookupSetter__('inheritedData'));
+
+    // Same for missing property.
+    print(obj.__lookupSetter__('noSuch'));
+
+    // .length and .name
+    print(Object.prototype.__lookupSetter__.length);
+    print(Object.prototype.__lookupSetter__.name);
+}
+
+try {
+    testLookupSetter();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-bi-object-proto-misc-accessor.js
+++ b/tests/ecmascript/test-bi-object-proto-misc-accessor.js
@@ -1,0 +1,39 @@
+/*
+ *  ES2017 Annex B: __defineGetter__, __defineSetter__, __lookupGetter__, __lookupSetter__
+ */
+
+/*===
+setter called: 123
+getter called
+BAR
+true
+true
+===*/
+
+function testMisc() {
+    var obj = {};
+
+    function myGetter() {
+        print('getter called');
+        return 'BAR';
+    }
+    function mySetter(v) {
+        print('setter called:', v);
+    }
+
+    // Set both getter and setter using the Annex B API.
+    obj.__defineGetter__('foo', myGetter);
+    obj.__defineSetter__('foo', mySetter);
+    obj.foo = 123;
+    print(obj.foo);
+
+    // Read back and compare functions.
+    print(obj.__lookupGetter__('foo') === myGetter);
+    print(obj.__lookupSetter__('foo') === mySetter);
+}
+
+try {
+    testMisc();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
- [x] Add `__lookupGetter__`, `__lookupSetter__`
- [x] Add polyfills (for older versions and different configs), rework polyfills to capture Object methods needed
- [x] Testcase coverage
- [x] Releases entry