### PR TITLE
Add initial provider for Windows monotonic time

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2989,6 +2989,9 @@ Planned
   mechanisms; if absent (default), monotonic time defaults to
   DUK_USE_DATE_GET_NOW() (GH-1659)
 
+* Add monotonic time provider for Windows based on QueryPerformanceCounter(),
+  enabled by default if _WIN32_WINNT indicates Vista or above (GH-1662)
+
 * Use monotonic time (if available) for debugger transport peeking, so that
   the peek callback is called with the same realtime rate even if the
   Ecmascript time source jumps or doesn't advance in realtime (GH-1659)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,6 +131,7 @@ build_script:
 test_script:
   - cmd: echo --- VS2015
   - cmd: duk-vs2015-%PLATFORM%.exe -e "print(Duktape.env); print('Hello world!');"
+  - cmd: duk-vs2015-%PLATFORM%.exe -e "print(Date.now(), performance.now(), performance.now());"
   - cmd: duk-dll-vs2015-%PLATFORM%.exe -e "print(Duktape.env); print('Hello world!');"
   - cmd: duk-cxx-vs2015-%PLATFORM%.exe -e "print(Duktape.env); print('Hello world!');"
 

--- a/config/config-options/DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC.yaml
+++ b/config/config-options/DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC.yaml
@@ -1,0 +1,7 @@
+define: DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC
+introduced: 2.2.0
+default: false
+tags:
+  - portability
+description: >
+  Use QueryPerformanceCounter() for monotonic time on Windows.

--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -51,4 +51,12 @@
 /* No provider for DUK_USE_DATE_FORMAT_STRING(), fall back to ISO 8601 only. */
 #endif
 
+#if defined(DUK_USE_GET_MONOTONIC_TIME)
+/* External provider already defined. */
+#elif defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC)
+#define DUK_USE_GET_MONOTONIC_TIME(ctx)  duk_bi_date_get_monotonic_time_windows_qpc()
+#else
+/* No provider for DUK_USE_GET_MONOTONIC_TIME(), fall back to DUK_USE_DATE_GET_NOW(). */
+#endif
+
 #endif  /* DUK_COMPILING_DUKTAPE */

--- a/config/platforms/platform_windows.h.in
+++ b/config/platforms/platform_windows.h.in
@@ -21,6 +21,16 @@
 #include <windows.h>
 #endif
 
+/* QueryPerformanceCounter() may go backwards in Windows XP, so enable for
+ * Vista and later: https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408(v=vs.85).aspx#qpc_support_in_windows_versions
+ * Check against _WIN32_WINNT which defines the lowest targeted Windows
+ * version (we obviously don't know the runtime version at compile time).
+ */
+#if !defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC) && \
+    defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
+#define DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC
+#endif
+
 #define DUK_USE_OS_STRING "windows"
 
 /* On Windows, assume we're little endian.  Even Itanium which has a

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -50,6 +50,10 @@ DUK_INTERNAL_DECL duk_bool_t duk_bi_date_parse_string_getdate(duk_hthread *thr, 
 DUK_INTERNAL_DECL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_int_t *parts, duk_int_t tzoffset, duk_small_uint_t flags);
 #endif
 
+#if defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC)
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_monotonic_time_windows_qpc(void);
+#endif
+
 DUK_INTERNAL_DECL
 void duk_bi_json_parse_helper(duk_hthread *thr,
                               duk_idx_t idx_value,


### PR DESCRIPTION
- [x] Rebase
- [x] Add DUK_USE_GET_MONOTONIC_TIME for Windows unless provided explicitly
- [x] Use QueryPerformanceCounter() and QueryPerformanceFrequency() as a base implementation
- [x] Windows version check: only enable when certain to exist and work
- [x] What to do if performance counters are not available; this is only apparent at runtime, so maybe then default to Ecmascript time with fractions (at runtime) -> since WinXP QPC() cannot fail
- [x] Dealing with performance counter jumps, see https://support.microsoft.com/en-us/help/274323/performance-counter-value-may-unexpectedly-leap-forward -> these shouldn't happen since Vista
- [x] Releases entry