### PR TITLE
Rework call handling for smaller footprint and less duplication

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2940,6 +2940,10 @@ Planned
   calling a function or reserving value stack space explicitly and only
   shrunk in mark-and-sweep (GH-1526)
 
+* Remove automatic value stack reserve check from duk_safe_call() to
+  ensure 'nrets' return values fit into the value stack; the check was not
+  guaranteed by the API and is mostly unnecessary (GH-1552)
+
 * Internal change: set REACHABLE for all READONLY objects (relevant when
   using ROM built-ins) so that mark-and-sweep doesn't need an explicit
   READONLY check (GH-1502)
@@ -2954,6 +2958,9 @@ Planned
 
 * Internal change: simple freelists for duk_activation and duk_catcher
   (GH-1491)
+
+* Miscellaneous footprint improvements: rework call handling to improve
+  code sharing (GH-1552)
 
 * Miscellaneous performance improvements: move rare/large opcodes into
   NOINLINE helpers (GH-1510), duk_harray fast path for internal array

--- a/debugger/duk_opcodes.yaml
+++ b/debugger/duk_opcodes.yaml
@@ -871,7 +871,7 @@ opcodes:
     args:
       - A_I
       - BC_R
-  - name: NEW
+  - name: CONSCALL
     args:
       - A_I
       - BC_R

--- a/doc/release-notes-v2-2.rst
+++ b/doc/release-notes-v2-2.rst
@@ -15,6 +15,14 @@ Upgrading from Duktape 2.1
 No action (other than recompiling) should be needed for most users to upgrade
 from Duktape v2.1.x.  Note the following:
 
+* duk_safe_call() no longer automatically extends the value stack to ensure
+  there's space for 'nrets' return values.  This was not guaranteed by the
+  API and the check is mostly unnecessary overhead.  If a duk_safe_call()
+  call site now fails due to this change, simply ``duk_require_stack()``
+  to ensure that there's reserve for ``nargs - nrets`` more elements
+  (conceptually 'nargs' arguments are consumed, and 'nrets' result values
+  pushed).
+
 * Call stack (including both activation records and catcher records) is no
   longer a resized monolithic allocation which improves memory behavior for
   very low memory targets.  If you're using a pool allocator, you may need to

--- a/examples/cmdline/duk_cmdline_ajduk.c
+++ b/examples/cmdline/duk_cmdline_ajduk.c
@@ -105,6 +105,7 @@ static const AJS_HeapConfig ajsheap_config[] = {
 	{ 400,    1,    AJS_POOL_BORROW,  0 },  /* duk_hthread, with heap ptr compression, RAM strings+objects */
 	{ 536,    1,    AJS_POOL_BORROW,  0 },  /* duk_heap, with heap ptr compression, RAM strings+objects */
 	{ 512,    16,   AJS_POOL_BORROW,  0 },
+	{ 768,    1,    AJS_POOL_BORROW,  0 },  /* initial value stack */
 	{ 1024,   6,    AJS_POOL_BORROW,  0 },
 	{ 2048,   5,    AJS_POOL_BORROW,  0 },
 	{ 4096,   3,    0,                0 },

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -1,16 +1,88 @@
 /*
  *  Calls.
  *
- *  Protected variants should avoid ever throwing an error.
+ *  Protected variants should avoid ever throwing an error.  Must be careful
+ *  to catch errors related to value stack manipulation and property lookup,
+ *  not just the call itself.
+ *
+ *  The only exception is when arguments are insane, e.g. nargs/nrets are out
+ *  of bounds; in such cases an error is thrown for two reasons.  First, we
+ *  can't always respect the value stack input/output guarantees in such cases
+ *  so the caller would end up with the value stack in an unexpected state.
+ *  Second, an attempt to create an error might itself fail (although this
+ *  could be avoided by pushing a preallocated object/string or a primitive
+ *  value).
  */
 
 #include "duk_internal.h"
+
+/*
+ *  Helpers
+ */
+
+struct duk__pcall_prop_args {
+	duk_idx_t obj_idx;
+	duk_idx_t nargs;
+	duk_small_uint_t call_flags;
+};
+typedef struct duk__pcall_prop_args duk__pcall_prop_args;
+
+struct duk__pcall_method_args {
+	duk_idx_t nargs;
+	duk_small_uint_t call_flags;
+};
+typedef struct duk__pcall_method_args duk__pcall_method_args;
+
+struct duk__pcall_args {
+	duk_idx_t nargs;
+	duk_small_uint_t call_flags;
+};
+typedef struct duk__pcall_args duk__pcall_args;
+
+/* Compute and validate idx_func for a certain 'nargs' and 'other'
+ * parameter count (1 or 2, depending on whether 'this' binding is
+ * present).
+ */
+DUK_LOCAL duk_idx_t duk__call_get_idx_func(duk_context *ctx, duk_idx_t nargs, duk_idx_t other) {
+	duk_idx_t idx_func;
+
+	/* XXX: byte arithmetic? */
+
+	DUK_ASSERT(other >= 0);
+
+	idx_func = duk_get_top(ctx) - nargs - other;
+	if (DUK_UNLIKELY((idx_func | nargs) < 0)) {  /* idx_func < 0 || nargs < 0; OR sign bits */
+		DUK_ERROR_TYPE_INVALID_ARGS((duk_hthread *) ctx);
+		/* unreachable */
+	}
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
+	return idx_func;
+}
+
+/* Compute idx_func, assume index will be valid.  This is a valid assumption
+ * for protected calls: nargs < 0 is checked explicitly and duk_safe_call()
+ * validates the argument count.
+ */
+DUK_LOCAL duk_idx_t duk__call_get_idx_func_unvalidated(duk_context *ctx, duk_idx_t nargs, duk_idx_t other) {
+	duk_idx_t idx_func;
+
+	/* XXX: byte arithmetic? */
+
+	DUK_ASSERT(nargs >= 0);
+	DUK_ASSERT(other >= 0);
+
+	idx_func = duk_get_top(ctx) - nargs - other;
+	DUK_ASSERT(idx_func >= 0);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
+	return idx_func;
+}
 
 /* Prepare value stack for a method call through an object property.
  * May currently throw an error e.g. when getting the property.
  */
 DUK_LOCAL void duk__call_prop_prep_stack(duk_context *ctx, duk_idx_t normalized_obj_idx, duk_idx_t nargs) {
 	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(nargs >= 0);
 
 	DUK_DDD(DUK_DDDPRINT("duk__call_prop_prep_stack, normalized_obj_idx=%ld, nargs=%ld, stacktop=%ld",
 	                     (long) normalized_obj_idx, (long) nargs, (long) duk_get_top(ctx)));
@@ -19,7 +91,7 @@ DUK_LOCAL void duk__call_prop_prep_stack(duk_context *ctx, duk_idx_t normalized_
 
 	/* duplicate key */
 	duk_dup(ctx, -nargs - 1);  /* Note: -nargs alone would fail for nargs == 0, this is OK */
-	duk_get_prop(ctx, normalized_obj_idx);
+	(void) duk_get_prop(ctx, normalized_obj_idx);
 
 	DUK_DDD(DUK_DDDPRINT("func: %!T", (duk_tval *) duk_get_tval(ctx, -1)));
 
@@ -43,23 +115,13 @@ DUK_EXTERNAL void duk_call(duk_context *ctx, duk_idx_t nargs) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
 
-	idx_func = duk_get_top(ctx) - nargs - 1;
-	if (DUK_UNLIKELY(idx_func < 0 || nargs < 0)) {
-		/* note that we can't reliably pop anything here */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	}
+	idx_func = duk__call_get_idx_func(ctx, nargs, 1);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
 
-	/* XXX: awkward; we assume there is space for this, overwrite
-	 * directly instead?
-	 */
-	duk_push_undefined(ctx);
-	duk_insert(ctx, idx_func + 1);
+	duk_insert_undefined(ctx, idx_func + 1);
 
 	call_flags = 0;  /* not protected, respect reclimit, not constructor */
-
-	duk_handle_call_unprotected(thr,           /* thread */
-	                            nargs,         /* num_stack_args */
-	                            call_flags);   /* call_flags */
+	duk_handle_call_unprotected(thr, idx_func, call_flags);
 }
 
 DUK_EXTERNAL void duk_call_method(duk_context *ctx, duk_idx_t nargs) {
@@ -70,20 +132,16 @@ DUK_EXTERNAL void duk_call_method(duk_context *ctx, duk_idx_t nargs) {
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
 
-	idx_func = duk_get_top(ctx) - nargs - 2;  /* must work for nargs <= 0 */
-	if (DUK_UNLIKELY(idx_func < 0 || nargs < 0)) {
-		/* note that we can't reliably pop anything here */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	}
+	idx_func = duk__call_get_idx_func(ctx, nargs, 2);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
 
 	call_flags = 0;  /* not protected, respect reclimit, not constructor */
-
-	duk_handle_call_unprotected(thr,           /* thread */
-	                            nargs,         /* num_stack_args */
-	                            call_flags);   /* call_flags */
+	duk_handle_call_unprotected(thr, idx_func, call_flags);
 }
 
 DUK_EXTERNAL void duk_call_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+
 	/*
 	 *  XXX: if duk_handle_call() took values through indices, this could be
 	 *  made much more sensible.  However, duk_handle_call() needs to fudge
@@ -94,107 +152,116 @@ DUK_EXTERNAL void duk_call_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t n
 	DUK_ASSERT_CTX_VALID(ctx);
 
 	obj_idx = duk_require_normalize_index(ctx, obj_idx);  /* make absolute */
+	if (DUK_UNLIKELY(nargs < 0)) {
+		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+	}
 
 	duk__call_prop_prep_stack(ctx, obj_idx, nargs);
 
 	duk_call_method(ctx, nargs);
 }
 
-DUK_EXTERNAL duk_int_t duk_pcall(duk_context *ctx, duk_idx_t nargs) {
+DUK_LOCAL duk_ret_t duk__pcall_raw(duk_context *ctx, void *udata) {
 	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_small_uint_t call_flags;
+	duk__pcall_args *args;
 	duk_idx_t idx_func;
-	duk_int_t rc;
+	duk_int_t ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
-	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(udata != NULL);
 
-	idx_func = duk_get_top(ctx) - nargs - 1;  /* must work for nargs <= 0 */
-	if (DUK_UNLIKELY(idx_func < 0 || nargs < 0)) {
-		/* We can't reliably pop anything here because the stack input
-		 * shape is incorrect.  So we throw an error; if the caller has
-		 * no catch point for this, a fatal error will occur.  Another
-		 * alternative would be to just return an error.  But then the
-		 * stack would be in an unknown state which might cause some
-		 * very hard to diagnose problems later on.  Also note that even
-		 * if we did not throw an error here, the underlying call handler
-		 * might STILL throw an out-of-memory error or some other internal
-		 * fatal error.
-		 */
+	args = (duk__pcall_args *) udata;
+	idx_func = duk__call_get_idx_func_unvalidated(ctx, args->nargs, 1);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
+
+	duk_insert_undefined(ctx, idx_func + 1);
+
+	ret = duk_handle_call_unprotected(thr, idx_func, args->call_flags);
+	DUK_ASSERT(ret == 0);
+	DUK_UNREF(ret);
+
+	return 1;
+}
+
+DUK_EXTERNAL duk_int_t duk_pcall(duk_context *ctx, duk_idx_t nargs) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk__pcall_args args;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	args.nargs = nargs;
+	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
+	args.call_flags = 0;
 
-	/* Rely on the internal value stack reserve for these operations. */
-	duk_push_undefined(ctx);
-	duk_insert(ctx, idx_func + 1);
+	return duk_safe_call(ctx, duk__pcall_raw, (void *) &args /*udata*/, nargs + 1 /*nargs*/, 1 /*nrets*/);
+}
 
-	call_flags = 0;  /* respect reclimit, not constructor */
+DUK_LOCAL duk_ret_t duk__pcall_method_raw(duk_context *ctx, void *udata) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk__pcall_method_args *args;
+	duk_idx_t idx_func;
+	duk_int_t ret;
 
-	rc = duk_handle_call_protected(thr,           /* thread */
-	                               nargs,         /* num_stack_args */
-	                               call_flags);   /* call_flags */
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(udata != NULL);
 
-	return rc;
+	args = (duk__pcall_method_args *) udata;
+
+	idx_func = duk__call_get_idx_func_unvalidated(ctx, args->nargs, 2);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
+
+	ret = duk_handle_call_unprotected(thr, idx_func, args->call_flags);
+	DUK_ASSERT(ret == 0);
+	DUK_UNREF(ret);
+
+	return 1;
+}
+
+DUK_INTERNAL duk_int_t duk_pcall_method_flags(duk_context *ctx, duk_idx_t nargs, duk_small_uint_t call_flags) {
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk__pcall_method_args args;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+
+	args.nargs = nargs;
+	if (DUK_UNLIKELY(nargs < 0)) {
+		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		return DUK_EXEC_ERROR;  /* unreachable */
+	}
+	args.call_flags = call_flags;
+
+	return duk_safe_call(ctx, duk__pcall_method_raw, (void *) &args /*udata*/, nargs + 2 /*nargs*/, 1 /*nrets*/);
 }
 
 DUK_EXTERNAL duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs) {
-	duk_hthread *thr = (duk_hthread *) ctx;
-	duk_small_uint_t call_flags;
-	duk_idx_t idx_func;
-	duk_int_t rc;
-
-	DUK_ASSERT_CTX_VALID(ctx);
-	DUK_ASSERT(thr != NULL);
-
-	idx_func = duk_get_top(ctx) - nargs - 2;  /* must work for nargs <= 0 */
-	if (DUK_UNLIKELY(idx_func < 0 || nargs < 0)) {
-		/* See comments in duk_pcall(). */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
-	}
-
-	call_flags = 0;  /* respect reclimit, not constructor */
-
-	rc = duk_handle_call_protected(thr,           /* thread */
-	                               nargs,         /* num_stack_args */
-	                               call_flags);   /* call_flags */
-
-	return rc;
+	return duk_pcall_method_flags(ctx, nargs, 0);
 }
 
-struct duk__pcall_prop_args {
-	duk_idx_t obj_idx;
-	duk_idx_t nargs;
-};
-typedef struct duk__pcall_prop_args duk__pcall_prop_args;
-
 DUK_LOCAL duk_ret_t duk__pcall_prop_raw(duk_context *ctx, void *udata) {
-	duk_idx_t obj_idx;
-	duk_idx_t nargs;
 	duk__pcall_prop_args *args;
+	duk_idx_t obj_idx;
+	duk_int_t ret;
 
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(udata != NULL);
 
 	args = (duk__pcall_prop_args *) udata;
-	obj_idx = args->obj_idx;
-	nargs = args->nargs;
 
-	obj_idx = duk_require_normalize_index(ctx, obj_idx);  /* make absolute */
-	duk__call_prop_prep_stack(ctx, obj_idx, nargs);
-	duk_call_method(ctx, nargs);
+	obj_idx = duk_require_normalize_index(ctx, args->obj_idx);  /* make absolute */
+	duk__call_prop_prep_stack(ctx, obj_idx, args->nargs);
+
+	ret = duk_handle_call_unprotected_nargs((duk_hthread *) ctx, args->nargs, args->call_flags);
+	DUK_ASSERT(ret == 0);
+	DUK_UNREF(ret);
 	return 1;
 }
 
 DUK_EXTERNAL duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_idx, duk_idx_t nargs) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk__pcall_prop_args args;
-
-	/*
-	 *  Must be careful to catch errors related to value stack manipulation
-	 *  and property lookup, not just the call itself.
-	 */
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
@@ -204,11 +271,8 @@ DUK_EXTERNAL duk_int_t duk_pcall_prop(duk_context *ctx, duk_idx_t obj_idx, duk_i
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
+	args.call_flags = 0;
 
-	/* Inputs: explicit arguments (nargs), +1 for key.  If the value stack
-	 * does not contain enough args, an error is thrown; this matches
-	 * behavior of the other protected call API functions.
-	 */
 	return duk_safe_call(ctx, duk__pcall_prop_raw, (void *) &args /*udata*/, nargs + 1 /*nargs*/, 1 /*nrets*/);
 }
 
