### PR TITLE
Use sort key for enum sort

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2887,7 +2887,7 @@ Planned
   code is not yet fully correct (GH-1544, GH-1572)
 
 * Add proper string vs. symbol sorting to Reflect.ownKeys() and other
-  enumeration call sites (GH-1460)
+  enumeration call sites (GH-1460, GH-1607)
 
 * Add an internal type for representing Proxy instances (duk_hproxy) to
   simplify Proxy operations and improve performance (GH-1500, GH-1136)


### PR DESCRIPTION
Use an explicit sort key for enum sort. The sort key must cover:
- Array indices 0 to 0xfffffffe.
- Some value higher than 0xfffffffe for strings (same value for all strings).
- Some value higher than the string value for symbols (same value for all symbols).

The type must be larger than 32 bits to allow these values. The current approach uses `duk_uint64_t` or `duk_double_t` if 64-bit types are not available. The sort keys are:
- Array index: as is.
- Strings: duk_hstring arridx as is = 0xffffffff.
- Symbols: duk_hstring arridx as is (= 0xffffffff) + masked but unshifted DUK_HSTRING_FLAG_SYMBOL flag; guaranteed not to overflow, but result is higher than 0xffffffff.

As a result the sort key is computed without branches in just a few opcodes, e.g.:

```
  40b66d:       8b 11                   mov    (%rcx),%edx
  40b66f:       8b 49 14                mov    0x14(%rcx),%ecx
  40b672:       81 e2 00 02 00 00       and    $0x200,%edx
  40b678:       48 01 ca                add    %rcx,%rdx
```