### PR TITLE
Remove 'thr' argument from Ecmascript/monotonic time calls

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3010,6 +3010,10 @@ Planned
   available); performance.timeOrigin is intentionally absent for now,
   until semantics are decided for Duktape (GH-1660)
 
+* Change Unix time provider to tolerate (unlikely) gettimeofday() errors
+  without throwing, as internals are not always expecting to deal with an
+  error when reading current time (GH-1666)
+
 * Fix incorrect handling of register bound unary operation target for
   unary minus, unary plus, and bitwise NOT (GH-1623, GH-1624)
 
@@ -3108,7 +3112,8 @@ Planned
 * Internal change: DUK_ASSERT_API_ENTRY() assertion for later use (GH-1642)
 
 * Miscellaneous footprint improvements: rework call handling to improve
-  code sharing (GH-1552); optional lazy charlen (GH-1337)
+  code sharing (GH-1552); optional lazy charlen (GH-1337); remove 'thr'
+  argument from Date 'now' providers (GH-1666)
 
 * Miscellaneous performance improvements: move rare/large opcodes into
   NOINLINE helpers (GH-1510); duk_harray fast path for internal array

--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -11,13 +11,13 @@
 #if defined(DUK_USE_DATE_GET_NOW)
 /* External provider already defined. */
 #elif defined(DUK_USE_DATE_NOW_GETTIMEOFDAY)
-#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_gettimeofday((ctx))
+#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_gettimeofday()
 #elif defined(DUK_USE_DATE_NOW_TIME)
-#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_time((ctx))
+#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_time()
 #elif defined(DUK_USE_DATE_NOW_WINDOWS)
-#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows((ctx))
+#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows()
 #elif defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
-#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows_subms((ctx))
+#define DUK_USE_DATE_GET_NOW(ctx)            duk_bi_date_get_now_windows_subms()
 #else
 #error no provider for DUK_USE_DATE_GET_NOW()
 #endif

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -338,6 +338,7 @@ DUK_INTERNAL_DECL duk_int_t duk_pcall_method_flags(duk_hthread *thr, duk_idx_t n
 	 (thr)->valstack_bottom - 1)
 
 DUK_INTERNAL_DECL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_double_t duk_time_get_ecmascript_time_nofrac(duk_hthread *thr);
 DUK_INTERNAL_DECL duk_double_t duk_time_get_monotonic_time(duk_hthread *thr);
 
 #endif  /* DUK_API_INTERNAL_H_INCLUDED */

--- a/src-input/duk_api_time.c
+++ b/src-input/duk_api_time.c
@@ -8,6 +8,7 @@ DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr) {
 	/* Ecmascript time, with millisecond fractions.  Exposed via
 	 * duk_get_now() for example.
 	 */
+	DUK_UNREF(thr);
 	return (duk_double_t) DUK_USE_DATE_GET_NOW(thr);
 }
 
@@ -15,10 +16,12 @@ DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time_nofrac(duk_hthread *thr) 
 	/* Ecmascript time without millisecond fractions.  Exposed via
 	 * the Date built-in which doesn't allow fractions.
 	 */