@@ -219,8 +283,17 @@ DUK_EXTERNAL duk_int_t duk_safe_call(duk_context *ctx, duk_safe_call_function fu
 	DUK_ASSERT_CTX_VALID(ctx);
 	DUK_ASSERT(thr != NULL);
 
-	if (DUK_UNLIKELY(duk_get_top(ctx) < nargs || nargs < 0 || nrets < 0)) {
-		/* See comments in duk_pcall(). */
+	/* nargs condition; fail if: top - bottom < nargs
+	 *                      <=>  top < bottom + nargs
+	 * nrets condition; fail if: end - (top - nargs) < nrets
+	 *                      <=>  end - top + nargs < nrets
+	 *                      <=>  end + nargs < top + nrets
+	 */
+	/* XXX: check for any reserve? */
+
+	if (DUK_UNLIKELY((nargs | nrets) < 0 ||  /* nargs < 0 || nrets < 0; OR sign bits */
+	                 thr->valstack_top < thr->valstack_bottom + nargs ||        /* nargs too large compared to top */
+	                 thr->valstack_end + nargs < thr->valstack_top + nrets)) {  /* nrets too large compared to reserve */
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
 		return DUK_EXEC_ERROR;  /* unreachable */
 	}
@@ -240,16 +313,13 @@ DUK_EXTERNAL void duk_new(duk_context *ctx, duk_idx_t nargs) {
 
 	DUK_ASSERT_CTX_VALID(ctx);
 
-	idx_func = duk_get_top(ctx) - nargs - 1;
-	if (DUK_UNLIKELY(idx_func < 0 || nargs < 0)) {
-		/* note that we can't reliably pop anything here */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	}
+	idx_func = duk__call_get_idx_func(ctx, nargs, 1);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
 
 	duk_push_object(ctx);  /* default instance; internal proto updated by call handling */
 	duk_insert(ctx, idx_func + 1);
 
-	duk_handle_call_unprotected((duk_hthread *) ctx, nargs, DUK_CALL_FLAG_CONSTRUCTOR_CALL);
+	duk_handle_call_unprotected(thr, idx_func, DUK_CALL_FLAG_CONSTRUCTOR_CALL);
 }
 
 DUK_LOCAL duk_ret_t duk__pnew_helper(duk_context *ctx, void *udata) {

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -37,6 +37,7 @@ DUK_INTERNAL_DECL void duk_dup_m3(duk_context *ctx);
 DUK_INTERNAL_DECL void duk_dup_m4(duk_context *ctx);
 
 DUK_INTERNAL_DECL void duk_remove_m2(duk_context *ctx);
+DUK_INTERNAL_DECL void duk_remove_n(duk_context *ctx, duk_idx_t idx, duk_idx_t count);
 
 DUK_INTERNAL_DECL duk_int_t duk_get_type_tval(duk_tval *tv);
 DUK_INTERNAL_DECL duk_uint_t duk_get_type_mask_tval(duk_tval *tv);
@@ -291,6 +292,11 @@ DUK_INTERNAL_DECL void duk_pop_n_nodecref_unsafe(duk_context *ctx, duk_idx_t cou
 DUK_INTERNAL_DECL void duk_pop_unsafe(duk_context *ctx);
 
 DUK_INTERNAL_DECL void duk_compact_m1(duk_context *ctx);
+
+DUK_INTERNAL_DECL void duk_insert_undefined(duk_context *ctx, duk_idx_t idx);
+DUK_INTERNAL_DECL void duk_insert_undefined_n(duk_context *ctx, duk_idx_t idx, duk_idx_t count);
+
+DUK_INTERNAL_DECL duk_int_t duk_pcall_method_flags(duk_context *ctx, duk_idx_t nargs, duk_small_uint_t call_flags);
 
 /* Raw internal valstack access macros: access is unsafe so call site
  * must have a guarantee that the index is valid.  When that is the case,

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1095,6 +1095,26 @@ DUK_EXTERNAL void duk_insert(duk_context *ctx, duk_idx_t to_idx) {
 	}
 }
 
+DUK_INTERNAL void duk_insert_undefined(duk_context *ctx, duk_idx_t idx) {
+	DUK_ASSERT(idx >= 0);  /* Doesn't support negative indices. */
+	duk_push_undefined(ctx);
+	duk_insert(ctx, idx);
+}
+
+DUK_INTERNAL void duk_insert_undefined_n(duk_context *ctx, duk_idx_t idx, duk_idx_t count) {
+	duk_tval *tv, *tv_end;
+
+	DUK_ASSERT(idx >= 0);  /* Doesn't support negative indices or count. */
+	DUK_ASSERT(count >= 0);
+
+	tv = duk_reserve_gap(ctx, idx, count);
+	tv_end = tv + count;
+	while (tv != tv_end) {
+		DUK_TVAL_SET_UNDEFINED(tv);
+		tv++;
+	}
+}
+
 DUK_EXTERNAL void duk_replace(duk_context *ctx, duk_idx_t to_idx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv1;
@@ -1175,8 +1195,54 @@ DUK_EXTERNAL void duk_remove(duk_context *ctx, duk_idx_t idx) {
 #endif
 }
 
-DUK_INTERNAL_DECL void duk_remove_m2(duk_context *ctx) {
+DUK_INTERNAL void duk_remove_m2(duk_context *ctx) {
 	duk_remove(ctx, -2);
+}
+
+DUK_INTERNAL void duk_remove_n(duk_context *ctx, duk_idx_t idx, duk_idx_t count) {
+#if defined(DUK_USE_PREFER_SIZE)
+	/* XXX: maybe too slow even when preferring size? */
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(count >= 0);
+	DUK_ASSERT(idx >= 0);
+
+	while (count-- > 0) {
+		duk_remove(ctx, idx);
+	}
+#else  /* DUK_USE_PREFER_SIZE */
+	duk_hthread *thr = (duk_hthread *) ctx;
+	duk_tval *tv_src;
+	duk_tval *tv_dst;
+	duk_tval *tv_newtop;
+	duk_tval *tv;
+	duk_size_t bytes;
+
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(count >= 0);
+	DUK_ASSERT(idx >= 0);
+
+	tv_dst = thr->valstack_bottom + idx;
+	DUK_ASSERT(tv_dst <= thr->valstack_top);
+	tv_src = tv_dst + count;
+	DUK_ASSERT(tv_src <= thr->valstack_top);
+	bytes = (duk_size_t) ((duk_uint8_t *) thr->valstack_top - (duk_uint8_t *) tv_src);
+
+	for (tv = tv_dst; tv < tv_src; tv++) {
+		DUK_TVAL_DECREF_NORZ(thr, tv);
+	}
+
+	DUK_MEMMOVE((void *) tv_dst, (const void *) tv_src, bytes);
+
+	tv_newtop = thr->valstack_top - count;
+	for (tv = tv_newtop; tv < thr->valstack_top; tv++) {
+		DUK_TVAL_SET_UNDEFINED(tv);
+	}
+	thr->valstack_top = tv_newtop;
+
+	/* When not preferring size, only NORZ macros are used; caller
+	 * is expected to DUK_REFZERO_CHECK().
+	 */
+#endif  /* DUK_USE_PREFER_SIZE */
 }
 
 /*
@@ -2065,7 +2131,7 @@ DUK_EXTERNAL void duk_require_function(duk_context *ctx, duk_idx_t idx) {
 	}
 }
 
-DUK_INTERNAL_DECL void duk_require_constructable(duk_context *ctx, duk_idx_t idx) {
+DUK_INTERNAL void duk_require_constructable(duk_context *ctx, duk_idx_t idx) {
 	duk_hobject *h;
 
 	h = duk_require_hobject_accept_mask(ctx, idx, DUK_TYPE_MASK_LIGHTFUNC);

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -58,7 +58,7 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows(duk_context *ctx) {
 
 
 #if defined(DUK_USE_DATE_TZO_WINDOWS)
-DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t d) {
+DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t d) {
 	SYSTEMTIME st1;
 	SYSTEMTIME st2;
 	SYSTEMTIME st3;
@@ -98,7 +98,7 @@ DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t 
 #endif  /* DUK_USE_DATE_TZO_WINDOWS */
 
 #if defined(DUK_USE_DATE_TZO_WINDOWS_NO_DST)
-DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows_no_dst(duk_double_t d) {
+DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_windows_no_dst(duk_double_t d) {
 	SYSTEMTIME st1;
 	SYSTEMTIME st2;
 	FILETIME ft1;

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -590,9 +590,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_context *ctx) {
 		 */
 		call_flags |= DUK_CALL_FLAG_DIRECT_EVAL;
 	}
-	duk_handle_call_unprotected(thr,           /* thread */
-	                            0,             /* num_stack_args */
-	                            call_flags);   /* call_flags */
+	duk_handle_call_unprotected_nargs(thr, 0, call_flags);
 
 	/* [ env? source template result ] */
 

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -126,7 +126,7 @@ DUK_LOCAL void duk__err_augment_user(duk_hthread *thr, duk_small_uint_t stridx_c
 	DUK_ASSERT(thr->heap->augmenting_error == 0);
 	thr->heap->augmenting_error = 1;
 
-	rc = duk_handle_call_protected(thr, 1, 0 /*call_flags*/);
+	rc = duk_pcall_method(ctx, 1);
 	DUK_UNREF(rc);  /* no need to check now: both success and error are OK */
 
 	DUK_ASSERT(thr->heap->augmenting_error == 1);

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -48,17 +48,17 @@
 
 #define DUK__NO_ARRAY_INDEX             DUK_HSTRING_NO_ARRAY_INDEX
 
-/* marker values for hash part */
+/* Marker values for hash part. */
 #define DUK__HASH_UNUSED                DUK_HOBJECT_HASHIDX_UNUSED
 #define DUK__HASH_DELETED               DUK_HOBJECT_HASHIDX_DELETED
 
-/* valstack space that suffices for all local calls, including recursion
- * of other than Duktape calls (getters etc)
+/* Valstack space that suffices for all local calls, excluding any recursion
+ * into Ecmascript or Duktape/C calls (Proxy, getters, etc).
  */
 #define DUK__VALSTACK_SPACE             10
 
-/* valstack space allocated especially for proxy lookup which does a
- * recursive property lookup
+/* Valstack space allocated especially for proxy lookup which does a
+ * recursive property lookup.
  */
 #define DUK__VALSTACK_PROXY_LOOKUP      20
 

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -12,15 +12,19 @@
  *  Stack constants
  */
 
-#define DUK_VALSTACK_INITIAL_SIZE       128     /* roughly 1.0 kiB */
-#define DUK_VALSTACK_INTERNAL_EXTRA     64      /* internal extra elements assumed on function entry,
-                                                 * always added to user-defined 'extra' for e.g. the
-                                                 * duk_check_stack() call.
-                                                 */
+/* Initial valstack size, roughly 0.7kiB. */
+#define DUK_VALSTACK_INITIAL_SIZE       96
+
+/* Internal extra elements assumed on function entry, always added to
+ * user-defined 'extra' for e.g. the duk_check_stack() call.
+ */
+#define DUK_VALSTACK_INTERNAL_EXTRA     32
+
+/* Number of elements guaranteed to be user accessible (in addition to call
+ * arguments) on Duktape/C function entry.  This is the major public API
+ * commitment.
+ */
 #define DUK_VALSTACK_API_ENTRY_MINIMUM  DUK_API_ENTRY_STACK
-                                                /* number of elements guaranteed to be user accessible
-                                                 * (in addition to call arguments) on Duktape/C function entry.
-                                                 */
 
 /*
  *  Activation defines

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -622,6 +622,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			DUK_UNREF(h_func);
 
 			/* XXX: add into init data? */
+
 			/* Special call handling, not described in init data. */
 			if (c_func == duk_bi_function_prototype_call ||
 			    c_func == duk_bi_function_prototype_apply ||

--- a/src-input/duk_hthread_stacks.c
+++ b/src-input/duk_hthread_stacks.c
@@ -387,7 +387,8 @@ DUK_INTERNAL void duk_hthread_valstack_torture_realloc(duk_hthread *thr) {
 		return;
 	}
 
-	new_ptr = (duk_tval *) DUK_ALLOC(thr->heap, alloc_size);
+	/* Use DUK_ALLOC_RAW() to avoid side effects. */
+	new_ptr = (duk_tval *) DUK_ALLOC_RAW(thr->heap, alloc_size);
 	if (new_ptr != NULL) {
 		DUK_MEMCPY((void *) new_ptr, (const void *) thr->valstack, alloc_size);
 		DUK_MEMSET((void *) thr->valstack, 0x55, alloc_size);

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -6,10 +6,10 @@
 #define DUK_JS_H_INCLUDED
 
 /* Flags for call handling. */
-#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 0)  /* duk_handle_call_xxx: constructor call (i.e. called as 'new Foo()') */
-#define DUK_CALL_FLAG_IS_RESUME              (1 << 1)  /* duk_handle_ecma_call_setup: setup for a resume() */
-#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 2)  /* duk_handle_ecma_call_setup: setup for a tail call */
-#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 3)  /* call is a direct eval call */
+#define DUK_CALL_FLAG_CONSTRUCTOR_CALL       (1 << 0)  /* duk_handle_call_unprotected: constructor call (i.e. called as 'new Foo()') */
+#define DUK_CALL_FLAG_IS_TAILCALL            (1 << 1)  /* duk_handle_call_unprotected: setup for a tail call */
+#define DUK_CALL_FLAG_DIRECT_EVAL            (1 << 2)  /* duk_handle_call_unprotected: call is a direct eval call */
+#define DUK_CALL_FLAG_ALLOW_ECMATOECMA       (1 << 3)  /* duk_handle_call_unprotected: ecma-to-ecma call with executor reuse is possible */
 
 /* Flags for duk_js_equals_helper(). */
 #define DUK_EQUALS_FLAG_SAMEVALUE            (1 << 0)  /* use SameValue instead of non-strict equality */
@@ -93,10 +93,9 @@ DUK_INTERNAL_DECL void duk_js_push_closure(duk_hthread *thr,
                                            duk_bool_t add_auto_proto);
 
 /* call handling */
-DUK_INTERNAL_DECL duk_int_t duk_handle_call_protected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
-DUK_INTERNAL_DECL void duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL duk_int_t duk_handle_call_unprotected(duk_hthread *thr, duk_idx_t idx_func, duk_small_uint_t call_flags);
+DUK_INTERNAL_DECL duk_int_t duk_handle_call_unprotected_nargs(duk_hthread *thr, duk_idx_t nargs, duk_small_uint_t call_flags);
 DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, void *udata, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
-DUK_INTERNAL_DECL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr, duk_idx_t num_stack_args, duk_small_uint_t call_flags, duk_small_uint_t *out_call_flags);
 DUK_INTERNAL_DECL void duk_call_construct_postprocess(duk_context *ctx);
 
 /* bytecode execution */

--- a/src-input/duk_js_bytecode.h
+++ b/src-input/duk_js_bytecode.h
@@ -369,9 +369,9 @@ typedef duk_uint32_t duk_instr_t;
 #define DUK_OP_THROW                173
 #define DUK_OP_CSREG                174
 #define DUK_OP_EVALCALL             175
-#define DUK_OP_CALL                 176  /* must be even */
-#define DUK_OP_TAILCALL             177  /* must be odd */
-#define DUK_OP_NEW                  178
+#define DUK_OP_CALL                 176  /* op & 0x03 must be 0 */
+#define DUK_OP_TAILCALL             177  /* op & 0x03 must be 1 */
+#define DUK_OP_CONSCALL             178  /* op & 0x03 must be 2 */
 #define DUK_OP_NEWOBJ               179
 #define DUK_OP_NEWARR               180
 #define DUK_OP_MPUTOBJ              181

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1,77 +1,35 @@
 /*
  *  Call handling.
  *
- *  Main functions are:
+ *  duk_handle_call_unprotected():
  *
- *    - duk_handle_call_unprotected(): unprotected call to Ecmascript or
- *      Duktape/C function
- *    - duk_handle_call_protected(): protected call to Ecmascript or
- *      Duktape/C function
- *    - duk_handle_safe_call(): make a protected C call within current
- *      activation
- *    - duk_handle_ecma_call_setup(): Ecmascript-to-Ecmascript calls
- *      (not always possible), including tail calls and coroutine resume
+ *    - Unprotected call to Ecmascript or Duktape/C function, from native
+ *      code or bytecode executor.
+ *
+ *    - Also handles Ecma-to-Ecma calls which reuses a currently running
+ *      executor instance to avoid native recursion.  Call setup is done
+ *      normally, but just before calling the bytecode executor a special
+ *      return code is used to indicate that a calling executor is reused.
+ *
+ *    - Also handles tailcalls, i.e. reuse of current duk_activation.
+ *
+ *    - Also handles setup for initial Duktape.Thread.resume().
+ *
+ *  duk_handle_safe_call():
+ *
+ *    - Protected C call within current activation.
+ *
+ *  setjmp() and local variables have a nasty interaction, see execution.rst;
+ *  non-volatile locals modified after setjmp() call are not guaranteed to
+ *  keep their value and can cause compiler or compiler version specific
+ *  difficult to replicate issues.
  *
  *  See 'execution.rst'.
- *
- *  Note: setjmp() and local variables have a nasty interaction,
- *  see execution.rst; non-volatile locals modified after setjmp()
- *  call are not guaranteed to keep their value.
  */
 
 #include "duk_internal.h"
 
 /* XXX: heap->error_not_allowed for success path too? */
-
-/*
- *  Forward declarations.
- */
-
-DUK_LOCAL_DECL void duk__handle_call_inner(duk_hthread *thr,
-                                           duk_idx_t num_stack_args,
-                                           duk_small_uint_t call_flags,
-                                           duk_idx_t idx_func);
-DUK_LOCAL_DECL void duk__handle_call_error(duk_hthread *thr,
-                                           duk_activation *entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-                                           duk_size_t entry_callstack_top,
-#endif
-                                           duk_size_t entry_valstack_bottom_byteoff,
-                                           duk_size_t entry_valstack_end_byteoff,
-                                           duk_int_t entry_call_recursion_depth,
-                                           duk_hthread *entry_curr_thread,
-                                           duk_uint_fast8_t entry_thread_state,
-                                           duk_instr_t **entry_ptr_curr_pc,
-                                           duk_idx_t idx_func,
-                                           duk_jmpbuf *old_jmpbuf_ptr);
-DUK_LOCAL_DECL void duk__handle_safe_call_inner(duk_hthread *thr,
-                                                duk_safe_call_function func,
-                                                void *udata,
-#if defined(DUK_USE_ASSERTIONS)
-                                                duk_size_t entry_valstack_bottom_byteoff,
-                                                duk_size_t entry_callstack_top,
-#endif
-                                                duk_idx_t idx_retbase,
-                                                duk_idx_t num_stack_rets);
-DUK_LOCAL_DECL void duk__handle_safe_call_error(duk_hthread *thr,
-                                                duk_activation *entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-                                                duk_size_t entry_callstack_top,
-#endif
-                                                duk_idx_t idx_retbase,
-                                                duk_idx_t num_stack_rets,
-                                                duk_size_t entry_valstack_bottom_byteoff,
-                                                duk_jmpbuf *old_jmpbuf_ptr);
-DUK_LOCAL_DECL void duk__handle_safe_call_shared(duk_hthread *thr,
-                                                 duk_idx_t idx_retbase,
-                                                 duk_idx_t num_stack_rets,
-#if defined(DUK_USE_ASSERTIONS)
-                                                 duk_size_t entry_callstack_top,
-#endif
-                                                 duk_int_t entry_call_recursion_depth,
-                                                 duk_hthread *entry_curr_thread,
-                                                 duk_uint_fast8_t entry_thread_state,
-                                                 duk_instr_t **entry_ptr_curr_pc);
 
 /*
  *  Limit check helpers.
@@ -82,7 +40,7 @@ DUK_LOCAL_DECL void duk__handle_safe_call_shared(duk_hthread *thr,
  * for, e.g. a print() call at the deepest level, and an extra
  * +1 for protected call wrapping.
  */
-#define DUK__CALL_RELAX_COUNT  (10 + 2)
+#define DUK__AUGMENT_CALL_RELAX_COUNT  (10 + 2)
 
 DUK_LOCAL DUK_NOINLINE void duk__call_c_recursion_limit_check_slowpath(duk_hthread *thr) {
 	/* When augmenting an error, the effective limit is a bit higher.
@@ -90,17 +48,13 @@ DUK_LOCAL DUK_NOINLINE void duk__call_c_recursion_limit_check_slowpath(duk_hthre
 	 */
 #if defined(DUK_USE_AUGMENT_ERROR_THROW) || defined(DUK_USE_AUGMENT_ERROR_CREATE)
 	if (thr->heap->augmenting_error) {
-		if (thr->heap->call_recursion_depth < thr->heap->call_recursion_limit + DUK__CALL_RELAX_COUNT) {
+		if (thr->heap->call_recursion_depth < thr->heap->call_recursion_limit + DUK__AUGMENT_CALL_RELAX_COUNT) {
 			DUK_D(DUK_DPRINT("C recursion limit reached but augmenting error and within relaxed limit"));
 			return;
 		}
 	}
 #endif
 
-	/* XXX: error message is a bit misleading: we reached a recursion
-	 * limit which is also essentially the same as a C callstack limit
-	 * (except perhaps with some relaxed threading assumptions).
-	 */
 	DUK_D(DUK_DPRINT("call prevented because C recursion limit reached"));
 	DUK_ERROR_RANGE(thr, DUK_STR_C_CALLSTACK_LIMIT);
 }
@@ -125,7 +79,7 @@ DUK_LOCAL DUK_NOINLINE void duk__call_callstack_limit_check_slowpath(duk_hthread
 	 */
 #if defined(DUK_USE_AUGMENT_ERROR_THROW) || defined(DUK_USE_AUGMENT_ERROR_CREATE)
 	if (thr->heap->augmenting_error) {
-		if (thr->callstack_top < DUK_USE_CALLSTACK_LIMIT + DUK__CALL_RELAX_COUNT) {
+		if (thr->callstack_top < DUK_USE_CALLSTACK_LIMIT + DUK__AUGMENT_CALL_RELAX_COUNT) {
 			DUK_D(DUK_DPRINT("call stack limit reached but augmenting error and within relaxed limit"));
 			return;
 		}
@@ -198,8 +152,7 @@ DUK_LOCAL void duk__interrupt_fixup(duk_hthread *thr, duk_hthread *entry_curr_th
 DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
                                             duk_hobject *func,
                                             duk_hobject *varenv,
-                                            duk_idx_t idx_argbase,        /* idx of first argument on stack */
-                                            duk_idx_t num_stack_args) {   /* num args starting from idx_argbase */
+                                            duk_idx_t idx_args) {
 	duk_context *ctx = (duk_context *) thr;
 	duk_hobject *arg;          /* 'arguments' */
 	duk_hobject *formals;      /* formals for 'func' (may be NULL if func is a C function) */
@@ -210,24 +163,24 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	duk_idx_t i_argbase;
 	duk_idx_t n_formals;
 	duk_idx_t idx;
+	duk_idx_t num_stack_args;
 	duk_bool_t need_map;
-
-	DUK_DDD(DUK_DDDPRINT("creating arguments object for func=%!iO, varenv=%!iO, "
-	                     "idx_argbase=%ld, num_stack_args=%ld",
-	                     (duk_heaphdr *) func, (duk_heaphdr *) varenv,
-	                     (long) idx_argbase, (long) num_stack_args));
 
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(func != NULL);
 	DUK_ASSERT(DUK_HOBJECT_IS_NONBOUND_FUNCTION(func));
 	DUK_ASSERT(varenv != NULL);
-	DUK_ASSERT(idx_argbase >= 0);  /* assumed to bottom relative */
-	DUK_ASSERT(num_stack_args >= 0);
+
+	/* [ ... func this arg1(@idx_args) ... argN envobj ]
+	 * [ arg1(@idx_args) ... argN envobj ] (for tailcalls)
+	 */
 
 	need_map = 0;
 
-	i_argbase = idx_argbase;
+	i_argbase = idx_args;
+	num_stack_args = duk_get_top(ctx) - i_argbase - 1;
 	DUK_ASSERT(i_argbase >= 0);
+	DUK_ASSERT(num_stack_args >= 0);
 
 	duk_push_hobject(ctx, func);
 	duk_get_prop_stridx_short(ctx, -1, DUK_STRIDX_INT_FORMALS);
@@ -301,7 +254,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	duk_xdef_prop_stridx(ctx, i_arg, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_WC);
 
 	/*
-	 *  Init argument related properties
+	 *  Init argument related properties.
 	 */
 
 	/* step 11 */
@@ -438,22 +391,21 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	                     (long) i_map, (duk_heaphdr *) duk_get_hobject(ctx, i_map),
 	                     (long) i_mappednames, (duk_heaphdr *) duk_get_hobject(ctx, i_mappednames)));
 
-	/* [ args(n) [crud] formals arguments map mappednames ] */
+	/* [ args(n) envobj formals arguments map mappednames ] */
 
 	duk_pop_2(ctx);
 	duk_remove_m2(ctx);
 
-	/* [ args [crud] arguments ] */
+	/* [ args(n) envobj arguments ] */
 }
 
 /* Helper for creating the arguments object and adding it to the env record
- * on top of the value stack.  This helper has a very strict dependency on
- * the shape of the input stack.
+ * on top of the value stack.
  */
 DUK_LOCAL void duk__handle_createargs_for_call(duk_hthread *thr,
                                                duk_hobject *func,
                                                duk_hobject *env,
-                                               duk_idx_t num_stack_args) {
+                                               duk_idx_t idx_args) {
 	duk_context *ctx = (duk_context *) thr;
 
 	DUK_DDD(DUK_DDDPRINT("creating arguments object for function call"));
@@ -462,15 +414,13 @@ DUK_LOCAL void duk__handle_createargs_for_call(duk_hthread *thr,
 	DUK_ASSERT(func != NULL);
 	DUK_ASSERT(env != NULL);
 	DUK_ASSERT(DUK_HOBJECT_HAS_CREATEARGS(func));
-	DUK_ASSERT(duk_get_top(ctx) >= num_stack_args + 1);
 
 	/* [ ... arg1 ... argN envobj ] */
 
 	duk__create_arguments_object(thr,
 	                             func,
 	                             env,
-	                             duk_get_top(ctx) - num_stack_args - 1,    /* idx_argbase */
-	                             num_stack_args);
+	                             idx_args);
 
 	/* [ ... arg1 ... argN envobj argobj ] */
 
@@ -524,7 +474,7 @@ DUK_LOCAL void duk__update_default_instance_proto(duk_context *ctx, duk_idx_t id
 
 	duk_get_prop_stridx_short(ctx, idx_func, DUK_STRIDX_PROTOTYPE);
 	proto = duk_get_hobject(ctx, -1);
-	if (!proto) {
+	if (proto == NULL) {
 		DUK_DDD(DUK_DDDPRINT("constructor has no 'prototype' property, or value not an object "
 		                     "-> leave standard Object prototype as fallback prototype"));
 	} else {
@@ -579,10 +529,10 @@ DUK_INTERNAL void duk_call_construct_postprocess(duk_context *ctx) {
  *  the target is non-bound or there is one bound function that points to a
  *  nonbound target.
  *
- *  Prepends the bound arguments to the value stack (at idx_func + 2),
- *  updating 'num_stack_args' in the process.  The 'this' binding is also
- *  updated if necessary (at idx_func + 1).  Note that for constructor calls
- *  the 'this' binding is never updated by [[BoundThis]].
+ *  Prepends the bound arguments to the value stack (at idx_func + 2).
+ *  The 'this' binding is also updated if necessary (at idx_func + 1).
+ *  Note that for constructor calls the 'this' binding is never updated by
+ *  [[BoundThis]].
  */
 
 DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
@@ -676,7 +626,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
  *  Helper for inline handling of .call(), .apply(), and .construct().
  */
 
-DUK_LOCAL void duk__handle_callapply_for_call(duk_hthread *thr, duk_idx_t idx_func, duk_hobject *func, duk_small_uint_t *call_flags) {
+DUK_LOCAL void duk__handle_specialfuncs_for_call(duk_hthread *thr, duk_idx_t idx_func, duk_hobject *func, duk_small_uint_t *call_flags) {
 	duk_context *ctx = (duk_context *) thr;
 #if defined(DUK_USE_ASSERTIONS)
 	duk_c_function natfunc;
@@ -701,9 +651,8 @@ DUK_LOCAL void duk__handle_callapply_for_call(duk_hthread *thr, duk_idx_t idx_fu
 
 	duk_remove(ctx, idx_func);
 
-	/* Handle .call() and .apply() based on them having the
-	 * DUK_HOBJECT_FLAG_SPECIAL_CALL flag; their magic value
-	 * is used for switch-case.
+	/* Handle special functions based on the DUK_HOBJECT_FLAG_SPECIAL_CALL
+	 * flag; their magic value is used for switch-case.
 	 *
 	 * NOTE: duk_unpack_array_like() reserves value stack space
 	 * for the result values (unlike most other value stack calls).
@@ -797,7 +746,7 @@ DUK_LOCAL void duk__handle_callapply_for_call(duk_hthread *thr, duk_idx_t idx_fu
 		*call_flags |= DUK_CALL_FLAG_CONSTRUCTOR_CALL;
 		duk_remove(ctx, idx_func);  /* remove Reflect.construct 'this' binding */
 		top = duk_get_top(ctx);
-		if (top < idx_func + 1 || !duk_is_constructable(ctx, idx_func)) {
+		if (!duk_is_constructable(ctx, idx_func)) {
 			/* Target constructability must be checked before
 			 * unpacking argArray (which may cause side effects).
 			 * Just return; caller will throw the error.
@@ -1047,11 +996,10 @@ DUK_LOCAL DUK_INLINE void duk__coerce_nonstrict_this_binding(duk_hthread *thr, d
 	}
 }
 
-DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__resolve_target_fastpath_check(duk_context *ctx, duk_idx_t idx_func, duk_tval *out_tv_func, duk_hobject **out_func, duk_small_uint_t call_flags) {
+DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__resolve_target_fastpath_check(duk_context *ctx, duk_idx_t idx_func, duk_hobject **out_func, duk_small_uint_t call_flags) {
 #if defined(DUK_USE_PREFER_SIZE)
 	DUK_UNREF(ctx);
 	DUK_UNREF(idx_func);
-	DUK_UNREF(out_tv_func);
 	DUK_UNREF(out_func);
 #else  /* DUK_USE_PREFER_SIZE */
 	duk_tval *tv_func;
@@ -1069,7 +1017,6 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__resolve_target_fastpath_check(duk_co
 		if (DUK_HOBJECT_IS_CALLABLE(func) &&
 		    !DUK_HOBJECT_HAS_BOUNDFUNC(func) &&
 		    !DUK_HOBJECT_HAS_SPECIAL_CALL(func)) {
-			DUK_TVAL_SET_TVAL(out_tv_func, tv_func);
 			*out_func = func;
 
 			if (DUK_HOBJECT_HAS_STRICT(func)) {
@@ -1081,7 +1028,6 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__resolve_target_fastpath_check(duk_co
 			return 1;
 		}
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv_func)) {
-		DUK_TVAL_SET_TVAL(out_tv_func, tv_func);
 		*out_func = NULL;
 
 		/* Lightfuncs are considered strict, so 'this' binding is
@@ -1095,8 +1041,6 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__resolve_target_fastpath_check(duk_co
 
 DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_context *ctx,
                                                                  duk_idx_t idx_func,
-                                                                 duk_idx_t *out_num_stack_args,
-                                                                 duk_tval *out_tv_func,
                                                                  duk_small_uint_t *call_flags) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_tval *tv_func;
@@ -1113,12 +1057,11 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_context *ct
 		if (DUK_TVAL_IS_OBJECT(tv_func)) {
 			func = DUK_TVAL_GET_OBJECT(tv_func);
 			if (DUK_UNLIKELY(!DUK_HOBJECT_IS_CALLABLE(func))) {
-				goto not_callable_error;
+				goto not_callable;
 			}
 			if (DUK_LIKELY(!DUK_HOBJECT_HAS_BOUNDFUNC(func) && !DUK_HOBJECT_HAS_SPECIAL_CALL(func))) {
 				/* Common case, so test for using a single bitfield test. */
 
-				DUK_TVAL_SET_TVAL(out_tv_func, tv_func);
 				if (!DUK_HOBJECT_HAS_STRICT(func)) {
 					/* Non-strict target needs 'this' coercion.
 					 * This has potential side effects invalidating
@@ -1162,28 +1105,21 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_context *ct
 					 */
 					goto not_constructable;
 				}
-				duk__handle_callapply_for_call(thr, idx_func, func, call_flags);
+				duk__handle_specialfuncs_for_call(thr, idx_func, func, call_flags);
 			}
 			/* Retry loop. */
 		} else if (DUK_TVAL_IS_LIGHTFUNC(tv_func)) {
 			/* Lightfuncs are strict, so no 'this' coercion.
 			 * Lightfuncs are also always constructable, so no
-			 * constructability check.
+			 * constructability check.  Finally, specialfuncs
+			 * cannot currently be lightfuncs.
 			 */
-			DUK_TVAL_SET_TVAL(out_tv_func, tv_func);
 			func = NULL;
 			break;
 		} else {
-			goto not_callable_error;
+			goto not_callable;
 		}
 	}
-
-	/* Recompute num_stack_args.
-	 * XXX: the whole num_stack_args tracking could be removed
-	 * from the call site.
-	 */
-	DUK_ASSERT(duk_get_top(ctx) >= idx_func + 2);
-	*out_num_stack_args = duk_get_top(ctx) - (idx_func + 2);
 
 #if defined(DUK_USE_ASSERTIONS)
 	{
@@ -1197,6 +1133,7 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_context *ct
 		DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));
 		DUK_ASSERT(func == NULL || (DUK_HOBJECT_IS_COMPFUNC(func) ||
 		                            DUK_HOBJECT_IS_NATFUNC(func)));
+		DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_SPECIAL_CALL(func));
 		DUK_ASSERT(func == NULL || (DUK_HOBJECT_HAS_CONSTRUCTABLE(func) ||
 		                            (*call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) == 0));
 	}
@@ -1204,7 +1141,7 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_context *ct
 
 	return func;
 
- not_callable_error:
+ not_callable:
 	DUK_ASSERT(tv_func != NULL);
 #if defined(DUK_USE_VERBOSE_ERRORS)
 #if defined(DUK_USE_PARANOID_ERRORS)
@@ -1252,6 +1189,9 @@ DUK_LOCAL void duk__safe_call_adjust_valstack(duk_hthread *thr, duk_idx_t idx_re
 	DUK_ASSERT(num_actual_rets >= 0);
 
 	idx_rcbase = duk_get_top(ctx) - num_actual_rets;  /* base of known return values */
+	if (DUK_UNLIKELY(idx_rcbase < 0)) {
+		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_CFUNC_RC);
+	}
 
 	DUK_DDD(DUK_DDDPRINT("adjust valstack after func call: "
 	                     "num_stack_rets=%ld, num_actual_rets=%ld, stack_top=%ld, idx_retbase=%ld, idx_rcbase=%ld",
@@ -1260,452 +1200,234 @@ DUK_LOCAL void duk__safe_call_adjust_valstack(duk_hthread *thr, duk_idx_t idx_re
 
 	DUK_ASSERT(idx_rcbase >= 0);  /* caller must check */
 
-	/* Ensure space for final configuration (idx_retbase + num_stack_rets)
-	 * and intermediate configurations.
+	/* Space for num_stack_rets was reserved before the safe call.
+	 * Because value stack reserve cannot shrink except in call returns,
+	 * the reserve is still in place.  Adjust valstack, carefully
+	 * ensuring we don't overstep the reserve.
 	 */
-	duk_require_stack_top(ctx,
-	                      (idx_rcbase > idx_retbase ? idx_rcbase : idx_retbase) +
-	                      num_stack_rets);
 
-	/* Chop extra retvals away / extend with undefined. */
-	duk_set_top(ctx, idx_rcbase + num_stack_rets);
-
-	if (idx_rcbase >= idx_retbase) {
+	/* Match idx_rcbase with idx_retbase so that the return values
+	 * start at the correct index.
+	 */
+	if (idx_rcbase > idx_retbase) {
 		duk_idx_t count = idx_rcbase - idx_retbase;
-		duk_idx_t i;
 
 		DUK_DDD(DUK_DDDPRINT("elements at/after idx_retbase have enough to cover func retvals "
 		                     "(idx_retbase=%ld, idx_rcbase=%ld)", (long) idx_retbase, (long) idx_rcbase));
 
-		/* nuke values at idx_retbase to get the first retval (initially
-		 * at idx_rcbase) to idx_retbase
+		/* Remove values between irc_rcbase (start of intended return
+		 * values) and idx_retbase to lower return values to idx_retbase.
 		 */
-
-		DUK_ASSERT(count >= 0);
-
-		for (i = 0; i < count; i++) {
-			/* XXX: inefficient; block remove primitive */
-			duk_remove(ctx, idx_retbase);
-		}
+		DUK_ASSERT(count > 0);
+		duk_remove_n(ctx, idx_retbase, count);  /* may be NORZ */
 	} else {
 		duk_idx_t count = idx_retbase - idx_rcbase;
-		duk_idx_t i;
 
 		DUK_DDD(DUK_DDDPRINT("not enough elements at/after idx_retbase to cover func retvals "
 		                     "(idx_retbase=%ld, idx_rcbase=%ld)", (long) idx_retbase, (long) idx_rcbase));
 
-		/* insert 'undefined' values at idx_rcbase to get the
-		 * return values to idx_retbase
+		/* Insert 'undefined' at idx_rcbase (start of intended return
+		 * values) to lift return values to idx_retbase.
 		 */
-
-		DUK_ASSERT(count > 0);
-
-		for (i = 0; i < count; i++) {
-			/* XXX: inefficient; block insert primitive */
-			duk_push_undefined(ctx);
-			duk_insert(ctx, idx_rcbase);
-		}
+		DUK_ASSERT(count >= 0);
+		DUK_ASSERT(thr->valstack_end - thr->valstack_top >= count);  /* reserve cannot shrink */
+		duk_insert_undefined_n(ctx, idx_rcbase, count);
 	}
+
+	/* Chop extra retvals away / extend with undefined. */
+	duk_set_top(ctx, idx_retbase + num_stack_rets);
 }
 
 /*
- *  Misc shared helpers.
+ *  Activation setup for tailcalls and non-tailcalls.
  */
 
-/* Get valstack index for the func argument or throw if insane stack. */
-DUK_LOCAL duk_idx_t duk__get_idx_func(duk_hthread *thr, duk_idx_t num_stack_args) {
-	duk_size_t off_stack_top;
-	duk_size_t off_stack_args;
-	duk_size_t off_stack_all;
-	duk_idx_t idx_func;         /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
+#if defined(DUK_USE_TAILCALL)
+DUK_LOCAL duk_small_uint_t duk__call_setup_act_attempt_tailcall(duk_hthread *thr,
+                                                                duk_small_uint_t call_flags,
+                                                                duk_idx_t idx_func,
+                                                                duk_hobject *func,
+                                                                duk_size_t entry_valstack_bottom_byteoff,
+                                                                duk_size_t entry_valstack_end_byteoff,
+                                                                duk_idx_t *out_nargs,
+                                                                duk_idx_t *out_nregs,
+                                                                duk_size_t *out_vs_min_bytes,
+                                                                duk_activation **out_act) {
+	duk_activation *act;
+	duk_tval *tv1, *tv2;
+	duk_idx_t idx_args;
 
-	/* Argument validation and func/args offset. */
-	off_stack_top = (duk_size_t) ((duk_uint8_t *) thr->valstack_top - (duk_uint8_t *) thr->valstack_bottom);
-	off_stack_args = (duk_size_t) ((duk_size_t) num_stack_args * sizeof(duk_tval));
-	off_stack_all = off_stack_args + 2 * sizeof(duk_tval);
-	if (DUK_UNLIKELY(off_stack_all > off_stack_top)) {
-		/* Since stack indices are not reliable, we can't do anything useful
-		 * here.  Invoke the existing setjmp catcher, or if it doesn't exist,
-		 * call the fatal error handler.
+	DUK_UNREF(entry_valstack_end_byteoff);
+
+	/* Tailcall cannot be flagged to resume calls, and a
+	 * previous frame must exist.
+	 */
+	DUK_ASSERT(thr->callstack_top >= 1);
+
+	act = thr->callstack_curr;
+	DUK_ASSERT(act != NULL);
+	*out_act = act;
+
+	if (func == NULL || !DUK_HOBJECT_IS_COMPFUNC(func)) {
+		DUK_DDD(DUK_DDDPRINT("tail call prevented by target not being ecma function"));
+		return 0;
+	} else if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
+		DUK_DDD(DUK_DDDPRINT("tail call prevented by current activation having DUK_ACT_FLAG_PREVENT_YIELD"));
+		return 0;
+	} else if (((act->flags & DUK_ACT_FLAG_CONSTRUCT) && !(call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL)) ||
+	           (!(act->flags & DUK_ACT_FLAG_CONSTRUCT) && (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL))) {
+		/* Cannot tailcall if mixing normal and constructor
+		 * calls.  Current function and potential tailcall
+		 * must have same return value handling (normal or
+		 * constructor special handling).
 		 */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_DDD(DUK_DDDPRINT("tail call prevented by incompatible return value handling"));
+		return 0;
+	} else if (DUK_HOBJECT_HAS_NOTAIL(func)) {
+		/* See: test-bug-tailcall-preventyield-assert.c. */
+		DUK_DDD(DUK_DDDPRINT("tail call prevented by function having a notail flag"));
 		return 0;
 	}
-	idx_func = (duk_idx_t) ((off_stack_top - off_stack_all) / sizeof(duk_tval));
-	return idx_func;
-}
-
-/*
- *  duk_handle_call_protected() and duk_handle_call_unprotected():
- *  call into a Duktape/C or an Ecmascript function from any state.
- *
- *  Input stack (thr):
- *
- *    [ func this arg1 ... argN ]
- *
- *  Output stack (thr):
- *
- *    [ retval ]         (DUK_EXEC_SUCCESS)
- *    [ errobj ]         (DUK_EXEC_ERROR (normal error), protected call)
- *
- *  Even when executing a protected call an error may be thrown in rare cases
- *  such as an insane num_stack_args argument.  If there is no catchpoint for
- *  such errors, the fatal error handler is called.
- *
- *  The error handling path should be error free, even for out-of-memory
- *  errors, to ensure safe sandboxing.  (As of Duktape 1.4.0 this is not
- *  yet the case, see XXX notes below.)
- */
-
-DUK_INTERNAL duk_int_t duk_handle_call_protected(duk_hthread *thr,
-                                                 duk_idx_t num_stack_args,
-                                                 duk_small_uint_t call_flags) {
-	duk_context *ctx;
-#if defined(DUK_USE_ASSERTIONS)
-	duk_size_t entry_callstack_top;
-#endif
-	duk_activation *entry_act;
-	duk_size_t entry_valstack_bottom_byteoff;
-	duk_size_t entry_valstack_end_byteoff;
-	duk_int_t entry_call_recursion_depth;
-	duk_hthread *entry_curr_thread;
-	duk_uint_fast8_t entry_thread_state;
-	duk_instr_t **entry_ptr_curr_pc;
-	duk_jmpbuf *old_jmpbuf_ptr = NULL;
-	duk_jmpbuf our_jmpbuf;
-	duk_idx_t idx_func;  /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
-
-	/* XXX: Multiple tv_func lookups are now avoided by making a local
-	 * copy of tv_func.  Another approach would be to compute an offset
-	 * for tv_func from valstack bottom and recomputing the tv_func
-	 * pointer quickly as valstack + offset instead of calling duk_get_tval().
-	 */
-
-	ctx = (duk_context *) thr;
-	DUK_UNREF(ctx);
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_CTX_VALID(ctx);
-	DUK_ASSERT(num_stack_args >= 0);
-	/* XXX: currently NULL allocations are not supported; remove if later allowed */
-	DUK_ASSERT(thr->valstack != NULL);
-
-	/* Argument validation and func/args offset. */
-	idx_func = duk__get_idx_func(thr, num_stack_args);
-
-	/* Preliminaries, required by setjmp() handler.  Must be careful not
-	 * to throw an unintended error here.
-	 */
-
-	entry_act = thr->callstack_curr;
-#if defined(DUK_USE_ASSERTIONS)
-	entry_callstack_top = thr->callstack_top;
-#endif
-	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
-	entry_valstack_end_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
-	entry_call_recursion_depth = thr->heap->call_recursion_depth;
-	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
-	entry_thread_state = thr->state;
-	entry_ptr_curr_pc = thr->ptr_curr_pc;  /* may be NULL */
-
-	DUK_DD(DUK_DDPRINT("duk_handle_call_protected: thr=%p, num_stack_args=%ld, "
-	                   "call_flags=0x%08lx (constructor=%ld), "
-	                   "valstack_top=%ld, idx_func=%ld, idx_args=%ld, rec_depth=%ld/%ld, "
-	                   "entry_act=%p, entry_valstack_bottom_byteoff=%ld, entry_valstack_end_byteoff=%ld, "
-	                   "entry_call_recursion_depth=%ld, "
-	                   "entry_curr_thread=%p, entry_thread_state=%ld",
-	                   (void *) thr,
-	                   (long) num_stack_args,
-	                   (unsigned long) call_flags,
-	                   (long) ((call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) != 0 ? 1 : 0),
-	                   (long) duk_get_top(ctx),
-	                   (long) idx_func,
-	                   (long) (idx_func + 2),
-	                   (long) thr->heap->call_recursion_depth,
-	                   (long) thr->heap->call_recursion_limit,
-	                   (void *) entry_act,
-	                   (long) entry_valstack_bottom_byteoff,
-	                   (long) entry_valstack_end_byteoff,
-	                   (long) entry_call_recursion_depth,
-	                   (void *) entry_curr_thread,
-	                   (long) entry_thread_state));
-
-	old_jmpbuf_ptr = thr->heap->lj.jmpbuf_ptr;
-	thr->heap->lj.jmpbuf_ptr = &our_jmpbuf;
-
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	try {
-#else
-	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == &our_jmpbuf);
-	if (DUK_SETJMP(our_jmpbuf.jb) == 0) {
-#endif
-		/* Call handling and success path.  Success path exit cleans
-		 * up almost all state.
-		 */
-		duk__handle_call_inner(thr, num_stack_args, call_flags, idx_func);
-
-		thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
-
-		return DUK_EXEC_SUCCESS;
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	} catch (duk_internal_exception &exc) {
-#else
-	} else {
-#endif
-		/* Error; error value is in heap->lj.value1. */
-
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-		DUK_UNREF(exc);
-#endif
-
-		duk__handle_call_error(thr,
-		                       entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-		                       entry_callstack_top,
-#endif
-		                       entry_valstack_bottom_byteoff,
-		                       entry_valstack_end_byteoff,
-		                       entry_call_recursion_depth,
-		                       entry_curr_thread,
-		                       entry_thread_state,
-		                       entry_ptr_curr_pc,
-		                       idx_func,
-		                       old_jmpbuf_ptr);
-
-		return DUK_EXEC_ERROR;
-	}
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	catch (std::exception &exc) {
-		const char *what = exc.what();
-		if (!what) {
-			what = "unknown";
-		}
-		DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
-		try {
-			DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
-		} catch (duk_internal_exception exc) {
-			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
-			DUK_UNREF(exc);
-			duk__handle_call_error(thr,
-			                       entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-			                       entry_callstack_top,
-#endif
-			                       entry_valstack_bottom_byteoff,
-			                       entry_valstack_end_byteoff,
-			                       entry_call_recursion_depth,
-			                       entry_curr_thread,
-			                       entry_thread_state,
-			                       entry_ptr_curr_pc,
-			                       idx_func,
-			                       old_jmpbuf_ptr);
-
-			return DUK_EXEC_ERROR;
-		}
-	} catch (...) {
-		DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
-		try {
-			DUK_ERROR_TYPE(thr, "caught invalid c++ exception (perhaps thrown by user code)");
-		} catch (duk_internal_exception exc) {
-			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
-			DUK_UNREF(exc);
-			duk__handle_call_error(thr,
-			                       entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-			                       entry_callstack_top,
-#endif
-			                       entry_valstack_bottom_byteoff,
-			                       entry_valstack_end_byteoff,
-			                       entry_call_recursion_depth,
-			                       entry_curr_thread,
-			                       entry_thread_state,
-			                       entry_ptr_curr_pc,
-			                       idx_func,
-			                       old_jmpbuf_ptr);
-
-			return DUK_EXEC_ERROR;
-		}
-	}
-#endif
-}
-
-DUK_INTERNAL void duk_handle_call_unprotected(duk_hthread *thr,
-                                              duk_idx_t num_stack_args,
-                                              duk_small_uint_t call_flags) {
-	duk_idx_t idx_func;         /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
-
-	/* Argument validation and func/args offset. */
-	idx_func = duk__get_idx_func(thr, num_stack_args);
-
-	duk__handle_call_inner(thr, num_stack_args, call_flags, idx_func);
-}
-
-/* XXX: idx_func and num_stack_args are redundant */
-DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
-                                      duk_idx_t num_stack_args,
-                                      duk_small_uint_t call_flags,
-                                      duk_idx_t idx_func) {
-	duk_context *ctx;
-#if defined(DUK_USE_ASSERTIONS)
-	duk_activation *entry_act;
-	duk_size_t entry_callstack_top;
-#endif
-	duk_size_t entry_valstack_bottom_byteoff;
-	duk_size_t entry_valstack_end_byteoff;
-	duk_int_t entry_call_recursion_depth;
-	duk_hthread *entry_curr_thread;
-	duk_uint_fast8_t entry_thread_state;
-	duk_instr_t **entry_ptr_curr_pc;
-	duk_idx_t nargs;            /* # argument registers target function wants (< 0 => "as is") */
-	duk_idx_t nregs;            /* # total registers target function wants on entry (< 0 => "as is") */
-	duk_size_t vs_min_regs;     /* temporary */
-	duk_size_t vs_min_bytes;    /* minimum value stack size (bytes) for handling call */
-	duk_hobject *func;          /* 'func' on stack (borrowed reference) */
-	duk_tval *tv_func;          /* duk_tval ptr for 'func' on stack (borrowed reference) or tv_func_copy */
-	duk_tval tv_func_copy;      /* to avoid relookups */
-	duk_activation *new_act;
-	duk_activation *act;
-	duk_hobject *env;
-	duk_ret_t rc;
-
-	ctx = (duk_context *) thr;
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT_CTX_VALID(ctx);
-	DUK_ASSERT(ctx != NULL);
-	DUK_ASSERT(num_stack_args >= 0);
-	/* XXX: currently NULL allocations are not supported; remove if later allowed */
-	DUK_ASSERT(thr->valstack != NULL);
-
-	DUK_DD(DUK_DDPRINT("duk__handle_call_inner: num_stack_args=%ld, call_flags=0x%08lx, top=%ld",
-	                   (long) num_stack_args, (long) call_flags, (long) duk_get_top(ctx)));
 
 	/*
-	 *  Store entry state.
-	 */
-
-#if defined(DUK_USE_ASSERTIONS)
-	entry_act = thr->callstack_curr;
-	entry_callstack_top = thr->callstack_top;
-#endif
-	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
-	entry_valstack_end_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
-	entry_call_recursion_depth = thr->heap->call_recursion_depth;
-	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
-	entry_thread_state = thr->state;
-	entry_ptr_curr_pc = thr->ptr_curr_pc;  /* may be NULL */
-
-	/* If thr->ptr_curr_pc is set, sync curr_pc to act->pc.  Then NULL
-	 * thr->ptr_curr_pc so that it's not accidentally used with an incorrect
-	 * activation when side effects occur.
-	 */
-	duk_hthread_sync_and_null_currpc(thr);
-
-	DUK_DD(DUK_DDPRINT("duk__handle_call_inner: thr=%p, num_stack_args=%ld, "
-	                   "call_flags=0x%08lx (constructor=%ld), "
-	                   "valstack_top=%ld, idx_func=%ld, idx_args=%ld, rec_depth=%ld/%ld, "
-	                   "entry_valstack_bottom_byteoff=%ld, entry_valstack_end_byteoff=%ld, "
-	                   "entry_call_recursion_depth=%ld, "
-	                   "entry_curr_thread=%p, entry_thread_state=%ld",
-	                   (void *) thr,
-	                   (long) num_stack_args,
-	                   (unsigned long) call_flags,
-	                   (long) ((call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) != 0 ? 1 : 0),
-	                   (long) duk_get_top(ctx),
-	                   (long) idx_func,
-	                   (long) (idx_func + 2),
-	                   (long) thr->heap->call_recursion_depth,
-	                   (long) thr->heap->call_recursion_limit,
-	                   (long) entry_valstack_bottom_byteoff,
-	                   (long) entry_valstack_end_byteoff,
-	                   (long) entry_call_recursion_depth,
-	                   (void *) entry_curr_thread,
-	                   (long) entry_thread_state));
-
-
-	/*
-	 *  Thread state check and book-keeping.
-	 */
-
-	if (thr == thr->heap->curr_thread) {
-		/* same thread */
-		if (thr->state != DUK_HTHREAD_STATE_RUNNING) {
-			/* should actually never happen, but check anyway */
-			goto thread_state_error;
-		}
-	} else {
-		/* different thread */
-		DUK_ASSERT(thr->heap->curr_thread == NULL ||
-		           thr->heap->curr_thread->state == DUK_HTHREAD_STATE_RUNNING);
-		if (thr->state != DUK_HTHREAD_STATE_INACTIVE) {
-			goto thread_state_error;
-		}
-		DUK_HEAP_SWITCH_THREAD(thr->heap, thr);
-		thr->state = DUK_HTHREAD_STATE_RUNNING;
-
-		/* Note: multiple threads may be simultaneously in the RUNNING
-		 * state, but not in the same "resume chain".
-		 */
-	}
-	DUK_ASSERT(thr->heap->curr_thread == thr);
-	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
-
-	/*
-	 *  C call recursion depth check, which provides a reasonable upper
-	 *  bound on maximum C stack size (arbitrary C stack growth is only
-	 *  possible by recursive handle_call / handle_safe_call calls).
-	 */
-
-	duk__call_c_recursion_limit_check(thr);
-	thr->heap->call_recursion_depth++;
-
-	/*
-	 *  Check the function type, handle bound functions, and prepare
-	 *  parameters for the rest of the call handling.  Also figure out the
-	 *  effective 'this' binding, which replaces the current value at
-	 *  idx_func + 1.
+	 *  Tailcall handling
 	 *
-	 *  If the target function is a 'bound' one, resolve the non-bound
-	 *  target.  Since Duktape 2.2 bound function chains are collapsed on
-	 *  creation, so the target of a duk_hboundfunc is always non-bound.
-	 *  During this process, bound arguments are 'prepended' to existing
-	 *  ones, and the "this" binding is overridden.  See E5 Section
-	 *  15.3.4.5.1 for the conceptual algorithm.
-	 *
-	 *  Lightfunc detection happens here too.  Note that lightweight
-	 *  functions can be wrapped by (non-lightweight) bound functions so
-	 *  we must resolve a possible bound function first.
+	 *  Although the callstack entry is reused, we need to explicitly unwind
+	 *  the current activation (or simulate an unwind).  In particular, the
+	 *  current activation must be closed, otherwise something like
+	 *  test-bug-reduce-judofyr.js results.  Also catchers need to be unwound
+	 *  because there may be non-error-catching label entries in valid tail calls.
 	 */
 
-	if (duk__resolve_target_fastpath_check(ctx, idx_func, &tv_func_copy, &func, call_flags)) {
-		DUK_DDD(DUK_DDDPRINT("fast path target resolve"));
-	} else {
-		DUK_DDD(DUK_DDDPRINT("slow path target resolve"));
-		func = duk__resolve_target_func_and_this_binding(ctx, idx_func, &num_stack_args, &tv_func_copy, &call_flags);
+	DUK_DDD(DUK_DDDPRINT("is tail call, reusing activation at callstack top, at index %ld",
+                             (long) (thr->callstack_top - 1)));
+
+	DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));
+	DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(func));
+	DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
+	DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
+	DUK_ASSERT(call_flags & DUK_CALL_FLAG_ALLOW_ECMATOECMA);
+
+	/* Unwind the topmost callstack entry before reusing it.  This
+	 * also unwinds the catchers related to the topmost entry.
+	 */
+	DUK_ASSERT(thr->callstack_top > 0);
+	DUK_ASSERT(thr->callstack_curr != NULL);
+	duk_hthread_activation_unwind_reuse_norz(thr);
+	DUK_ASSERT(act == thr->callstack_curr);
+
+	/* XXX: We could restore the caller's value stack reserve
+	 * here, as if we did an actual unwind-and-call.  Without
+	 * the restoration, value stack reserve may remain higher
+	 * than would otherwise be possible until we return to a
+	 * non-tailcall.
+	 */
+
+	/* Then reuse the unwound activation. */
+	act->cat = NULL;
+	act->var_env = NULL;
+	act->lex_env = NULL;
+	DUK_ASSERT(func != NULL);
+	DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
+	act->func = func;  /* don't want an intermediate exposed state with func == NULL */
+#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
+	act->prev_caller = NULL;
+#endif
+	/* don't want an intermediate exposed state with invalid pc */
+	act->curr_pc = DUK_HCOMPFUNC_GET_CODE_BASE(thr->heap, (duk_hcompfunc *) func);
+#if defined(DUK_USE_DEBUGGER_SUPPORT)
+	act->prev_line = 0;
+#endif
+	DUK_TVAL_SET_OBJECT(&act->tv_func, func);  /* borrowed, no refcount */
+	DUK_HOBJECT_INCREF(thr, func);
+
+	act->flags = DUK_ACT_FLAG_TAILCALLED;
+	if (DUK_HOBJECT_HAS_STRICT(func)) {
+		act->flags |= DUK_ACT_FLAG_STRICT;
 	}
-	tv_func = &tv_func_copy;
-
-	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));
-	DUK_ASSERT(func == NULL || (DUK_HOBJECT_IS_COMPFUNC(func) ||
-	                            DUK_HOBJECT_IS_NATFUNC(func)));
-
 	if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
-		/* Update default instance internal prototype based on the
-		 * .prototype property of the final, non-bound target
-		 * function.
-		 */
-		duk__update_default_instance_proto(ctx, idx_func);
+		act->flags |= DUK_ACT_FLAG_CONSTRUCT;
 	}
 
-	/* [ ... func this arg1 ... argN ] */
+	DUK_ASSERT(DUK_ACT_GET_FUNC(act) == func);      /* already updated */
+	DUK_ASSERT(act->var_env == NULL);
+	DUK_ASSERT(act->lex_env == NULL);
+	act->bottom_byteoff = entry_valstack_bottom_byteoff;  /* tail call -> reuse current "frame" */
+#if 0
+	/* Topmost activation retval_byteoff is considered garbage, no need to init. */
+	act->retval_byteoff = 0;
+#endif
+	/* Filled in when final reserve is known, dummy value doesn't matter
+	 * even in error unwind because reserve_byteoff is only used when
+	 * returning to -this- activation.
+	 */
+	act->reserve_byteoff = 0;
 
 	/*
-	 *  Setup a preliminary activation and figure out nargs/nregs and
-	 *  value stack minimum size.
+	 *  Manipulate valstack so that args are on the current bottom and the
+	 *  previous caller's 'this' binding (which is the value preceding the
+	 *  current bottom) is replaced with the new 'this' binding:
 	 *
-	 *  Don't touch valstack_bottom or valstack_top yet so that Duktape API
-	 *  calls work normally.
+	 *       [ ... this_old | (crud) func this_new arg1 ... argN ]
+	 *  -->  [ ... this_new | arg1 ... argN ]
 	 *
-	 *  Because 'act' is not zeroed, all fields must be filled in.
+	 *  For tail calling to work properly, the valstack bottom must not grow
+	 *  here; otherwise crud would accumulate on the valstack.
 	 */
+
+	tv1 = thr->valstack_bottom - 1;
+	tv2 = thr->valstack_bottom + idx_func + 1;
+	DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);  /* tv1 is -below- valstack_bottom */
+	DUK_ASSERT(tv2 >= thr->valstack_bottom && tv2 < thr->valstack_top);
+	DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv2);  /* side effects */
+
+	idx_args = idx_func + 2;
+	duk_remove_n((duk_context *) thr, 0, idx_args);  /* may be NORZ */
+
+	idx_func = 0; DUK_UNREF(idx_func);  /* really 'not applicable' anymore, should not be referenced after this */
+	idx_args = 0;
+
+	*out_nargs = ((duk_hcompfunc *) func)->nargs;
+	*out_nregs = ((duk_hcompfunc *) func)->nregs;
+	DUK_ASSERT(*out_nregs >= 0);
+	DUK_ASSERT(*out_nregs >= *out_nargs);
+	*out_vs_min_bytes = entry_valstack_bottom_byteoff + sizeof(duk_tval) * (*out_nregs + DUK_VALSTACK_INTERNAL_EXTRA);
+
+
+#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
+#if defined(DUK_USE_TAILCALL)
+#error incorrect options: tail calls enabled with function caller property
+#endif
+	/* XXX: This doesn't actually work properly for tail calls, so
+	 * tail calls are disabled when DUK_USE_NONSTD_FUNC_CALLER_PROPERTY
+	 * is in use.
+	 */
+	duk__update_func_caller_prop(thr, func);
+#endif
+
+	/* [ ... this_new | arg1 ... argN ] */
+
+	return 1;
+}
+#endif  /* DUK_USE_TAILCALL */
+
+DUK_LOCAL void duk__call_setup_act_not_tailcall(duk_hthread *thr,
+                                                duk_small_uint_t call_flags,
+                                                duk_idx_t idx_func,
+                                                duk_hobject *func,
+                                                duk_size_t entry_valstack_bottom_byteoff,
+                                                duk_size_t entry_valstack_end_byteoff,
+                                                duk_idx_t *out_nargs,
+                                                duk_idx_t *out_nregs,
+                                                duk_size_t *out_vs_min_bytes,
+                                                duk_activation **out_act) {
+	duk_activation *act;
+	duk_activation *new_act;
+
+	DUK_UNREF(entry_valstack_end_byteoff);
+
+	DUK_DDD(DUK_DDDPRINT("not a tail call, pushing a new activation to callstack, to index %ld",
+	                     (long) (thr->callstack_top)));
 
 	duk__call_callstack_limit_check(thr);
 	new_act = duk_hthread_activation_alloc(thr);
@@ -1714,7 +1436,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	act = thr->callstack_curr;
 	if (act != NULL) {
 		/*
-		 *  Update return value stack index of current activation.
+		 *  Update return value stack index of current activation (if any).
 		 *
 		 *  Although it might seem this is not necessary (bytecode executor
 		 *  does this for Ecmascript-to-Ecmascript calls; other calls are
@@ -1730,15 +1452,14 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	thr->callstack_curr = new_act;
 	thr->callstack_top++;
 	act = new_act;
+	*out_act = act;
 
 	DUK_ASSERT(thr->valstack_top > thr->valstack_bottom);  /* at least effective 'this' */
 	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));
 
 	act->cat = NULL;
-	act->flags = 0;
 
-	/* For now all calls except Ecma-to-Ecma calls prevent a yield. */
-	act->flags |= DUK_ACT_FLAG_PREVENT_YIELD;
+	act->flags = 0;
 	if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
 		act->flags |= DUK_ACT_FLAG_CONSTRUCT;
 	}
@@ -1746,61 +1467,60 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 		act->flags |= DUK_ACT_FLAG_DIRECT_EVAL;
 	}
 
-	/* These base values are never used, but if the compiler doesn't know
-	 * that DUK_ERROR() won't return, these are needed to silence warnings.
-	 * On the other hand, scan-build will warn about the values not being
-	 * used, so add a DUK_UNREF.
-	 */
-	nargs = 0; DUK_UNREF(nargs);
-	nregs = 0; DUK_UNREF(nregs);
-
 	/* start of arguments: idx_func + 2. */
+	act->func = func;  /* NULL for lightfunc */
 	if (DUK_LIKELY(func != NULL)) {
+		DUK_TVAL_SET_OBJECT(&act->tv_func, func);  /* borrowed, no refcount */
 		if (DUK_HOBJECT_HAS_STRICT(func)) {
 			act->flags |= DUK_ACT_FLAG_STRICT;
 		}
 		if (DUK_HOBJECT_IS_COMPFUNC(func)) {
-			nargs = ((duk_hcompfunc *) func)->nargs;
-			nregs = ((duk_hcompfunc *) func)->nregs;
-			DUK_ASSERT(nregs >= 0);
-			DUK_ASSERT(nregs >= nargs);
-			vs_min_regs = nregs + DUK_VALSTACK_INTERNAL_EXTRA;
+			*out_nargs = ((duk_hcompfunc *) func)->nargs;
+			*out_nregs = ((duk_hcompfunc *) func)->nregs;
+			DUK_ASSERT(*out_nregs >= 0);
+			DUK_ASSERT(*out_nregs >= *out_nargs);
+			*out_vs_min_bytes = entry_valstack_bottom_byteoff +
+				sizeof(duk_tval) * (idx_func + 2 + *out_nregs + DUK_VALSTACK_INTERNAL_EXTRA);
 		} else {
 			/* True because of call target lookup checks. */
 			DUK_ASSERT(DUK_HOBJECT_IS_NATFUNC(func));
 
-			/* Note: nargs (and nregs) may be negative for a native,
-			 * function, which indicates that the function wants the
-			 * input stack "as is" (i.e. handles "vararg" arguments).
-			 */
-			nargs = ((duk_hnatfunc *) func)->nargs;
-			nregs = nargs;
-			if (nargs >= 0) {
-				vs_min_regs = nregs + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA;
+			*out_nargs = ((duk_hnatfunc *) func)->nargs;
+			*out_nregs = *out_nargs;
+			if (*out_nargs >= 0) {
+				*out_vs_min_bytes = entry_valstack_bottom_byteoff +
+					sizeof(duk_tval) * (idx_func + 2 + *out_nregs + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA);
 			} else {
-				vs_min_regs = num_stack_args + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA;
+				/* Vararg function. */
+				duk_size_t valstack_top_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_top - ((duk_uint8_t *) thr->valstack));
+				*out_vs_min_bytes = valstack_top_byteoff +
+					sizeof(duk_tval) * (DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA);
 			}
 		}
 	} else {
 		duk_small_uint_t lf_flags;
-
-		DUK_ASSERT(DUK_TVAL_IS_LIGHTFUNC(tv_func));
-		lf_flags = DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv_func);
-		nargs = DUK_LFUNC_FLAGS_GET_NARGS(lf_flags);
-		if (nargs == DUK_LFUNC_NARGS_VARARGS) {
-			nargs = -1;  /* vararg */
-			vs_min_regs = num_stack_args + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA;
-		} else {
-			vs_min_regs = nregs + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA;
-		}
-		nregs = nargs;
+		duk_tval *tv_func;
 
 		act->flags |= DUK_ACT_FLAG_STRICT;
+
+		tv_func = DUK_GET_TVAL_POSIDX((duk_context *) thr, idx_func);
+		DUK_ASSERT(DUK_TVAL_IS_LIGHTFUNC(tv_func));
+		DUK_TVAL_SET_TVAL(&act->tv_func, tv_func);  /* borrowed, no refcount */
+
+		lf_flags = DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv_func);
+		*out_nargs = DUK_LFUNC_FLAGS_GET_NARGS(lf_flags);
+		if (*out_nargs != DUK_LFUNC_NARGS_VARARGS) {
+			*out_vs_min_bytes = entry_valstack_bottom_byteoff +
+				sizeof(duk_tval) * (idx_func + 2 + *out_nargs + DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA);
+		} else {
+			duk_size_t valstack_top_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_top - ((duk_uint8_t *) thr->valstack));
+			*out_vs_min_bytes = valstack_top_byteoff +
+				sizeof(duk_tval) * (DUK_VALSTACK_API_ENTRY_MINIMUM + DUK_VALSTACK_INTERNAL_EXTRA);
+			*out_nargs = -1;  /* vararg */
+		}
+		*out_nregs = *out_nargs;
 	}
 
-	vs_min_bytes = entry_valstack_bottom_byteoff + sizeof(duk_tval) * (idx_func + 2 + vs_min_regs);
-
-	act->func = func;  /* NULL for lightfunc */
 	act->var_env = NULL;
 	act->lex_env = NULL;
 #if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
@@ -1814,17 +1534,11 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 #if 0
 	act->retval_byteoff = 0;   /* topmost activation retval_byteoff is considered garbage, no need to init */
 #endif
-	act->reserve_byteoff = 0;  /* filled in below */
-	DUK_TVAL_SET_TVAL(&act->tv_func, tv_func);  /* borrowed, no refcount */
-
-	/* XXX: remove the preventcount and make yield walk the callstack?
-	 * Or perhaps just use a single flag, not a counter, faster to just
-	 * set and restore?
+	/* Filled in when final reserve is known, dummy value doesn't matter
+	 * even in error unwind because reserve_byteoff is only used when
+	 * returning to -this- activation.
 	 */
-	if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
-		/* duk_hthread_activation_unwind_norz() will decrease this on unwind */
-		thr->callstack_preventcount++;
-	}
+	act->reserve_byteoff = 0;  /* filled in by caller */
 
 	/* XXX: Is this INCREF necessary? 'func' is always a borrowed
 	 * reference reachable through the value stack?  If changed, stack
@@ -1837,21 +1551,14 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 		duk__update_func_caller_prop(thr, func);
 	}
 #endif
+}
 
-	/* [ ... func this arg1 ... argN ] */
+/*
+ *  Environment setup.
+ */
 
-	/*
-	 *  Environment record creation and 'arguments' object creation.
-	 *  Named function expression name binding is handled by the
-	 *  compiler; the compiled function's parent env will contain
-	 *  the (immutable) binding already.
-	 *
-	 *  This handling is now identical for C and Ecmascript functions.
-	 *  C functions always have the 'NEWENV' flag set, so their
-	 *  environment record initialization is delayed (which is good).
-	 *
-	 *  Delayed creation (on demand) is handled in duk_js_var.c.
-	 */
+DUK_LOCAL void duk__call_env_setup(duk_hthread *thr, duk_hobject *func, duk_activation *act, duk_idx_t idx_args) {
+	duk_hobject *env;
 
 	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));  /* bound function has already been resolved */
 
@@ -1876,7 +1583,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 				/* [ ... func this arg1 ... argN envobj ] */
 
 				DUK_ASSERT(DUK_HOBJECT_HAS_CREATEARGS(func));
-				duk__handle_createargs_for_call(thr, func, env, num_stack_args);
+				duk__handle_createargs_for_call(thr, func, env, idx_args);
 
 				/* [ ... func this arg1 ... argN envobj ] */
 
@@ -1884,7 +1591,7 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 				act->var_env = env;
 				DUK_HOBJECT_INCREF(thr, env);
 				DUK_HOBJECT_INCREF(thr, env);  /* XXX: incref by count (2) directly */
-				duk_pop(ctx);
+				duk_pop((duk_context *) thr);
 			}
 		} else {
 			/* Use existing env (e.g. for non-strict eval); cannot have
@@ -1894,7 +1601,6 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			DUK_ASSERT(!DUK_HOBJECT_HAS_CREATEARGS(func));
 
 			duk__handle_oldenv_for_call(thr, func, act);
-			/* No need to re-lookup 'act' at present: no side effects. */
 
 			DUK_ASSERT(act->lex_env != NULL);
 			DUK_ASSERT(act->var_env != NULL);
@@ -1904,42 +1610,319 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 		DUK_ASSERT(act->lex_env == NULL);
 		DUK_ASSERT(act->var_env == NULL);
 	}
+}
+
+/*
+ *  Misc shared helpers.
+ */
+
+/* Check thread state, update current thread. */
+DUK_LOCAL void duk__call_thread_state_update(duk_hthread *thr) {
+	DUK_ASSERT(thr != NULL);
+
+	if (DUK_LIKELY(thr == thr->heap->curr_thread)) {
+		if (DUK_UNLIKELY(thr->state != DUK_HTHREAD_STATE_RUNNING)) {
+			/* Should actually never happen, but check anyway. */
+			goto thread_state_error;
+		}
+	} else {
+		DUK_ASSERT(thr->heap->curr_thread == NULL ||
+		           thr->heap->curr_thread->state == DUK_HTHREAD_STATE_RUNNING);
+		if (DUK_UNLIKELY(thr->state != DUK_HTHREAD_STATE_INACTIVE)) {
+			goto thread_state_error;
+		}
+		DUK_HEAP_SWITCH_THREAD(thr->heap, thr);
+		thr->state = DUK_HTHREAD_STATE_RUNNING;
+
+		/* Multiple threads may be simultaneously in the RUNNING
+		 * state, but not in the same "resume chain".
+		 */
+	}
+	DUK_ASSERT(thr->heap->curr_thread == thr);
+	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
+	return;
+
+ thread_state_error:
+	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "invalid thread state (%ld)", (long) thr->state);
+	DUK_UNREACHABLE();
+}
+
+/*
+ *  Main unprotected call handler, handles:
+ *
+ *    - All combinations of native/Ecmascript caller and native/Ecmascript
+ *      target.
+ *
+ *    - Optimized Ecmascript-to-Ecmascript call where call handling only
+ *      sets up a new duk_activation but reuses an existing bytecode executor
+ *      (the caller) without native recursion.
+ *
+ *    - Tailcalls, where an activation is reused without increasing call
+ *      stack (duk_activation) depth.
+ *
+ *    - Setup for an initial Duktape.Thread.resume().
+ *
+ *  The call handler doesn't provide any protection guarantees, protected calls
+ *  must be implemented e.g. by wrapping the call in a duk_safe_call().
+ *  Call setup may fail at any stage, even when the new activation is in
+ *  place; the only guarantee is that the state is consistent for unwinding.
+ */
+
+DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
+                                         duk_idx_t idx_func,
+                                         duk_small_uint_t call_flags) {
+	duk_context *ctx;
+#if defined(DUK_USE_ASSERTIONS)
+	duk_activation *entry_act;
+	duk_size_t entry_callstack_top;
+#endif
+	duk_size_t entry_valstack_bottom_byteoff;
+	duk_size_t entry_valstack_end_byteoff;
+	duk_int_t entry_call_recursion_depth;
+	duk_hthread *entry_curr_thread;
+	duk_uint_fast8_t entry_thread_state;
+	duk_instr_t **entry_ptr_curr_pc;
+	duk_idx_t idx_args;
+	duk_idx_t nargs;            /* # argument registers target function wants (< 0 => "as is") */
+	duk_idx_t nregs;            /* # total registers target function wants on entry (< 0 => "as is") */
+	duk_size_t vs_min_bytes;    /* minimum value stack size (bytes) for handling call */
+	duk_hobject *func;          /* 'func' on stack (borrowed reference) */
+	duk_activation *act;
+	duk_ret_t rc;
+	duk_small_uint_t use_tailcall;
+
+	ctx = (duk_context *) thr;
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT_CTX_VALID(ctx);
+	DUK_ASSERT(duk_is_valid_index(ctx, idx_func));
+	DUK_ASSERT(idx_func >= 0);
+
+	/* If a tail call:
+	 *   - an Ecmascript activation must be on top of the callstack
+	 *   - there cannot be any catch stack entries that would catch
+	 *     a return
+	 */
+#if defined(DUK_USE_ASSERTIONS)
+	if (call_flags & DUK_CALL_FLAG_IS_TAILCALL) {
+		duk_activation *tmp_act;
+		duk_catcher *tmp_cat;
+
+		DUK_ASSERT(thr->callstack_top >= 1);
+		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);
+		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
+
+		/* No entry in the catch stack which would actually catch a
+		 * throw can refer to the callstack entry being reused.
+		 * There *can* be catch stack entries referring to the current
+		 * callstack entry as long as they don't catch (e.g. label sites).
+		 */
+
+		tmp_act = thr->callstack_curr;
+		for (tmp_cat = tmp_act->cat; tmp_cat != NULL; tmp_cat = tmp_cat->parent) {
+			DUK_ASSERT(DUK_CAT_GET_TYPE(tmp_cat) == DUK_CAT_TYPE_LABEL); /* a non-catching entry */
+		}
+	}
+#endif  /* DUK_USE_ASSERTIONS */
+
+	/*
+	 *  Store entry state.
+	 */
+
+#if defined(DUK_USE_ASSERTIONS)
+	entry_act = thr->callstack_curr;
+	entry_callstack_top = thr->callstack_top;
+#endif
+	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
+	entry_valstack_end_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
+	entry_call_recursion_depth = thr->heap->call_recursion_depth;
+	entry_curr_thread = thr->heap->curr_thread;  /* may be NULL if first call */
+	entry_thread_state = thr->state;
+	entry_ptr_curr_pc = thr->ptr_curr_pc;  /* may be NULL */
+
+	/* If thr->ptr_curr_pc is set, sync curr_pc to act->pc.  Then NULL
+	 * thr->ptr_curr_pc so that it's not accidentally used with an incorrect
+	 * activation when side effects occur.
+	 */
+	duk_hthread_sync_and_null_currpc(thr);
+	DUK_ASSERT(thr->ptr_curr_pc == NULL);
+
+	DUK_DD(DUK_DDPRINT("duk__handle_call_raw: thr=%p, idx_func=%ld, "
+	                   "call_flags=0x%08lx (constructor=%ld), "
+	                   "valstack_top=%ld, idx_func=%ld, idx_args=%ld, rec_depth=%ld/%ld, "
+	                   "entry_valstack_bottom_byteoff=%ld, entry_valstack_end_byteoff=%ld, "
+	                   "entry_call_recursion_depth=%ld, "
+	                   "entry_curr_thread=%p, entry_thread_state=%ld",
+	                   (void *) thr,
+	                   (long) idx_func,
+	                   (unsigned long) call_flags,
+	                   (long) ((call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) != 0 ? 1 : 0),
+	                   (long) duk_get_top(ctx),
+	                   (long) idx_func,
+	                   (long) (idx_func + 2),
+	                   (long) thr->heap->call_recursion_depth,
+	                   (long) thr->heap->call_recursion_limit,
+	                   (long) entry_valstack_bottom_byteoff,
+	                   (long) entry_valstack_end_byteoff,
+	                   (long) entry_call_recursion_depth,
+	                   (void *) entry_curr_thread,
+	                   (long) entry_thread_state));
+
+	/*
+	 *  Thread state check and book-keeping.
+	 */
+
+	duk__call_thread_state_update(thr);
+
+	/*
+	 *  Resolve final target function; handle bound functions and special
+	 *  functions like .call() and .apply().  Also figure out the effective
+	 *  'this' binding, which replaces the current value at idx_func + 1.
+	 */
+
+	if (DUK_LIKELY(duk__resolve_target_fastpath_check(ctx, idx_func, &func, call_flags))) {
+		DUK_DDD(DUK_DDDPRINT("fast path target resolve"));
+	} else {
+		DUK_DDD(DUK_DDDPRINT("slow path target resolve"));
+		func = duk__resolve_target_func_and_this_binding(ctx, idx_func, &call_flags);
+	}
+	DUK_ASSERT(duk_get_top(ctx) - idx_func >= 2);  /* at least func and this present */
+
+	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_BOUNDFUNC(func));
+	DUK_ASSERT(func == NULL || (DUK_HOBJECT_IS_COMPFUNC(func) ||
+	                            DUK_HOBJECT_IS_NATFUNC(func)));
+	DUK_ASSERT(func == NULL || !DUK_HOBJECT_HAS_SPECIAL_CALL(func));
+
+	/* [ ... func this arg1 ... argN ] */
+
+	/*
+	 *  Setup a preliminary activation and figure out nargs/nregs and
+	 *  value stack minimum size.
+	 *
+	 *  Don't touch valstack_bottom or valstack_top yet so that Duktape API
+	 *  calls work normally.
+	 *
+	 *  Because 'act' is not zeroed, all fields must be filled in.
+	 */
+
+#if defined(DUK_USE_TAILCALL)
+	use_tailcall = (call_flags & DUK_CALL_FLAG_IS_TAILCALL);
+	if (use_tailcall) {
+		use_tailcall = duk__call_setup_act_attempt_tailcall(thr,
+		                                                    call_flags,
+		                                                    idx_func,
+		                                                    func,
+		                                                    entry_valstack_bottom_byteoff,
+		                                                    entry_valstack_end_byteoff,
+		                                                    &nargs,
+		                                                    &nregs,
+		                                                    &vs_min_bytes,
+		                                                    &act);
+	}
+#else
+	DUK_ASSERT((call_flags & DUK_CALL_FLAG_IS_TAILCALL) == 0);  /* compiler ensures this */
+	use_tailcall = 0;
+#endif
+
+	if (use_tailcall) {
+		idx_args = 0;
+	} else {
+		duk__call_setup_act_not_tailcall(thr,
+		                                 call_flags,
+		                                 idx_func,
+		                                 func,
+		                                 entry_valstack_bottom_byteoff,
+		                                 entry_valstack_end_byteoff,
+		                                 &nargs,
+		                                 &nregs,
+		                                 &vs_min_bytes,
+		                                 &act);
+		idx_args = idx_func + 2;
+	}
+	/* After this point idx_func is no longer valid for tailcalls. */
+
+	DUK_ASSERT(act != NULL);
+
+	/* [ ... func this arg1 ... argN ] */
+
+	/*
+	 *  Environment record creation and 'arguments' object creation.
+	 *  Named function expression name binding is handled by the
+	 *  compiler; the compiled function's parent env will contain
+	 *  the (immutable) binding already.
+	 *
+	 *  This handling is now identical for C and Ecmascript functions.
+	 *  C functions always have the 'NEWENV' flag set, so their
+	 *  environment record initialization is delayed (which is good).
+	 *
+	 *  Delayed creation (on demand) is handled in duk_js_var.c.
+	 */
+
+	duk__call_env_setup(thr, func, act, idx_args);
 
 	/* [ ... func this arg1 ... argN ] */
 
 	/*
 	 *  Setup value stack: clamp to 'nargs', fill up to 'nregs',
-	 *  ensure value stack size matches target requirements.
+	 *  ensure value stack size matches target requirements, and
+	 *  switch value stack bottom.  Valstack top is kept.
 	 *
 	 *  Value stack can only grow here.
 	 */
 
 	duk_valstack_grow_check_throw(ctx, vs_min_bytes);
 	act->reserve_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
