### PR TITLE
Fix bug in RegExp class dash parsing (Duktape 2.0 and later)

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2891,6 +2891,10 @@ Planned
 
 * Add a wrap check to duk_{check,require}_stack{_top}() (GH-1537)
 
+* Fix incorrect lookahead in RegExp class range dash ('-') parsing which
+  caused RegExp classes ending in a dash (e.g. [abc-]) to be handled
+  incorrectly (GH-1569, GH-1570)
+
 * Fix duk_pcall_prop(), duk_safe_call(), and duk_pnew() argument validation,
   in some cases a negative nargs/nrets argument (which is always invalid)
   could be accepted (GH-1553)

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -2243,7 +2243,7 @@ DUK_INTERNAL void duk_lexer_parse_re_ranges(duk_lexer_ctx *lex_ctx, duk_re_range
 			DUK__ADVANCECHARS(lex_ctx, 1);  /* eat ']' before finishing */
 			break;
 		} else if (x == DUK_ASC_MINUS) {
-			if (start >= 0 && !dash && DUK__L0() != DUK_ASC_RBRACKET) {
+			if (start >= 0 && !dash && DUK__L1() != DUK_ASC_RBRACKET) {
 				/* '-' as a range indicator */
 				dash = 1;
 				continue;

--- a/tests/ecmascript/test-bug-regexp-class-dash.js
+++ b/tests/ecmascript/test-bug-regexp-class-dash.js
@@ -1,0 +1,30 @@
+/*
+ *  Bug in RegExp class dash parsing: https://github.com/svaarala/duktape/issues/1569
+ */
+
+/*===
+true
+true
+true
+true
+===*/
+
+function test() {
+    var re;
+
+    re = /^[a-zA-Z0-9_!#$%&'*+.^`|~-]+$/;
+    print(re.test('Content-Type'));
+    re = /^[a-zA-Z0-9_!#$%&'*+.^`|~\-]+$/;
+    print(re.test('Content-Type'));
+
+    re = /[-]/;
+    print(re.test('-'));
+    re = /[\-]/;
+    print(re.test('-'));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Fix incorrect forward lookup when parsing a dash (`-`) in a RegExp class. If the dash is the last character before the right bracket (`]`) it should be interpreted literally. However, the lookup for the right bracket was incorrect in Duktape 2.0 and later. Fix the lookup index.

Fixes #1569.