### PR TITLE
Fix incorrect propcall paranoid error message

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2909,7 +2909,7 @@ Planned
 
 * Improve error message for property-based call TypeError (e.g. foo.noSuch()),
   error message now includes the key for easier debugging (GH-1627, GH-1630,
-  GH-1631, GH-1644)
+  GH-1631, GH-1644, GH-1645)
 
 * Add duk_seal() and duk_freeze() API calls, equivalent to Object.seal()
   and Object.freeze() (GH-1594)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -2806,8 +2806,8 @@ DUK_INTERNAL DUK_NOINLINE DUK_COLD void duk_call_setup_propcall_error(duk_hthrea
 
 #if defined(DUK_USE_PARANOID_ERRORS)
 	str1 = duk_get_type_name(thr, -1);
-	str2 = duk_get_type_name(thr, -3);
-	str3 = duk_get_type_name(thr, -5);
+	str2 = duk_get_type_name(thr, -2);
+	str3 = duk_get_type_name(thr, -3);
 	duk_push_error_object(thr, DUK_ERR_TYPE_ERROR | DUK_ERRCODE_FLAG_NOBLAME_FILELINE, "%s not callable (property %s of %s)", str1, str2, str3);
 #else
 	str1 = duk_push_string_readable(thr, -1);


### PR DESCRIPTION
Fix unreleased bug in property-based call error message when paranoid errors enabled. The fixed message is still not ideal and looks like:

```
duk> Math.foo()
TypeError: undefined not callable (property string of object)
    at [anon] (duk_js_call.c:2811) internal
    at global (input:1) preventsyield
```

Because the key is intentionally hidden with paranoid errors, the stuff in parenthesis doesn't add much. It does provide some type info, e.g.:

```
duk> Math[true]()
TypeError: undefined not callable (property boolean of object)
    at [anon] (duk_js_call.c:2811) internal
    at global (input:1) preventsyield
```

so I'll keep it for now.