### PR TITLE
Reverse property read entry vs. array part check order

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3007,7 +3007,8 @@ Planned
   literals) (GH-1596, GH-1597); duk_concat_2() internal helper for str+str
   arithmetic (GH-1599); larger spare for bufwriter in non-lowmem build
   (GH-1611); faster internal duk_to_number_tval() (GH-1612); minor
-  optimizations to duk_is_callable() and duk_is_constructable() (GH-1631)
+  optimizations to duk_is_callable() and duk_is_constructable() (GH-1631);
+  check entry part before array part in property lookup (GH-1634)
 
 3.0.0 (XXXX-XX-XX)
 ------------------


### PR DESCRIPTION
Because almost all array part reads go through the fast path, check the entry part first (previously array part was checked first) which is slightly faster. A property never exists in both parts at the same time, so the check order has no functional importance.