### PR TITLE
Add public macros to create symbol strings

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2947,6 +2947,9 @@ Planned
 * Add duk_push_proxy() API call which allows a Proxy to be created from C
   code (GH-1500, GH-837)
 
+* Add DUK_HIDDEN_SYMBOL(), DUK_GLOBAL_SYMBOL(), DUK_LOCAL_SYMBOL(), and
+  DUK_WELLKNOWN_SYMBOL() macros for creating symbol literals (GH-1673)
+
 * Add support for Proxy 'apply' and 'construct' traps (GH-1601)
 
 * Add minimal new.target support, evaluates to undefined for non-constructor

--- a/doc/release-notes-v2-2.rst
+++ b/doc/release-notes-v2-2.rst
@@ -19,6 +19,10 @@ Upgrading from Duktape 2.1
 No action (other than recompiling) should be needed for most users to upgrade
 from Duktape v2.1.x.  Note the following:
 
+* There are public API macros to create different Symbol types as C literals.
+  For example, DUK_HIDDEN_SYMBOL("myPointer") can now be used instead of
+  manually creating the internal representation ("\xFF" "myPointer").
+
 * Case insensitive RegExps are still much slower than case sensitive ones.
   The small canonicalization lookup (256 bytes) is enabled by default.  The
   small lookup is still slower than DUK_USE_REGEXP_CANON_WORKAROUND but the

--- a/doc/symbols.rst
+++ b/doc/symbols.rst
@@ -113,6 +113,9 @@ Useful comparisons (``p`` is pointer to string data) for internal use only:
 
 * ``(p[0] & 0xc0) == 0x80``: ES2015 Symbol, visible to Ecmascript code
 
