### PR TITLE
module-node fixes

### DIFF
--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -292,7 +292,13 @@ void duk_module_node_init(duk_context *ctx) {
 
 	/* Initialize the require cache to a fresh object. */
 	duk_push_global_stash(ctx);
+#if DUK_VERSION >= 19999
 	duk_push_bare_object(ctx);
+#else
+	duk_push_object(ctx);
+	duk_push_undefined(ctx);
+	duk_set_prototype(ctx, -2);
+#endif
 	duk_put_prop_string(ctx, -2, "\xff" "requireCache");
 	duk_pop(ctx);
 

--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -112,7 +112,7 @@ static duk_ret_t duk__handle_require(duk_context *ctx) {
 	ret = duk_pcall(ctx, 3);
 	if (ret != DUK_EXEC_SUCCESS) {
 		duk__del_cached_module(ctx, id);
-		duk_throw(ctx);  /* rethrow */
+		(void) duk_throw(ctx);  /* rethrow */
 	}
 
 	if (duk_is_string(ctx, -1)) {
@@ -127,13 +127,13 @@ static duk_ret_t duk__handle_require(duk_context *ctx) {
 #endif
 		if (ret != DUK_EXEC_SUCCESS) {
 			duk__del_cached_module(ctx, id);
-			duk_throw(ctx);  /* rethrow */
+			(void) duk_throw(ctx);  /* rethrow */
 		}
 	} else if (duk_is_undefined(ctx, -1)) {
 		duk_pop(ctx);
 	} else {
 		duk__del_cached_module(ctx, id);
-		duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid module load callback return value");
+		(void) duk_error(ctx, DUK_ERR_TYPE_ERROR, "invalid module load callback return value");
 	}
 
 	/* fall through */


### PR DESCRIPTION
The duk_throw/duk_error calls result in compiler warnings with Duktape 2.x unless we cast them to void.
Also, duk_push_bare_object isn't available in Duktape 1.x so duk_push_object/duk_set_prototype have to be used.