### PR TITLE
Fix tailcall in constructor handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2855,13 +2855,13 @@ Planned
 * Handle Function.prototype.call(), Function.prototype.apply(),
   Reflect.apply(), and Reflect.construct() inline in call handling; as a side
   effect .call(), .apply(), and .construct() no longer appear in the call stack
-  (tracebacks etc) (GH-1421, GH-1522, GH-1545)
+  (tracebacks etc) (GH-1421, GH-1522, GH-1545, GH-1557)
 
 * Function.prototype.call(), Function.prototype.apply(), Reflect.apply(),
   and Reflect.construct() can now be used in tailcalls (e.g.
   'return func.call(null, 123);'), don't grow the native C stack when doing an
   Ecmascript-to-Ecmascript call, and no longer prevent coroutine yielding
-  (GH-1421, GH-1545)
+  (GH-1421, GH-1545, GH-1557)
 
 * Constructor calls (new Func()) can be used in tailcalls, don't grow
   the native C stack when doing an Ecmascript-to-Ecmascript call, and no

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -2873,10 +2873,19 @@ DUK_INTERNAL duk_bool_t duk_handle_ecma_call_setup(duk_hthread *thr,
 		DUK_ASSERT(act != NULL);
 		if (act->flags & DUK_ACT_FLAG_PREVENT_YIELD) {
 			/* See: test-bug-tailcall-preventyield-assert.c. */
-			DUK_DDD(DUK_DDDPRINT("tail call prevented by current activation having DUK_ACT_FLAG_PREVENTYIELD"));
+			DUK_DDD(DUK_DDDPRINT("tail call prevented by current activation preventing a yield"));
+			use_tailcall = 0;
+		} else if (((act->flags & DUK_ACT_FLAG_CONSTRUCT) && !(call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL)) ||
+		           (!(act->flags & DUK_ACT_FLAG_CONSTRUCT) && (call_flags & DUK_CALL_FLAG_CONSTRUCTOR_CALL))) {
+			/* Cannot tailcall if mixing normal and constructor
+			 * calls.  Current function and potential tailcall
+			 * must have same return value handling (normal or
+			 * constructor special handling).
+			 */
+			DUK_DDD(DUK_DDDPRINT("tail call prevented by incompatible return value handling"));
 			use_tailcall = 0;
 		} else if (DUK_HOBJECT_HAS_NOTAIL(func)) {
-			DUK_D(DUK_DPRINT("tail call prevented by function having a notail flag"));
+			DUK_DDD(DUK_DDDPRINT("tail call prevented by function having a notail flag"));
 			use_tailcall = 0;
 		}
 	}

--- a/tests/ecmascript/test-bi-reflect-construct-tail.js
+++ b/tests/ecmascript/test-bi-reflect-construct-tail.js
@@ -2,7 +2,10 @@
  *  In Duktape 2.2 Reflect.construct() is handled inline in call handling and
  *  doesn't involve a native call.  Ecmascript-to-Ecmascript Reflect.construct()
  *  calls are thus only limited by callstack limit (not recursion C limit).