-	if (nregs >= 0) {
+
+	if (use_tailcall) {
+		DUK_ASSERT(nregs >= 0);
 		DUK_ASSERT(nregs >= nargs);
-		duk_set_top_and_wipe(ctx, idx_func + 2 + nregs, idx_func + 2 + nargs);
+		duk_set_top_and_wipe(ctx, nregs, nargs);
+	} else {
+		if (nregs >= 0) {
+			DUK_ASSERT(nregs >= nargs);
+			duk_set_top_and_wipe(ctx, idx_func + 2 + nregs, idx_func + 2 + nargs);
+		} else {
+			;
+		}
+		thr->valstack_bottom = thr->valstack_bottom + idx_func + 2;
 	}
+	DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
+	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
+	DUK_ASSERT(thr->valstack_end >= thr->valstack_top);
 
 	/*
-	 *  Determine call type, then finalize activation, shift to
-	 *  new value stack bottom, and call the target.
+	 *  Make the actual call.  For Ecma-to-Ecma calls detect that
+	 *  setup is complete, then return with a status code that allows
+	 *  the caller to reuse the running executor.
 	 */
 
 	if (func != NULL && DUK_HOBJECT_IS_COMPFUNC(func)) {
 		/*
-		 *  Ecmascript call
+		 *  Ecmascript call.
 		 */
 
 		DUK_ASSERT(func != NULL);
 		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
 		act->curr_pc = DUK_HCOMPFUNC_GET_CODE_BASE(thr->heap, (duk_hcompfunc *) func);
 
-		thr->valstack_bottom = thr->valstack_bottom + idx_func + 2;
-		/* keep current valstack_top */
-		DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
-		DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
-		DUK_ASSERT(thr->valstack_end >= thr->valstack_top);
+		if (call_flags & DUK_CALL_FLAG_ALLOW_ECMATOECMA) {
+			DUK_DD(DUK_DDPRINT("avoid native call, use existing executor"));
+			DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
+			DUK_REFZERO_CHECK_FAST(thr);
+			DUK_ASSERT(thr->ptr_curr_pc == NULL);
+			return 1;  /* 1=reuse executor */
+		}
+		DUK_ASSERT(use_tailcall == 0);
+
+		/* duk_hthread_activation_unwind_norz() will decrease this on unwind */
+		DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
+		act->flags |= DUK_ACT_FLAG_PREVENT_YIELD;
+		thr->callstack_preventcount++;
+
+		/* XXX: we could just do this on entry regardless of reuse, as long
+		 * as recursion depth is decreased for e2e case.
+		 */
+		duk__call_c_recursion_limit_check(thr);
+		thr->heap->call_recursion_depth++;
 
 		/* [ ... func this | arg1 ... argN ] ('this' must precede new bottom) */
 
@@ -1965,22 +1948,35 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 		 *  Native call.
 		 */
 
-		thr->valstack_bottom = thr->valstack_bottom + idx_func + 2;
-		/* keep current valstack_top */
-		DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
-		DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
-		DUK_ASSERT(thr->valstack_end >= thr->valstack_top);
 		DUK_ASSERT(func == NULL || ((duk_hnatfunc *) func)->func != NULL);
+		DUK_ASSERT(use_tailcall == 0);
 
 		/* [ ... func this | arg1 ... argN ] ('this' must precede new bottom) */
+
+		/* duk_hthread_activation_unwind_norz() will decrease this on unwind */
+		DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
+		act->flags |= DUK_ACT_FLAG_PREVENT_YIELD;
+		thr->callstack_preventcount++;
+
+		/* XXX: we could just do this on entry regardless of reuse, as long
+		 * as recursion depth is decreased for e2e case.
+		 */
+		duk__call_c_recursion_limit_check(thr);
+		thr->heap->call_recursion_depth++;
 
 		/* For native calls must be NULL so we don't sync back */
 		DUK_ASSERT(thr->ptr_curr_pc == NULL);
 
+		/* XXX: native funcptr could come out of call setup. */
 		if (func) {
 			rc = ((duk_hnatfunc *) func)->func((duk_context *) thr);
 		} else {
-			duk_c_function funcptr = DUK_TVAL_GET_LIGHTFUNC_FUNCPTR(tv_func);
+			duk_tval *tv_func;
+			duk_c_function funcptr;
+
+			tv_func = &act->tv_func;
+			DUK_ASSERT(DUK_TVAL_IS_LIGHTFUNC(tv_func));
+			funcptr = DUK_TVAL_GET_LIGHTFUNC_FUNCPTR(tv_func);
 			rc = funcptr((duk_context *) thr);
 		}
 
@@ -1996,18 +1992,23 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 			duk_error_throw_from_negative_rc(thr, rc);
 			DUK_UNREACHABLE();
 		} else {
-			DUK_ERROR_TYPE(thr, "c function returned invalid rc");
+			DUK_ERROR_TYPE(thr, DUK_STR_INVALID_CFUNC_RC);
 		}
 	}
 	DUK_ASSERT(thr->ptr_curr_pc == NULL);
