### PR TITLE
Add clock_gettime(CLOCK_MONOTONIC) monotonic time source

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2992,6 +2992,10 @@ Planned
 * Add monotonic time provider for Windows based on QueryPerformanceCounter(),
   enabled by default if _WIN32_WINNT indicates Vista or above (GH-1662)
 
+* Add monotonic time provider for Unix platforms using clock_gettime() and
+  CLOCK_MONOTONIC time source; the time provider is disabled by default, enable
+  using -DDUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME (GH-1667)
+
 * Use monotonic time (if available) for debugger transport peeking, so that
   the peek callback is called with the same realtime rate even if the
   Ecmascript time source jumps or doesn't advance in realtime (GH-1659)

--- a/config/config-options/DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME.yaml
+++ b/config/config-options/DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME.yaml
@@ -1,0 +1,8 @@
+define: DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME
+introduced: 2.2.0
+default: false
+tags:
+  - portability
+description: >
+  Use clock_gettime(CLOCK_MONOTONIC, ...) for monotonic time on POSIX
+  platforms.

--- a/config/header-snippets/date_provider.h.in
+++ b/config/header-snippets/date_provider.h.in
@@ -55,6 +55,8 @@
 
 #if defined(DUK_USE_GET_MONOTONIC_TIME)
 /* External provider already defined. */
+#elif defined(DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME)
+#define DUK_USE_GET_MONOTONIC_TIME(ctx)  duk_bi_date_get_monotonic_time_clock_gettime()
 #elif defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC)
 #define DUK_USE_GET_MONOTONIC_TIME(ctx)  duk_bi_date_get_monotonic_time_windows_qpc()
 #else

--- a/config/platforms/platform_linux.h.in
+++ b/config/platforms/platform_linux.h.in
@@ -26,4 +26,8 @@
 #define DUK_USE_DATE_PRS_STRPTIME
 #define DUK_USE_DATE_FMT_STRFTIME
 
+#if 0  /* XXX: safe condition? */
+#define DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME
+#endif
+
 #define DUK_USE_OS_STRING "linux"

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -41,7 +41,7 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_time(void) {
 	t = time(NULL);
 	if (t == (time_t) -1) {
 		DUK_D(DUK_DPRINT("time() failed"));
-		return 0;
+		return 0.0;
 	}
 	return ((duk_double_t) t) * 1000.0;
 }
@@ -310,3 +310,16 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_
 	return 1;
 }
 #endif  /* DUK_USE_DATE_FMT_STRFTIME */
+
+#if defined(DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME)
+DUK_INTERNAL duk_double_t duk_bi_date_get_monotonic_time_clock_gettime(void) {
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+		return (duk_double_t) ts.tv_sec * 1000.0 + (duk_double_t) ts.tv_nsec / 1000000.0;
+	} else {
+		DUK_D(DUK_DPRINT("clock_gettime(CLOCK_MONOTONIC) failed"));
+		return 0.0;
+	}
+}
+#endif

--- a/src-input/duk_bi_protos.h
+++ b/src-input/duk_bi_protos.h
@@ -53,6 +53,9 @@ DUK_INTERNAL_DECL duk_bool_t duk_bi_date_parse_string_getdate(duk_hthread *thr, 
 DUK_INTERNAL_DECL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_int_t *parts, duk_int_t tzoffset, duk_small_uint_t flags);
 #endif
 
+#if defined(DUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME)
+DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_monotonic_time_clock_gettime(void);
+#endif
 #if defined(DUK_USE_GET_MONOTONIC_TIME_WINDOWS_QPC)
 DUK_INTERNAL_DECL duk_double_t duk_bi_date_get_monotonic_time_windows_qpc(void);
 #endif


### PR DESCRIPTION
For now the time source is disabled by default, enabled using configure.py -DDUK_USE_GET_MONOTONIC_TIME_CLOCK_GETTIME. It'd be nice to enable the monotonic time source but coming up with a safe condition (guaranteeing the source is available) for each Unix platform needs a lot of investigation.

The default Date provider, which performance.now() falls back to in absence of a monotonic time provider, has sub-millisecond resolution for Unix. So performance.now() works reasonably for common use cases, though the time is not necessarily jump free.