### PR TITLE
Trivia for commented out realloc props code

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2693,7 +2693,7 @@ Miscellaneous:
 * Fix out-of-memory handling for object property table resize, previously
   an out-of-memory during property table resize could leave internal state
   in a state which prevented mark-and-sweep from fully working afterwards
-  (GH-1426, GH-1427)
+  (GH-1426, GH-1427, GH-1650)
 
 * Fix a garbage collection bug where a finalizer triggered by mark-and-sweep
   could cause a recursive entry into mark-and-sweep (leading to memory unsafe

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -637,6 +637,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 		 */
 #if 0  /* XXX: inject test */
 		if (1) {
+			new_p = NULL;
 			goto alloc_failed;
 		}
 #endif


### PR DESCRIPTION
Placeholder realloc props error injection code was missing a NULL assignment (failed if uncommented manually).