### PR TITLE
Some cleanups for DUK_CONSOLE_FLUSH

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2947,6 +2947,8 @@ Planned
 * Add some statistics dumps to mark-and-sweep with debug logging enabled
   (GH-1579)
 
+* Add DUK_CONSOLE_FLUSH flag to extras/duktape-console (GH-1587, GH-1588)
+
 * Internal change: set REACHABLE for all READONLY objects (relevant when
   using ROM built-ins) so that mark-and-sweep doesn't need an explicit
   READONLY check (GH-1502)

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -1161,7 +1161,7 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int aj
 
 	/* Register console object. */
 #if defined(DUK_CMDLINE_CONSOLE_SUPPORT)
-	duk_console_init(ctx, DUK_CONSOLE_PROXY_WRAPPER /*flags*/);
+	duk_console_init(ctx, DUK_CONSOLE_PROXY_WRAPPER | DUK_CONSOLE_FLUSH /*flags*/);
 #endif
 
 	/* Register Duktape.Logger (removed in Duktape 2.x). */


### PR DESCRIPTION
- [x] Faster flush flag lookup: pass flags into the log functions through the function magic value
- [x] Add console flush to 'duk' command
- [x] Releases entry