+	DUK_ASSERT(use_tailcall == 0);
 
-	/* Constructor call post processing. */
+	/*
+	 *  Constructor call post processing.
+	 */
 
 	if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
 		duk_call_construct_postprocess(ctx);
 	}
 
-	/* Unwind. */
+	/*
+	 *  Unwind, restore valstack bottom and other book-keeping.
+	 */
 
 	DUK_ASSERT(thr->callstack_curr != NULL);
 	DUK_ASSERT(thr->callstack_curr->parent == entry_act);
@@ -2093,150 +2094,29 @@ DUK_LOCAL void duk__handle_call_inner(duk_hthread *thr,
 	/* Restored by success path. */
 	DUK_ASSERT(thr->heap->call_recursion_depth == entry_call_recursion_depth);
 	DUK_ASSERT(thr->ptr_curr_pc == entry_ptr_curr_pc);
-
 	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
 
 	DUK_REFZERO_CHECK_FAST(thr);
 
-	return;
-
- thread_state_error:
-	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for call (%ld)", (long) thr->state);
-	DUK_UNREACHABLE();
-	return;  /* never executed */
+	return 0;  /* 0=call handled inline */
 }
 
-DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
-                                      duk_activation *entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-                                      duk_size_t entry_callstack_top,
-#endif
-                                      duk_size_t entry_valstack_bottom_byteoff,
-                                      duk_size_t entry_valstack_end_byteoff,
-                                      duk_int_t entry_call_recursion_depth,
-                                      duk_hthread *entry_curr_thread,
-                                      duk_uint_fast8_t entry_thread_state,
-                                      duk_instr_t **entry_ptr_curr_pc,
-                                      duk_idx_t idx_func,
-                                      duk_jmpbuf *old_jmpbuf_ptr) {
-	duk_context *ctx;
-	duk_tval *tv_ret;
+DUK_INTERNAL duk_int_t duk_handle_call_unprotected_nargs(duk_hthread *thr,
+                                                         duk_idx_t nargs,
+                                                         duk_small_uint_t call_flags) {
+	duk_idx_t idx_func;
+	DUK_ASSERT(duk_get_top((duk_context *) thr) >= nargs + 2);
+	idx_func = duk_get_top((duk_context *) thr) - (nargs + 2);
+	DUK_ASSERT(idx_func >= 0);
+	return duk_handle_call_unprotected(thr, idx_func, call_flags);
+}
 
-	ctx = (duk_context *) thr;
-
-	DUK_DDD(DUK_DDDPRINT("error caught during duk__handle_call_inner(): %!T",
-	                     (duk_tval *) &thr->heap->lj.value1));
-
-	/* Other longjmp types are handled by executor before propagating
-	 * the error here.
-	 */
-	DUK_ASSERT(thr->heap->lj.type == DUK_LJ_TYPE_THROW);
-	DUK_ASSERT_LJSTATE_SET(thr->heap);
-	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
-
-	/* We don't need to sync back thr->ptr_curr_pc here because
-	 * the bytecode executor always has a setjmp catchpoint which
-	 * does that before errors propagate to here.
-	 */
-	DUK_ASSERT(thr->ptr_curr_pc == NULL);
-
-	/* Restore the previous setjmp catcher so that any error in
-	 * error handling will propagate outwards rather than re-enter
-	 * the same handler.  However, the error handling path must be
-	 * designed to be error free so that sandboxing guarantees are
-	 * reliable, see e.g. https://github.com/svaarala/duktape/issues/476.
-	 */
-	thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
-
-	/* XXX: callstack unwind may now throw an error when closing
-	 * scopes; this is a sandboxing issue, described in:
-	 * https://github.com/svaarala/duktape/issues/476
-	 */
-	/* XXX: "unwind to" primitive? */
-	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
-	while (thr->callstack_curr != entry_act) {
-		DUK_ASSERT(thr->callstack_curr != NULL);
-		duk_hthread_activation_unwind_norz(thr);
-	}
-	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
-
-	thr->valstack_bottom = (duk_tval *) (void *) ((duk_uint8_t *) thr->valstack + entry_valstack_bottom_byteoff);
-	tv_ret = thr->valstack_bottom + idx_func;  /* XXX: byte offset? */
-	DUK_TVAL_SET_TVAL_UPDREF(thr, tv_ret, &thr->heap->lj.value1);  /* side effects */
-#if defined(DUK_USE_FASTINT)
-	/* Explicit check for fastint downgrade. */
-	DUK_TVAL_CHKFAST_INPLACE_FAST(tv_ret);
-#endif
-	duk_set_top(ctx, idx_func + 1);  /* XXX: could be eliminated with valstack adjust */
-
-	/* [ ... errobj ] */
-
-	/* Restore caller's value stack reserve (cannot fail). */
-	DUK_ASSERT((duk_uint8_t *) thr->valstack + entry_valstack_end_byteoff >= (duk_uint8_t *) thr->valstack_top);
-	DUK_ASSERT((duk_uint8_t *) thr->valstack + entry_valstack_end_byteoff <= (duk_uint8_t *) thr->valstack_alloc_end);
-	thr->valstack_end = (duk_tval *) (void *) ((duk_uint8_t *) thr->valstack + entry_valstack_end_byteoff);
-
-	/* These are just convenience "wiping" of state.  Side effects should
-	 * not be an issue here: thr->heap and thr->heap->lj have a stable
-	 * pointer.  Finalizer runs etc capture even out-of-memory errors so
-	 * nothing should throw here.
-	 */
-	thr->heap->lj.type = DUK_LJ_TYPE_UNKNOWN;
-	thr->heap->lj.iserror = 0;
-	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
-	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
-
-	/* Restore entry thread executor curr_pc stack frame pointer. */
-	thr->ptr_curr_pc = entry_ptr_curr_pc;
-
-	DUK_HEAP_SWITCH_THREAD(thr->heap, entry_curr_thread);  /* may be NULL */
-	thr->state = (duk_uint8_t) entry_thread_state;
-
-	/* Disabled assert: triggered with some torture tests. */
-#if 0
-	DUK_ASSERT((thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread == NULL) ||  /* first call */
-	           (thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread != NULL) ||  /* other call */
-	           (thr->state == DUK_HTHREAD_STATE_RUNNING && thr->heap->curr_thread == thr));     /* current thread */
-#endif
-
-	thr->heap->call_recursion_depth = entry_call_recursion_depth;
-
-	/* If the debugger is active we need to force an interrupt so that
-	 * debugger breakpoints are rechecked.  This is important for function
-	 * calls caused by side effects (e.g. when doing a DUK_OP_GETPROP), see
-	 * GH-303.  Only needed for success path, error path always causes a
-	 * breakpoint recheck in the executor.  It would be enough to set this
-	 * only when returning to an Ecmascript activation, but setting the flag
-	 * on every return should have no ill effect.
-	 */
-#if defined(DUK_USE_DEBUGGER_SUPPORT)
-	if (duk_debug_is_attached(thr->heap)) {
-		DUK_DD(DUK_DDPRINT("returning with debugger enabled, force interrupt"));
-		DUK_ASSERT(thr->interrupt_counter <= thr->interrupt_init);
-		thr->interrupt_init -= thr->interrupt_counter;
-		thr->interrupt_counter = 0;
-		thr->heap->dbg_force_restart = 1;
-	}
-#endif
-
-#if defined(DUK_USE_INTERRUPT_COUNTER) && defined(DUK_USE_DEBUG)
-	duk__interrupt_fixup(thr, entry_curr_thread);
-#endif
-
-	/* Error handling complete, remove side effect protections and
-	 * process pending finalizers.
-	 */
-#if defined(DUK_USE_ASSERTIONS)
-	DUK_ASSERT(thr->heap->error_not_allowed == 1);
-	thr->heap->error_not_allowed = 0;
-#endif
-	DUK_ASSERT(thr->heap->pf_prevent_count > 0);
-	thr->heap->pf_prevent_count--;
-	DUK_DD(DUK_DDPRINT("call error handled, pf_prevent_count updated to %ld", (long) thr->heap->pf_prevent_count));
-
-	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
-
-	DUK_REFZERO_CHECK_SLOW(thr);
+DUK_INTERNAL duk_int_t duk_handle_call_unprotected(duk_hthread *thr,
+                                                   duk_idx_t idx_func,
+                                                   duk_small_uint_t call_flags) {
+	DUK_ASSERT(duk_is_valid_index((duk_context *) thr, idx_func));
+	DUK_ASSERT(idx_func >= 0);
+	return duk__handle_call_raw(thr, idx_func, call_flags);
 }
 
 /*
@@ -2244,184 +2124,17 @@ DUK_LOCAL void duk__handle_call_error(duk_hthread *thr,
  *  current activation.
  *
  *  The allowed thread states for making a call are the same as for
- *  duk_handle_call_xxx().
+ *  duk_handle_call_protected().
  *
- *  Error handling is similar to duk_handle_call_xxx(); errors may be thrown
- *  (and result in a fatal error) for insane arguments.
+ *  Even though this call is protected, errors are thrown for insane arguments
+ *  and may result in a fatal error unless there's another protected call which
+ *  catches such errors.
+ *
+ *  The error handling path should be error free, even for out-of-memory
+ *  errors, to ensure safe sandboxing.  (As of Duktape 2.2.0 this is not
+ *  yet the case for environment closing which may run out of memory, see
+ *  XXX notes below.)
  */
-
-/* XXX: bump preventcount by one for the duration of this call? */
-
-DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
-                                            duk_safe_call_function func,
-                                            void *udata,
-                                            duk_idx_t num_stack_args,
-                                            duk_idx_t num_stack_rets) {
-	duk_context *ctx = (duk_context *) thr;
-	duk_activation *entry_act;
-	duk_size_t entry_valstack_bottom_byteoff;
-#if defined(DUK_USE_ASSERTIONS)
-	duk_size_t entry_callstack_top;
-#endif
-	duk_int_t entry_call_recursion_depth;
-	duk_hthread *entry_curr_thread;
-	duk_uint_fast8_t entry_thread_state;
-	duk_instr_t **entry_ptr_curr_pc;
-	duk_jmpbuf *old_jmpbuf_ptr = NULL;
-	duk_jmpbuf our_jmpbuf;
-	duk_idx_t idx_retbase;
-	duk_int_t retval;
-
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT(ctx != NULL);
-
-	/* Note: careful with indices like '-x'; if 'x' is zero, it refers to bottom */
-	entry_act = thr->callstack_curr;
-	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
-#if defined(DUK_USE_ASSERTIONS)
-	entry_callstack_top = thr->callstack_top;
-#endif
-	entry_call_recursion_depth = thr->heap->call_recursion_depth;
-	entry_curr_thread = thr->heap->curr_thread;  /* Note: may be NULL if first call */
-	entry_thread_state = thr->state;
-	entry_ptr_curr_pc = thr->ptr_curr_pc;  /* may be NULL */
-	idx_retbase = duk_get_top(ctx) - num_stack_args;  /* Note: not a valid stack index if num_stack_args == 0 */
-
-	/* Note: cannot portably debug print a function pointer, hence 'func' not printed! */
-	DUK_DD(DUK_DDPRINT("duk_handle_safe_call: thr=%p, num_stack_args=%ld, num_stack_rets=%ld, "
-	                   "valstack_top=%ld, idx_retbase=%ld, rec_depth=%ld/%ld, "
-	                   "entry_act=%p, entry_valstack_bottom_byteoff=%ld, entry_call_recursion_depth=%ld, "
-	                   "entry_curr_thread=%p, entry_thread_state=%ld",
-	                   (void *) thr,
-	                   (long) num_stack_args,
-	                   (long) num_stack_rets,
-	                   (long) duk_get_top(ctx),
-	                   (long) idx_retbase,
-	                   (long) thr->heap->call_recursion_depth,
-	                   (long) thr->heap->call_recursion_limit,
-	                   (void *) entry_act,
-	                   (long) entry_valstack_bottom_byteoff,
-	                   (long) entry_call_recursion_depth,
-	                   (void *) entry_curr_thread,
-	                   (long) entry_thread_state));
-
-	if (idx_retbase < 0) {
-		/* Since stack indices are not reliable, we can't do anything useful
-		 * here.  Invoke the existing setjmp catcher, or if it doesn't exist,
-		 * call the fatal error handler.
-		 */
-
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	}
-
-	/* setjmp catchpoint setup */
-
-	old_jmpbuf_ptr = thr->heap->lj.jmpbuf_ptr;
-	thr->heap->lj.jmpbuf_ptr = &our_jmpbuf;
-
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	try {
-#else
-	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == &our_jmpbuf);
-	if (DUK_SETJMP(our_jmpbuf.jb) == 0) {
-		/* Success path. */
-#endif
-		DUK_DDD(DUK_DDDPRINT("safe_call setjmp catchpoint setup complete"));
-
-		duk__handle_safe_call_inner(thr,
-		                            func,
-		                            udata,
-#if defined(DUK_USE_ASSERTIONS)
-		                            entry_valstack_bottom_byteoff,
-		                            entry_callstack_top,
-#endif
-		                            idx_retbase,
-		                            num_stack_rets);
-
-		/* Note: either pointer may be NULL (at entry), so don't assert */
-		thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
-
-		retval = DUK_EXEC_SUCCESS;
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	} catch (duk_internal_exception &exc) {
-		DUK_UNREF(exc);
-#else
-	} else {
-		/* Error path. */
-#endif
-		duk__handle_safe_call_error(thr,
-		                            entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-		                            entry_callstack_top,
-#endif
-		                            idx_retbase,
-		                            num_stack_rets,
-		                            entry_valstack_bottom_byteoff,
-		                            old_jmpbuf_ptr);
-
-		retval = DUK_EXEC_ERROR;
-	}
-#if defined(DUK_USE_CPP_EXCEPTIONS)
-	catch (std::exception &exc) {
-		const char *what = exc.what();
-		if (!what) {
-			what = "unknown";
-		}
-		DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
-		try {
-			DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
-		} catch (duk_internal_exception exc) {
-			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
-			DUK_UNREF(exc);
-			duk__handle_safe_call_error(thr,
-			                            entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-			                            entry_callstack_top,
-#endif
-			                            idx_retbase,
-			                            num_stack_rets,
-			                            entry_valstack_bottom_byteoff,
-			                            old_jmpbuf_ptr);
-			retval = DUK_EXEC_ERROR;
-		}
-	} catch (...) {
-		DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
-		try {
-			DUK_ERROR_TYPE(thr, "caught invalid c++ exception (perhaps thrown by user code)");
-		} catch (duk_internal_exception exc) {
-			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
-			DUK_UNREF(exc);
-			duk__handle_safe_call_error(thr,
-			                            entry_act,
-#if defined(DUK_USE_ASSERTIONS)
-			                            entry_callstack_top,
-#endif
-			                            idx_retbase,
-			                            num_stack_rets,
-			                            entry_valstack_bottom_byteoff,
-			                            old_jmpbuf_ptr);
-			retval = DUK_EXEC_ERROR;
-		}
-	}
-#endif
-
-	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == old_jmpbuf_ptr);  /* success/error path both do this */
-
-	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
-
-	duk__handle_safe_call_shared(thr,
-	                             idx_retbase,
-	                             num_stack_rets,
-#if defined(DUK_USE_ASSERTIONS)
-	                             entry_callstack_top,
-#endif
-	                             entry_call_recursion_depth,
-	                             entry_curr_thread,
-	                             entry_thread_state,
-	                             entry_ptr_curr_pc);
-
-	return retval;
-}
 
 DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_safe_call_function func,