- *  Reflect.construct() can be used in tailcall position.
+ *
+ *  Reflect.construct() can be used in tailcall position as long as the function
+ *  making the call is also a constructor function, so that both functions share
+ *  the same return value constructor postprocessing.
  */
 
 /*---

--- a/tests/ecmascript/test-bug-tailcall-in-constructor-gh1554.js
+++ b/tests/ecmascript/test-bug-tailcall-in-constructor-gh1554.js
@@ -1,0 +1,23 @@
+/*===
+object
+===*/
+
+function replacement() {
+    //console.trace();
+    return null;
+}
+
+function MyConstructor() {
+    return replacement();
+}
+
+function test() {
+    var O = new MyConstructor();
+    print(typeof O);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/ecmascript/test-dev-tailcall-constructor-normal-mixing.js
+++ b/tests/ecmascript/test-dev-tailcall-constructor-normal-mixing.js
@@ -1,0 +1,129 @@
+/*
+ *  Tailcall requires that current and target function share the same return
+ *  value handling; constructor calls have a special return value handling
+ *  compared to normal function calls.
+ */
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+normal -> normal
+- tailcall
+normal -> normal, using call
+- tailcall
+normal -> normal, using apply
+- tailcall
+normal -> normal, using Reflect.apply
+- tailcall
+constructor -> constructor, using new
+- not a tailcall
+constructor -> constructor, using Reflect.construct
+- tailcall
+normal -> constructor call, using new
+- not a tailcall
+normal -> constructor call, using Reflect.construct
+- not a tailcall
+constructor -> normal call
+- not a tailcall
+constructor -> normal call, using call
+- not a tailcall
+constructor -> normal call, using apply
+- not a tailcall
+constructor -> normal call, using Reflect.apply
+- not a tailcall
+===*/
+
+function getDepth() {
+    //console.trace();
+    for (var i = -1; Duktape.act(i); i--) {
+    }
+    return -i;
+}
+
+function test() {
+    var baseline;
+
+    function check() {
+        var d = getDepth() - 1;  // account for check() call
+        if (d === baseline) {
+            print('- not a tailcall');
+        } else if (d > baseline) {
+            print('- deeper than baseline');
+        } else {
+            print('- tailcall');
+        }
+    }
+
+    // Baseline: normal, non-tailcall call stack depth.
+    function baseline_a() { baseline = getDepth(); }
+    function baseline_b() { baseline_a(); }
+    baseline_b();
+
+    // Normal -> normal tail call.
+    print('normal -> normal');
+    function nn_a() { check(); }
+    function nn_b() { return nn_a(); }
+    nn_b();
+    print('normal -> normal, using call');
+    function nncall_a() { check(); }
+    function nncall_b() { return nncall_a.call(); }
+    nncall_b();
+    print('normal -> normal, using apply');
+    function nnapply_a() { check(); }
+    function nnapply_b() { return nnapply_a.apply(); }
+    nnapply_b();
+    print('normal -> normal, using Reflect.apply');
+    function nnrapply_a() { check(); }
+    function nnrapply_b() { return Reflect.apply(nnrapply_a, null, []); }
+    nnrapply_b();
+
+    // Constructor -> constructor tail call.  This works now with
+    // Reflect.construct() but with with 'new Xxx()' but this is
+    // easy to fix.
+    print('constructor -> constructor, using new');
+    function cc_a() { check(); }
+    function cc_b() { return new cc_a(); }
+    new cc_b();
+    print('constructor -> constructor, using Reflect.construct');
+    function cccons_a() { check(); }
+    function cccons_b() { return Reflect.construct(cccons_a, []); }
+    new cccons_b();
+
+    // Normal -> constructor call, not a tailcall.
+    print('normal -> constructor call, using new');
+    function nc_a() { check(); }
+    function nc_b() { return new nc_a(); }
+    nc_b();
+    print('normal -> constructor call, using Reflect.construct');
+    function nccons_a() { check(); }
+    function nccons_b() { return Reflect.construct(nccons_a, []); }
+    nccons_b();
+
+    // Constructor -> normal call, not a tailcall.
+    print('constructor -> normal call');
+    function cn_a() { check(); }
+    function cn_b() { return cn_a(); }
+    new cn_b();
+    print('constructor -> normal call, using call');
+    function cncall_a() { check(); }
+    function cncall_b() { return cncall_a.call(); }
+    new cncall_b();
+    print('constructor -> normal call, using apply');
+    function cnapply_a() { check(); }
+    function cnapply_b() { return cnapply_a.apply(); }
+    new cnapply_b();
+    print('constructor -> normal call, using Reflect.apply');
+    function cnrapply_a() { check(); }
+    function cnrapply_b() { return Reflect.apply(cnrapply_a, null, []); }
+    new cnrapply_b();
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Fix bug in constructor call handling where a tailcall inside a constructor would be handled with a tailcall, losing the necessary internal book-keeping to perform constructor call return value post-processsing.

This is described in #1554 and is only broken in master so no need to merge into 2.1.x maintenance etc.

Fixes #1554.