### PR TITLE
Add codepolicycheck for longlong consts, fix a few consts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -986,6 +986,7 @@ codepolicycheck:
 		--check-nonleading-tab \
 		--check-cpp-comment \
 		--check-ifdef-ifndef \
+		--check-longlong-constants \
 		--dump-vim-commands \
 		src-input/*.c src-input/*.h src-input/*.h.in tests/api/*.c
 	@$(PYTHON) util/check_code_policy.py \

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2927,6 +2927,9 @@ Planned
 
 * Fix MSVC cast warning in error augmentation code (GH-1511)
 
+* Improve support for old MSVC versions without __pragma(), long long, and
+  LL/ULL constants (GH-1559, GH-1562)
+
 * Simplify handling of ENDFIN opcode a bit (GH-1508)
 
 * Rework value stack grow/shrink handling; value stack is now grown when

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -125,6 +125,6 @@ DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_windows_no_dst(duk_do
 	FileTimeToSystemTime((const FILETIME *) &ft2, &st2);
 	duk__convert_systime_to_ularge((const SYSTEMTIME *) &st2, &tmp2);
 
-	return (duk_int_t) (((LONGLONG) tmp2.QuadPart - (LONGLONG) tmp1.QuadPart) / 10000000LL);  /* seconds */
+	return (duk_int_t) (((LONGLONG) tmp2.QuadPart - (LONGLONG) tmp1.QuadPart) / DUK_I64_CONSTANT(10000000));  /* seconds */
 }
 #endif  /* DUK_USE_DATE_TZO_WINDOWS_NO_DST */

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -1110,8 +1110,8 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	res->rnd_state[0] = (duk_uint64_t) DUK_USE_DATE_GET_NOW((duk_context *) res->heap_thread);
 	DUK_ASSERT(res->rnd_state[1] == 0);  /* Not filled here, filled in by seed preparation. */
 #if 0  /* Manual test values matching misc/xoroshiro128plus_test.c. */
-	res->rnd_state[0] = 0xdeadbeef12345678ULL;
-	res->rnd_state[1] = 0xcafed00d12345678ULL;
+	res->rnd_state[0] = DUK_U64_CONSTANT(0xdeadbeef12345678);
+	res->rnd_state[1] = DUK_U64_CONSTANT(0xcafed00d12345678);
 #endif
 	duk_util_tinyrandom_prepare_seed(res->heap_thread);
 	/* Mix in heap pointer: this ensures that if two Duktape heaps are

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -117,7 +117,7 @@ DUK_LOCAL duk_uint32_t duk__tval_fastint_to_arr_idx(duk_tval *tv) {
 	DUK_ASSERT(DUK_TVAL_IS_FASTINT(tv));
 
 	t = DUK_TVAL_GET_FASTINT(tv);
-	if ((t & ~0xffffffffULL) != 0) {
+	if ((t & ~DUK_U64_CONSTANT(0xffffffff)) != 0) {
 		/* Catches >0x100000000 and negative values. */
 		return DUK__NO_ARRAY_INDEX;
 	}