@@ -2430,6 +2143,8 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
                                            duk_size_t entry_valstack_bottom_byteoff,
                                            duk_size_t entry_callstack_top,
 #endif
+                                           duk_hthread *entry_curr_thread,
+                                           duk_uint_fast8_t entry_thread_state,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets) {
 	duk_context *ctx;
@@ -2443,48 +2158,17 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 	 *  Thread state check and book-keeping.
 	 */
 
-	if (thr == thr->heap->curr_thread) {
-		/* same thread */
-		if (thr->state != DUK_HTHREAD_STATE_RUNNING) {
-			/* should actually never happen, but check anyway */
-			goto thread_state_error;
-		}
-	} else {
-		/* different thread */
-		DUK_ASSERT(thr->heap->curr_thread == NULL ||
-		           thr->heap->curr_thread->state == DUK_HTHREAD_STATE_RUNNING);
-		if (thr->state != DUK_HTHREAD_STATE_INACTIVE) {
-			goto thread_state_error;
-		}
-		DUK_HEAP_SWITCH_THREAD(thr->heap, thr);
-		thr->state = DUK_HTHREAD_STATE_RUNNING;
-
-		/* Note: multiple threads may be simultaneously in the RUNNING
-		 * state, but not in the same "resume chain".
-		 */
-	}
-
-	DUK_ASSERT(thr->heap->curr_thread == thr);
-	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
+	duk__call_thread_state_update(thr);
 
 	/*
 	 *  Recursion limit check.
-	 *
-	 *  Note: there is no need for an "ignore recursion limit" flag
-	 *  for duk_handle_safe_call now.
 	 */
 
 	duk__call_c_recursion_limit_check(thr);
 	thr->heap->call_recursion_depth++;
 
 	/*
-	 *  Valstack spare check
-	 */
-
-	duk_require_stack(ctx, 0);  /* internal spare */
-
-	/*
-	 *  Make the C call
+	 *  Make the C call.
 	 */
 
 	rc = func(ctx, udata);
@@ -2502,28 +2186,15 @@ DUK_LOCAL void duk__handle_safe_call_inner(duk_hthread *thr,
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	DUK_ASSERT(thr->valstack_end >= thr->valstack_top);
 
-	if (rc < 0) {
+	if (DUK_UNLIKELY(rc < 0)) {
 		duk_error_throw_from_negative_rc(thr, rc);
 	}
 	DUK_ASSERT(rc >= 0);
 
-	if (duk_get_top(ctx) < rc) {
-		DUK_ERROR_RANGE(thr, "not enough stack values for safe_call rc");
-	}
+	duk__safe_call_adjust_valstack(thr, idx_retbase, num_stack_rets, rc);  /* throws for insane rc */
 
-	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
-
-	duk__safe_call_adjust_valstack(thr, idx_retbase, num_stack_rets, rc);
-
-	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
-
-	DUK_REFZERO_CHECK_FAST(thr);
-
-	return;
-
- thread_state_error:
-	DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "invalid thread state for safe_call (%ld)", (long) thr->state);
-	DUK_UNREACHABLE();
+	DUK_HEAP_SWITCH_THREAD(thr->heap, entry_curr_thread);  /* may be NULL */
+	thr->state = (duk_uint8_t) entry_thread_state;
 }
 
 DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
@@ -2531,6 +2202,8 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
 #if defined(DUK_USE_ASSERTIONS)
                                            duk_size_t entry_callstack_top,
 #endif
+                                           duk_hthread *entry_curr_thread,
+                                           duk_uint_fast8_t entry_thread_state,
                                            duk_idx_t idx_retbase,
                                            duk_idx_t num_stack_rets,
                                            duk_size_t entry_valstack_bottom_byteoff,
@@ -2557,8 +2230,14 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
 	DUK_ASSERT(thr->heap->lj.type == DUK_LJ_TYPE_THROW);
 	DUK_ASSERT_LJSTATE_SET(thr->heap);
 
-	/* Note: either pointer may be NULL (at entry), so don't assert. */
+	/* Either pointer may be NULL (at entry), so don't assert. */
 	thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
+
+	/* XXX: callstack unwind may now throw an error when closing
+	 * scopes; this is a sandboxing issue, described in:
+	 * https://github.com/svaarala/duktape/issues/476
+	 */
+	/* XXX: "unwind to" primitive? */
 
 	DUK_ASSERT(thr->callstack_top >= entry_callstack_top);
 	while (thr->callstack_curr != entry_act) {
@@ -2567,39 +2246,40 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
 	}
 	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
 
+	/* Switch active thread before any side effects to avoid a
+	 * dangling curr_thread pointer.
+	 */
+	DUK_HEAP_SWITCH_THREAD(thr->heap, entry_curr_thread);  /* may be NULL */
+	thr->state = (duk_uint8_t) entry_thread_state;
+
+	DUK_ASSERT((thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread == NULL) ||  /* first call */
+	           (thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread != NULL) ||  /* other call */
+	           (thr->state == DUK_HTHREAD_STATE_RUNNING && thr->heap->curr_thread == thr));     /* current thread */
+
+	/* Restore valstack bottom. */
 	thr->valstack_bottom = (duk_tval *) (void *) ((duk_uint8_t *) thr->valstack + entry_valstack_bottom_byteoff);
 
 	/* [ ... | (crud) ] */
 
-	/* XXX: space in valstack?  see discussion in duk_handle_call_xxx(). */
+	/* XXX: ensure space in valstack (now relies on internal reserve)? */
 	duk_push_tval(ctx, &thr->heap->lj.value1);
 
 	/* [ ... | (crud) errobj ] */
 
 	DUK_ASSERT(duk_get_top(ctx) >= 1);  /* at least errobj must be on stack */
 
-	/* check that the valstack has space for the final amount and any
-	 * intermediate space needed; this is unoptimal but should be safe
-	 */
-	duk_require_stack_top(ctx, idx_retbase + num_stack_rets);  /* final configuration */
-	duk_require_stack(ctx, num_stack_rets);
-
 	duk__safe_call_adjust_valstack(thr, idx_retbase, num_stack_rets, 1);  /* 1 = num actual 'return values' */
 
 	/* [ ... | ] or [ ... | errobj (M * undefined)] where M = num_stack_rets - 1 */
 
-	/* These are just convenience "wiping" of state.  Side effects should
-	 * not be an issue here: thr->heap and thr->heap->lj have a stable
-	 * pointer.  Finalizer runs etc capture even out-of-memory errors so
-	 * nothing should throw here.
-	 */
+	/* Reset longjmp state. */
 	thr->heap->lj.type = DUK_LJ_TYPE_UNKNOWN;
 	thr->heap->lj.iserror = 0;
-	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value1);  /* side effects */
-	DUK_TVAL_SET_UNDEFINED_UPDREF(thr, &thr->heap->lj.value2);  /* side effects */
+	DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, &thr->heap->lj.value1);
+	DUK_TVAL_SET_UNDEFINED_UPDREF_NORZ(thr, &thr->heap->lj.value2);
 
