### PR TITLE
Fix duk_debug.js source code scan

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2936,6 +2936,9 @@ Planned
 
 * Fix MSVC cast warning in error augmentation code (GH-1511)
 
+* Fix duk_debug.js --source-dirs scanning for file dropdown; the dropdown was
+  empty (GH-1580)
+
 * Improve support for old MSVC versions without __pragma(), long long, and
   LL/ULL constants (GH-1559, GH-1562)
 


### PR DESCRIPTION
The source code scan doesn't currently work as expected and the source dropdown is empty. This doesn't prevent debugged source files from being loaded during an active debug session, but source code files can't be browsed in the dropdown.