### PR TITLE
Refactor debugger automatic pause handling

### DIFF
--- a/doc/debugger.rst
+++ b/doc/debugger.rst
@@ -1606,9 +1606,11 @@ Example::
     REQ 20 EOM
     REP EOM
 
-Resume execution and pause when execution exits the current line.  If a
-function call occurs before that, go into the function and pause execution
-there.
+Resume execution and pause when execution exits the current line, enters
+another function, exits the current function, or an error is thrown past
+the current function (in which case execution pauses in the error catcher,
+if any).  If the current function doesn't have line information (e.g. it is
+native), pauses on function entry/exit or error throw.
 
 StepOver request (0x15)
 -----------------------
@@ -1623,8 +1625,11 @@ Example::
     REQ 21 EOM
     REP EOM
 
-Resume execution and pause when execution exits the current line.  Don't pause
-on function calls occuring before that.
+Resume execution and pause when execution exits the current line, exits the
+current function, or an error is thrown past the current function (in which
+case execution pauses in the error catcher, if any).  If the current function
+doesn't have line information (e.g. it is native), pauses on function exit or
+error throw.
 
 StepOut request (0x16)
 ----------------------
@@ -1639,15 +1644,9 @@ Example::
     REQ 22 EOM
     REP EOM
 
-Resume execution and pause when execution exits the current function.  This can
-happen because:
-
-* The current function returns, in which case execution resumes in the calling
-  function.
-
-* The current function, or any function called by it, throws an error which is
-  not caught before it unwinds past the current function.  Execution resumes
-  in the error catcher.
+Resume execution and pause when execution exits the current function or an
+error is thrown past the current function (in which case execution pauses
+in the error catcher, if any).
 
 ListBreak request (0x17)
 ------------------------

--- a/doc/release-notes-v2-2.rst
+++ b/doc/release-notes-v2-2.rst
@@ -82,6 +82,11 @@ from Duktape v2.1.x.  Note the following:
   so duk_get_now() call sites may now get fractional millisecond timestamps
   even in default configuration.
 
