### PR TITLE
Add a flag that flushes the console output after writing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -82,6 +82,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * https://github.com/chris-y
 * Laurent Zubiaur (https://github.com/lzubiaur)
 * Neil Kolban (https://github.com/nkolban)
+* Simon Stone (https://github.com/sstone1)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/extras/console/duk_console.h
+++ b/extras/console/duk_console.h
@@ -6,6 +6,9 @@
 /* Use a proxy wrapper to make undefined methods (console.foo()) no-ops. */
 #define DUK_CONSOLE_PROXY_WRAPPER  (1 << 0)
 
+/* Flush output after every call. */
+#define DUK_CONSOLE_FLUSH          (1 << 1)
+
 extern void duk_console_init(duk_context *ctx, duk_uint_t flags);
 
 #endif  /* DUK_CONSOLE_H_INCLUDED */


### PR DESCRIPTION
We are using duktape (via go-duktape) to provide a JavaScript interpreter for Hyperledger Composer (https://hyperledger.github.io/composer/), which is a framework for rapidly building Blockchain solutions. More specifically, we use duktape to execute business logic that is written by our users in JavaScript.

Our users use `console.log()` as a quick and dirty debugging tool, however with duktape we see that the outputs are buffered and don't appear in the logs until the buffer is flushed. This is not great, hence this PR.

I am adding a new flag `DUK_CONSOLE_FLUSH` to the console extra that calls `fflush` after every write. This flag is off by default, so shouldn't change the behaviour for existing users.