### PR TITLE
Add sub-millisecond Windows Ecmascript time provider

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3002,7 +3002,8 @@ Planned
   millisecond timestamps (GH-773, GH-1660)
 
 * Add sub-millisecond resolution to the default POSIX and Windows Date
-  providers (DUK_USE_DATE_GET_NOW) (GH-1660)
+  providers (DUK_USE_DATE_GET_NOW); Windows sub-millisecond resolution
+  is available if _WIN32_WINNT indicates Windows 8 or above (GH-1660, GH-1664)
 
 * Add an initial version of the High Resolution Time API, providing
   performance.now() (which backs to DUK_USE_GET_MONOTONIC_TIME() if

--- a/config/config-options/DUK_USE_DATE_NOW_WINDOWS.yaml
+++ b/config/config-options/DUK_USE_DATE_NOW_WINDOWS.yaml
@@ -5,8 +5,4 @@ tags:
   - date
   - portability
 description: >
-  Use Win32 API calls to get current datetime.  When enabled, appropriate
-  date/time headers must be included.
-
-# FIXME: add an include file metadata entry to cause default #include
-# directives to be emitted?
+  Use Win32 API calls to get current datetime.

--- a/config/config-options/DUK_USE_DATE_NOW_WINDOWS_SUBMS.yaml
+++ b/config/config-options/DUK_USE_DATE_NOW_WINDOWS_SUBMS.yaml
@@ -1,0 +1,9 @@
+define: DUK_USE_DATE_NOW_WINDOWS_SUBMS
+introduced: 2.2.0
+default: false
+tags:
+  - date
+  - portability
+description: >
+  Like DUK_USE_DATE_NOW_WINDOWS but use GetSystemTimePreciseAsFileTime(),
+  available since Windows 8, for sub-millisecond resolution.

--- a/config/config-options/DUK_USE_DATE_TZO_WINDOWS.yaml
+++ b/config/config-options/DUK_USE_DATE_TZO_WINDOWS.yaml
@@ -6,7 +6,3 @@ tags:
   - portability
 description: >
   Use Win32 API calls to get local time offset at a certain time.
-  When enabled, appropriate date/time headers must be included.
-
-# FIXME: add an include file metadata entry to cause default #include
-# directives to be emitted?

--- a/config/config-options/DUK_USE_DATE_TZO_WINDOWS_NO_DST.yaml
+++ b/config/config-options/DUK_USE_DATE_TZO_WINDOWS_NO_DST.yaml
@@ -6,5 +6,4 @@ tags:
   - portability
 description: >
   Use Win32 API calls to get local time offset at a certain time.
-  Does not take into account daylight savings time.  When enabled,
-  appropriate date/time headers must be included.
+  Does not take into account daylight savings time.

--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -16,6 +16,8 @@
 #define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_time((ctx))
 #elif defined(DUK_USE_DATE_NOW_WINDOWS)
 #define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows((ctx))
+#elif defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
+#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows_subms((ctx))
 #else
 #error no provider for DUK_USE_DATE_GET_NOW()
 #endif

--- a/config/platforms/platform_windows.h.in
+++ b/config/platforms/platform_windows.h.in
@@ -1,3 +1,8 @@
+/* Windows version can't obviously be determined at compile time,
+ * but _WIN32_WINNT indicates the minimum version targeted:
+ * - https://msdn.microsoft.com/en-us/library/6sehtctf.aspx
+ */
+
 /* Initial fix: disable secure CRT related warnings when compiling Duktape
  * itself (must be defined before including Windows headers).  Don't define
  * for user code including duktape.h.
@@ -8,12 +13,7 @@
 
 /* Windows 32-bit and 64-bit are currently the same. */
 /* MSVC does not have sys/param.h */
-#define DUK_USE_DATE_NOW_WINDOWS
-#define DUK_USE_DATE_TZO_WINDOWS
-/* Note: PRS and FMT are intentionally left undefined for now.  This means
- * there is no platform specific date parsing/formatting but there is still
- * the ISO 8601 standard format.
- */
+
 #if defined(DUK_COMPILING_DUKTAPE)
 /* Only include when compiling Duktape to avoid polluting application build
  * with a lot of unnecessary defines.
@@ -21,10 +21,28 @@
 #include <windows.h>
 #endif
 
+/* GetSystemTimePreciseAsFileTime() available from Windows 8:
+ * https://msdn.microsoft.com/en-us/library/windows/desktop/hh706895(v=vs.85).aspx
+ */
+#if defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS) || defined(DUK_USE_DATE_NOW_WINDOWS)
+/* User forced provider. */
+#else
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)
+#define DUK_USE_DATE_NOW_WINDOWS_SUBMS
+#else
+#define DUK_USE_DATE_NOW_WINDOWS
+#endif
+#endif
+
+#define DUK_USE_DATE_TZO_WINDOWS
+
+/* Note: PRS and FMT are intentionally left undefined for now.  This means
+ * there is no platform specific date parsing/formatting but there is still
+ * the ISO 8601 standard format.
+ */
+
 /* QueryPerformanceCounter() may go backwards in Windows XP, so enable for
  * Vista and later: https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408(v=vs.85).aspx#qpc_support_in_windows_versions
- * Check against _WIN32_WINNT which defines the lowest targeted Windows
- * version (we obviously don't know the runtime version at compile time).
  */
 #if !defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC) && \
     defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -31,6 +31,9 @@ DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_time(duk_hthread *thr);
 #if defined(DUK_USE_DATE_NOW_WINDOWS)
 DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows(duk_hthread *thr);
 #endif
+#if defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows_subms(duk_hthread *thr);
+#endif
 #if defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME_S) || defined(DUK_USE_DATE_TZO_GMTIME)
 DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d);
 #endif


### PR DESCRIPTION
Use GetSystemTimePreciseAsFileTime() to get better resolution. The resolution won't be available via Date instances because Ecmascript requires their timestamps to be rounded to full milliseconds. The extra resolution is available through duk_get_now() and performance.now() if no monotonic time provider is configured.

- [x] Rebase
- [x] Config option changes
- [x] Proper Windows version check
- [x] Internal provider change
- [x] Releases entry (check entry for GH-1660)