+* Debugger StepInto, StepOver, and StepOut are now accepted also when the
+  current function doesn't have line information (i.e. it is native).  The
+  step commands will still pause on function entry/exit as appropriate; for
+  example, StepInto will pause on function entry or exit (or an error throw).
+
 Other minor differences:
 
 * When an Error instance is being constructed and Duktape.errCreate() is

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -86,9 +86,9 @@ DUK_EXTERNAL void duk_debugger_attach(duk_hthread *thr,
 	heap->dbg_processing = 0;
 	heap->dbg_state_dirty = 0;
 	heap->dbg_force_restart = 0;
-	heap->dbg_step_type = DUK_STEP_TYPE_NONE;
-	heap->dbg_step_act = NULL;
-	heap->dbg_step_startline = 0;
+	heap->dbg_pause_flags = 0;
+	heap->dbg_pause_act = NULL;
+	heap->dbg_pause_startline = 0;
 	heap->dbg_exec_counter = 0;
 	heap->dbg_last_counter = 0;
 	heap->dbg_last_time = 0.0;

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -86,9 +86,9 @@ DUK_LOCAL void duk__debug_do_detach1(duk_heap *heap, duk_int_t reason) {
 	/* heap->dbg_processing: keep on purpose to avoid debugger re-entry in detaching state */
 	heap->dbg_state_dirty = 0;
 	heap->dbg_force_restart = 0;
-	heap->dbg_step_type = 0;
-	heap->dbg_step_act = NULL;
-	heap->dbg_step_startline = 0;
+	heap->dbg_pause_flags = 0;
+	heap->dbg_pause_act = NULL;
+	heap->dbg_pause_startline = 0;
 	heap->dbg_have_next_byte = 0;
 	duk_debug_clear_paused(heap);  /* XXX: some overlap with field inits above */
 	heap->dbg_state_dirty = 0;     /* XXX: clear_paused sets dirty; rework? */
@@ -157,6 +157,34 @@ DUK_LOCAL void duk__debug_null_most_callbacks(duk_hthread *thr) {
 	heap->dbg_write_flush_cb = NULL;
 	heap->dbg_request_cb = NULL;
 	/* keep heap->dbg_detached_cb */
+}
+
+/*
+ *  Pause handling
+ */
+
+DUK_LOCAL void duk__debug_set_pause_state(duk_hthread *thr, duk_heap *heap, duk_small_uint_t pause_flags) {
+	duk_uint_fast32_t line;
+
+	line = duk_debug_curr_line(thr);
+	if (line == 0) {
+		/* No line info for current function. */
+		duk_small_uint_t updated_flags;
+
+		updated_flags = pause_flags & ~(DUK_PAUSE_FLAG_LINE_CHANGE);
+		DUK_D(DUK_DPRINT("no line info for current activation, disable line-based pause flags: 0x%08lx -> 0x%08lx",
+		                 (long) pause_flags, (long) updated_flags));
+		pause_flags = updated_flags;
+	}
+
+	heap->dbg_pause_flags = pause_flags;
+	heap->dbg_pause_act = thr->callstack_curr;
+	heap->dbg_pause_startline = line;
+	heap->dbg_state_dirty = 1;
+
+	DUK_D(DUK_DPRINT("set state for automatic pause triggers, flags=0x%08lx, act=%p, startline=%ld",
+	                 (long) heap->dbg_pause_flags, (void *) heap->dbg_pause_act,
+	                 (long) heap->dbg_pause_startline));
 }
 
 /*
@@ -1256,49 +1284,61 @@ DUK_LOCAL void duk__debug_handle_trigger_status(duk_hthread *thr, duk_heap *heap
 
 DUK_LOCAL void duk__debug_handle_pause(duk_hthread *thr, duk_heap *heap) {
 	DUK_D(DUK_DPRINT("debug command Pause"));
-
-	if (duk_debug_is_paused(heap)) {
-		DUK_D(DUK_DPRINT("Pause requested when already paused, ignore"));
-	} else {
-		duk_debug_set_paused(heap);
-	}
+	duk_debug_set_paused(heap);
 	duk_debug_write_reply(thr);
 	duk_debug_write_eom(thr);
 }
 
 DUK_LOCAL void duk__debug_handle_resume(duk_hthread *thr, duk_heap *heap) {
+	duk_small_uint_t pause_flags;
+
 	DUK_D(DUK_DPRINT("debug command Resume"));
 
 	duk_debug_clear_paused(heap);
+
+	pause_flags = 0;
+#if 0  /* manual testing */
+	pause_flags |= DUK_PAUSE_FLAG_ONE_OPCODE;
+	pause_flags |= DUK_PAUSE_FLAG_CAUGHT_ERROR;
+	pause_flags |= DUK_PAUSE_FLAG_UNCAUGHT_ERROR;
+#endif
+#if defined(DUK_USE_DEBUGGER_PAUSE_UNCAUGHT)
+	pause_flags |= DUK_PAUSE_FLAG_UNCAUGHT_ERROR;
+#endif
+
+	duk__debug_set_pause_state(thr, heap, pause_flags);
+
 	duk_debug_write_reply(thr);
 	duk_debug_write_eom(thr);
 }
 
 DUK_LOCAL void duk__debug_handle_step(duk_hthread *thr, duk_heap *heap, duk_int32_t cmd) {
-	duk_small_uint_t step_type;
-	duk_uint_fast32_t line;
+	duk_small_uint_t pause_flags;
 
 	DUK_D(DUK_DPRINT("debug command StepInto/StepOver/StepOut: %d", (int) cmd));
 
 	if (cmd == DUK_DBG_CMD_STEPINTO) {
-		step_type = DUK_STEP_TYPE_INTO;
+		pause_flags = DUK_PAUSE_FLAG_LINE_CHANGE |
+		              DUK_PAUSE_FLAG_FUNC_ENTRY |
+		              DUK_PAUSE_FLAG_FUNC_EXIT;
 	} else if (cmd == DUK_DBG_CMD_STEPOVER) {
-		step_type = DUK_STEP_TYPE_OVER;
+		pause_flags = DUK_PAUSE_FLAG_LINE_CHANGE |
+		              DUK_PAUSE_FLAG_FUNC_EXIT;
 	} else {
 		DUK_ASSERT(cmd == DUK_DBG_CMD_STEPOUT);
-		step_type = DUK_STEP_TYPE_OUT;
+		pause_flags = DUK_PAUSE_FLAG_FUNC_EXIT;
 	}
+#if defined(DUK_USE_DEBUGGER_PAUSE_UNCAUGHT)
+	pause_flags |= DUK_PAUSE_FLAG_UNCAUGHT_ERROR;
+#endif
 
-	line = duk_debug_curr_line(thr);
-	if (line > 0) {
-		duk_debug_clear_paused(heap);  /* XXX: overlap with fields below; separate macro/helper? */
-		heap->dbg_step_type = step_type;
-		heap->dbg_step_act = thr->callstack_curr;
-		heap->dbg_step_startline = line;
-		heap->dbg_state_dirty = 1;
-	} else {
-		DUK_D(DUK_DPRINT("cannot determine current line, stepinto/stepover/stepout ignored"));
-	}
+	/* If current activation doesn't have line information, line-based
+	 * pause flags are automatically disabled.  As a result, e.g.
+	 * StepInto will then pause on (native) function entry or exit.
+	 */
+	duk_debug_clear_paused(heap);
+	duk__debug_set_pause_state(thr, heap, pause_flags);
+
 	duk_debug_write_reply(thr);
 	duk_debug_write_eom(thr);
 }
@@ -2825,7 +2865,7 @@ DUK_INTERNAL void duk_debug_set_paused(duk_heap *heap) {
 	} else {
 		DUK_HEAP_SET_DEBUGGER_PAUSED(heap);
 		heap->dbg_state_dirty = 1;
-		duk_debug_clear_step_state(heap);
+		duk_debug_clear_pause_state(heap);
 		DUK_ASSERT(heap->ms_running == 0);  /* debugger can't be triggered within mark-and-sweep */
 		heap->ms_running = 1;  /* prevent mark-and-sweep, prevent refzero queueing */
 		heap->ms_prevent_count++;
@@ -2838,7 +2878,7 @@ DUK_INTERNAL void duk_debug_clear_paused(duk_heap *heap) {
 	if (duk_debug_is_paused(heap)) {
 		DUK_HEAP_CLEAR_DEBUGGER_PAUSED(heap);
 		heap->dbg_state_dirty = 1;
-		duk_debug_clear_step_state(heap);
+		duk_debug_clear_pause_state(heap);
 		DUK_ASSERT(heap->ms_running == 1);
 		DUK_ASSERT(heap->ms_prevent_count > 0);
 		heap->ms_prevent_count--;
@@ -2849,10 +2889,10 @@ DUK_INTERNAL void duk_debug_clear_paused(duk_heap *heap) {
 	}
 }
 
-DUK_INTERNAL void duk_debug_clear_step_state(duk_heap *heap) {
-	heap->dbg_step_type = DUK_STEP_TYPE_NONE;
-	heap->dbg_step_act = NULL;
-	heap->dbg_step_startline = 0;
+DUK_INTERNAL void duk_debug_clear_pause_state(duk_heap *heap) {
+	heap->dbg_pause_flags = 0;
+	heap->dbg_pause_act = NULL;
+	heap->dbg_pause_startline = 0;
 }
 
 #else  /* DUK_USE_DEBUGGER_SUPPORT */

--- a/src-input/duk_debugger.h
+++ b/src-input/duk_debugger.h
@@ -145,7 +145,7 @@ DUK_INTERNAL_DECL duk_bool_t duk_debug_is_attached(duk_heap *heap);
 DUK_INTERNAL_DECL duk_bool_t duk_debug_is_paused(duk_heap *heap);
 DUK_INTERNAL_DECL void duk_debug_set_paused(duk_heap *heap);
 DUK_INTERNAL_DECL void duk_debug_clear_paused(duk_heap *heap);
-DUK_INTERNAL_DECL void duk_debug_clear_step_state(duk_heap *heap);
+DUK_INTERNAL_DECL void duk_debug_clear_pause_state(duk_heap *heap);
 #endif  /* DUK_USE_DEBUGGER_SUPPORT */
 
 #endif  /* DUK_DEBUGGER_H_INCLUDED */

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -271,11 +271,14 @@ typedef void *(*duk_mem_getptr)(duk_heap *heap, void *ud);
 /* Milliseconds between status notify and transport peeks. */
 #define DUK_HEAP_DBG_RATELIMIT_MILLISECS  200
 
-/* Step types */
-#define DUK_STEP_TYPE_NONE  0
-#define DUK_STEP_TYPE_INTO  1
-#define DUK_STEP_TYPE_OVER  2
-#define DUK_STEP_TYPE_OUT   3
+/* Debugger pause flags. */
+#define DUK_PAUSE_FLAG_ONE_OPCODE        (1U << 0)   /* pause when a single opcode has been executed */
+#define DUK_PAUSE_FLAG_ONE_OPCODE_ACTIVE (1U << 1)   /* one opcode pause actually active; artifact of current implementation */
+#define DUK_PAUSE_FLAG_LINE_CHANGE       (1U << 2)   /* pause when current line number changes */
+#define DUK_PAUSE_FLAG_FUNC_ENTRY        (1U << 3)   /* pause when entering a function */
+#define DUK_PAUSE_FLAG_FUNC_EXIT         (1U << 4)   /* pause when exiting current function */
+#define DUK_PAUSE_FLAG_CAUGHT_ERROR      (1U << 5)   /* pause when about to throw an error that is caught */
+#define DUK_PAUSE_FLAG_UNCAUGHT_ERROR    (1U << 6)   /* pause when about to throw an error that won't be caught */
 
 struct duk_breakpoint {
 	duk_hstring *filename;
@@ -511,9 +514,9 @@ struct duk_heap {
 	duk_bool_t dbg_state_dirty;             /* resend state next time executor is about to run */
 	duk_bool_t dbg_force_restart;           /* force executor restart to recheck breakpoints; used to handle function returns (see GH-303) */
 	duk_bool_t dbg_detaching;               /* debugger detaching; used to avoid calling detach handler recursively */
-	duk_small_uint_t dbg_step_type;         /* step type: none, step into, step over, step out */
-	duk_activation *dbg_step_act;           /* activation related to step into/over/out */
-	duk_uint32_t dbg_step_startline;        /* starting line number */
+	duk_small_uint_t dbg_pause_flags;       /* flags for automatic pause behavior */
+	duk_activation *dbg_pause_act;          /* activation related to pause behavior (pause on line change, function entry/exit) */
+	duk_uint32_t dbg_pause_startline;       /* starting line number for line change related pause behavior */
 	duk_breakpoint dbg_breakpoints[DUK_HEAP_MAX_BREAKPOINTS];  /* breakpoints: [0,breakpoint_count[ gc reachable */
 	duk_small_uint_t dbg_breakpoint_count;
 	duk_breakpoint *dbg_breakpoints_active[DUK_HEAP_MAX_BREAKPOINTS + 1];  /* currently active breakpoints: NULL term, borrowed pointers */

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -943,7 +943,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	res->dbg_write_flush_cb = NULL;
 	res->dbg_request_cb = NULL;
 	res->dbg_udata = NULL;
-	res->dbg_step_act = NULL;
+	res->dbg_pause_act = NULL;
 #endif
 #endif  /* DUK_USE_EXPLICIT_NULL_INIT */
 

--- a/src-input/duk_hthread_stacks.c
+++ b/src-input/duk_hthread_stacks.c
@@ -220,13 +220,15 @@ DUK_LOCAL void duk__activation_unwind_nofree_norz(duk_hthread *thr) {
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	heap = thr->heap;
-	if (heap->dbg_step_act == thr->callstack_curr) {
-		if (duk_debug_is_paused(heap)) {
-			DUK_D(DUK_DPRINT("step pause trigger but already paused, ignoring"));
-		} else {
+	if (heap->dbg_pause_act == thr->callstack_curr) {
+		if (heap->dbg_pause_flags & DUK_PAUSE_FLAG_FUNC_EXIT) {
+			DUK_D(DUK_DPRINT("PAUSE TRIGGERED by function exit"));
 			duk_debug_set_paused(heap);
-			DUK_ASSERT(heap->dbg_step_act == NULL);
+		} else {
+			DUK_D(DUK_DPRINT("unwound past dbg_pause_act, set to NULL"));
+			heap->dbg_pause_act = NULL;  /* avoid stale pointers */
 		}
+		DUK_ASSERT(heap->dbg_pause_act == NULL);
 	}
 #endif
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1440,7 +1440,7 @@ DUK_LOCAL duk_small_uint_t duk__call_setup_act_attempt_tailcall(duk_hthread *thr
 	duk_idx_t idx_args;
 	duk_small_uint_t flags1, flags2;
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-	duk_activation *prev_step_act;
+	duk_activation *prev_pause_act;
 #endif
 
 	DUK_UNREF(entry_valstack_end_byteoff);
@@ -1520,12 +1520,12 @@ DUK_LOCAL duk_small_uint_t duk__call_setup_act_attempt_tailcall(duk_hthread *thr
 	DUK_ASSERT(thr->callstack_top > 0);
 	DUK_ASSERT(thr->callstack_curr != NULL);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-	prev_step_act = thr->heap->dbg_step_act;
-	thr->heap->dbg_step_act = NULL;
+	prev_pause_act = thr->heap->dbg_pause_act;
+	thr->heap->dbg_pause_act = NULL;
 #endif
 	duk_hthread_activation_unwind_reuse_norz(thr);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
-	thr->heap->dbg_step_act = prev_step_act;
+	thr->heap->dbg_pause_act = prev_pause_act;
 #endif
 	DUK_ASSERT(act == thr->callstack_curr);
 


### PR DESCRIPTION
Use a single pause flags field to implement Resume, StepInto, StepOver, and StepOut, and reserve (as yet unused) pause flags for pausing after a single opcode, and pausing after caught/uncaught error. No debugger protocol changes yet in this pull.

Also improve behavior of StepOver, StepInto, and StepOut when the current activation is native and has no line information. Previously e.g. StepInto was ignored in this state altogether (which was undocumented). The improved behavior is to ignore the line-based pause trigger but use the others, i.e. StepInto will pause on function entry, function exit, and an error thrown out past the current function.

- [x] Remove step_type and replace it with pause_flags
- [x] Rework StepXxx to use pause_flags
- [x] Rename step act/line to pause act/line to match pause flags
- [x] Make pause on caught/uncaught handling generic and enabled when debugger is enabled
- [x] Rework DUK_USE_DEBUGGER_PAUSE_UNCAUGHT to automatically set pause-on-uncaught flag
- [x] Implement pause after one opcode
- [x] Accept StepXxx even when current activation has no line information
- [x] 2.2 migration note for StepXxx behavior change
- [x] Test Resume
- [x] Test StepInto
- [x] Test StepOver
- [x] Test StepOut
- [x] Test pause-on-caught manually
- [x] Test pause-on-uncaught manually
- [x] Test step opcode manually
- [x] Test e.g. StepInto from an Ecmascript function without line information