-	/* Error handling complete, remove side effect protections and
-	 * process pending finalizers.
+	/* Error handling complete, remove side effect protections.  Caller
+	 * will process pending finalizers.
 	 */
 #if defined(DUK_USE_ASSERTIONS)
 	DUK_ASSERT(thr->heap->error_not_allowed == 1);
@@ -2609,21 +2289,21 @@ DUK_LOCAL void duk__handle_safe_call_error(duk_hthread *thr,
 	thr->heap->pf_prevent_count--;
 	DUK_DD(DUK_DDPRINT("safe call error handled, pf_prevent_count updated to %ld", (long) thr->heap->pf_prevent_count));
 
-	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
-
-	DUK_REFZERO_CHECK_SLOW(thr);
+	/* thr->ptr_curr_pc is restored by
+	 * duk__handle_safe_call_shared_unwind() which is also used for
+	 * success path.
+	 */
 }
 
-DUK_LOCAL void duk__handle_safe_call_shared(duk_hthread *thr,
-                                            duk_idx_t idx_retbase,
-                                            duk_idx_t num_stack_rets,
+DUK_LOCAL void duk__handle_safe_call_shared_unwind(duk_hthread *thr,
+                                                   duk_idx_t idx_retbase,
+                                                   duk_idx_t num_stack_rets,
 #if defined(DUK_USE_ASSERTIONS)
-                                            duk_size_t entry_callstack_top,
+                                                   duk_size_t entry_callstack_top,
 #endif
-                                            duk_int_t entry_call_recursion_depth,
-                                            duk_hthread *entry_curr_thread,
-                                            duk_uint_fast8_t entry_thread_state,
-                                            duk_instr_t **entry_ptr_curr_pc) {
+                                                   duk_int_t entry_call_recursion_depth,
+                                                   duk_hthread *entry_curr_thread,
+                                                   duk_instr_t **entry_ptr_curr_pc) {
 	duk_context *ctx;
 
 	DUK_ASSERT(thr != NULL);
@@ -2632,24 +2312,15 @@ DUK_LOCAL void duk__handle_safe_call_shared(duk_hthread *thr,
 	DUK_UNREF(ctx);
 	DUK_UNREF(idx_retbase);
 	DUK_UNREF(num_stack_rets);
+	DUK_UNREF(entry_curr_thread);
 
 	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
 
-	/* Restore entry thread executor curr_pc stack frame pointer. */
-	thr->ptr_curr_pc = entry_ptr_curr_pc;
-
-	/* XXX: because we unwind stacks above, thr->heap->curr_thread is at
-	 * risk of pointing to an already freed thread.  This was indeed the
-	 * case in test-bug-multithread-valgrind.c, until duk_handle_call()
-	 * was fixed to restore thr->heap->curr_thread before rethrowing an
-	 * uncaught error.
+	/* Restore entry thread executor curr_pc stack frame pointer.
+	 * XXX: would be enough to do in error path only, should nest
+	 * cleanly in success path.
 	 */
-	DUK_HEAP_SWITCH_THREAD(thr->heap, entry_curr_thread);  /* may be NULL */
-	thr->state = (duk_uint8_t) entry_thread_state;
-
-	DUK_ASSERT((thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread == NULL) ||  /* first call */
-	           (thr->state == DUK_HTHREAD_STATE_INACTIVE && thr->heap->curr_thread != NULL) ||  /* other call */
-	           (thr->state == DUK_HTHREAD_STATE_RUNNING && thr->heap->curr_thread == thr));     /* current thread */
+	thr->ptr_curr_pc = entry_ptr_curr_pc;
 
 	thr->heap->call_recursion_depth = entry_call_recursion_depth;
 
@@ -2663,502 +2334,223 @@ DUK_LOCAL void duk__handle_safe_call_shared(duk_hthread *thr,
 #if defined(DUK_USE_INTERRUPT_COUNTER) && defined(DUK_USE_DEBUG)
 	duk__interrupt_fixup(thr, entry_curr_thread);
 #endif
-
-	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
 }
 
-/*
- *  Helper for handling an Ecmascript-to-Ecmascript call or an Ecmascript
- *  function (initial) Duktape.Thread.resume().
- *
- *  Compared to normal calls handled by duk_handle_call(), there are a
- *  bunch of differences:
- *
- *    - the call is never protected
- *    - there is no C recursion depth increase (hence an "ignore recursion
- *      limit" flag is not applicable)
- *    - instead of making the call, this helper just performs the thread
- *      setup and returns; the bytecode executor then restarts execution
- *      internally
- *    - ecmascript functions are never 'vararg' functions (they access
- *      varargs through the 'arguments' object)
- *
- *  The callstack of the target contains an earlier Ecmascript call in case
- *  of an Ecmascript-to-Ecmascript call (whose retval_byteoff is updated), or
- *  is empty in case of an initial Duktape.Thread.resume().
- *
- *  The first thing to do here is to figure out whether an ecma-to-ecma
- *  call is actually possible.  It's not always the case, e.g. if the final
- *  target function is native.  In that case, return an error so caller can
- *  fall back to a normal call path.
- */
-
-DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
-                                                   duk_idx_t num_stack_args,
-                                                   duk_small_uint_t call_flags,
-                                                   duk_small_uint_t *out_call_flags) {
+DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
+                                            duk_safe_call_function func,
+                                            void *udata,
+                                            duk_idx_t num_stack_args,
+                                            duk_idx_t num_stack_rets) {
 	duk_context *ctx = (duk_context *) thr;
+	duk_activation *entry_act;
 	duk_size_t entry_valstack_bottom_byteoff;
-	duk_idx_t idx_func;      /* valstack index of 'func' and retval (relative to entry valstack_bottom) */
-	duk_idx_t idx_args;      /* valstack index of start of args (arg1) (relative to entry valstack_bottom) */
-	duk_idx_t nargs;         /* # argument registers target function wants (< 0 => never for ecma calls) */
-	duk_idx_t nregs;         /* # total registers target function wants on entry (< 0 => never for ecma calls) */
-	duk_size_t vs_min_bytes; /* minimum value stack size (bytes) for handling call */
-	duk_hobject *func;       /* 'func' on stack (borrowed reference) */
-	duk_tval tv_func_ignore; /* duk_tval for 'func' on stack */
-	duk_activation *act;
-	duk_activation *new_act;
-	duk_hobject *env;
-	duk_bool_t use_tailcall;
+#if defined(DUK_USE_ASSERTIONS)
+	duk_size_t entry_valstack_end_byteoff;
+	duk_size_t entry_callstack_top;
+	duk_size_t entry_callstack_preventcount;
+#endif
+	duk_int_t entry_call_recursion_depth;
+	duk_hthread *entry_curr_thread;
+	duk_uint_fast8_t entry_thread_state;
 	duk_instr_t **entry_ptr_curr_pc;
+	duk_jmpbuf *old_jmpbuf_ptr = NULL;
+	duk_jmpbuf our_jmpbuf;
+	duk_idx_t idx_retbase;
+	duk_int_t retval;
 
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(ctx != NULL);
-	DUK_ASSERT(!((call_flags & DUK_CALL_FLAG_IS_RESUME) != 0 && (call_flags & DUK_CALL_FLAG_IS_TAILCALL) != 0));
+	DUK_ASSERT(duk_get_top(ctx) >= num_stack_args);  /* Caller ensures. */
 
-	/* XXX: assume these? */
-	DUK_ASSERT(thr->valstack != NULL);
-
-	/* no need to handle thread state book-keeping here */
-	DUK_ASSERT((call_flags & DUK_CALL_FLAG_IS_RESUME) != 0 ||
-	           (thr->state == DUK_HTHREAD_STATE_RUNNING &&
-	            thr->heap->curr_thread == thr));
-
-	/* If thr->ptr_curr_pc is set, sync curr_pc to act->pc.  Then NULL
-	 * thr->ptr_curr_pc so that it's not accidentally used with an incorrect
-	 * activation when side effects occur.  If we end up not making the
-	 * call we must restore the value.
+	/* Value stack reserve handling: safe call assumes caller has reserved
+	 * space for nrets (assuming optimal unwind processing).  Value stack
+	 * reserve is not stored/restored as for normal calls because a safe
+	 * call conceptually happens in the same activation.
 	 */
-	entry_ptr_curr_pc = thr->ptr_curr_pc;
-	duk_hthread_sync_and_null_currpc(thr);
 
-	/* If a tail call:
-	 *   - an Ecmascript activation must be on top of the callstack
-	 *   - there cannot be any catch stack entries that would catch
-	 *     a return
-	 */
+	/* Careful with indices like '-x'; if 'x' is zero, it refers to bottom */
+	entry_act = thr->callstack_curr;
+	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
 #if defined(DUK_USE_ASSERTIONS)
-	if (call_flags & DUK_CALL_FLAG_IS_TAILCALL) {
-		duk_activation *tmp_act;
-		duk_catcher *tmp_cat;
+	entry_valstack_end_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
+	entry_callstack_top = thr->callstack_top;
+	entry_callstack_preventcount = thr->callstack_preventcount;
+#endif
+	entry_call_recursion_depth = thr->heap->call_recursion_depth;
+	entry_curr_thread = thr->heap->curr_thread;  /* may be NULL if first call */
+	entry_thread_state = thr->state;
+	entry_ptr_curr_pc = thr->ptr_curr_pc;  /* may be NULL */
+	idx_retbase = duk_get_top(ctx) - num_stack_args;  /* not a valid stack index if num_stack_args == 0 */
+	DUK_ASSERT(idx_retbase >= 0);
 
-		DUK_ASSERT(thr->callstack_top >= 1);
-		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL);
-		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)));
+	DUK_ASSERT((duk_idx_t) (thr->valstack_top - thr->valstack_bottom) >= num_stack_args);  /* Caller ensures. */
+	DUK_ASSERT((duk_idx_t) (thr->valstack_end - (thr->valstack_bottom + idx_retbase)) >= num_stack_rets);  /* Caller ensures. */
 
