### PR TITLE
First implementation for symbol summarization

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2945,6 +2945,9 @@ Planned
   using a small (256 byte, footprint impact is about 300-400 bytes)
   canonicalization lookup bitmap (GH-1616)
 
+* Add better symbol summary for e.g. error messages, "[Symbol global '?foo']"
+  instead of just "'?foo'" (GH-1643)
+
 * Fix incorrect handling of register bound unary operation target for
   unary minus, unary plus, and bitwise NOT (GH-1623, GH-1624)
 

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -73,7 +73,7 @@
 #define DUK__LOOP_STACK_DEPTH  256
 
 /* must match bytecode defines now; build autogenerate? */
-DUK_LOCAL const char *duk__bc_optab[256] = {
+DUK_LOCAL const char * const duk__bc_optab[256] = {
 	"LDREG", "STREG", "JUMP", "LDCONST", "LDINT", "LDINTX", "LDTHIS", "LDUNDEF",
 	"LDNULL", "LDTRUE", "LDFALSE", "GETVAR", "BNOT", "LNOT", "UNM", "UNP",
 	"EQ_RR", "EQ_CR", "EQ_RC", "EQ_CC", "NEQ_RR", "NEQ_CR", "NEQ_RC", "NEQ_CC",

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -135,7 +135,9 @@
 #define DUK_HSTRING_GET_DATA_END(x) \
 	(DUK_HSTRING_GET_DATA((x)) + (x)->blen)
 
-/* marker value; in E5 2^32-1 is not a valid array index (2^32-2 is highest valid) */
+/* Marker value; in E5 2^32-1 is not a valid array index (2^32-2 is highest
+ * valid).
+ */
 #define DUK_HSTRING_NO_ARRAY_INDEX  (0xffffffffUL)
 
 #if defined(DUK_USE_HSTRING_ARRIDX)
@@ -152,6 +154,12 @@
 #define DUK_HSTRING_GET_ARRIDX_SLOW(h)  \
 	(duk_js_to_arrayindex_hstring_fast((h)))
 #endif
+
+/* XXX: these actually fit into duk_hstring */
+#define DUK_SYMBOL_TYPE_HIDDEN 0
+#define DUK_SYMBOL_TYPE_GLOBAL 1
+#define DUK_SYMBOL_TYPE_LOCAL 2
+#define DUK_SYMBOL_TYPE_WELLKNOWN 3
 
 /*
  *  Misc


### PR DESCRIPTION
Allows e.g. more useful errors; from master:

```
duk> Symbol.for('foo')()
TypeError: '?foo' not callable
    at [anon] (duk_js_call.c:1332) internal
    at global (input:1) preventsyield
```

From this branch:

```
duk> Symbol.for('foo')()
TypeError: [Symbol global '?foo'] not callable
    at [anon] (duk_js_call.c:1332) internal
    at global (input:1) preventsyield
```

The summary includes the symbol type which is normally not available in `String(mySymbol)`:

```
TypeError: [Symbol local '?foo?0-1'] not callable
TypeError: [Symbol global '?foo'] not callable
TypeError: [Symbol wellknown '?Symbol.iterator?'] not callable (property 'iterator' of [object Function])
TypeError: [Symbol hidden '?foo'] not callable
```

 The string in the summary is a sanitized and length limited version of the internal representation. It's not ideal, and something to improve on. The upside is that the summary includes the running counter for local symbols, which differentiates two local symbols of the same name which are not usually identifiable:

```
duk> S1 = Symbol('foo')
= undefined
duk> S2 = Symbol('foo')
= undefined
duk> String(S1)
= "Symbol(foo)"
duk> String(S2)
= "Symbol(foo)"
duk> S1()
TypeError: [Symbol local '?foo?0-2'] not callable
    at [anon] (duk_js_call.c:1332) internal
    at global (input:1) preventsyield
duk> S2()
TypeError: [Symbol local '?foo?0-3'] not callable
    at [anon] (duk_js_call.c:1332) internal
    at global (input:1) preventsyield
```

Tasks:
- [x] Add symbol summary
- [x] Check consistency of #ifdef, there's no separation between symbol support vs. symbol built-in now
- [x] Releases entry