+There are public API macros (DUK_HIDDEN_SYMBOL() etc) to create symbol literals
+from C code.
+
 Global symbols
 ==============
 

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -288,6 +288,23 @@ struct duk_time_components {
 #define DUK_LEVEL_DDDEBUG                 2
 
 /*
+ *  Macros to create Symbols as C statically constructed strings.
+ *
+ *  Call e.g. as DUK_HIDDEN_SYMBOL("myProperty") <=> ("\xFF" "myProperty").
+ *  Local symbols have a unique suffix, caller should take care to avoid
+ *  conflicting with the Duktape internal representation by e.g. prepending
+ *  a '!' character: DUK_LOCAL_SYMBOL("myLocal", "!123").
+ *
+ *  Note that these can only be used for string constants, not dynamically
+ *  created strings.
+ */
+
+#define DUK_HIDDEN_SYMBOL(x)     ("\xFF" x)
+#define DUK_GLOBAL_SYMBOL(x)     ("\x80" x)
+#define DUK_LOCAL_SYMBOL(x,uniq) ("\x81" x "\xff" uniq)
+#define DUK_WELLKNOWN_SYMBOL(x)  ("\x81" x "\xff")
+
+/*
  *  If no variadic macros, __FILE__ and __LINE__ are passed through globals
  *  which is ugly and not thread safe.
  */

--- a/tests/api/test-symbol-macros.c
+++ b/tests/api/test-symbol-macros.c
@@ -1,0 +1,52 @@
+/*===
+*** test_1 (duk_safe_call)
+Ecma myGlobal: 1002
+C myHidden: 1001
+C myGlobal: 1002
+C myLocal: 1003
+C myWellKnown: 1004
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_object(ctx);
+	duk_push_uint(ctx, 1001);
+	duk_put_prop_string(ctx, -2, "\xFF" "myHidden");
+	duk_push_uint(ctx, 1002);
+	duk_put_prop_string(ctx, -2, "\x80" "myGlobal");
+	duk_push_uint(ctx, 1003);
+	duk_put_prop_string(ctx, -2, "\x81" "myLocal" "\xFF" "!123");
+	duk_push_uint(ctx, 1004);
+	duk_put_prop_string(ctx, -2, "\x81" "myWellKnown" "\xFF");
+
+	duk_eval_string(ctx,
+		"(function (o) {\n"
+		"    print('Ecma myGlobal:', o[Symbol.for('myGlobal')]);\n"
+		"})\n");
+	duk_dup(ctx, -2);
+	duk_call(ctx, 1);
+	duk_pop(ctx);
+
+	duk_get_prop_string(ctx, -1, DUK_HIDDEN_SYMBOL("myHidden"));
+	printf("C myHidden: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+	duk_get_prop_string(ctx, -1, DUK_GLOBAL_SYMBOL("myGlobal"));
+	printf("C myGlobal: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+	duk_get_prop_string(ctx, -1, DUK_LOCAL_SYMBOL("myLocal", "!123"));
+	printf("C myLocal: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+	duk_get_prop_string(ctx, -1, DUK_WELLKNOWN_SYMBOL("myWellKnown"));
+	printf("C myWellKnown: %s\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -342,6 +342,33 @@ typedef struct duk_number_list_entry duk_number_list_entry;
 </tr>
 </table>
 
+<h2>Symbol literal macros</h2>
+
+<p>The following macros are defined for creating internal Symbol representations
+as C literals.  All arguments must be string literals and cannot be computed
+values:</p>
+
+<table>
+<tr>
+<td><code>DUK_HIDDEN_SYMBOL(x)</code></td>
+<td>A C literal for a Duktape specific hidden Symbol</td>
+</tr>
+<tr>
+<td><code>DUK_GLOBAL_SYMBOL(x)</code></td>
+<td>A C literal for a global symbol, equivalent to <code>Symbol.for(x)</code></td>
+</tr>
+<tr>
+<td><code>DUK_LOCAL_SYMBOL(x,uniq)</code></td>
+<td>A C literal for a local symbol, equivalent to <code>Symbol(x)</code>,
+    unique part provided in 'uniq' must not conflict with Duktape internal
+    format, recommendation is to prefix the unique part with a "!"</td>
+</tr>
+<tr>
+<td><code>DUK_WELLKNOWN_SYMBOL(x)</code></td>
+<td>A C literal for a well-known symbol like <code>Symbol.iterator</code></td>
+</tr>
+</table>
+
 <h2>Misc defines</h2>
 
 <table>

--- a/website/guide/symbols.html
+++ b/website/guide/symbols.html
@@ -35,8 +35,17 @@ would be represented as the CESU-8 bytes <code>c3 bf 78 79 7a</code> in memory.
 <pre class="c-code">
 /* Create a hidden Symbol which can then be used to read/write properties.
  * The Symbol can be passed on to Ecmascript code like any other string or
- * Symbol.  Terminating a string literal after a hex escape is safest to
- * avoid some ambiguous cases like "\xffab".
+ * Symbol.
+ */
+duk_push_string(ctx, DUK_HIDDEN_SYMBOL("mySymbol"));
+</pre>
+
+<p>Before Duktape 2.2 <code>DUK_HIDDEN_SYMBOL()</code> and other symbol
+literal macros were not available and the internal representation would be
+used directly:</p>
+<pre class="c-code">
+/* Terminating a string literal after a hex escape is safest to avoid some
+ * ambiguous cases like "\xffab".
  */
 duk_push_string(ctx, "\xff" "mySymbol");
 </pre>


### PR DESCRIPTION
Add macros to create different symbol types as C string literals:
- `DUK_HIDDEN_SYMBOL(x)` <=> `("\xFF" x)`
- `DUK_GLOBAL_SYMBOL(x)` <=> `("\x80" x)`
- `DUK_LOCAL_SYMBOL(x,uniq)` <=> `("\x81" x "\xFF" uniq)`
- `DUK_WELLKNOWN_SYMBOL(x)` <=> `("\x81" x "\xFF")`

Usage is e.g. as:

```c
duk_put_prop_string(ctx, obj_idx, DUK_HIDDEN_SYMBOL("myPointer"));
```

instead of:

```c
duk_put_prop_string(ctx, obj_idx, "\xFF" "myPointer");
```

All macros expect their arguments to be C string literals. In particular, the unique suffix for a local symbol cannot be a dynamically constructed value.

Adding these macros is a slight versioning risk because the internal representation might change, and no longer be representable as a string literal. On the other hand, it's better for calling code to depend on these macros instead of writing out the internal representations: if the macros are removed, the calling code will fail to compile instead of just silently creating bogus values.

Tasks:
- [x] Add macros
- [x] Add API test coverage
- [x] Documentation
- [x] 2.2 migration note recommending at least DUK_HIDDEN_SYMBOL()
- [x] Releases entry

Implements part of #1230.