### PR TITLE
Reduce number of objects needing a thr->bidx[] entry

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3117,7 +3117,8 @@ Planned
 
 * Miscellaneous footprint improvements: rework call handling to improve
   code sharing (GH-1552); optional lazy charlen (GH-1337); remove 'thr'
-  argument from Date 'now' providers (GH-1666)
+  argument from Date 'now' providers (GH-1666); prune some objects from
+  thr->bidx[] array (GH-1668)
 
 * Miscellaneous performance improvements: move rare/large opcodes into
   NOINLINE helpers (GH-1510); duk_harray fast path for internal array

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2454,7 +2454,7 @@ objects:
   - id: bi_math
     class: Math
     internal_prototype: bi_object_prototype
-    bidx: true
+    bidx: false
     present_if: DUK_USE_MATH_BUILTIN
 
     # apparently no external "prototype" property
@@ -2719,7 +2719,7 @@ objects:
   - id: bi_json
     class: JSON
     internal_prototype: bi_object_prototype
-    bidx: true
+    bidx: false
     present_if:
       - DUK_USE_JSON_BUILTIN
       - DUK_USE_JSON_SUPPORT
@@ -2859,7 +2859,7 @@ objects:
     callable: true
     constructable: true
     duktape: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_COROUTINE_SUPPORT
 
     properties:
@@ -2943,7 +2943,7 @@ objects:
     callable: true
     constructable: true
     duktape: true
-    bidx: true
+    bidx: false
 
     properties:
       - key: "length"
@@ -3030,7 +3030,7 @@ objects:
     callable: true
     constructable: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_ES6_PROXY
 
     properties:
@@ -3052,7 +3052,7 @@ objects:
   - id: bi_reflect
     class: Object
     internal_prototype: bi_object_prototype
-    bidx: true
+    bidx: false
     present_if: DUK_USE_REFLECT_BUILTIN
 
     properties:
@@ -3159,7 +3159,7 @@ objects:
     es6: true
     nargs: 1
     magic: 0
-    bidx: true
+    bidx: false
     present_if: DUK_USE_SYMBOL_BUILTIN
 
     properties:
@@ -3345,7 +3345,7 @@ objects:
     constructable: true
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -3432,7 +3432,7 @@ objects:
     constructable: true
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -3755,7 +3755,7 @@ objects:
     magic: 0
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -3791,7 +3791,7 @@ objects:
     # no external_prototype (specific views provide it)
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     # Present even when DUK_USE_BUFFEROBJECT_SUPPORT is disabled
     # to support plain buffers.
 
@@ -3872,7 +3872,7 @@ objects:
       shift: 0
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -3940,7 +3940,7 @@ objects:
       shift: 0
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4029,7 +4029,7 @@ objects:
       shift: 0
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4097,7 +4097,7 @@ objects:
       shift: 1
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4165,7 +4165,7 @@ objects:
       shift: 1
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4233,7 +4233,7 @@ objects:
       shift: 2
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4301,7 +4301,7 @@ objects:
       shift: 2
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4369,7 +4369,7 @@ objects:
       shift: 2
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4437,7 +4437,7 @@ objects:
       shift: 3
     typedarray: true
     es6: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -4504,7 +4504,7 @@ objects:
     callable: true
     constructable: true
     nodejs_buffer: true
-    bidx: true
+    bidx: false
     present_if: DUK_USE_BUFFEROBJECT_SUPPORT
 
     properties:
@@ -5114,7 +5114,7 @@ objects:
     native: duk_bi_textencoder_constructor
     callable: true
     constructable: true
-    bidx: true
+    bidx: false
     encoding_api: true
     present_if: DUK_USE_ENCODING_BUILTINS
 
@@ -5137,7 +5137,7 @@ objects:
   - id: bi_textencoder_prototype
     internal_prototype: bi_object_prototype
     class: Object
-    bidx: true
+    bidx: false
     encoding_api: true
     present_if: DUK_USE_ENCODING_BUILTINS
 
@@ -5172,7 +5172,7 @@ objects:
     native: duk_bi_textdecoder_constructor
     callable: true
     constructable: true
-    bidx: true
+    bidx: false
     encoding_api: true
     present_if: DUK_USE_ENCODING_BUILTINS
 
@@ -5195,7 +5195,7 @@ objects:
   - id: bi_textdecoder_prototype
     internal_prototype: bi_object_prototype
     class: Object
-    bidx: true
+    bidx: false
     encoding_api: true
     present_if: DUK_USE_ENCODING_BUILTINS
 
