### PR TITLE
Faster bufwriter growth for non-lowmem targets

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2992,7 +2992,8 @@ Planned
   value stack pops where safe (GH-1583, GH-1584); initial object property
   table size estimates for NEWOBJ and NEWARR opcodes (object and array
   literals) (GH-1596, GH-1597); duk_concat_2() internal helper for str+str
-  arithmetic (GH-1599)
+  arithmetic (GH-1599); larger spare for bufwriter in non-lowmem build
+  (GH-1611)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -134,8 +134,13 @@ struct duk_bufwriter_ctx {
 	duk_hbuffer_dynamic *buf;
 };
 
+#if defined(DUK_USE_PREFER_SIZE)
 #define DUK_BW_SPARE_ADD           64
 #define DUK_BW_SPARE_SHIFT         4    /* 2^4 -> 1/16 = 6.25% spare */
+#else
+#define DUK_BW_SPARE_ADD           64
+#define DUK_BW_SPARE_SHIFT         2    /* 2^2 -> 1/4 = 25% spare */
+#endif
 
 /* Initialization and finalization (compaction), converting to other types. */
 


### PR DESCRIPTION
Use 25% spare instead of 6.25% spare on default (desktop) build.