### PR TITLE
Add ARM32/ARM64 to pointer size detection to fix MSVC2015 ARM compile

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3069,6 +3069,8 @@ Planned
 
 * Fix harmless GCC 7 -Wextra warning in Date built-in (GH-1646)
 
+* Fix pointer size detection for MSVC2015 ARM32/ARM64 (GH-1577, GH-1675)
+
 * Improve support for old MSVC versions without __pragma(), long long, and
   LL/ULL constants (GH-1559, GH-1562)
 

--- a/config/header-snippets/types1.h.in
+++ b/config/header-snippets/types1.h.in
@@ -49,12 +49,14 @@
     defined(DUK_F_BCC) || \
     (defined(__WORDSIZE) && (__WORDSIZE == 32)) || \
     ((defined(DUK_F_OLD_SOLARIS) || defined(DUK_F_AIX) || \
-      defined(DUK_F_HPUX)) && defined(_ILP32))
+      defined(DUK_F_HPUX)) && defined(_ILP32)) || \
+    defined(DUK_F_ARM32)
 #define DUK_F_32BIT_PTRS
 #elif defined(DUK_F_X64) || \
       (defined(__WORDSIZE) && (__WORDSIZE == 64)) || \
    ((defined(DUK_F_OLD_SOLARIS) || defined(DUK_F_AIX) || \
-     defined(DUK_F_HPUX)) && defined(_LP64))
+     defined(DUK_F_HPUX)) && defined(_LP64)) || \
+    defined(DUK_F_ARM64)
 #define DUK_F_64BIT_PTRS
 #else
 /* not sure, not needed with C99 anyway */


### PR DESCRIPTION
Fixes #1577. Adapted from https://github.com/svaarala/duktape/issues/1577#issuecomment-312233433 but using DUK_F_ARM64 for the second clause (instead of DUK_F_ARM).