### PR TITLE
Add 52-bit double fmod+div+floor split self test

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2719,6 +2719,8 @@ Miscellaneous:
   allowed typos like "-DFOO bar" to be accepted silently (here as "-DFOO" and
   an ignored pain "bar" argument) (GH-1425)
 
+* Add more self tests: fmod()+floor()+div splitting (GH-1657)
+
 * Fix unintuitive refcount triggered finalizer behavior where a finalizer loop
   would happen if the finalizer created a (garbage) object referencing the
   object being finalized (GH-1396, GH-1427)

--- a/src-input/duk_selftest.c
+++ b/src-input/duk_selftest.c
@@ -384,6 +384,7 @@ DUK_LOCAL duk_uint_t duk__selftest_double_rounding(void) {
 DUK_LOCAL duk_uint_t duk__selftest_fmod(void) {
 	duk_uint_t error_count = 0;
 	duk__test_double_union u1, u2;
+	volatile duk_double_t t1, t2, t3;
 
 	/* fmod() with integer argument and exponent 2^32 is used by e.g.
 	 * ToUint32() and some Duktape internals.
@@ -398,6 +399,22 @@ DUK_LOCAL duk_uint_t duk__selftest_fmod(void) {
 
 	u1.d = DUK_FMOD(73014444042.0, 4294967296.0);
 	u2.d = 10.0;
+	DUK__DBLUNION_CMP_TRUE(&u1, &u2);
+
+	/* 52-bit integer split into two parts:
+	 * >>> 0x1fedcba9876543
+	 * 8987183256397123
+	 * >>> float(0x1fedcba9876543) / float(2**53)
+	 * 0.9977777777777778
+	 */
+	u1.d = DUK_FMOD(8987183256397123.0, 4294967296.0);
+	u2.d = (duk_double_t) 0xa9876543UL;
+	DUK__DBLUNION_CMP_TRUE(&u1, &u2);
+	t1 = 8987183256397123.0;
+	t2 = 4294967296.0;
+	t3 = t1 / t2;
+	u1.d = DUK_FLOOR(t3);
+	u2.d = (duk_double_t) 0x1fedcbUL;
 	DUK__DBLUNION_CMP_TRUE(&u1, &u2);
 
 	/* C99 behavior is for fmod() result sign to mathc argument sign. */


### PR DESCRIPTION
There's a minimal fmod() self test already, but add a concrete fmod+div+floor split self test where a 52-bit integer (represented as a double) is split into 32-bit parts.