### PR TITLE
Add missing parenthesis in duk_safe_call() example

### DIFF
--- a/website/api/duk_safe_call.yaml
+++ b/website/api/duk_safe_call.yaml
@@ -108,7 +108,7 @@ example: |
       if (args->floor) {
           t = floor(t);
       }
-      duk_push_number(ctx, t;
+      duk_push_number(ctx, t);
 
       /* Indicates that there is only one return value.  Because the caller
        * requested two (nrets == 2), Duktape will automatically add an


### PR DESCRIPTION
I found another typo, a missing parenthesis in the duk_safe_call() example.