+	DUK_UNREF(thr);
 	return (duk_double_t) DUK_FLOOR(DUK_USE_DATE_GET_NOW(thr));
 }
 
 DUK_INTERNAL duk_double_t duk_time_get_monotonic_time(duk_hthread *thr) {
+	DUK_UNREF(thr);
 #if defined(DUK_USE_GET_MONOTONIC_TIME)
 	return (duk_double_t) DUK_USE_GET_MONOTONIC_TIME(thr);
 #else
@@ -28,6 +31,7 @@ DUK_INTERNAL duk_double_t duk_time_get_monotonic_time(duk_hthread *thr) {
 
 DUK_EXTERNAL duk_double_t duk_get_now(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
+	DUK_UNREF(thr);
 
 	/* This API intentionally allows millisecond fractions. */
 	return duk_time_get_ecmascript_time(thr);
@@ -36,6 +40,7 @@ DUK_EXTERNAL duk_double_t duk_get_now(duk_hthread *thr) {
 #if 0  /* XXX: worth exposing? */
 DUK_EXTERNAL duk_double_t duk_get_monotonic_time(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
+	DUK_UNREF(thr);
 
 	return duk_time_get_monotonic_time(thr);
 }

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -16,12 +16,13 @@
 
 #if defined(DUK_USE_DATE_NOW_GETTIMEOFDAY)
 /* Get current Ecmascript time (= UNIX/Posix time, but in milliseconds). */
-DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(duk_hthread *thr) {
+DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(void) {
 	struct timeval tv;
 	duk_double_t d;
 
 	if (gettimeofday(&tv, NULL) != 0) {
-		DUK_ERROR_INTERNAL(thr);
+		DUK_D(DUK_DPRINT("gettimeofday() failed"));
+		return 0.0;
 	}
 
 	/* As of Duktape 2.2.0 allow fractions. */
@@ -34,11 +35,14 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(duk_hthread *thr) {
 
 #if defined(DUK_USE_DATE_NOW_TIME)
 /* Not a very good provider: only full seconds are available. */
-DUK_INTERNAL duk_double_t duk_bi_date_get_now_time(duk_hthread *thr) {
+DUK_INTERNAL duk_double_t duk_bi_date_get_now_time(void) {
 	time_t t;
 
-	DUK_UNREF(thr);
 	t = time(NULL);
+	if (t == (time_t) -1) {
+		DUK_D(DUK_DPRINT("time() failed"));
+		return 0;
+	}
 	return ((duk_double_t) t) * 1000.0;
 }
 #endif  /* DUK_USE_DATE_NOW_TIME */

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -42,14 +42,12 @@ DUK_LOCAL void duk__set_systime_jan1970(SYSTEMTIME *st) {
 #endif  /* defined(DUK_USE_DATE_NOW_WINDOWS) || defined(DUK_USE_DATE_TZO_WINDOWS) */
 
 #if defined(DUK_USE_DATE_NOW_WINDOWS)
-DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows(duk_hthread *thr) {
+DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows(void) {
 	/* Suggested step-by-step method from documentation of RtlTimeToSecondsSince1970:
 	 * http://msdn.microsoft.com/en-us/library/windows/desktop/ms724928(v=vs.85).aspx
 	 */
 	SYSTEMTIME st1, st2;
 	ULARGE_INTEGER tmp1, tmp2;
-
-	DUK_UNREF(thr);
 
 	GetSystemTime(&st1);
 	duk__convert_systime_to_ularge((const SYSTEMTIME *) &st1, &tmp1);
@@ -66,15 +64,13 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows(duk_hthread *thr) {
 #endif  /* DUK_USE_DATE_NOW_WINDOWS */
 
 #if defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
-DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows_subms(duk_hthread *thr) {
+DUK_INTERNAL duk_double_t duk_bi_date_get_now_windows_subms(void) {
 	/* Variant of the basic algorithm using GetSystemTimePreciseAsFileTime()
 	 * for more accuracy.
 	 */
 	FILETIME ft1;
 	SYSTEMTIME st2;
 	ULARGE_INTEGER tmp1, tmp2;
-
-	DUK_UNREF(thr);
 
 	GetSystemTimePreciseAsFileTime(&ft1);
 	duk__convert_filetime_to_ularge((const FILETIME *) &ft1, &tmp1);

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -23,16 +23,16 @@ DUK_INTERNAL_DECL duk_bool_t duk_bi_date_year_in_valid_range(duk_double_t year);
 DUK_INTERNAL_DECL duk_bool_t duk_bi_date_timeval_in_leeway_range(duk_double_t x);
 /* Built-in providers */
 #if defined(DUK_USE_DATE_NOW_GETTIMEOFDAY)
-DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_gettimeofday(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_gettimeofday(void);
 #endif
 #if defined(DUK_USE_DATE_NOW_TIME)
-DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_time(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_time(void);
 #endif
 #if defined(DUK_USE_DATE_NOW_WINDOWS)
-DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows(void);
 #endif
 #if defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
-DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows_subms(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_now_windows_subms(void);
 #endif
 #if defined(DUK_USE_DATE_TZO_GMTIME_R) || defined(DUK_USE_DATE_TZO_GMTIME_S) || defined(DUK_USE_DATE_TZO_GMTIME)
 DUK_INTERNAL_DECL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d);


### PR DESCRIPTION
Remove the unneeded 'thr' (or 'ctx') argument from Ecmascript/monotonic time Unix and Windows provider calls. Unix gettimeofday() provider was different from others in that an error getting time resulted in an error, other providers return a dummy value instead because such an error is not expected. Change gettimeofday() to behave the same way; internals are not always prepared to deal with an error when getting time.