### PR TITLE
Add internal duk_concat_2() helper for str+str arithmetic

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2983,7 +2983,8 @@ Planned
   unpack for bound functions, .call, and .apply (GH-1525); unsafe internal
   value stack pops where safe (GH-1583, GH-1584); initial object property
   table size estimates for NEWOBJ and NEWARR opcodes (object and array
-  literals) (GH-1596, GH-1597)
+  literals) (GH-1596, GH-1597); duk_concat_2() internal helper for str+str
+  arithmetic (GH-1599)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -308,6 +308,8 @@ DUK_INTERNAL_DECL void duk_seal_freeze_raw(duk_context *ctx, duk_idx_t obj_idx, 
 DUK_INTERNAL_DECL void duk_insert_undefined(duk_context *ctx, duk_idx_t idx);
 DUK_INTERNAL_DECL void duk_insert_undefined_n(duk_context *ctx, duk_idx_t idx, duk_idx_t count);
 
+DUK_INTERNAL_DECL void duk_concat_2(duk_context *ctx);
+
 DUK_INTERNAL_DECL duk_int_t duk_pcall_method_flags(duk_context *ctx, duk_idx_t nargs, duk_small_uint_t call_flags);
 
 /* Raw internal valstack access macros: access is unsafe so call site

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -172,12 +172,10 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv
 		/* Symbols shouldn't technically be handled here, but should
 		 * go into the default ToNumber() coercion path instead and
 		 * fail there with a TypeError.  However, there's a ToString()
-		 * here which also fails with TypeError so no explicit check
-		 * is needed.
+		 * in duk_concat_2() which also fails with TypeError so no
+		 * explicit check is needed.
 		 */
-		duk_to_string(ctx, -2);
-		duk_to_string(ctx, -1);
-		duk_concat(ctx, 2);  /* [... s1 s2] -> [... s1+s2] */
+		duk_concat_2(ctx);  /* [... s1 s2] -> [... s1+s2] */
 	} else {
 		duk_double_t d1, d2;
 

--- a/tests/ecmascript/test-expr-add-coercion-order.js
+++ b/tests/ecmascript/test-expr-add-coercion-order.js
@@ -1,0 +1,37 @@
+/*===
+o1 valueOf
+o2 valueOf
+foobar
+o2 valueOf
+o1 valueOf
+barfoo
+o1 valueOf
+o2 valueOf
+o3 valueOf
+foobarquux
+===*/
+
+function test() {
+    var o1 = {
+        toString: function () { print('o1 toString'); return 'FOO' },
+        valueOf: function () { print('o1 valueOf'); return 'foo' },
+    };
+    var o2 = {
+        toString: function () { print('o2 toString'); return 'BAR' },
+        valueOf: function () { print('o2 valueOf'); return 'bar' },
+    };
+    var o3 = {
+        toString: function () { print('o3 toString'); return 'QUUX' },
+        valueOf: function () { print('o3 valueOf'); return 'quux' },
+    };
+
+    print(o1 + o2);
+    print(o2 + o1);
+    print(o1 + o2 + o3);
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}

--- a/tests/perf/test-arith-add-string.js
+++ b/tests/perf/test-arith-add-string.js
@@ -1,0 +1,29 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var x, y, z;
+    var i, n;
+
+    x = 'foo';
+    y = 'bar';
+
+    for (i = 0, n = 1e6; i < n; i++) {
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+        z = x + y;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
- [x] Add internal duk_concat_2() helper
- [x] Use it for executor str+str arithmetic, remove unnecessary ToString() in the call site (concat does it)
- [x] Add perf test
- [x] Releases entry