@@ -5242,7 +5242,7 @@ objects:
   - id: bi_performance
     internal_prototype: bi_object_prototype
     class: Object
-    bidx: true
+    bidx: false
     performance_api: true
     present_if: DUK_USE_PERFORMANCE_BUILTIN
 

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -275,7 +275,9 @@ DUK_INTERNAL_DECL void duk_xdef_prop_stridx_short_raw(duk_hthread *thr, duk_uint
 #define duk_xdef_prop_stridx_short_wec(thr,obj_idx,stridx) \
 	duk_xdef_prop_stridx_short((thr), (obj_idx), (stridx), DUK_PROPDESC_FLAGS_WEC)
 
+#if 0  /*unused*/
 DUK_INTERNAL_DECL void duk_xdef_prop_stridx_builtin(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags);  /* [] -> [] */
+#endif
 
 DUK_INTERNAL_DECL void duk_xdef_prop_stridx_thrower(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx);  /* [] -> [] */
 

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -355,6 +355,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx_short_raw(duk_hthread *thr, duk_uint_t pa
 	                          (duk_small_uint_t) (packed_args & 0xffL));
 }
 
+#if 0  /*unused*/
 DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_int_t builtin_idx, duk_small_uint_t desc_flags) {
 	duk_hobject *obj;
 	duk_hstring *key;
@@ -372,6 +373,7 @@ DUK_INTERNAL void duk_xdef_prop_stridx_builtin(duk_hthread *thr, duk_idx_t obj_i
 	duk_hobject_define_property_internal(thr, obj, key, desc_flags);
 	/* value popped by call */
 }
+#endif
 
 /* This is a rare property helper; it sets the global thrower (E5 Section 13.2.3)
  * setter/getter into an object property.  This is needed by the 'arguments'

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -412,7 +412,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 */
 			t--;
 			DUK_DDD(DUK_DDDPRINT("set external prototype: built-in %ld", (long) t));
-			duk_xdef_prop_stridx_builtin(thr, i, DUK_STRIDX_PROTOTYPE, t, DUK_PROPDESC_FLAGS_NONE);
+			duk_dup(thr, t);
+			duk_xdef_prop_stridx(thr, i, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_NONE);
 		}
 
 		t = (duk_small_uint_t) duk_bd_decode_varuint(bd);
@@ -424,7 +425,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 */
 			t--;
 			DUK_DDD(DUK_DDDPRINT("set external constructor: built-in %ld", (long) t));
-			duk_xdef_prop_stridx_builtin(thr, i, DUK_STRIDX_CONSTRUCTOR, t, DUK_PROPDESC_FLAGS_WC);
+			duk_dup(thr, t);
+			duk_xdef_prop_stridx(thr, i, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);
 		}
 
 		/* normal valued properties */

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -1137,7 +1137,7 @@ def load_metadata(opts, rom=False, build_info=None, active_opts=None):
     for i,o in enumerate(meta['objects']):
         if i < len(meta['objects_bidx']):
             assert(meta['objects_bidx'][i] == meta['objects'][i])
-        if o.has_key('bidx'):
+        if o.get('bidx', False):
             assert(o['bidx'] == i)
 
     # Create a set of helper lists and maps now that the metadata is

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -824,6 +824,7 @@ def metadata_remove_orphan_objects(meta):
         for o in meta['objects']:
             if not reachable.has_key(o['id']):
                 continue
+            _markId(o.get('internal_prototype', None))
             for p in o['properties']:
                 # Shorthand has been normalized so no need
                 # to support it here.
@@ -1192,6 +1193,7 @@ def load_metadata(opts, rom=False, build_info=None, active_opts=None):
     for i,o in enumerate(meta['objects_bidx']):
         assert(o.get('bidx_used', False) == True)
         meta['_objid_to_bidx'][o['id']] = i
+        assert(meta['_objid_to_bidx'][o['id']] == meta['_objid_to_idx'][o['id']])
         meta['_bidx_to_objid'][i] = o['id']
         meta['_bidx_to_object'][i] = o
     if meta.has_key('objects_ram_toplevel'):


### PR DESCRIPTION
Remove the internal bidx[] entry for several objects which are not actually needed at runtime (no code references thr->bidx[DUK_BIDX_xxx] explicitly) but which needed a bidx during RAM initialization of built-ins, e.g. because an internal prototype reference needed it.

Change RAM initialization to allow an internal prototype reference to be an index to the top level object list which includes objects with a bidx but may also contain other objects.

This changes the number of bidx entries from 77 to 51 in master. Linux x64 sizeof(duk_hthread) drops from 808 to 600.