### PR TITLE
Make string summarization longer (32 -> 96) for error messages

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2978,6 +2978,9 @@ Planned
   (64 -> 128 bytes) and make it configurable via DUK_USE_FATAL_MAXLEN
   (GH-1652)
 
+* Make error message summary strings longer (32 -> 96 character) to better
+  capture error messages for e.g. uncaught errors (GH-1653)
+
 * Fix incorrect handling of register bound unary operation target for
   unary minus, unary plus, and bitwise NOT (GH-1623, GH-1624)
 


### PR DESCRIPTION
Current summary string limit is 32 characters, which is not enough to capture verbose error messages when errors are summarized e.g. for fatal uncaught error. Increase the limit to 96 characters for error messages.

Also changes error aware summarization so that only string `.message` values are summarized. It's very rare for the message not to be a string so for the side effect free summarization it seems OK to accept that limitation.