### PR TITLE
Some duk_is_callable/constructable optimizations

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3002,7 +3002,8 @@ Planned
   table size estimates for NEWOBJ and NEWARR opcodes (object and array
   literals) (GH-1596, GH-1597); duk_concat_2() internal helper for str+str
   arithmetic (GH-1599); larger spare for bufwriter in non-lowmem build
-  (GH-1611); faster internal duk_to_number_tval() (GH-1612)
+  (GH-1611); faster internal duk_to_number_tval() (GH-1612); minor
+  optimizations to duk_is_callable() and duk_is_constructable() (GH-1631)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -96,6 +96,8 @@ DUK_INTERNAL_DECL duk_tval *duk_get_borrowed_this_tval(duk_hthread *thr);
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_string_notsymbol(duk_hthread *thr, duk_idx_t idx);
 
+DUK_INTERNAL_DECL duk_bool_t duk_is_callable_tval(duk_hthread *thr, duk_tval *tv);
+
 DUK_INTERNAL_DECL duk_hstring *duk_get_hstring(duk_hthread *thr, duk_idx_t idx);
 DUK_INTERNAL_DECL duk_hstring *duk_get_hstring_notsymbol(duk_hthread *thr, duk_idx_t idx);
 DUK_INTERNAL_DECL const char *duk_get_string_notsymbol(duk_hthread *thr, duk_idx_t idx);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3571,7 +3571,7 @@ DUK_INTERNAL const char *duk_get_type_name(duk_hthread *thr, duk_idx_t idx) {
 
 	return duk__type_names[type_tag];
 }
-#endif
+#endif  /* DUK_USE_VERBOSE_ERRORS && DUK_USE_PARANOID_ERRORS */
 
 DUK_INTERNAL duk_small_uint_t duk_get_class_number(duk_hthread *thr, duk_idx_t idx) {
 	duk_tval *tv;
@@ -3809,12 +3809,31 @@ DUK_EXTERNAL duk_bool_t duk_is_function(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(thr);
 
 	tv = duk_get_tval_or_unused(thr, idx);
+	if (DUK_TVAL_IS_OBJECT(tv)) {
+		duk_hobject *h;
+		h = DUK_TVAL_GET_OBJECT(tv);
+		DUK_ASSERT(h != NULL);
+		return DUK_HOBJECT_HAS_CALLABLE(h) ? 1 : 0;
+	}
 	if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
 		return 1;
 	}
-	return duk__obj_flag_any_default_false(thr,
-	                                       idx,
-	                                       DUK_HOBJECT_FLAG_CALLABLE);
+	return 0;
+}
+
+DUK_INTERNAL duk_bool_t duk_is_callable_tval(duk_hthread *thr, duk_tval *tv) {
+	DUK_ASSERT_CTX_VALID(thr);
+
+	if (DUK_TVAL_IS_OBJECT(tv)) {
+		duk_hobject *h;
+		h = DUK_TVAL_GET_OBJECT(tv);
+		DUK_ASSERT(h != NULL);
+		return DUK_HOBJECT_HAS_CALLABLE(h) ? 1 : 0;
+	}
+	if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
+		return 1;
+	}
+	return 0;
 }
 
 DUK_EXTERNAL duk_bool_t duk_is_constructable(duk_hthread *thr, duk_idx_t idx) {
@@ -3823,12 +3842,16 @@ DUK_EXTERNAL duk_bool_t duk_is_constructable(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_CTX_VALID(thr);
 
 	tv = duk_get_tval_or_unused(thr, idx);
+	if (DUK_TVAL_IS_OBJECT(tv)) {
+		duk_hobject *h;
+		h = DUK_TVAL_GET_OBJECT(tv);
+		DUK_ASSERT(h != NULL);
+		return DUK_HOBJECT_HAS_CONSTRUCTABLE(h) ? 1 : 0;
+	}
 	if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
 		return 1;
 	}
-	return duk__obj_flag_any_default_false(thr,
-	                                       idx,
-	                                       DUK_HOBJECT_FLAG_CONSTRUCTABLE);
+	return 0;
 }
 
 DUK_EXTERNAL duk_bool_t duk_is_c_function(duk_hthread *thr, duk_idx_t idx) {


### PR DESCRIPTION
- [x] Slightly faster way of checking callability/constructability
- [x] Add internal (currently unused) duk_is_callable_tval() helper
- [x] Releases entry