### PR TITLE
Fix Travis python-yaml import error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: c
 sudo: required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install python-yaml
+  #- sudo apt-get install python-yaml
   - sudo apt-get install tidy
   - sudo apt-get install valgrind
+  - pip install PyYAML
 #compiler:
 #  - clang
 #  - gcc


### PR DESCRIPTION
Not sure why 'sudo apt-get install python-yaml' no longer works when Travis updated Ubuntu base image. The install succeeds, but 'import yaml' fails in configure.py. Installing PyYAML via pip seems to work.