-		/* No entry in the catch stack which would actually catch a
-		 * throw can refer to the callstack entry being reused.
-		 * There *can* be catch stack entries referring to the current
-		 * callstack entry as long as they don't catch (e.g. label sites).
-		 */
-
-		tmp_act = thr->callstack_curr;
-		for (tmp_cat = tmp_act->cat; tmp_cat != NULL; tmp_cat = tmp_cat->parent) {
-			DUK_ASSERT(DUK_CAT_GET_TYPE(tmp_cat) == DUK_CAT_TYPE_LABEL); /* a non-catching entry */
-		}
-	}
-#endif  /* DUK_USE_ASSERTIONS */
-
-	/* XXX: rework */
-	idx_func = duk_normalize_index(thr, -num_stack_args - 2);
-	idx_args = idx_func + 2;
-
-	DUK_DD(DUK_DDPRINT("handle_ecma_call_setup: thr=%p, "
-	                   "num_stack_args=%ld, call_flags=0x%08lx (resume=%ld, tailcall=%ld), "
-	                   "idx_func=%ld, idx_args=%ld, entry_valstack_bottom_byteoff=%ld",
+	/* Cannot portably debug print a function pointer, hence 'func' not printed! */
+	DUK_DD(DUK_DDPRINT("duk_handle_safe_call: thr=%p, num_stack_args=%ld, num_stack_rets=%ld, "
+	                   "valstack_top=%ld, idx_retbase=%ld, rec_depth=%ld/%ld, "
+	                   "entry_act=%p, entry_valstack_bottom_byteoff=%ld, entry_call_recursion_depth=%ld, "
+	                   "entry_curr_thread=%p, entry_thread_state=%ld",
 	                   (void *) thr,
 	                   (long) num_stack_args,
-	                   (unsigned long) call_flags,
-	                   (long) ((call_flags & DUK_CALL_FLAG_IS_RESUME) != 0 ? 1 : 0),
-	                   (long) ((call_flags & DUK_CALL_FLAG_IS_TAILCALL) != 0 ? 1 : 0),
-	                   (long) idx_func,
-	                   (long) idx_args,
-	                   (long) entry_valstack_bottom_byteoff));
+	                   (long) num_stack_rets,
+	                   (long) duk_get_top(ctx),
+	                   (long) idx_retbase,
+	                   (long) thr->heap->call_recursion_depth,
+	                   (long) thr->heap->call_recursion_limit,
+	                   (void *) entry_act,
+	                   (long) entry_valstack_bottom_byteoff,
+	                   (long) entry_call_recursion_depth,
+	                   (void *) entry_curr_thread,
+	                   (long) entry_thread_state));
 
-	if (DUK_UNLIKELY(idx_func < 0 || idx_args < 0)) {
-		/* XXX: assert? compiler is responsible for this never happening */
-		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	}
+	/* Setjmp catchpoint setup. */
+	old_jmpbuf_ptr = thr->heap->lj.jmpbuf_ptr;
+	thr->heap->lj.jmpbuf_ptr = &our_jmpbuf;
 
-	/*
-	 *  Check the function type, handle bound functions, and prepare
-	 *  parameters for the rest of the call handling.  Also figure out
-	 *  the effective 'this' binding, which replaces the current value
-	 *  at idx_func + 1.
-	 *
-	 *  If the target function is a 'bound' one, resolve the non-bound
-	 *  target.  Since Duktape 2.2 bound function chains are collapsed on
-	 *  creation, so the target of a duk_hboundfunc is always non-bound.
-	 *  During this process, bound arguments are 'prepended' to existing
-	 *  ones, and the "this" binding is overridden.  See E5 Section
-	 *  15.3.4.5.1 for the conceptual algorithm.
-	 *
-	 *  If the final target function cannot be handled by an ecma-to-ecma
-	 *  call, return to the caller with a return value indicating this case.
-	 *  The bound function has been resolved and the caller can resume with
-	 *  a plain function call.
+	/* Prevent yields for the duration of the safe call.  This only
+	 * matters if the executor makes safe calls to functions that
+	 * yield, this doesn't currently happen.
 	 */
+	thr->callstack_preventcount++;
 
-	if (duk__resolve_target_fastpath_check(ctx, idx_func, &tv_func_ignore, &func, call_flags)) {
-		DUK_DDD(DUK_DDDPRINT("fast path target resolve"));
+#if defined(DUK_USE_CPP_EXCEPTIONS)
+	try {
+#else
+	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == &our_jmpbuf);
+	if (DUK_SETJMP(our_jmpbuf.jb) == 0) {
+		/* Success path. */
+#endif
+		DUK_DDD(DUK_DDDPRINT("safe_call setjmp catchpoint setup complete"));
+
+		duk__handle_safe_call_inner(thr,
+		                            func,
+		                            udata,
+#if defined(DUK_USE_ASSERTIONS)
+		                            entry_valstack_bottom_byteoff,
+		                            entry_callstack_top,
+#endif
+		                            entry_curr_thread,
+		                            entry_thread_state,
+		                            idx_retbase,
+		                            num_stack_rets);
+
+		/* Either pointer may be NULL (at entry), so don't assert */
+		thr->heap->lj.jmpbuf_ptr = old_jmpbuf_ptr;
+
+		/* If calls happen inside the safe call, these are restored by
+		 * whatever calls are made.  Reserve cannot decrease.
+		 */
+		DUK_ASSERT(thr->callstack_curr == entry_act);
+		DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
+
+		retval = DUK_EXEC_SUCCESS;
+#if defined(DUK_USE_CPP_EXCEPTIONS)
+	} catch (duk_internal_exception &exc) {
+		DUK_UNREF(exc);
+#else
 	} else {
-		DUK_DDD(DUK_DDDPRINT("slow path target resolve"));
-		func = duk__resolve_target_func_and_this_binding(ctx, idx_func, &num_stack_args, &tv_func_ignore, &call_flags);
-	}
-
-	/* Call flags may have changed in resolution: if Reflect.construct()
-	 * was encountered we're now dealing with a constructor call which
-	 * affects 'this' binding handling.  If Ecma-to-Ecma call fails, the
-	 * ordinary call setup needs to receive the constructor flag.
-	 */
-	*out_call_flags = call_flags;
-
-	if (func == NULL || !DUK_HOBJECT_IS_COMPFUNC(func)) {
-		DUK_DDD(DUK_DDDPRINT("final target is a lightfunc/nativefunc, cannot do ecma-to-ecma call"));
-		thr->ptr_curr_pc = entry_ptr_curr_pc;
-		return 0;
-	}
-	/* tv_func_ignore is not actually needed */
-
-	DUK_ASSERT(func != NULL);
-	DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));
-	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(func));
-
-	if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
-		duk__update_default_instance_proto(ctx, idx_func);
-	}
-
-	nargs = ((duk_hcompfunc *) func)->nargs;
-	nregs = ((duk_hcompfunc *) func)->nregs;
-	DUK_ASSERT(nregs >= 0);
-	DUK_ASSERT(nregs >= nargs);
-
-	entry_valstack_bottom_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack);
-	vs_min_bytes = entry_valstack_bottom_byteoff + sizeof(duk_tval) * (idx_args + nregs + DUK_VALSTACK_INTERNAL_EXTRA);
-
-	/* [ ... func this arg1 ... argN ] */
-
-	/*
-	 *  Preliminary activation record and valstack manipulation.
-	 *  The concrete actions depend on whether the we're dealing
-	 *  with a tail call (reuse an existing activation), a resume,
-	 *  or a normal call.
-	 *
-	 *  The basic actions, in varying order, are:
-	 *
-	 *    - Check stack size for call handling
-	 *    - Grow call stack if necessary (non-tail-calls)
-	 *    - Update current activation (retval_byteoff) if necessary
-	 *      (non-tail, non-resume calls)
-	 *    - Move start of args (idx_args) to valstack bottom
-	 *      (tail calls)
-	 *
-	 *  Don't touch valstack_bottom or valstack_top yet so that Duktape API
-	 *  calls work normally.
-	 */
-
-	/* XXX: some overlapping code; cleanup */
-	use_tailcall = call_flags & DUK_CALL_FLAG_IS_TAILCALL;
-#if !defined(DUK_USE_TAILCALL)
-	DUK_ASSERT(use_tailcall == 0);  /* compiler ensures this */
+		/* Error path. */
 #endif
-	if (use_tailcall) {
-		/* tailcall cannot be flagged to resume calls, and a
-		 * previous frame must exist
-		 */
-		DUK_ASSERT(thr->callstack_top >= 1);
-		DUK_ASSERT((call_flags & DUK_CALL_FLAG_IS_RESUME) == 0);
+		DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
 
-		act = thr->callstack_curr;
-		DUK_ASSERT(act != NULL);
-		if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
-			/* See: test-bug-tailcall-preventyield-assert.c. */
-			DUK_DDD(DUK_DDDPRINT("tail call prevented by current activation preventing a yield"));
-			use_tailcall = 0;
-		} else if (((act->flags & DUK_ACT_FLAG_CONSTRUCT) && !(call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL)) ||
-		           (!(act->flags & DUK_ACT_FLAG_CONSTRUCT) && (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL))) {
-			/* Cannot tailcall if mixing normal and constructor
-			 * calls.  Current function and potential tailcall
-			 * must have same return value handling (normal or
-			 * constructor special handling).
-			 */
-			DUK_DDD(DUK_DDDPRINT("tail call prevented by incompatible return value handling"));
-			use_tailcall = 0;
-		} else if (DUK_HOBJECT_HAS_NOTAIL(func)) {
-			DUK_DDD(DUK_DDDPRINT("tail call prevented by function having a notail flag"));
-			use_tailcall = 0;
+		duk__handle_safe_call_error(thr,
+		                            entry_act,
+#if defined(DUK_USE_ASSERTIONS)
+		                            entry_callstack_top,
+#endif
+		                            entry_curr_thread,
+		                            entry_thread_state,
+		                            idx_retbase,
+		                            num_stack_rets,
+		                            entry_valstack_bottom_byteoff,
+		                            old_jmpbuf_ptr);
+
+		retval = DUK_EXEC_ERROR;
+	}
+#if defined(DUK_USE_CPP_EXCEPTIONS)
+	catch (std::exception &exc) {
+		const char *what = exc.what();
+		DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
+		if (!what) {
+			what = "unknown";
+		}
+		DUK_D(DUK_DPRINT("unexpected c++ std::exception (perhaps thrown by user code)"));
+		try {
+			DUK_ERROR_FMT1(thr, DUK_ERR_TYPE_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
+		} catch (duk_internal_exception exc) {
+			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
+			DUK_UNREF(exc);
+			duk__handle_safe_call_error(thr,
+			                            entry_act,
+#if defined(DUK_USE_ASSERTIONS)
+			                            entry_callstack_top,
+#endif
+			                            entry_curr_thread,
+			                            entry_thread_state,
+			                            idx_retbase,
+			                            num_stack_rets,
+			                            entry_valstack_bottom_byteoff,
+			                            old_jmpbuf_ptr);
+			retval = DUK_EXEC_ERROR;
+		}
+	} catch (...) {
+		DUK_D(DUK_DPRINT("unexpected c++ exception (perhaps thrown by user code)"));
+		DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
+		try {
+			DUK_ERROR_TYPE(thr, "caught invalid c++ exception (perhaps thrown by user code)");
+		} catch (duk_internal_exception exc) {
+			DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
+			DUK_UNREF(exc);
+			duk__handle_safe_call_error(thr,
+			                            entry_act,
+#if defined(DUK_USE_ASSERTIONS)
+			                            entry_callstack_top,
+#endif
+			                            entry_curr_thread,
+			                            entry_thread_state,
+			                            idx_retbase,
+			                            num_stack_rets,
+			                            entry_valstack_bottom_byteoff,
+			                            old_jmpbuf_ptr);
+			retval = DUK_EXEC_ERROR;
 		}
 	}
-
-	if (use_tailcall) {
-		duk_tval *tv1, *tv2;
-		duk_idx_t i_arg;
-
-		/*
-		 *  Tailcall handling
-		 *
-		 *  Although the callstack entry is reused, we need to explicitly unwind
-		 *  the current activation (or simulate an unwind).  In particular, the
-		 *  current activation must be closed, otherwise something like
-		 *  test-bug-reduce-judofyr.js results.  Also catchers need to be unwound
-		 *  because there may be non-error-catching label entries in valid tail calls.
-		 */
-
-		DUK_DDD(DUK_DDDPRINT("is tail call, reusing activation at callstack top, at index %ld",
-		                     (long) (thr->callstack_top - 1)));
-
-		/* 'act' already set above */
-
-		DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));
-		DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(func));
-		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
-		DUK_ASSERT((act->flags & DUK_ACT_FLAG_PREVENT_YIELD) == 0);
-
-		/* Unwind the topmost callstack entry before reusing it.  This
-		 * also unwinds the catchers related to the topmost entry.
-		 */
-		DUK_ASSERT(thr->callstack_top > 0);
-		DUK_ASSERT(thr->callstack_curr != NULL);
-		duk_hthread_activation_unwind_reuse_norz(thr);
-		DUK_ASSERT(act == thr->callstack_curr);
-
-		/* XXX: We could restore the caller's value stack reserve
-		 * here, as if we did an actual unwind-and-call.  Without
-		 * the restoration, value stack reserve may remain higher
-		 * than would otherwise be possible until we return to a
-		 * non-tailcall.
-		 */
-
-		/* Then reuse the unwound activation. */
-		act->cat = NULL;
-		act->var_env = NULL;
-		act->lex_env = NULL;
-		DUK_ASSERT(func != NULL);
-		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
-		act->func = func;  /* don't want an intermediate exposed state with func == NULL */
-#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
-		act->prev_caller = NULL;
-#endif
-		/* don't want an intermediate exposed state with invalid pc */
-		act->curr_pc = DUK_HCOMPFUNC_GET_CODE_BASE(thr->heap, (duk_hcompfunc *) func);
-#if defined(DUK_USE_DEBUGGER_SUPPORT)
-		act->prev_line = 0;
-#endif
-		DUK_TVAL_SET_OBJECT(&act->tv_func, func);  /* borrowed, no refcount */
-#if defined(DUK_USE_REFERENCE_COUNTING)
-		DUK_HOBJECT_INCREF(thr, func);
 #endif
 
-#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
-#if defined(DUK_USE_TAILCALL)
-#error incorrect options: tail calls enabled with function caller property
+	DUK_ASSERT(thr->heap->lj.jmpbuf_ptr == old_jmpbuf_ptr);  /* success/error path both do this */
+
+	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
+
+	DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
+	duk__handle_safe_call_shared_unwind(thr,
+	                                    idx_retbase,
+	                                    num_stack_rets,
+#if defined(DUK_USE_ASSERTIONS)
+	                                    entry_callstack_top,
 #endif
-		/* XXX: this doesn't actually work properly for tail calls, so
-		 * tail calls are disabled when DUK_USE_NONSTD_FUNC_CALLER_PROPERTY
-		 * is in use.
-		 */
-		duk__update_func_caller_prop(thr, func);
-#endif
+	                                    entry_call_recursion_depth,
+	                                    entry_curr_thread,
+	                                    entry_ptr_curr_pc);
 
-		act->flags = (DUK_HOBJECT_HAS_STRICT(func) ?
-		              DUK_ACT_FLAG_STRICT | DUK_ACT_FLAG_TAILCALLED :
-		              DUK_ACT_FLAG_TAILCALLED);
-		if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
-			act->flags |= DUK_ACT_FLAG_CONSTRUCT;
-		}
+	/* Restore preventcount. */
+	thr->callstack_preventcount--;
+	DUK_ASSERT(thr->callstack_preventcount == entry_callstack_preventcount);
 
-		DUK_ASSERT(DUK_ACT_GET_FUNC(act) == func);      /* already updated */
-		DUK_ASSERT(act->var_env == NULL);
-		DUK_ASSERT(act->lex_env == NULL);
-		act->bottom_byteoff = entry_valstack_bottom_byteoff;  /* tail call -> reuse current "frame" */
-		DUK_ASSERT(nregs >= 0);
-#if 0  /* topmost activation retval_byteoff is considered garbage, no need to init */
-		act->retval_byteoff = 0;
-#endif
-		act->reserve_byteoff = 0;  /* filled in below */
+	/* Final asserts. */
+	DUK_ASSERT(thr->callstack_curr == entry_act);
+	DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_bottom - (duk_uint8_t *) thr->valstack) == entry_valstack_bottom_byteoff);
+	DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
+	DUK_ASSERT(thr->callstack_top == entry_callstack_top);
+	DUK_ASSERT(thr->heap->call_recursion_depth == entry_call_recursion_depth);
+	DUK_ASSERT(thr->heap->curr_thread == entry_curr_thread);
+	DUK_ASSERT(thr->state == entry_thread_state);
+	DUK_ASSERT(thr->ptr_curr_pc == entry_ptr_curr_pc);
+	DUK_ASSERT(duk_get_top(ctx) == idx_retbase + num_stack_rets);
+	DUK_ASSERT_LJSTATE_UNSET(thr->heap);
 
-		/*
-		 *  Manipulate valstack so that args are on the current bottom and the
-		 *  previous caller's 'this' binding (which is the value preceding the
-		 *  current bottom) is replaced with the new 'this' binding:
-		 *
-		 *       [ ... this_old | (crud) func this_new arg1 ... argN ]
-		 *  -->  [ ... this_new | arg1 ... argN ]
-		 *
-		 *  For tail calling to work properly, the valstack bottom must not grow
-		 *  here; otherwise crud would accumulate on the valstack.
-		 */
-
-		tv1 = thr->valstack_bottom - 1;
-		tv2 = thr->valstack_bottom + idx_func + 1;
-		DUK_ASSERT(tv1 >= thr->valstack && tv1 < thr->valstack_top);  /* tv1 is -below- valstack_bottom */
-		DUK_ASSERT(tv2 >= thr->valstack_bottom && tv2 < thr->valstack_top);
-		DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv2);  /* side effects */
-
-		for (i_arg = 0; i_arg < idx_args; i_arg++) {
-			/* XXX: block removal API primitive */
-			/* Note: 'func' is popped from valstack here, but it is
-			 * already reachable from the activation.
-			 */
-			duk_remove(ctx, 0);
-		}
-		idx_func = 0; DUK_UNREF(idx_func);  /* really 'not applicable' anymore, should not be referenced after this */
-		idx_args = 0;
-
-		/* [ ... this_new | arg1 ... argN ] */
-	} else {
-		DUK_DDD(DUK_DDDPRINT("not a tail call, pushing a new activation to callstack, to index %ld",
-		                     (long) (thr->callstack_top)));
-
-		duk__call_callstack_limit_check(thr);
-		new_act = duk_hthread_activation_alloc(thr);
-		DUK_ASSERT(new_act != NULL);
-
-		act = thr->callstack_curr;
-		if (call_flags & DUK_CALL_FLAG_IS_RESUME) {
-			DUK_DDD(DUK_DDDPRINT("is resume -> no update to current activation (may not even exist)"));
-		} else {
-			DUK_DDD(DUK_DDDPRINT("update to current activation retval_byteoff"));
-			DUK_ASSERT(thr->callstack_top >= 1);
-			DUK_ASSERT(DUK_ACT_GET_FUNC(act) != NULL);
-			DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(act)));
-			act->retval_byteoff = entry_valstack_bottom_byteoff + sizeof(duk_tval) * idx_func;
-		}
-
-		new_act->parent = act;
-		thr->callstack_curr = new_act;
-		thr->callstack_top++;
-		act = new_act;
-
-		DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));
-		DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(func));
-		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
-
-		act->cat = NULL;
-		act->flags = (DUK_HOBJECT_HAS_STRICT(func) ?
-		              DUK_ACT_FLAG_STRICT :
-		              0);
-		if (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL) {
-			act->flags |= DUK_ACT_FLAG_CONSTRUCT;
-		}
-		act->func = func;
-		act->var_env = NULL;
-		act->lex_env = NULL;
-#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
-		act->prev_caller = NULL;
-#endif
-		DUK_ASSERT(func != NULL);
-		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func));
-		act->curr_pc = DUK_HCOMPFUNC_GET_CODE_BASE(thr->heap, (duk_hcompfunc *) func);
-#if defined(DUK_USE_DEBUGGER_SUPPORT)
-		act->prev_line = 0;
-#endif
-		act->bottom_byteoff = entry_valstack_bottom_byteoff + sizeof(duk_tval) * idx_args;
-		DUK_ASSERT(nregs >= 0);
-#if 0  /* topmost activation retval_byteoff is considered garbage, no need to init */
-		act->retval_byteoff = 0;
-#endif
-		act->reserve_byteoff = 0;  /* filled in below */
-		DUK_TVAL_SET_OBJECT(&act->tv_func, func);  /* borrowed, no refcount */
-
-		DUK_HOBJECT_INCREF(thr, func);  /* act->func */
-
-#if defined(DUK_USE_NONSTD_FUNC_CALLER_PROPERTY)
-		duk__update_func_caller_prop(thr, func);
-#endif
-	}
-
-	/* [ ... func this arg1 ... argN ]  (not tail call)
-	 * [ this | arg1 ... argN ]         (tail call)
-	 *
-	 * idx_args updated to match
-	 */
-
-	/*
-	 *  Environment record creation and 'arguments' object creation.
-	 *  Named function expression name binding is handled by the
-	 *  compiler; the compiled function's parent env will contain
-	 *  the (immutable) binding already.
-	 *
-	 *  Delayed creation (on demand) is handled in duk_js_var.c.
-	 */
-
-	/* XXX: unify handling with native call. */
-
-	DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));  /* bound function has already been resolved */
-
-	if (!DUK_HOBJECT_HAS_NEWENV(func)) {
-		/* use existing env (e.g. for non-strict eval); cannot have
-		 * an own 'arguments' object (but can refer to the existing one)
-		 */
-
-		duk__handle_oldenv_for_call(thr, func, act);
-		/* No need to re-lookup 'act' at present: no side effects. */
-
-		DUK_ASSERT(act->lex_env != NULL);
-		DUK_ASSERT(act->var_env != NULL);
-		goto env_done;
-	}
-
-	DUK_ASSERT(DUK_HOBJECT_HAS_NEWENV(func));
-
-	if (!DUK_HOBJECT_HAS_CREATEARGS(func)) {
-		/* no need to create environment record now; leave as NULL */
-		DUK_ASSERT(act->lex_env == NULL);
-		DUK_ASSERT(act->var_env == NULL);
-		goto env_done;
-	}
-
-	/* third arg: absolute offset (to entire valstack) of bottom of new activation */
-	env = duk_create_activation_environment_record(thr, func, act->bottom_byteoff);
-	DUK_ASSERT(env != NULL);
-
-	/* [ ... arg1 ... argN envobj ] */
-
-	/* original input stack before nargs/nregs handling must be
-	 * intact for 'arguments' object
-	 */
-	DUK_ASSERT(DUK_HOBJECT_HAS_CREATEARGS(func));
-	duk__handle_createargs_for_call(thr, func, env, num_stack_args);
-
-	/* [ ... arg1 ... argN envobj ] */
-
-	act->lex_env = env;
-	act->var_env = env;
-	DUK_HOBJECT_INCREF(thr, act->lex_env);
-	DUK_HOBJECT_INCREF(thr, act->var_env);
-	duk_pop(ctx);
-
- env_done:
-	/* [ ... arg1 ... argN ] */
-
-	/*
-	 *  Setup value stack: clamp to 'nargs', fill up to 'nregs'
-	 */
-
-	duk_valstack_grow_check_throw(ctx, vs_min_bytes);
-	act->reserve_byteoff = (duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack);
-	DUK_ASSERT(nargs >= 0);
-	DUK_ASSERT(nregs >= 0);
-	DUK_ASSERT(nregs >= nargs);
-
-	duk_set_top_and_wipe(ctx, idx_args + nregs, idx_args + nargs);
-
-	/*
-	 *  Shift to new valstack_bottom.
-	 */
-
-	thr->valstack_bottom = thr->valstack_bottom + idx_args;
-	/* keep current valstack_top */
-	DUK_ASSERT(thr->valstack_bottom >= thr->valstack);
-	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
-	DUK_ASSERT(thr->valstack_end >= thr->valstack_top);
-
-	/*
-	 *  Return to bytecode executor, which will resume execution from
-	 *  the topmost activation.
-	 */
-
+	/* Pending side effects. */
 	DUK_REFZERO_CHECK_FAST(thr);