@@ -2901,7 +2901,7 @@ DUK_LOCAL duk_uint32_t duk__to_new_array_length_checked(duk_hthread *thr, duk_tv
 		/* Very common case. */
 		duk_int64_t fi;
 		fi = DUK_TVAL_GET_FASTINT(tv);
-		if (fi < 0 || fi > 0xffffffffLL) {
+		if (fi < 0 || fi > DUK_I64_CONSTANT(0xffffffff)) {
 			goto fail_range;
 		}
 		return (duk_uint32_t) fi;

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -129,7 +129,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv
 		v2 = DUK_TVAL_GET_FASTINT(tv_y);
 		v3 = v1 + v2;
 		v3_hi = (duk_int32_t) (v3 >> 32);
-		if (DUK_LIKELY(v3_hi >= -0x8000LL && v3_hi <= 0x7fffLL)) {
+		if (DUK_LIKELY(v3_hi >= DUK_I64_CONSTANT(-0x8000) && v3_hi <= DUK_I64_CONSTANT(0x7fff))) {
 			tv_z = thr->valstack_bottom + idx_z;
 			DUK_TVAL_SET_FASTINT_UPDREF(thr, tv_z, v3);  /* side effects */
 			return;
@@ -240,8 +240,8 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tv
 			 * 32-bit inputs.  Avoid zero inputs to avoid
 			 * negative zero issues (-1 * 0 = -0, for instance).
 			 */
-			if (v1 >= -0x80000000LL && v1 <= 0x7fffffffLL && v1 != 0 &&
-			    v2 >= -0x80000000LL && v2 <= 0x7fffffffLL && v2 != 0) {
+			if (v1 >= DUK_I64_CONSTANT(-0x80000000) && v1 <= DUK_I64_CONSTANT(0x7fffffff) && v1 != 0 &&
+			    v2 >= DUK_I64_CONSTANT(-0x80000000) && v2 <= DUK_I64_CONSTANT(0x7fffffff) && v2 != 0) {
 				v3 = v1 * v2;
 			} else {
 				goto skip_fastint;
@@ -284,7 +284,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tv
 		}
 
 		v3_hi = (duk_int32_t) (v3 >> 32);
-		if (DUK_LIKELY(v3_hi >= -0x8000LL && v3_hi <= 0x7fffLL)) {
+		if (DUK_LIKELY(v3_hi >= DUK_I64_CONSTANT(-0x8000) && v3_hi <= DUK_I64_CONSTANT(0x7fff))) {
 			tv_z = thr->valstack_bottom + idx_z;
 			DUK_TVAL_SET_FASTINT_UPDREF(thr, tv_z, v3);  /* side effects */
 			return;

--- a/src-input/duk_selftest.c
+++ b/src-input/duk_selftest.c
@@ -458,7 +458,7 @@ DUK_LOCAL duk_uint_t duk__selftest_64bit_arithmetic(void) {
 	/* Catch a double-to-int64 cast issue encountered in practice. */
 	d = 2147483648.0;
 	i = (duk_int64_t) d;
-	if (i != 0x80000000LL) {
+	if (i != DUK_I64_CONSTANT(0x80000000)) {
 		DUK__FAILED("casting 2147483648.0 to duk_int64_t failed");
 	}
 #else

--- a/src-input/duk_tval.c
+++ b/src-input/duk_tval.c
@@ -35,9 +35,9 @@ DUK_INTERNAL DUK_ALWAYS_INLINE void duk_tval_set_number_chkfast_fast(duk_tval *t
 	if (shift >= 0 && shift <= 46) {  /* exponents 1023 to 1069 */
 		duk_int64_t t;
 
-		if (((0x000fffffffffffffLL >> shift) & i) == 0) {
-			t = i | 0x0010000000000000LL;  /* implicit leading one */
-			t = t & 0x001fffffffffffffLL;
+		if (((DUK_I64_CONSTANT(0x000fffffffffffff) >> shift) & i) == 0) {
+			t = i | DUK_I64_CONSTANT(0x0010000000000000);  /* implicit leading one */
+			t = t & DUK_I64_CONSTANT(0x001fffffffffffff);
 			t = t >> (52 - shift);
 			if (i < 0) {
 				t = -t;
@@ -46,13 +46,13 @@ DUK_INTERNAL DUK_ALWAYS_INLINE void duk_tval_set_number_chkfast_fast(duk_tval *t
 			return;
 		}
 	} else if (shift == -1023) {  /* exponent 0 */
-		if (i >= 0 && (i & 0x000fffffffffffffLL) == 0) {
+		if (i >= 0 && (i & DUK_I64_CONSTANT(0x000fffffffffffff)) == 0) {
 			/* Note: reject negative zero. */
 			DUK_TVAL_SET_FASTINT(tv, (duk_int64_t) 0);
 			return;
 		}
 	} else if (shift == 47) {  /* exponent 1070 */
-		if (i < 0 && (i & 0x000fffffffffffffLL) == 0) {
+		if (i < 0 && (i & DUK_I64_CONSTANT(0x000fffffffffffff)) == 0) {
 			DUK_TVAL_SET_FASTINT(tv, (duk_int64_t) DUK_FASTINT_MIN);
 			return;
 		}
@@ -78,15 +78,15 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_double_t duk_tval_get_number_packed(duk_tval 
 	t = (duk_uint64_t) DUK_DBLUNION_GET_UINT64(tv);
 	if ((t >> 48) != DUK_TAG_FASTINT) {
 		return tv->d;
-	} else if (t & 0x0000800000000000ULL) {
+	} else if (t & DUK_U64_CONSTANT(0x0000800000000000)) {
 		t = (duk_uint64_t) (-((duk_int64_t) t));  /* avoid unary minus on unsigned */
-		t = t & 0x0000ffffffffffffULL;  /* negative */
-		t |= 0xc330000000000000ULL;
+		t = t & DUK_U64_CONSTANT(0x0000ffffffffffff);  /* negative */
+		t |= DUK_U64_CONSTANT(0xc330000000000000);
 		DUK_DBLUNION_SET_UINT64(&du, t);
 		return du.d + 4503599627370496.0;  /* 1 << 52 */
 	} else if (t != 0) {
-		t &= 0x0000ffffffffffffULL;  /* positive */
-		t |= 0x4330000000000000ULL;
+		t &= DUK_U64_CONSTANT(0x0000ffffffffffff);  /* positive */
+		t |= DUK_U64_CONSTANT(0x4330000000000000);
 		DUK_DBLUNION_SET_UINT64(&du, t);
 		return du.d - 4503599627370496.0;  /* 1 << 52 */
 	} else {
@@ -105,11 +105,11 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_double_t duk_tval_get_number_unpacked(duk_tva
 
 	if (tv->t == DUK_TAG_FASTINT) {
 		if (tv->v.fi >= 0) {
-			t = 0x4330000000000000ULL | (duk_uint64_t) tv->v.fi;
+			t = DUK_U64_CONSTANT(0x4330000000000000) | (duk_uint64_t) tv->v.fi;
 			DUK_DBLUNION_SET_UINT64(&du, t);
 			return du.d - 4503599627370496.0;  /* 1 << 52 */
 		} else {
-			t = 0xc330000000000000ULL | (duk_uint64_t) (-tv->v.fi);
+			t = DUK_U64_CONSTANT(0xc330000000000000) | (duk_uint64_t) (-tv->v.fi);
 			DUK_DBLUNION_SET_UINT64(&du, t);
 			return du.d + 4503599627370496.0;  /* 1 << 52 */
 		}
@@ -128,11 +128,11 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_double_t duk_tval_get_number_unpacked_fastint
 	DUK_ASSERT(tv->t == DUK_TAG_FASTINT);
 
 	if (tv->v.fi >= 0) {
-		t = 0x4330000000000000ULL | (duk_uint64_t) tv->v.fi;
+		t = DUK_U64_CONSTANT(0x4330000000000000) | (duk_uint64_t) tv->v.fi;
 		DUK_DBLUNION_SET_UINT64(&du, t);
 		return du.d - 4503599627370496.0;  /* 1 << 52 */
 	} else {
-		t = 0xc330000000000000ULL | (duk_uint64_t) (-tv->v.fi);
+		t = DUK_U64_CONSTANT(0xc330000000000000) | (duk_uint64_t) (-tv->v.fi);
 		DUK_DBLUNION_SET_UINT64(&du, t);
 		return du.d + 4503599627370496.0;  /* 1 << 52 */
 	}

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -131,7 +131,7 @@ typedef struct {
 	} while (0)
 #else
 #define DUK__TVAL_SET_I48(tv,i)  do { \
-		(tv)->ull[DUK_DBL_IDX_ULL0] = (((duk_uint64_t) DUK_TAG_FASTINT) << 48) | (((duk_uint64_t) (i)) & 0x0000ffffffffffffULL); \
+		(tv)->ull[DUK_DBL_IDX_ULL0] = (((duk_uint64_t) DUK_TAG_FASTINT) << 48) | (((duk_uint64_t) (i)) & DUK_U64_CONSTANT(0x0000ffffffffffff)); \
 	} while (0)
 #define DUK__TVAL_SET_U32(tv,i)  do { \
 		(tv)->ull[DUK_DBL_IDX_ULL0] = (((duk_uint64_t) DUK_TAG_FASTINT) << 48) | (duk_uint64_t) (i); \
@@ -621,8 +621,8 @@ DUK_INTERNAL_DECL duk_double_t duk_tval_get_number_unpacked_fastint(duk_tval *tv
 
 /* fastint constants etc */
 #if defined(DUK_USE_FASTINT)
-#define DUK_FASTINT_MIN           (-0x800000000000LL)
-#define DUK_FASTINT_MAX           0x7fffffffffffLL
+#define DUK_FASTINT_MIN           (DUK_I64_CONSTANT(-0x800000000000))
+#define DUK_FASTINT_MAX           (DUK_I64_CONSTANT(0x7fffffffffff))
 #define DUK_FASTINT_BITS          48
 
 DUK_INTERNAL_DECL void duk_tval_set_number_chkfast_fast(duk_tval *tv, duk_double_t x);

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -32,6 +32,8 @@ re_identifier = re.compile(r'[A-Za-z0-9_]+')
 re_nonascii = re.compile(r'^.*?[\x80-\xff].*?$')
 re_func_decl_or_def = re.compile(r'^(\w+)\s+(?:\w+\s+)*(\w+)\(.*?.*?$')  # may not finish on same line
 re_cpp_comment = re.compile(r'^.*?//.*?$')
+re_longlong_constant_dec = re.compile(r'[0-9]+(LL|ULL)')
+re_longlong_constant_hex = re.compile(r'0x[0-9a-fA-F]+(LL|ULL)')
 
 fixmeString = 'FIX' + 'ME'  # avoid triggering a code policy check warning :)
 
@@ -351,6 +353,16 @@ def checkIfdefIfndef(lines, idx, filename):
     if line.startswith('#ifndef'):
         raise Exception('#ifndef found, #if !defined is preferred')
 
+def checkLongLongConstants(lines, idx, filename):
+    line = lines[idx]
+
+    if not 'LL' in line:
+        return
+    for m in re.finditer(re_longlong_constant_hex, line):
+        raise Exception('plain longlong constant, use DUK_U64_CONSTANT or DUK_I64_CONSTANT: ' + str(m.group(0)))
+    for m in re.finditer(re_longlong_constant_dec, line):
+        raise Exception('plain longlong constant, use DUK_U64_CONSTANT or DUK_I64_CONSTANT: ' + str(m.group(0)))
+
 def checkCppComment(lines, idx, filename):
     line = lines[idx]
     m = re_cpp_comment.match(line)
@@ -419,6 +431,7 @@ def main():
     parser.add_option('--check-nonleading-tab', dest='check_nonleading_tab', action='store_true', default=False, help='Check for non-leading tab characters')
     parser.add_option('--check-cpp-comment', dest='check_cpp_comment', action='store_true', default=False, help='Check for c++ comments ("// ...")')
     parser.add_option('--check-ifdef-ifndef', dest='check_ifdef_ifndef', action='store_true', default=False, help='Check for #ifdef and #ifndef (prefer #if defined and #if !defined)')
+    parser.add_option('--check-longlong-constants', dest='check_longlong_constants', action='store_true', default=False, help='Check for plain 123LL or 123ULL constants')
     parser.add_option('--fail-on-errors', dest='fail_on_errors', action='store_true', default=False, help='Fail on errors (exit code != 0)')
 
     (opts, args) = parser.parse_args()
@@ -436,6 +449,8 @@ def main():
         checkersRaw.append(checkNoSymbolVisibility)
     if opts.check_ifdef_ifndef:
         checkersRaw.append(checkIfdefIfndef)
+    if opts.check_longlong_constants:
+        checkersRaw.append(checkLongLongConstants)
 
     checkersNoCCommentsOrLiterals = []
     if opts.check_cpp_comment:


### PR DESCRIPTION
Some older compilers don't have `xxULL` or `xxLL` constants but may support a different form like `xxui64` or `xxi64`. To support these compilers LL/ULL constants are wrapped in `DUK_U64_CONSTANT()` and `DUK_I64_CONSTANT()`.

Add a codepolicycheck to catch non-wrapped constants to minimize the chance of breaking the build for older compilers. Also fix a few constants not handled by #1559.