### PR TITLE
Allow built-in functions to be construct only

### DIFF
--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -3015,7 +3015,7 @@ objects:
     internal_prototype: bi_function_prototype
     # no external prototype
     native: duk_bi_proxy_constructor
-    callable: true
+    callable: false
     constructable: true
     es6: true
     bidx: true
@@ -3329,7 +3329,7 @@ objects:
     internal_prototype: bi_function_prototype
     varargs: false
     native: duk_bi_arraybuffer_constructor
-    callable: true
+    callable: false
     constructable: true
     typedarray: true
     es6: true
@@ -3416,7 +3416,7 @@ objects:
     internal_prototype: bi_function_prototype
     varargs: false
     native: duk_bi_dataview_constructor
-    callable: true
+    callable: false
     constructable: true
     typedarray: true
     es6: true
@@ -3737,7 +3737,7 @@ objects:
     internal_prototype: bi_function_prototype
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: false
     nargs: 0
     magic: 0
@@ -3852,7 +3852,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -3920,7 +3920,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4009,7 +4009,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4077,7 +4077,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4145,7 +4145,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4213,7 +4213,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4281,7 +4281,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4349,7 +4349,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -4417,7 +4417,7 @@ objects:
     internal_prototype: bi_typedarray_constructor
     varargs: false
     native: duk_bi_typedarray_constructor
-    callable: true
+    callable: false
     constructable: true
     magic:
       type: typedarray_constructor
@@ -5100,7 +5100,7 @@ objects:
     internal_prototype: bi_function_prototype
     nargs: 0
     native: duk_bi_textencoder_constructor
-    callable: true
+    callable: false
     constructable: true
     bidx: true
     encoding_api: true
@@ -5158,7 +5158,7 @@ objects:
     internal_prototype: bi_function_prototype
     nargs: 2
     native: duk_bi_textdecoder_constructor
