### PR TITLE
Optimize duk_propdesc filling when property not found

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3008,7 +3008,8 @@ Planned
   arithmetic (GH-1599); larger spare for bufwriter in non-lowmem build
   (GH-1611); faster internal duk_to_number_tval() (GH-1612); minor
   optimizations to duk_is_callable() and duk_is_constructable() (GH-1631);
-  check entry part before array part in property lookup (GH-1634)
+  check entry part before array part in property lookup (GH-1634); optimize
+  duk_propdesc filling in property lookups (GH-1635)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -417,6 +417,19 @@
 	DUK_ASSERT(thr->valstack_top < thr->valstack_end)
 
 /*
+ *  Helper to initialize a memory area (e.g. struct) with garbage when
+ *  assertions enabled.
+ */
+
+#if defined(DUK_USE_ASSERTIONS)
+#define DUK_ASSERT_SET_GARBAGE(ptr,size) do { \
+		DUK_MEMSET((void *) (ptr), 0x5a, size); \
+	} while (0)
+#else
+#define DUK_ASSERT_SET_GARBAGE(ptr,size) do {} while (0)
+#endif
+
+/*
  *  Helper for valstack space
  *
  *  Caller of DUK_ASSERT_VALSTACK_SPACE() estimates the number of free stack entries

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -903,7 +903,7 @@ DUK_INTERNAL_DECL void duk_hobject_resize_arraypart(duk_hthread *thr,
 #endif
 
 /* low-level property functions */
-DUK_INTERNAL_DECL void duk_hobject_find_existing_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *e_idx, duk_int_t *h_idx);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_find_existing_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *e_idx, duk_int_t *h_idx);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_hstring *key);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *out_attrs);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_array_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_uarridx_t i);

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -1579,8 +1579,8 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 		/* must be found: was found earlier, and cannot be inherited */
 		for (;;) {
 			DUK_ASSERT(holder != NULL);
-			duk_hobject_find_existing_entry(thr->heap, holder, name, &e_idx, &h_idx);
-			if (e_idx >= 0) {
+			if (duk_hobject_find_existing_entry(thr->heap, holder, name, &e_idx, &h_idx)) {
+				DUK_ASSERT(e_idx >= 0);
 				break;
 			}
 			/* SCANBUILD: NULL pointer dereference, doesn't actually trigger,

--- a/tests/ecmascript/test-dev-16bit-overflows.js
+++ b/tests/ecmascript/test-dev-16bit-overflows.js
@@ -44,8 +44,8 @@ function bufferConcatLenTest() {
 
     var s = makeString(32768);
     var t = s.substring(0, 32767);
-    s = Duktape.Buffer(s);
-    t = Duktape.Buffer(t);
+    s = Uint8Array.allocPlain(s);
+    t = Uint8Array.allocPlain(t);
     print(s.length);
     print(t.length);
     var justok = s + t;    // 65535 exactly
@@ -57,9 +57,9 @@ function bufferConcatLenTest() {
 function bufferConstructTest() {
     var b;
 
-    b = new Duktape.Buffer(65535);  // ok
+    b = new Uint8Array(65535);  // ok
     print(b.length);
-    b = new Duktape.Buffer(65536);  // overflow
+    b = new Uint8Array(65536);  // overflow
     print(b.length);
 }
 

--- a/tests/knownissues/test-dev-16bit-overflows-3.txt
+++ b/tests/knownissues/test-dev-16bit-overflows-3.txt
@@ -1,0 +1,13 @@
+summary: requires lowmem 16-bit field options
+---
+32768
+32767
+65535
+65536
+32768
+32767
+38
+38
+65535
+65536
+Reached: 65535

--- a/tests/perf/test-prop-read-inherited.js
+++ b/tests/perf/test-prop-read-inherited.js
@@ -1,0 +1,33 @@
+/*
+ *  Basic property read performance for an inherited property
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var parent = { xxx1: 1, xxx2: 2, xxx3: 3, xxx4: 4, foo: 123 };
+    var i;
+    var ign;
+    var obj = Object.create(parent);
+    obj = Object.create(obj);  // two levels of inheritance
+
+    for (i = 0; i < 1e7; i++) {
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+        ign = obj.foo;
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}


### PR DESCRIPTION
When looking for a property through the inheritance chain, current code first fills in "not found" values to the output `duk_propdesc` and then modifies only the necessary fields, e.g. setting e_idx and flags. This happens even when the property is not found, and is done for every level of the inheritance chain check.

Change the code to fill in the `duk_propdesc` only when the property is found. Don't fill in anything if the property is not found, the return code of the lookup is enough for the caller to ignore any values in the struct.

Tasks:
- [x] Rebase
- [x] Check call sites to ensure they respect propdesc lookup return value
- [x] Use explicit return value for "find existing entry", fix call sites
- [x] Perf test
- [x] Manual assert test run
- [x] Releases entry