-	return 1;
+
+	return retval;
 }

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -3409,7 +3409,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 
 		DUK_DDD(DUK_DDDPRINT("begin parsing new expression"));
 
-		reg_target = DUK__ALLOCTEMP(comp_ctx);
+		reg_target = DUK__ALLOCTEMPS(comp_ctx, 2);
 
 #if defined(DUK_USE_ES6)
 		if (comp_ctx->curr_token.t == DUK_TOK_PERIOD) {
@@ -3433,7 +3433,8 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 #endif  /* DUK_USE_ES6 */
 
 		duk__expr_toforcedreg(comp_ctx, res, DUK__BP_CALL /*rbp_flags*/, reg_target /*forced_reg*/);
-		DUK__SETTEMP(comp_ctx, reg_target + 1);
+		duk__emit_bc(comp_ctx, DUK_OP_NEWOBJ, reg_target + 1);  /* default instance */
+		DUK__SETTEMP(comp_ctx, reg_target + 2);
 
 		if (comp_ctx->curr_token.t == DUK_TOK_LPAREN) {
 			/* 'new' MemberExpression Arguments */
@@ -3451,7 +3452,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 		 * is not allowed.
 		 */
 		duk__emit_a_bc(comp_ctx,
-		              DUK_OP_NEW | DUK__EMIT_FLAG_NO_SHUFFLE_A,
+		              DUK_OP_CONSCALL | DUK__EMIT_FLAG_NO_SHUFFLE_A,
 		              nargs /*num_args*/,
 		              reg_target /*target*/);
 

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -66,6 +66,7 @@
 #define DUK_STR_DECODE_FAILED                    "decode failed"
 #define DUK_STR_NO_SOURCECODE                    "no sourcecode"
 #define DUK_STR_RESULT_TOO_LONG                  "result too long"
+#define DUK_STR_INVALID_CFUNC_RC                 "invalid C function rc"
 
 /* JSON */
 #define DUK_STR_FMT_PTR                          "%p"
@@ -125,7 +126,7 @@
 #define DUK_STR_INVALID_GETSET_NAME              "invalid getter/setter name"
 #define DUK_STR_FUNC_NAME_REQUIRED               "function name required"
 
-/* Regexp */
+/* RegExp */
 #define DUK_STR_INVALID_QUANTIFIER               "invalid regexp quantifier"
 #define DUK_STR_INVALID_QUANTIFIER_NO_ATOM       "quantifier without preceding atom"
 #define DUK_STR_INVALID_QUANTIFIER_VALUES        "quantifier values invalid (qmin > qmax)"

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -145,6 +145,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_is_buffer_data(ctx, 0);
 	(void) duk_is_callable(ctx, 0);
 	(void) duk_is_c_function(ctx, 0);
+	(void) duk_is_constructable(ctx, 0);
 	(void) duk_is_constructor_call(ctx);
 	(void) duk_is_dynamic_buffer(ctx, 0);
 	(void) duk_is_ecmascript_function(ctx, 0);

--- a/tests/api/test-is-calls.c
+++ b/tests/api/test-is-calls.c
@@ -1,27 +1,28 @@
 /*===
 *** test_1 (duk_safe_call)
-00: valididx=1 und=1 null=0 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
-01: valididx=1 und=0 null=1 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
-02: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-03: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-04: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-05: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-06: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=1 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-07: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-08: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-09: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-10: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-11: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-12: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=1 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-13: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-14: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=1 bfun=0 call=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-15: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=1 call=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-16: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=1 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-17: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=1 dyn=0 fix=1 ext=0 ptr=0 prim=0 objcoerc=1
-18: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=1 dyn=1 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-19: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=1 dyn=0 fix=0 ext=1 ptr=0 prim=0 objcoerc=1
-20: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=1 prim=1 objcoerc=1
-21: valididx=0 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=0
+00: valididx=1 und=1 null=0 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
+01: valididx=1 und=0 null=1 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
+02: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+03: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+04: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+05: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+06: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=1 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+07: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+08: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+09: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+10: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+11: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+12: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=1 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+13: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+14: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=1 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+15: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=1 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+16: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+17: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=1 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+18: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=1 ext=0 ptr=0 prim=0 objcoerc=1
+19: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=1 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+20: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=0 ext=1 ptr=0 prim=0 objcoerc=1
+21: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=1 prim=1 objcoerc=1
+22: valididx=0 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=0
 ==> rc=0, result='undefined'
 ===*/
 
@@ -83,26 +84,27 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	duk_push_c_function(ctx, my_c_func, DUK_VARARGS);
 
 	/* 14 */
-	duk_push_string(ctx, "(function() { print('hello'); })");
-	duk_eval(ctx);
+	duk_eval_string(ctx, "(function() { print('hello'); })");
 
 	/* 15 */
-	duk_push_string(ctx, "escape.bind(null, 'foo')");
-	duk_eval(ctx);
+	duk_eval_string(ctx, "escape.bind(null, 'foo')");
 
 	/* 16 */
-	duk_push_thread(ctx);
+	duk_eval_string(ctx, "Math.cos");  /* callable, not constructable */
 
 	/* 17 */
-	duk_push_buffer(ctx, 1024, 0 /*dynamic*/);
+	duk_push_thread(ctx);
 
 	/* 18 */
-	duk_push_buffer(ctx, 1024, 1 /*dynamic*/);
+	duk_push_buffer(ctx, 1024, 0 /*dynamic*/);
 
 	/* 19 */
-	duk_push_external_buffer(ctx);
+	duk_push_buffer(ctx, 1024, 1 /*dynamic*/);
 
 	/* 20 */
+	duk_push_external_buffer(ctx);
+
+	/* 21 */
 	duk_push_pointer(ctx, (void *) 0xf00);
 
 	/*
@@ -130,6 +132,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 		printf(" efun=%d", (int) duk_is_ecmascript_function(ctx, i));
 		printf(" bfun=%d", (int) duk_is_bound_function(ctx, i));
 		printf(" call=%d", (int) duk_is_callable(ctx, i));
+		printf(" construct=%d", (int) duk_is_constructable(ctx, i));
 		printf(" thr=%d", (int) duk_is_thread(ctx, i));
 		printf(" buf=%d", (int) duk_is_buffer(ctx, i));
 		printf(" dyn=%d", (int) duk_is_dynamic_buffer(ctx, i));

--- a/tests/api/test-pcall-method-nargs.c
+++ b/tests/api/test-pcall-method-nargs.c
@@ -1,0 +1,106 @@
+/*
+ *  duk_pcall_method() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus3 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return 0;
+}
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, 3 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus3(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -3 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+	TEST_SAFE_CALL(test_nargs_negative_minus3);
+}

--- a/tests/api/test-pcall-nargs.c
+++ b/tests/api/test-pcall-nargs.c
@@ -1,0 +1,80 @@
+/*
+ *  duk_pcall() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return 0;
+}
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, 3 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+}

--- a/tests/api/test-pcall-prop-nargs.c
+++ b/tests/api/test-pcall-prop-nargs.c
@@ -1,0 +1,81 @@
+/*
+ *  duk_pcall_prop() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	/* NOTE: nargs == 3 isn't technically too large because the object
+	 * will be used as the key too.
+	 */
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, 4 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+}

--- a/tests/api/test-safe-call-invalid-nargs.c
+++ b/tests/api/test-safe-call-invalid-nargs.c
@@ -6,7 +6,7 @@
 *** test_nargs_too_large (duk_safe_call)
 top before: 3
 ==> rc=1, result='TypeError: invalid args'
-*** test_nargs_negative (duk_safe_call)
+*** test_nargs_minus1 (duk_safe_call)
 top before: 3
 ==> rc=1, result='TypeError: invalid args'
 ===*/
@@ -32,7 +32,7 @@ static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
 	return 0;
 }
 
-static duk_ret_t test_nargs_negative(duk_context *ctx, void *udata) {
+static duk_ret_t test_nargs_minus1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
 
 	duk_push_null(ctx);
@@ -49,5 +49,5 @@ static duk_ret_t test_nargs_negative(duk_context *ctx, void *udata) {
 
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_nargs_too_large);
-	TEST_SAFE_CALL(test_nargs_negative);
+	TEST_SAFE_CALL(test_nargs_minus1);
 }

--- a/tests/api/test-safe-call-invalid-nrets.c
+++ b/tests/api/test-safe-call-invalid-nrets.c
@@ -5,15 +5,13 @@
 /*===
 *** test_nrets_too_large (duk_safe_call)
 top before: 3
-duk_safe_call rc: 0
-final top: 1025
-==> rc=0, result='undefined'
+==> rc=1, result='TypeError: invalid args'
 *** test_nrets_too_large_fixed (duk_safe_call)
 top before: 3
 duk_safe_call rc: 0
 final top: 1025
 ==> rc=0, result='undefined'
-*** test_nrets_negative (duk_safe_call)
+*** test_nrets_minus1 (duk_safe_call)
 top before: 3
 ==> rc=1, result='TypeError: invalid args'
 ===*/
@@ -63,7 +61,7 @@ static duk_ret_t test_nrets_too_large_fixed(duk_context *ctx, void *udata) {
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
-static duk_ret_t test_nrets_negative(duk_context *ctx, void *udata) {
+static duk_ret_t test_nrets_minus1(duk_context *ctx, void *udata) {
 	duk_int_t rc;
 
 	duk_push_null(ctx);
@@ -81,5 +79,5 @@ static duk_ret_t test_nrets_negative(duk_context *ctx, void *udata) {
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_nrets_too_large);
 	TEST_SAFE_CALL(test_nrets_too_large_fixed);
-	TEST_SAFE_CALL(test_nrets_negative);
+	TEST_SAFE_CALL(test_nrets_minus1);
 }

--- a/tests/api/test-safe-call-reserve.c
+++ b/tests/api/test-safe-call-reserve.c
@@ -1,0 +1,91 @@
+/*
+ *  duk_safe_call() reserve handling
+ */
+
+/*===
+*** test_1 (duk_pcall)
+top before: 8
+top in dummy_func: 8
+duk_safe_call() rc: 0
+final top: 4101
+==> rc=0, result='undefined'
+*** test_2 (duk_pcall)
+top before: 8
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy_func(duk_context *ctx, void *udata) {
+	(void) udata;
+	printf("top in dummy_func: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_1(duk_context *ctx) {
+	duk_int_t rc;
+
+	/* Some ignored values. */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+	duk_push_string(ctx, "quux");
+
+	duk_require_stack(ctx, 4096 - 3);  /* 4096 nrets values */
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_safe_call(ctx, dummy_func, NULL, 3 /*nargs*/, 4096 /*nrets*/);
+	printf("duk_safe_call() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_2(duk_context *ctx) {
+	duk_int_t rc;
+
+	/* Some ignored values. */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+	duk_push_string(ctx, "quux");
+
+	duk_require_stack(ctx, 4096 - 3);  /* 4096 nrets values */
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	/* This safe call tries to use 'nrets' too large for the current
+	 * value stack reserve.  The reserve check is not exact and doesn't
+	 * differentiate internal and user reserve (managing the user reserve
+	 * is always the responsibility of calling code).
+	 *
+	 * The call fails with a throw (at least currently) rather than an
+	 * error return value and a value at stack top; it may not always be
+	 * possible to push an error object if there's no reserve at all.
+	 *
+	 * Internal reserve in Duktape 2.2: 32 entries, public reserve on
+	 * Duktape/C function entry (and empty call stack) is 64 entries.
+	 */
+	rc = duk_safe_call(ctx, dummy_func, NULL, 3 /*nargs*/, 4096 + 32 + 8 /*nrets*/);
+	printf("duk_safe_call() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	/* Use duk_pcall() so that value stack reserve is not extended
+	 * for the top level activation.
+	 */
+	TEST_PCALL(test_1);
+	TEST_PCALL(test_2);
+}

--- a/tests/api/test-safe-call-retbase-padding.c
+++ b/tests/api/test-safe-call-retbase-padding.c
@@ -1,0 +1,95 @@
+/*
+ *  If duk_safe_call() target pops too many value stcak elements,
+ *  'undefined' values are inserted at the index where return
+ *  values begin to restore the stack shape.
+ *
+ *  Example, duk_safe_call() with nargs=4, nrets=5:
+ *
+ *    [ a b c d e f g X Y Z W ]
+ *                    <----->   args
+ *                    ^
+ *                    `---- retbase=7 (index from bottom)
+ *
+ *  Caller pops too much:
+ *
+ *    [ a b ]
+ *
+ *  then pushes two return values L and M:
+ *
+ *    [ a b L M ]
+ *
+ *  and returns rc=2 to indicate two actual return values are present.
+ *
+ *  This is resolved by injecting 'undefined' values to lift the intended
+ *  return values to 'retbase' index (U=undefined):
+ *
+ *    [ a b U U U U U L M ]
+ *
+ *  Finally, because 5 values were expected, further 'undefined' values are
+ *  pushed to fulfill the API contract:
+ *
+ *    [ a b U U U U U L M U U U ]
+ *                    <------->
+ *                    ^
+ *                    `---- retbase=7
+ */
+
+/*===
+a b c d e f g X Y Z W
+top before: 11
+a b L M
+duk_safe_call() rc: 0
+a b undefined undefined undefined undefined undefined L M undefined undefined undefined
+final top: 12
+===*/
+
+static void dump_value_stack(duk_context *ctx) {
+	duk_idx_t i;
+
+	for (i = 0; i < duk_get_top(ctx); i++) {
+		if (i > 0) {
+			printf(" ");
+		}
+		duk_dup(ctx, i);
+		printf("%s", duk_to_string(ctx, -1));
+		duk_pop(ctx);
+	}
+	printf("\n");
+}
+
+static duk_ret_t my_func(duk_context *ctx, void *udata) {
+	(void) udata;
+	duk_set_top(ctx, 2);
+	duk_push_string(ctx, "L");
+	duk_push_string(ctx, "M");
+	dump_value_stack(ctx);
+	return 2;
+}
+
+void test(duk_context *ctx) {
+	duk_int_t rc;
+
+	duk_push_string(ctx, "a");
+	duk_push_string(ctx, "b");
+	duk_push_string(ctx, "c");
+	duk_push_string(ctx, "d");
+	duk_push_string(ctx, "e");
+	duk_push_string(ctx, "f");
+	duk_push_string(ctx, "g");
+
+	duk_push_string(ctx, "X");
+	duk_push_string(ctx, "Y");
+	duk_push_string(ctx, "Z");
+	duk_push_string(ctx, "W");
+
+	dump_value_stack(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_safe_call(ctx, my_func, NULL, 4, 5);
+	printf("duk_safe_call() rc: %ld\n", (long) rc);
+
+	dump_value_stack(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+}

--- a/tests/api/test-suspend-resume-pthread.c
+++ b/tests/api/test-suspend-resume-pthread.c
@@ -108,6 +108,7 @@ void test(duk_context *ctx) {
 
 	printf("spawn threads\n"); fflush(stdout);
 	my_lock();
+	duk_require_stack(ctx, NUM_THREADS);
 	for (i = 0; i < NUM_THREADS; i++) {
 		/* Each thread gets a Duktape thread which is passed as the
 		 * thread 'arg'.  We keep the mutex while we're creating

--- a/tests/ecmascript/test-dev-eval-bound.js
+++ b/tests/ecmascript/test-dev-eval-bound.js
@@ -1,0 +1,42 @@
+/*
+ *  A bound eval call is an indirect eval, even if called via 'eval'
+ *  and the final function being the built-in native eval function.
+ */
+
+/*===
+6
+local foo
+global foo
+global foo
+===*/
+
+var FOO = 'global foo';
+
+var origEval = eval;
+
+function test() {
+    var eval;
+    var FOO = 'local foo';
+
+    // Basic test.
+    eval = origEval.bind(null, 'print(1+2+3)');
+    eval('print(1000)');
+
+    // Direct eval sees our closure.
+    eval = origEval;
+    eval('print(FOO)');
+
+    // Indirect eval does not.
+    eval = origEval;
+    (1, eval)('print(FOO)');
+
+    // Bound eval also doesn't see our closure.
+    eval = origEval.bind(null, 'print(FOO)');
+    eval('print(1000)');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-eval-shadowed-ecmatoecma.js
+++ b/tests/ecmascript/test-dev-eval-shadowed-ecmatoecma.js
@@ -1,0 +1,29 @@
+/*
+ *  'eval()' call with eval mapping to something else than the built-in
+ *  native eval() function allows Ecma-to-Ecma calls without native
+ *  recursion.
+ */
+
+/*===
+count: 3000
+===*/
+
+var origEval = eval;
+var count = 0;
+
+var eval = function (x) {
+    count++;
+    if (x <= 1) { return; }
+    test(x - 1);
+}
+
+function test(x) {
+    eval(x);
+}
+
+try {
+    test(3e3);
+    print('count:', count);
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-tailcall-arguments-object.js
+++ b/tests/ecmascript/test-dev-tailcall-arguments-object.js
@@ -1,0 +1,40 @@
+/*
+ *  Arguments object for tailcalls.
+ */
+
+/*===
+object
+3
+foo
+bar
+quux
+undefined
+undefined
+undefined
+===*/
+
+function foo() {
+    var args = arguments;
+    print(typeof arguments);
+    print(arguments.length);
+    print(arguments[0]);
+    print(arguments[1]);
+    print(arguments[2]);
+    print(arguments[3]);
+    print(arguments[4]);
+    print(arguments[5]);
+}
+
+function bar(a,b,c,d) {
+    return foo(a,b,c);
+}
+
+function test() {
+    bar('foo', 'bar', 'quux', 'baz', 'quuux', 'baz');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-add-int.js
+++ b/tests/perf/test-add-int.js
@@ -1,0 +1,27 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+    var x = 123;
+    var t;
+
+    for (i = 0; i < 1e7; i++) {
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+        t = x + 3;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-call-native.js
+++ b/tests/perf/test-call-native.js
@@ -25,7 +25,7 @@ function test() {
     }
 
     var t2 = Date.now();
-    print((1e4 * 10 / (t2 - t1)) + ' calls per millisecond');
+    print((1e4 * 10 * arr.length / (t2 - t1)) + ' calls per millisecond');
 }
 
 try {

--- a/tests/perf/test-call-tail-1.js
+++ b/tests/perf/test-call-tail-1.js
@@ -1,0 +1,27 @@
+/*
+ *  Basic tail call performance.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+
+    function f(x) { if (x <= 1) { return; } else { return f(x - 1); } }
+
+    var t1 = Date.now();
+
+    for (i = 0; i < 1e5; i++) {
+        f(100);
+    }
+
+    var t2 = Date.now();
+    print((1e5 * 100 / (t2 - t1)) + ' calls per millisecond');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-call-tail-2.js
+++ b/tests/perf/test-call-tail-2.js
@@ -1,0 +1,29 @@
+/*
+ *  Basic tail call performance.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+
+    function f(x, A, B, C, D, E, F, G, H, I, J) {
+        if (x <= 1) { return; } else { return f(x - 1); }
+    }
+
+    var t1 = Date.now();
+
+    for (i = 0; i < 1e5; i++) {
+        f(100);
+    }
+
+    var t2 = Date.now();
+    print((1e5 * 100 / (t2 - t1)) + ' calls per millisecond');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-empty-loop-step3.js
+++ b/tests/perf/test-empty-loop-step3.js
@@ -1,0 +1,15 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+
+    for (i = 0; i < 3e8; i += 3) {
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-fib-2.js
+++ b/tests/perf/test-fib-2.js
@@ -1,0 +1,19 @@
+/*
+ *  Fibonacci test, exercises call handling and recursion
+ *
+ *  Artificial variant where slow path function name lookup is avoided
+ *  to better measure the actual call handling part of the overhead.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function fib(f, n) {
+    return n <= 1 ? n : f(f, n - 2) + f(f, n - 1);
+}
+
+try {
+    print(fib(fib, 35));
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
Rework call handling to reduce footprint and duplication:
- Remove internal duk_handle_call_protected() and implement protected calls using duk_safe_call() wrapping.
- Remove separate Ecma-to-Ecma call setup helper and add Ecma-to-Ecma call support to duk_handle_call_unprotected().

Several smaller changes:
- Rework call handling to use small helper functions for better readability.
- Rework DUK_OP_NEW so that default instance is created by bytecode and DUK_OP_CONSCALL (replaces DUK_OP_NEW) is just an ordinary call with a constructor flag set.
- Remove special handling for initial resume call.
- Support Ecma-to-Ecma calls for `eval(xxx)` calls when the target function is not actually eval but a shadowing Ecmascript function (this worked before 2.0 release also).
- Use internal duk_remove_n() primitive to improve tailcall handling value stack manipulation.
- Remove value stack reserve adjustments from duk_safe_call(): caller must ensure them and safe calls shouldn't adjust the reserve.
- Reduce internal valstack extra from 64 to 32 (could maybe be reduced to 16 or 24); entry to Duktape/C function now automatically reserved 64 + 16 elements (64 is the user reserve guaranteed on entry).

Tasks:
- [x] Finalize changes
- [x] Testcase coverage
- [x] Manual full assertion run
- [x] Documentation
- [x] Releases entry
- [x] 2.2 migration notes: internal reserve change, duk_safe_call() reservation behavior