-    callable: true
+    callable: false
     constructable: true
     bidx: true
     encoding_api: true

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -661,7 +661,7 @@ DUK_INTERNAL duk_ret_t duk_bi_arraybuffer_constructor(duk_context *ctx) {
 	thr = (duk_hthread *) ctx;
 	DUK_UNREF(thr);
 
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(!duk_is_constructor_call(ctx));
 
 	len = duk_to_int(ctx, 0);
 	if (len < 0) {
@@ -722,7 +722,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 	 * buffer functions.
 	 */
 
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(!duk_is_constructor_call(ctx));
 
 	/* We could fit built-in index into magic but that'd make the magic
 	 * number dependent on built-in numbering (genbuiltins.py doesn't
@@ -1061,7 +1061,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_context *ctx) {
 	 * buffer functions.
 	 */
 
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(!duk_is_constructor_call(ctx));
 
 	elem_length_signed = duk_require_int(ctx, 0);
 	if (elem_length_signed < 0) {
@@ -1086,7 +1086,7 @@ DUK_INTERNAL duk_ret_t duk_bi_dataview_constructor(duk_context *ctx) {
 	duk_uint_t offset;
 	duk_uint_t length;
 
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(!duk_is_constructor_call(ctx));
 
 	h_bufarg = duk__require_bufobj_value(ctx, 0);
 	DUK_ASSERT(h_bufarg != NULL);

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -344,7 +344,8 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_constructor(duk_context *ctx) {
 	 * does nothing on purpose.
 	 */
 
-	duk_require_constructor_call(ctx);
+	DUK_UNREF(ctx);
+	DUK_ASSERT(duk_is_constructor_call(ctx));
 	return 0;
 }
 
@@ -441,7 +442,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_context *ctx) {
 	duk_bool_t ignore_bom = 0;
 
 	DUK_ASSERT_TOP(ctx, 2);
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(duk_is_constructor_call(ctx));
 	if (!duk_is_undefined(ctx, 0)) {
 		/* XXX: For now ignore 'label' (encoding identifier). */
 		duk_to_string(ctx, 0);

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2104,6 +2104,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 			 * value is NOT looked up like for e.g. String objects).
 			 */
 			DUK_ASSERT(h != NULL);
+			/* FIXME: grep all CALLABLE checks and see if they should be CALLABLE || CONSTRUCTABLE */
 			if (DUK_HOBJECT_IS_CALLABLE(h)) {
 #if defined(DUK_USE_JX) || defined(DUK_USE_JC)
 				if (js_ctx->flags & (DUK_JSON_FLAG_EXT_CUSTOM |

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -89,7 +89,7 @@ DUK_INTERNAL void duk_proxy_ownkeys_postprocess(duk_context *ctx, duk_hobject *h
 DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor(duk_context *ctx) {
 	DUK_ASSERT_TOP(ctx, 2);  /* [ target handler ] */
 
-	duk_require_constructor_call(ctx);
+	DUK_ASSERT(duk_is_constructor_call(ctx));
 	duk_push_proxy(ctx);  /* [ target handler ] -> [ proxy ] */
 	return 1;  /* replacement */
 }

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -36,6 +36,11 @@
  * inspection code.
  */
 
+/* FIXME: ES spec: all construct-only functions have [[Call]] and [[Construct]]
+ * so the modeling is not 1:1.  Maybe rename so that _CALLABLE means either one?
+ * _CONSTRUCTABLE..
+ */
+
 /* XXX: some flags are object subtype specific (e.g. common to all function
  * subtypes, duk_harray, etc) and could be reused for different subtypes.
  */
@@ -187,6 +192,7 @@
                                                         DUK_HOBJECT_FLAG_NATFUNC)
 
 #define DUK_HOBJECT_IS_CALLABLE(h)             DUK_HOBJECT_HAS_CALLABLE((h))
+#define DUK_HOBJECT_IS_CONSTRUCTABLE(h)        DUK_HOBJECT_HAS_CONSTRUCTABLE((h))
 
 /* Object has any exotic behavior(s). */
 #define DUK_HOBJECT_EXOTIC_BEHAVIOR_FLAGS      (DUK_HOBJECT_FLAG_EXOTIC_ARRAY | \

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -279,8 +279,14 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 			/* Almost all global level Function objects are constructable
 			 * but not all: Function.prototype is a non-constructable,
-			 * callable Function.
+			 * callable Function.  Some built-ins are only constructable,
+			 * not callable as normal functions, e.g. Uint8Array constructor.
 			 */
+			if (duk_bd_decode_flag(bd)) {
+				DUK_ASSERT(DUK_HOBJECT_HAS_CALLABLE(h));
+			} else {
+				DUK_HOBJECT_CLEAR_CALLABLE(h);
+			}
 			if (duk_bd_decode_flag(bd)) {
 				DUK_ASSERT(DUK_HOBJECT_HAS_CONSTRUCTABLE(h));
 			} else {

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1699,17 +1699,14 @@ def gen_ramobj_initdata_for_object(meta, be, bi, string_to_stridx, natfunc_name_
             assert(length is not None)
             be.bits(0, 1)  # flag: default nargs OK
 
-        # All Function-classed global level objects are callable
-        # (have [[Call]]) but not all are constructable (have
-        # [[Construct]]).  Flag that.
-
-        assert(bi.has_key('callable'))
-        assert(bi['callable'] == True)
-
         assert(prop_name is not None)
         assert(isinstance(prop_name['value'], str))
         _stridx_or_string(prop_name['value'])
 
+        if bi.get('callable', False):
+            be.bits(1, 1)    # flag: callable
+        else:
+            be.bits(0, 1)    # flag: not callable
         if bi.get('constructable', False):
             be.bits(1, 1)    # flag: constructable
         else:


### PR DESCRIPTION
With the explicit DUK_HOBJECT_FLAG_CALLABLE it's now possible to create functions that are constructable but not callable as normal functions. This is a prototype branch to see how that would work out in practice. Work in progress.