### PR TITLE
Protected call stack shape

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2889,6 +2889,10 @@ Planned
 
 * Add a wrap check to duk_{check,require}_stack{_top}() (GH-1537)
 
+* Fix duk_pcall_prop(), duk_safe_call(), and duk_pnew() argument validation,
+  in some cases a negative nargs/nrets argument (which is always invalid)
+  could be accepted (GH-1553)
+
 * Fix potential segfault in debugger GetHeapObjInfo command, caused by
   key/mask list being out of sync (GH-1540)
 

--- a/tests/api/test-pcall-invalid-nargs.c
+++ b/tests/api/test-pcall-invalid-nargs.c
@@ -1,0 +1,80 @@
+/*
+ *  duk_pcall() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return 0;
+}
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, 3 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall(ctx, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+}

--- a/tests/api/test-pcall-method-invalid-nargs.c
+++ b/tests/api/test-pcall-method-invalid-nargs.c
@@ -1,0 +1,106 @@
+/*
+ *  duk_pcall_method() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus3 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx) {
+	DUK_UNREF(ctx);
+	return 0;
+}
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, 3 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus3(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_c_function(ctx, dummy, 0);
+	duk_push_string(ctx, "mythis");
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_method(ctx, -3 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+	TEST_SAFE_CALL(test_nargs_negative_minus3);
+}

--- a/tests/api/test-pcall-prop-invalid-nargs.c
+++ b/tests/api/test-pcall-prop-invalid-nargs.c
@@ -1,0 +1,81 @@
+/*
+ *  duk_pcall_prop() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus2 (duk_safe_call)
+top before: 4
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	/* NOTE: nargs == 3 isn't technically too large because the object
+	 * will be used as the key too.
+	 */
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, 4 /*nargs, too large*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, -1 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative_minus2(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "({ prop: function () { print('propcall'); } })");
+	duk_push_string(ctx, "prop");  /* key + 2 args */
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4 /*obj idx*/, -2 /*nargs, negative*/);
+	printf("duk_pcall rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+	TEST_SAFE_CALL(test_nargs_negative_minus2);
+}

--- a/tests/api/test-pcall-prop-obj-is-key.c
+++ b/tests/api/test-pcall-prop-obj-is-key.c
@@ -1,0 +1,93 @@
+/*
+ *  duk_pcall_prop() allows a situation where the nargs count is such that
+ *  the target object is identified as the key or even part of the argument
+ *  list.
+ *
+ *  This behavior is not very useful but test for the current behavior.
+ */
+
+/*===
+*** test_obj_is_key (duk_safe_call)
+top before: 4
+toString() called
+myProp called
+foo bar
+duk_pcall_prop() rc: 0
+final top: 1
+==> rc=0, result='undefined'
+*** test_obj_is_arg (duk_safe_call)
+top before: 5
+myProp called
+toString() called
+myProp foo
+duk_pcall_prop() rc: 0
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_obj_is_key(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_eval_string(ctx,
+		"({\n"
+		"    toString: function () { print('toString() called'); return 'myProp' },\n"
+		"    myProp: function (a, b) { print('myProp called'); print(a, b); }\n"
+		"})\n");
+
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+	duk_push_string(ctx, "quux");
+
+	/* [ obj 'foo' 'bar' 'quux' ]
+	 *
+	 *  <key> <--- args ------>
+	 *
+	 *   ^
+	 *   `-- obj_idx
+	 */
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4, 3 /*nargs */);
+	printf("duk_pcall_prop() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_obj_is_arg(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_string(ctx, "myProp");
+
+	duk_eval_string(ctx,
+		"({\n"
+		"    toString: function () { print('toString() called'); return 'myProp' },\n"
+		"    myProp: function (a, b) { print('myProp called'); print(a, b); }\n"
+		"})\n");
+
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+	duk_push_string(ctx, "quux");
+
+	/* [ 'myProp' obj 'foo' 'bar' 'quux' ]
+	 *
+	 *    <key>   <------- args ------>
+	 *
+	 *             ^
+	 *             `-- obj_idx
+	 */
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcall_prop(ctx, -4, 4 /*nargs */);
+	printf("duk_pcall_prop() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_obj_is_key);
+	TEST_SAFE_CALL(test_obj_is_arg);
+}

--- a/tests/api/test-pcompile-invalid-stack.c
+++ b/tests/api/test-pcompile-invalid-stack.c
@@ -1,0 +1,46 @@
+/*
+ *  duk_pcompile() invalid input stack
+ */
+
+/*===
+*** test_top_0 (duk_safe_call)
+top before: 0
+==> rc=1, result='TypeError: invalid args'
+*** test_top_1 (duk_safe_call)
+top before: 1
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+duk_ret_t test_top_0(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcompile(ctx, 0);
+	printf("duk_pcompile() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+duk_ret_t test_top_1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_string(ctx, "dummy");
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pcompile(ctx, 0);
+	printf("duk_pcompile() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_top_0);
+	TEST_SAFE_CALL(test_top_1);
+}

--- a/tests/api/test-peval-invalid-stack.c
+++ b/tests/api/test-peval-invalid-stack.c
@@ -1,0 +1,27 @@
+/*
+ *  duk_peval() invalid input stack
+ */
+
+/*===
+*** test_top_0 (duk_safe_call)
+top before: 0
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+duk_ret_t test_top_0(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_peval(ctx);
+	printf("duk_peval() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_top_0);
+}

--- a/tests/api/test-pnew-invalid-nargs.c
+++ b/tests/api/test-pnew-invalid-nargs.c
@@ -1,0 +1,52 @@
+/*
+ *  duk_pnew() invalid input stack
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 2
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative_minus1 (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pnew(ctx, 2);  /* not enough value stack args */
+	printf("duk_pnew() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+duk_ret_t test_nargs_negative_minus1(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	(void) udata;
+
+	duk_eval_string(ctx, "(function () {})");
+	duk_push_string(ctx, "foo");
+	duk_push_string(ctx, "bar");
+
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_pnew(ctx, -1);  /* negative nargs */
+	printf("duk_pnew() rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative_minus1);
+}

--- a/tests/api/test-safe-call-invalid-nargs.c
+++ b/tests/api/test-safe-call-invalid-nargs.c
@@ -1,0 +1,53 @@
+/*
+ *  duk_safe_call() with invalid nargs
+ */
+
+/*===
+*** test_nargs_too_large (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+*** test_nargs_negative (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx, void *udata) {
+	(void) ctx;
+	(void) udata;
+	return 0;
+}
+
+static duk_ret_t test_nargs_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_safe_call(ctx, dummy, NULL, 4 /*nargs, too large*/, 0 /*nrets*/);
+	printf("duk_safe_call rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nargs_negative(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_safe_call(ctx, dummy, NULL, -1 /*nargs, negative*/, 0 /*nrets*/);
+	printf("duk_safe_call rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nargs_too_large);
+	TEST_SAFE_CALL(test_nargs_negative);
+}

--- a/tests/api/test-safe-call-invalid-nrets.c
+++ b/tests/api/test-safe-call-invalid-nrets.c
@@ -1,0 +1,85 @@
+/*
+ *  duk_safe_call() with invalid nrets
+ */
+
+/*===
+*** test_nrets_too_large (duk_safe_call)
+top before: 3
+duk_safe_call rc: 0
+final top: 1025
+==> rc=0, result='undefined'
+*** test_nrets_too_large_fixed (duk_safe_call)
+top before: 3
+duk_safe_call rc: 0
+final top: 1025
+==> rc=0, result='undefined'
+*** test_nrets_negative (duk_safe_call)
+top before: 3
+==> rc=1, result='TypeError: invalid args'
+===*/
+
+static duk_ret_t dummy(duk_context *ctx, void *udata) {
+	(void) ctx;
+	(void) udata;
+	return 0;
+}
+
+static duk_ret_t test_nrets_too_large(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	/* Here 'nrets' is too large, beyond the current value stack
+	 * reserve.  (This succeeds in Duktape 2.1 and prior because
+	 * the implementation did a reserve check.)
+	 */
+	rc = duk_safe_call(ctx, dummy, NULL, 2 /*nargs*/, 1024 /*nrets, too large*/);
+	printf("duk_safe_call rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nrets_too_large_fixed(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	/* Here duk_check_stack() is used to extend the value stack
+	 * reserve to accommodate 'nrets'.  The required reserve is:
+	 *     current_top - nargs + nrets
+	 * which may be negative if nargs >= nrets.
+	 */
+	rc = duk_check_stack(ctx, duk_get_top(ctx) - 2 + 1024);
+	rc = duk_safe_call(ctx, dummy, NULL, 2 /*nargs*/, 1024 /*nrets, too large*/);
+	printf("duk_safe_call rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+static duk_ret_t test_nrets_negative(duk_context *ctx, void *udata) {
+	duk_int_t rc;
+
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	duk_push_null(ctx);
+	printf("top before: %ld\n", (long) duk_get_top(ctx));
+
+	rc = duk_safe_call(ctx, dummy, NULL, 2 /*nargs*/, -1 /*nrets, negative*/);
+	printf("duk_safe_call rc: %ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_nrets_too_large);
+	TEST_SAFE_CALL(test_nrets_too_large_fixed);
+	TEST_SAFE_CALL(test_nrets_negative);
+}

--- a/website/api/duk_pcall.yaml
+++ b/website/api/duk_pcall.yaml
@@ -20,8 +20,7 @@ summary: |
       that one can check for success with a "zero or non-zero" check.)</li>
   <li><code>DUK_EXEC_ERROR</code>: call failed, <code>nargs</code> arguments are replaced with a
       single error value.  (In exceptional cases, e.g. when there are too few
-      arguments on the value stack, the call returns non-zero but may leave the stack
-      in an inconsistent state.)</li>
+      arguments on the value stack, the call may throw.)</li>
   </ul>
 
   <div class="note">

--- a/website/api/duk_pcompile.yaml
+++ b/website/api/duk_pcompile.yaml
@@ -13,6 +13,8 @@ summary: |
   value indicates success and the compiled function is left on the stack top.
   A non-zero return value indicates an error, and the error is left on the stack top.</p>
 
+  <p>If value stack top is too low (smaller than 2), an error is thrown.</p>
+
 example: |
   duk_push_string(ctx, "print('program'); syntax error here=");
   duk_push_string(ctx, "hello-with-syntax-error");

--- a/website/api/duk_peval.yaml
+++ b/website/api/duk_peval.yaml
@@ -13,6 +13,8 @@ summary: |
   value indicates success and the eval result is left on the stack top.
   A non-zero return value indicates an error, and the error is left on the stack top.</p>
 
+  <p>If value stack top is too low (smaller than 1), an error is thrown.</p>
+
 example: |
   duk_push_string(ctx, "print('Hello world!'); syntax error here=");
   if (duk_peval(ctx) != 0) {

--- a/website/api/duk_pnew.yaml
+++ b/website/api/duk_pnew.yaml
@@ -13,6 +13,9 @@ summary: |
   the stack top.  A non-zero return value indicates an error, and the error
   is left on the stack top.</p>
 
+  <p>If value stack top is too low (smaller than nargs + 1), or <code>nargs</code>
+  is negative, an error is thrown.</p>
+
 example: |
   duk_ret_t rc;
 

--- a/website/api/duk_safe_call.yaml
+++ b/website/api/duk_safe_call.yaml
@@ -11,7 +11,11 @@ summary: |
   frame (the call is not visible on the call stack).  <code>nargs</code>
   topmost values in the current value stack frame are identified as call
   arguments, and <code>nrets</code> return values are provided after the call
-  returns.  The <code>udata</code> (userdata) pointer is passed on to
+  returns.  Calling code must ensure value stack has reserve for <code>nrets</code>
+  using e.g. <code><a href="duk_check_stack()">duk_check_stack</a></code>, and
+  handling reservation errors.</p>
+
+  <p>The <code>udata</code> (userdata) pointer is passed on to
   <code>func</code> as is, and makes it easy to pass one or more C values to
   the target function without using the value stack.  Multiple values can be
   passed by packing them into a stack-allocated C struct and passing a pointer
@@ -27,7 +31,7 @@ summary: |
   <li><code>DUK_EXEC_ERROR</code>: call failed, <code>nargs</code> arguments are replaced with
       <code>nrets</code> values, first of which is an error value and the rest are <code>undefined</code>.
       (In exceptional cases, e.g. when there are too few arguments on the value stack, the call
-      returns non-zero but may leave the stack in an inconsistent state.)</li>
+      may throw.)</li>
   </ul>
 
   <div class="note">


### PR DESCRIPTION
Fix duk_pcall_prop() and duk_safe_call() argument validation, in some cases a negative nargs/nrets argument (which is always invalid) could be accepted. This only affects cases where calling code provides invalid arguments that would normally be rejected.

Also fix API documentation for protected call behavior when the value stack shape doesn't match the arguments given. The current behavior is to throw an error e.g. if duk_safe_call() nargs is too large for the current value stack; this was chosen because in such cases it's not always possible to conform to the API contract for return values so throwing, even for protected calls, is more consistent. API documentation describes an early alternative where an error code is returned with the value stack left in an undefined state.