### PR TITLE
Fix some GCC -Wsign-conversion warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an 
 CCOPTS_SHARED += -Wmissing-prototypes
 # -Wfloat-equal is too picky, there's no apparent way to compare floats
 # (even when you know it's safe) without triggering warnings
+CCOPTS_SHARED += -Wsign-conversion
 CCOPTS_SHARED += -fmax-errors=3  # prevent floods of errors if e.g. parenthesis missing
 CCOPTS_SHARED += -I./linenoise
 CCOPTS_SHARED += -I./examples/alloc-logging

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2950,6 +2950,10 @@ Planned
 * Add DUK_HIDDEN_SYMBOL(), DUK_GLOBAL_SYMBOL(), DUK_LOCAL_SYMBOL(), and
   DUK_WELLKNOWN_SYMBOL() macros for creating symbol literals (GH-1673)
 
+* Change duk_bool_t type to unsigned integer (previously signed integer)
+  and make DUK_TYPE_xxx, DUK_TYPE_MASK_xxx, and flags constants unsigned
+  in the API header (GH-1688)
+
 * Add support for Proxy 'apply' and 'construct' traps (GH-1601)
 
 * Add minimal new.target support, evaluates to undefined for non-constructor
@@ -2985,6 +2989,11 @@ Planned
 
 * Make error message summary strings longer (32 -> 96 character) to better
   capture error messages for e.g. uncaught errors (GH-1653)
+
+* Add an explicit buffer size wrap check for Buffer.concat() (GH-1688)
+
+* Reject an attempt to unpack an array with >= 2G elements cleanly with a
+  RangeError rather than failing during the process (GH-1688)
 
 * Add DUK_USE_GET_MONOTONIC_TIME() to allow an application to provide a
   monotonic time source (similar to clock_gettime() CLOCK_MONOTONIC) which
@@ -3078,6 +3087,8 @@ Planned
   module-duktape, module-node, and duk-v1-compat extras (GH-1646)
 
 * Fix harmless GCC 7 -Wextra warning in Date built-in (GH-1646)
+
+* Fix -Wsign-conversion warnings for GCC / Clang (GH-1688)
 
 * Fix pointer size detection for MSVC2015 ARM32/ARM64 (GH-1577, GH-1675)
 

--- a/config/header-snippets/types2.h.in
+++ b/config/header-snippets/types2.h.in
@@ -53,8 +53,8 @@ typedef duk_uint_fast16_t duk_small_uint_fast_t;
 #define DUK_SMALL_UINT_FAST_MIN   DUK_UINT_FAST16_MIN
 #define DUK_SMALL_UINT_FAST_MAX   DUK_UINT_FAST16_MAX
 
-/* Boolean values are represented with the platform 'int'. */
-typedef duk_small_int_t duk_bool_t;
+/* Boolean values are represented with the platform 'unsigned int'. */
+typedef duk_small_uint_t duk_bool_t;
 #define DUK_BOOL_MIN              DUK_SMALL_INT_MIN
 #define DUK_BOOL_MAX              DUK_SMALL_INT_MAX
 

--- a/doc/release-notes-v2-2.rst
+++ b/doc/release-notes-v2-2.rst
@@ -19,6 +19,12 @@ Upgrading from Duktape 2.1
 No action (other than recompiling) should be needed for most users to upgrade
 from Duktape v2.1.x.  Note the following:
 
+* The typedef for duk_bool_t was changed from duk_small_int_t (typically
+  'int') to duk_small_uint_t (typically 'unsigned int').  API constants for
+  DUK_TYPE_xxx, DUK_TYPE_MASK_xxx, flags, etc were changed to unsigned
+  (e.g. '(1U << 3)) to match their C type.  These changes may cause some
+  sign conversion warnings in application call sites.
+
 * There are public API macros to create different Symbol types as C literals.
   For example, DUK_HIDDEN_SYMBOL("myPointer") can now be used instead of
   manually creating the internal representation ("\xFF" "myPointer").

--- a/examples/alloc-hybrid/duk_alloc_hybrid.c
+++ b/examples/alloc-hybrid/duk_alloc_hybrid.c
@@ -105,7 +105,7 @@ void *duk_alloc_hybrid_init(void) {
 #if defined(DUK_ALLOC_HYBRID_DEBUG)
 		printf("Pool %d: size %ld, count %ld\n", i, (long) pool_sizes[i].size, (long) pool_sizes[i].count);
 #endif
-		total_size += pool_sizes[i].size * pool_sizes[i].count;
+		total_size += pool_sizes[i].size * (size_t) pool_sizes[i].count;
 		if (pool_sizes[i].size > max_size) {
 			max_size = pool_sizes[i].size;
 		}
@@ -127,7 +127,7 @@ void *duk_alloc_hybrid_init(void) {
 		pool_header *hdr = st->headers + i;
 
 		hdr->alloc_start = p;
-		hdr->alloc_end = p + pool_sizes[i].size * pool_sizes[i].count;
+		hdr->alloc_end = p + pool_sizes[i].size * (size_t) pool_sizes[i].count;
 		hdr->free = (pool_free_entry *) (void *) p;
 		hdr->size = pool_sizes[i].size;
 		hdr->count = pool_sizes[i].count;

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -218,7 +218,7 @@ static void print_pop_error(duk_context *ctx, FILE *f) {
 static duk_ret_t wrapped_compile_execute(duk_context *ctx, void *udata) {
 	const char *src_data;
 	duk_size_t src_len;
-	int comp_flags;
+	duk_uint_t comp_flags;
 
 	(void) udata;
 

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -95,7 +95,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_string_prop(duk_hthread *thr, duk_uint8_t *p, d
 		DUK_ASSERT(h_str != NULL);
 	}
 	DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL);  /* ensures no overflow */
-	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4 + DUK_HSTRING_GET_BYTELEN(h_str), p);
+	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(h_str), p);
 	p = duk__dump_hstring_raw(p, h_str);
 	return p;
 }
@@ -109,10 +109,10 @@ DUK_LOCAL duk_uint8_t *duk__dump_buffer_prop(duk_hthread *thr, duk_uint8_t *p, d
 		h_buf = DUK_TVAL_GET_BUFFER(tv);
 		DUK_ASSERT(h_buf != NULL);
 		DUK_ASSERT(DUK_HBUFFER_MAX_BYTELEN <= 0x7fffffffUL);  /* ensures no overflow */
-		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4 + DUK_HBUFFER_GET_SIZE(h_buf), p);
+		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HBUFFER_GET_SIZE(h_buf), p);
 		p = duk__dump_hbuffer_raw(thr, p, h_buf);
 	} else {
-		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4, p);
+		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 		DUK_RAW_WRITE_U32_BE(p, 0);
 	}
 	return p;
@@ -128,7 +128,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_uint32_prop(duk_hthread *thr, duk_uint8_t *p, d
 	} else {
 		val = def_value;
 	}
-	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4, p);
+	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 	DUK_RAW_WRITE_U32_BE(p, val);
 	return p;
 }
@@ -169,12 +169,12 @@ DUK_LOCAL duk_uint8_t *duk__dump_varmap(duk_hthread *thr, duk_uint8_t *p, duk_bu
 #endif
 
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL);  /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4 + DUK_HSTRING_GET_BYTELEN(key) + 4, p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(key) + 4U, p);
 			p = duk__dump_hstring_raw(p, key);
 			DUK_RAW_WRITE_U32_BE(p, val);
 		}
 	}
-	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4, p);
+	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 	DUK_RAW_WRITE_U32_BE(p, 0);  /* end of _Varmap */
 	return p;
 }
@@ -197,7 +197,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_formals(duk_hthread *thr, duk_uint8_t *p, duk_b
 		DUK_ASSERT(DUK_HOBJECT_IS_ARRAY((duk_hobject *) h));
 		DUK_ASSERT(h->length <= DUK_HOBJECT_GET_ASIZE((duk_hobject *) h));
 
-		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4, p);
+		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 		DUK_ASSERT(h->length != DUK__NO_FORMALS);  /* limits */
 		DUK_RAW_WRITE_U32_BE(p, h->length);
 
@@ -214,12 +214,12 @@ DUK_LOCAL duk_uint8_t *duk__dump_formals(duk_hthread *thr, duk_uint8_t *p, duk_b
 			DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(varname) >= 1);
 
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL);  /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4 + DUK_HSTRING_GET_BYTELEN(varname), p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(varname), p);
 			p = duk__dump_hstring_raw(p, varname);
 		}
 	} else {
 		DUK_DD(DUK_DDPRINT("dumping function without _Formals, emit marker to indicate missing _Formals"));
-		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4, p);
+		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 		DUK_RAW_WRITE_U32_BE(p, DUK__NO_FORMALS);  /* marker: no formals */
 	}
 	return p;
@@ -256,7 +256,7 @@ static duk_uint8_t *duk__dump_func(duk_hthread *thr, duk_hcompfunc *func, duk_bu
 
 	DUK_ASSERT(DUK_USE_ESBC_MAX_BYTES <= 0x7fffffffUL);  /* ensures no overflow */
 	count_instr = (duk_uint32_t) DUK_HCOMPFUNC_GET_CODE_COUNT(thr->heap, func);
-	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 3 * 4 + 2 * 2 + 3 * 4 + count_instr * 4, p);
+	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 3U * 4U + 2U * 2U + 3U * 4U + count_instr * 4U, p);
 
 	/* Fixed header info. */
 	tmp32 = count_instr;
@@ -311,12 +311,12 @@ static duk_uint8_t *duk__dump_func(duk_hthread *thr, duk_hcompfunc *func, duk_bu
 			h_str = DUK_TVAL_GET_STRING(tv);
 			DUK_ASSERT(h_str != NULL);
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL);  /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1 + 4 + DUK_HSTRING_GET_BYTELEN(h_str), p),
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1U + 4U + DUK_HSTRING_GET_BYTELEN(h_str), p),
 			*p++ = DUK__SER_STRING;
 			p = duk__dump_hstring_raw(p, h_str);
 		} else {
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv));
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1 + 8, p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1U + 8U, p);
 			*p++ = DUK__SER_NUMBER;
 			d = DUK_TVAL_GET_NUMBER(tv);
 			DUK_RAW_WRITE_DOUBLE_BE(p, d);
@@ -423,7 +423,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	 * inner functions being loaded.  Require enough space to handle
 	 * large functions correctly.
 	 */
-	duk_require_stack(thr, 2 + count_const + count_funcs);
+	duk_require_stack(thr, (duk_idx_t) (2 + count_const + count_funcs));
 	idx_base = duk_get_top(thr);
 
 	/* Push function object, init flags etc.  This must match

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -19,7 +19,7 @@ DUK_EXTERNAL void duk_push_context_dump(duk_hthread *thr) {
 	duk_push_array(thr);
 	for (idx = 0; idx < top; idx++) {
 		duk_dup(thr, idx);
-		duk_put_prop_index(thr, -2, idx);
+		duk_put_prop_index(thr, -2, (duk_uarridx_t) idx);
 	}
 
 	/* XXX: conversion errors should not propagate outwards.

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -25,7 +25,7 @@ DUK_LOCAL void duk__inspect_multiple_uint(duk_hthread *thr, const char *fmt, duk
 		if (val >= 0) {
 			/* Negative values are markers to skip key. */
 			duk_push_string(thr, p_curr);
-			duk_push_uint(thr, val);
+			duk_push_int(thr, val);
 			duk_put_prop(thr, -3);
 		}
 	}
@@ -73,7 +73,7 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 	h = (DUK_TVAL_IS_HEAP_ALLOCATED(tv) ? DUK_TVAL_GET_HEAPHDR(tv) : NULL);
 
 	vals[DUK__IDX_TYPE] = duk_get_type_tval(tv);
-	vals[DUK__IDX_ITAG] = (duk_uint_t) DUK_TVAL_GET_TAG(tv);
+	vals[DUK__IDX_ITAG] = (duk_int_t) DUK_TVAL_GET_TAG(tv);
 
 	duk_push_bare_object(thr);  /* Invalidates 'tv'. */
 	tv = NULL;
@@ -166,10 +166,10 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 				vals[DUK__IDX_VARIANT] = 1;  /* buffer variant 1: dynamic */
 				vals[DUK__IDX_HBYTES] = (duk_uint_t) (sizeof(duk_hbuffer_dynamic));
 			}
-			vals[DUK__IDX_DBYTES] = (duk_uint_t) (DUK_HBUFFER_GET_SIZE(h_buf));
+			vals[DUK__IDX_DBYTES] = (duk_int_t) (DUK_HBUFFER_GET_SIZE(h_buf));
 		} else {
 			DUK_ASSERT(vals[DUK__IDX_VARIANT] == 0);  /* buffer variant 0: fixed */
-			vals[DUK__IDX_HBYTES] = (duk_uint_t) (sizeof(duk_hbuffer_fixed) + DUK_HBUFFER_GET_SIZE(h_buf));
+			vals[DUK__IDX_HBYTES] = (duk_int_t) (sizeof(duk_hbuffer_fixed) + DUK_HBUFFER_GET_SIZE(h_buf));
 		}
 		break;
 	}

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -95,7 +95,7 @@ DUK_LOCAL duk_bool_t duk__put_prop_shared(duk_hthread *thr, duk_idx_t obj_idx, d
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
 	duk_tval *tv_val;
-	duk_small_int_t throw_flag;
+	duk_bool_t throw_flag;
 	duk_bool_t rc;
 
 	/* Note: copying tv_obj and tv_key to locals to shield against a valstack
@@ -173,7 +173,7 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx_short_raw(duk_hthread *thr, duk_uint
 DUK_EXTERNAL duk_bool_t duk_del_prop(duk_hthread *thr, duk_idx_t obj_idx) {
 	duk_tval *tv_obj;
 	duk_tval *tv_key;
-	duk_small_int_t throw_flag;
+	duk_bool_t throw_flag;
 	duk_bool_t rc;
 
 	DUK_ASSERT_API_ENTRY(thr);

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -89,10 +89,10 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_hthread *thr, duk_idx_t count_in,
 
 	if (is_join) {
 		duk_replace(thr, -((duk_idx_t) count) - 2);  /* overwrite sep */
-		duk_pop_n(thr, count);
+		duk_pop_n(thr, (duk_idx_t) count);
 	} else {
 		duk_replace(thr, -((duk_idx_t) count) - 1);  /* overwrite str1 */
-		duk_pop_n(thr, count-1);
+		duk_pop_n(thr, (duk_idx_t) (count - 1));
 	}
 
 	/* [ ... buf ] */

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -234,7 +234,7 @@ DUK_LOCAL duk_bool_t duk__parse_string_iso8601_subset(duk_hthread *thr, const ch
 			}
 		} else {
 			duk_uint_fast32_t match_val;
-			duk_small_int_t sep_idx;
+			duk_small_uint_t sep_idx;
 
 			if (ndigits <= 0) {
 				goto reject;
@@ -989,7 +989,7 @@ DUK_LOCAL void duk__format_parts_iso8601(duk_int_t *parts, duk_int_t tzoffset, d
 		arg_hours = tmp / 60;
 		arg_minutes = tmp % 60;
 		DUK_ASSERT(arg_hours <= 24);  /* Even less is actually guaranteed for a valid tzoffset. */
-		arg_hours = arg_hours & 0x3fU;  /* For [0,24] this is a no-op, but fixes GCC 7 warning, see https://github.com/svaarala/duktape/issues/1602. */
+		arg_hours = arg_hours & 0x3f;  /* For [0,24] this is a no-op, but fixes GCC 7 warning, see https://github.com/svaarala/duktape/issues/1602. */
 
 		DUK_SNPRINTF(tzstr, sizeof(tzstr), fmt, (int) arg_hours, (int) arg_minutes);
 		tzstr[sizeof(tzstr) - 1] = (char) 0;
@@ -1178,7 +1178,7 @@ DUK_LOCAL duk_ret_t duk__set_part_helper(duk_hthread *thr, duk_small_uint_t flag
 			duk__twodigit_year_fixup(thr, (duk_idx_t) i);
 		}
 
-		dparts[idx] = duk_to_number(thr, i);
+		dparts[idx] = duk_to_number(thr, (duk_idx_t) i);
 
 		if (idx == DUK_DATE_IDX_DAY) {
 			/* Day-of-month is one-based in the API, but zero-based
@@ -1411,8 +1411,8 @@ static duk_uint16_t duk__date_magics[] = {
 };
 
 DUK_LOCAL duk_small_uint_t duk__date_get_indirect_magic(duk_hthread *thr) {
-	duk_small_int_t magicidx = (duk_small_uint_t) duk_get_current_magic(thr);
-	DUK_ASSERT(magicidx >= 0 && magicidx < (duk_small_int_t) (sizeof(duk__date_magics) / sizeof(duk_uint16_t)));
+	duk_small_uint_t magicidx = (duk_small_uint_t) duk_get_current_magic(thr);
+	DUK_ASSERT(magicidx < (duk_small_int_t) (sizeof(duk__date_magics) / sizeof(duk_uint16_t)));
 	return (duk_small_uint_t) duk__date_magics[magicidx];
 }
 

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -196,7 +196,7 @@ DUK_LOCAL void duk__utf8_encode_char(void *udata, duk_codepoint_t codepoint) {
 	/* Codepoint may be original input, a decoded surrogate pair, or may
 	 * have been replaced with U+FFFD.
 	 */
-	enc_ctx->out += duk_unicode_encode_xutf8(codepoint, enc_ctx->out);
+	enc_ctx->out += duk_unicode_encode_xutf8((duk_ucodepoint_t) codepoint, enc_ctx->out);
 }
 #endif  /* DUK_USE_ENCODING_BUILTINS */
 
@@ -306,7 +306,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_hthread *thr, duk__decode_context *de
 			}
 		}
 
-		out += duk_unicode_encode_cesu8(codepoint, out);
+		out += duk_unicode_encode_cesu8((duk_ucodepoint_t) codepoint, out);
 		DUK_ASSERT(out <= output + (3 + (3 * len)));
 	}
 

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -141,8 +141,8 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 		/* Current tracedata contains 2 entries per callstack entry. */
 		for (i = 0; ; i += 2) {
 			duk_int_t pc;
-			duk_int_t line;
-			duk_int_t flags;
+			duk_uint_t line;
+			duk_uint_t flags;
 			duk_double_t d;
 			const char *funcname;
 			const char *filename;
@@ -150,11 +150,11 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 			duk_hstring *h_name;
 
 			duk_require_stack(thr, 5);
-			duk_get_prop_index(thr, idx_td, i);
-			duk_get_prop_index(thr, idx_td, i + 1);
+			duk_get_prop_index(thr, idx_td, (duk_uarridx_t) i);
+			duk_get_prop_index(thr, idx_td, (duk_uarridx_t) (i + 1));
 			d = duk_to_number_m1(thr);
 			pc = (duk_int_t) DUK_FMOD(d, DUK_DOUBLE_2TO32);
-			flags = (duk_int_t) DUK_FLOOR(d / DUK_DOUBLE_2TO32);
+			flags = (duk_uint_t) DUK_FLOOR(d / DUK_DOUBLE_2TO32);
 			t = (duk_small_int_t) duk_get_type(thr, -2);
 
 			if (t == DUK_TYPE_OBJECT || t == DUK_TYPE_LIGHTFUNC) {
@@ -174,7 +174,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 				duk_get_prop_stridx_short(thr, -3, DUK_STRIDX_FILE_NAME);
 
 #if defined(DUK_USE_PC2LINE)
-				line = duk_hobject_pc2line_query(thr, -4, (duk_uint_fast32_t) pc);
+				line = (duk_uint_t) duk_hobject_pc2line_query(thr, -4, (duk_uint_fast32_t) pc);
 #else
 				line = 0;
 #endif
@@ -188,7 +188,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 					if (output_type == DUK__OUTPUT_TYPE_FILENAME) {
 						return 1;
 					} else if (output_type == DUK__OUTPUT_TYPE_LINENUMBER) {
-						duk_push_int(thr, line);
+						duk_push_uint(thr, line);
 						return 1;
 					}
 				}
@@ -223,10 +223,10 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 					                 (const char *) ((flags & DUK_ACT_FLAG_DIRECT_EVAL) ? str_directeval : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_PREVENT_YIELD) ? str_prevyield : str_empty));
 				} else {
-					duk_push_sprintf(thr, "at %s (%s:%ld)%s%s%s%s%s",
+					duk_push_sprintf(thr, "at %s (%s:%lu)%s%s%s%s%s",
 					                 (const char *) funcname,
 					                 (const char *) filename,
-					                 (long) line,
+					                 (unsigned long) line,
 					                 (const char *) ((flags & DUK_ACT_FLAG_STRICT) ? str_strict : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_TAILCALLED) ? str_tailcall : str_empty),
 					                 (const char *) ((flags & DUK_ACT_FLAG_CONSTRUCT) ? str_construct : str_empty),
@@ -359,7 +359,7 @@ DUK_LOCAL duk_ret_t duk__error_setter_helper(duk_hthread *thr, duk_small_uint_t 
 	DUK_ASSERT_TOP(thr, 1);  /* fixed arg count: value */
 
 	duk_push_this(thr);
-	duk_push_hstring_stridx(thr, (duk_small_int_t) stridx_key);
+	duk_push_hstring_stridx(thr, stridx_key);
 	duk_dup_0(thr);
 
 	/* [ ... obj key value ] */

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -322,8 +322,10 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_hthread *thr) {
 	h_bound->args = tv_res;
 	h_bound->nargs = bound_nargs;
 
-	duk_copy_tvals_incref(thr, tv_res, tv_prevbound, n_prevbound);
-	duk_copy_tvals_incref(thr, tv_res + n_prevbound, DUK_GET_TVAL_POSIDX(thr, 1), nargs);
+	DUK_ASSERT(n_prevbound >= 0);
+	duk_copy_tvals_incref(thr, tv_res, tv_prevbound, (duk_size_t) n_prevbound);
+	DUK_ASSERT(nargs >= 0);
+	duk_copy_tvals_incref(thr, tv_res + n_prevbound, DUK_GET_TVAL_POSIDX(thr, 1), (duk_size_t) nargs);
 
 	/* [ thisArg arg1 ... argN func boundFunc ] */
 
@@ -395,12 +397,12 @@ DUK_INTERNAL duk_ret_t duk_bi_native_function_length(duk_hthread *thr) {
 		func_nargs = h->nargs;
 		duk_push_int(thr, func_nargs == DUK_HNATFUNC_NARGS_VARARGS ? 0 : func_nargs);
 	} else if (DUK_TVAL_IS_LIGHTFUNC(tv)) {
-		duk_int_t lf_flags;
-		duk_int_t lf_len;
+		duk_small_uint_t lf_flags;
+		duk_small_uint_t lf_len;
 
 		lf_flags = DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv);
 		lf_len = DUK_LFUNC_FLAGS_GET_LENGTH(lf_flags);
-		duk_push_int(thr, lf_len);
+		duk_push_uint(thr, lf_len);
 	} else {
 		goto fail_type;
 	}

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -327,7 +327,7 @@ DUK_LOCAL void duk__transform_callback_decode_uri(duk__transform_context *tfm_ct
 			DUK_ASSERT(cp < 0x100000L);
 
 			DUK_BW_WRITE_RAW_XUTF8(tfm_ctx->thr, &tfm_ctx->bw, ((cp >> 10) + 0xd800L));
-			DUK_BW_WRITE_RAW_XUTF8(tfm_ctx->thr, &tfm_ctx->bw, ((cp & 0x03ffUL) + 0xdc00L));
+			DUK_BW_WRITE_RAW_XUTF8(tfm_ctx->thr, &tfm_ctx->bw, ((cp & 0x03ffL) + 0xdc00L));
 		} else {
 			DUK_BW_WRITE_RAW_XUTF8(tfm_ctx->thr, &tfm_ctx->bw, cp);
 		}
@@ -638,7 +638,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_int(duk_hthread *thr) {
 	}
 
 	duk_dup_0(thr);
-	duk_numconv_parse(thr, radix, s2n_flags);
+	duk_numconv_parse(thr, (duk_small_int_t) radix, s2n_flags);
 	return 1;
 
  ret_nan:
@@ -650,12 +650,9 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_int(duk_hthread *thr) {
 #if defined(DUK_USE_GLOBAL_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_float(duk_hthread *thr) {
 	duk_small_uint_t s2n_flags;
-	duk_int32_t radix;
 
 	DUK_ASSERT_TOP(thr, 1);
 	duk_to_string(thr, 0);  /* Reject symbols. */
-
-	radix = 10;
 
 	/* XXX: check flags */
 	s2n_flags = DUK_S2N_FLAG_TRIM_WHITE |
@@ -669,7 +666,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_float(duk_hthread *thr) {
 	            DUK_S2N_FLAG_ALLOW_EMPTY_FRAC |
 	            DUK_S2N_FLAG_ALLOW_LEADING_ZERO;
 
-	duk_numconv_parse(thr, radix, s2n_flags);
+	duk_numconv_parse(thr, 10 /*radix*/, s2n_flags);
 	return 1;
 }
 #endif  /* DUK_USE_GLOBAL_BUILTIN */
@@ -681,7 +678,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_parse_float(duk_hthread *thr) {
 #if defined(DUK_USE_GLOBAL_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_global_object_is_nan(duk_hthread *thr) {
 	duk_double_t d = duk_to_number(thr, 0);
-	duk_push_boolean(thr, DUK_ISNAN(d));
+	duk_push_boolean(thr, (duk_bool_t) DUK_ISNAN(d));
 	return 1;
 }
 #endif  /* DUK_USE_GLOBAL_BUILTIN */
@@ -689,7 +686,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_is_nan(duk_hthread *thr) {
 #if defined(DUK_USE_GLOBAL_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_global_object_is_finite(duk_hthread *thr) {
 	duk_double_t d = duk_to_number(thr, 0);
-	duk_push_boolean(thr, DUK_ISFINITE(d));
+	duk_push_boolean(thr, (duk_bool_t) DUK_ISFINITE(d));
 	return 1;
 }
 #endif  /* DUK_USE_GLOBAL_BUILTIN */

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -239,7 +239,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_is_sealed_frozen_shared(duk_hth
 	duk_bool_t is_frozen;
 	duk_uint_t mask;
 
-	is_frozen = duk_get_current_magic(thr);
+	is_frozen = (duk_bool_t) duk_get_current_magic(thr);
 	mask = duk_get_type_mask(thr, 0);
 	if (mask & (DUK_TYPE_MASK_LIGHTFUNC | DUK_TYPE_MASK_BUFFER)) {
 		DUK_ASSERT(is_frozen == 0 || is_frozen == 1);
@@ -306,13 +306,13 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_is_prototype_of(duk_hthread *thr)
 
 #if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_has_own_property(duk_hthread *thr) {
-	return duk_hobject_object_ownprop_helper(thr, 0 /*required_desc_flags*/);
+	return (duk_ret_t) duk_hobject_object_ownprop_helper(thr, 0 /*required_desc_flags*/);
 }
 #endif  /* DUK_USE_OBJECT_BUILTIN */
 
 #if defined(DUK_USE_OBJECT_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_property_is_enumerable(duk_hthread *thr) {
-	return duk_hobject_object_ownprop_helper(thr, DUK_PROPDESC_FLAG_ENUMERABLE /*required_desc_flags*/);
+	return (duk_ret_t) duk_hobject_object_ownprop_helper(thr, DUK_PROPDESC_FLAG_ENUMERABLE /*required_desc_flags*/);
 }
 #endif  /* DUK_USE_OBJECT_BUILTIN */
 
@@ -487,7 +487,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 	duk_hobject *set;
 	duk_idx_t idx_value;
 	duk_uint_t defprop_flags;
-	duk_int_t magic;
+	duk_small_uint_t magic;
 	duk_bool_t throw_flag;
 	duk_bool_t ret;
 
@@ -501,7 +501,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 
 	/* [ obj key desc ] */
 
-	magic = duk_get_current_magic(thr);
+	magic = (duk_small_uint_t) duk_get_current_magic(thr);
 
 	/* Lightfuncs are currently supported by coercing to a temporary
 	 * Function object; changes will be allowed (the coerced value is
@@ -535,8 +535,8 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 	 *  Use Object.defineProperty() helper for the actual operation.
 	 */
 
-	DUK_ASSERT(magic == 0 || magic == 1);
-	throw_flag = magic ^ 1;
+	DUK_ASSERT(magic == 0U || magic == 1U);
+	throw_flag = magic ^ 1U;
 	ret = duk_hobject_define_property_helper(thr,
 	                                         defprop_flags,
 	                                         obj,
@@ -550,7 +550,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 	 * they're popped automatically.
 	 */
 
-	if (magic == 0) {
+	if (magic == 0U) {
 		/* Object.defineProperty(): return target object. */
 		duk_push_hobject(thr, obj);
 	} else {

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -158,7 +158,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_flags(duk_hthread *thr) {
 /* Shared helper for providing .source, .global, .multiline, etc getters. */
 DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_shared_getter(duk_hthread *thr) {
 	duk_hstring *h_bc;
-	duk_small_int_t re_flags;
+	duk_small_uint_t re_flags;
 	duk_hobject *h;
 	duk_int_t magic;
 

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -55,7 +55,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 	duk_hthread *thr = (duk_hthread *) ctx;
 	duk_hthread *thr_resume;
 	duk_hobject *caller_func;
-	duk_small_int_t is_error;
+	duk_small_uint_t is_error;
 
 	DUK_DDD(DUK_DDDPRINT("Duktape.Thread.resume(): thread=%!T, value=%!T, is_error=%!T",
 	                     (duk_tval *) duk_get_tval(thr, 0),
@@ -66,7 +66,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 	DUK_ASSERT(thr->heap->curr_thread == thr);
 
 	thr_resume = duk_require_hthread(thr, 0);
-	is_error = (duk_small_int_t) duk_to_boolean(thr, 2);
+	is_error = (duk_small_uint_t) duk_to_boolean(thr, 2);
 	duk_set_top(thr, 2);
 
 	/* [ thread value ] */
@@ -206,7 +206,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 #if defined(DUK_USE_COROUTINE_SUPPORT)
 DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_hthread *thr) {
 	duk_hobject *caller_func;
-	duk_small_int_t is_error;
+	duk_small_uint_t is_error;
 
 	DUK_DDD(DUK_DDDPRINT("Duktape.Thread.yield(): value=%!T, is_error=%!T",
 	                     (duk_tval *) duk_get_tval(thr, 0),
@@ -215,7 +215,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_hthread *thr) {
 	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
 	DUK_ASSERT(thr->heap->curr_thread == thr);
 
-	is_error = (duk_small_int_t) duk_to_boolean(thr, 1);
+	is_error = (duk_small_uint_t) duk_to_boolean(thr, 1);
 	duk_set_top(thr, 1);
 
 	/* [ value ] */

--- a/src-input/duk_debug_fixedbuffer.c
+++ b/src-input/duk_debug_fixedbuffer.c
@@ -49,7 +49,7 @@ DUK_INTERNAL void duk_fb_sprintf(duk_fixedbuffer *fb, const char *fmt, ...) {
 			}
 		} else {
 			/* normal */
-			fb->offset += res;
+			fb->offset += (duk_size_t) res;
 		}
 	}
 	va_end(ap);

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -791,8 +791,8 @@ DUK_LOCAL void duk__print_instr(duk__dprint_state *st, duk_instr_t ins) {
 	/* XXX: option to fix opcode length so it lines up nicely */
 
 	if (op == DUK_OP_JUMP) {
-		duk_int_t diff1 = DUK_DEC_ABC(ins) - DUK_BC_JUMP_BIAS;  /* from next pc */
-		duk_int_t diff2 = diff1 + 1;                            /* from curr pc */
+		duk_int_t diff1 = (duk_int_t) (DUK_DEC_ABC(ins) - DUK_BC_JUMP_BIAS);  /* from next pc */
+		duk_int_t diff2 = diff1 + 1;                                          /* from curr pc */
 
 		duk_fb_sprintf(fb, "%s %ld (to pc%c%ld)",
 		               (const char *) op_name, (long) diff1,
@@ -1034,7 +1034,7 @@ DUK_INTERNAL void duk_debug_format_funcptr(char *buf, duk_size_t buf_size, duk_u
 #else
 		ch = fptr[fptr_size - 1 - i];
 #endif
-		p += DUK_SNPRINTF((char *) p, left, "%02lx", (unsigned long) ch);
+		p += DUK_SNPRINTF((char *) p, (duk_size_t) left, "%02lx", (unsigned long) ch);
 	}
 }
 

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -341,7 +341,7 @@ DUK_LOCAL duk_uint32_t duk__debug_read_uint32_raw(duk_hthread *thr) {
 	       (duk_uint32_t) buf[3];
 }
 
-DUK_LOCAL duk_uint32_t duk__debug_read_int32_raw(duk_hthread *thr) {
+DUK_LOCAL duk_int32_t duk__debug_read_int32_raw(duk_hthread *thr) {
 	return (duk_int32_t) duk__debug_read_uint32_raw(thr);
 }
 
@@ -980,7 +980,7 @@ DUK_INTERNAL void duk_debug_write_error_eom(duk_hthread *thr, duk_small_uint_t e
 
 DUK_INTERNAL void duk_debug_write_notify(duk_hthread *thr, duk_small_uint_t command) {
 	duk_debug_write_byte(thr, DUK_DBG_IB_NOTIFY);
-	duk_debug_write_int(thr, command);
+	duk_debug_write_int(thr, (duk_int32_t) command);
 }
 
 DUK_INTERNAL void duk_debug_write_eom(duk_hthread *thr) {
@@ -1065,7 +1065,7 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 	DUK_ASSERT(thr->valstack_top > thr->valstack);  /* At least: ... [err] */
 
 	duk_debug_write_notify(thr, DUK_DBG_CMD_THROW);
-	duk_debug_write_int(thr, fatal);
+	duk_debug_write_int(thr, (duk_int32_t) fatal);
 
 	/* Report thrown value to client coerced to string */
 	duk_dup_top(thr);
@@ -1124,7 +1124,7 @@ DUK_LOCAL duk_bool_t duk__debug_skip_dvalue(duk_hthread *thr) {
 		return 0;
 	}
 	if (x >= 0x60) {
-		duk_debug_skip_bytes(thr, x - 0x60);
+		duk_debug_skip_bytes(thr, (duk_size_t) (x - 0x60));
 		return 0;
 	}
 	switch(x) {
@@ -1694,9 +1694,9 @@ DUK_LOCAL void duk__debug_dump_heaphdr(duk_hthread *thr, duk_heap *heap, duk_hea
 	case DUK_HTYPE_STRING: {
 		duk_hstring *h = (duk_hstring *) hdr;
 
-		duk_debug_write_uint(thr, (duk_int32_t) DUK_HSTRING_GET_BYTELEN(h));
-		duk_debug_write_uint(thr, (duk_int32_t) DUK_HSTRING_GET_CHARLEN(h));
-		duk_debug_write_uint(thr, (duk_int32_t) DUK_HSTRING_GET_HASH(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_BYTELEN(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_CHARLEN(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_HASH(h));
 		duk_debug_write_hstring(thr, h);
 		break;
 	}
@@ -2164,7 +2164,7 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 			duk_harray *h_arr;
 			h_arr = (duk_harray *) h_obj;
 
-			duk__debug_getinfo_prop_int(thr, "length", h_arr->length);
+			duk__debug_getinfo_prop_uint(thr, "length", (duk_uint_t) h_arr->length);
 			duk__debug_getinfo_prop_bool(thr, "length_nonwritable", h_arr->length_nonwritable);
 		}
 
@@ -2352,8 +2352,8 @@ DUK_LOCAL void duk__debug_handle_get_obj_prop_desc_range(duk_hthread *thr, duk_h
 	DUK_UNREF(heap);
 
 	h = duk_debug_read_any_ptr(thr);
-	idx_start = duk_debug_read_int(thr);
-	idx_end = duk_debug_read_int(thr);
+	idx_start = (duk_uint_t) duk_debug_read_int(thr);
+	idx_end = (duk_uint_t) duk_debug_read_int(thr);
 	if (h == NULL || DUK_HEAPHDR_GET_TYPE(h) != DUK_HTYPE_OBJECT) {
 		goto fail_args;
 	}
@@ -2761,7 +2761,7 @@ DUK_INTERNAL duk_small_int_t duk_debug_add_breakpoint(duk_hthread *thr, duk_hstr
 	b->line = line;
 	DUK_HSTRING_INCREF(thr, filename);
 
-	return heap->dbg_breakpoint_count - 1;  /* index */
+	return (duk_small_int_t) (heap->dbg_breakpoint_count - 1);  /* index */
 }
 
 DUK_INTERNAL duk_bool_t duk_debug_remove_breakpoint(duk_hthread *thr, duk_small_uint_t breakpoint_index) {

--- a/src-input/duk_debugger.h
+++ b/src-input/duk_debugger.h
@@ -73,8 +73,8 @@
 /* The low 8 bits map directly to duk_hobject.h DUK_PROPDESC_FLAG_xxx.
  * The remaining flags are specific to the debugger.
  */
-#define DUK_DBG_PROPFLAG_SYMBOL          (1 << 8)
-#define DUK_DBG_PROPFLAG_HIDDEN          (1 << 9)
+#define DUK_DBG_PROPFLAG_SYMBOL          (1U << 8)
+#define DUK_DBG_PROPFLAG_HIDDEN          (1U << 9)
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 DUK_INTERNAL_DECL void duk_debug_do_detach(duk_heap *heap);

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -14,10 +14,10 @@
  *  Heap flags
  */
 
-#define DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED            (1 << 0)  /* mark-and-sweep marking reached a recursion limit and must use multi-pass marking */
-#define DUK_HEAP_FLAG_INTERRUPT_RUNNING                        (1 << 1)  /* executor interrupt running (used to avoid nested interrupts) */
-#define DUK_HEAP_FLAG_FINALIZER_NORESCUE                       (1 << 2)  /* heap destruction ongoing, finalizer rescue no longer possible */
-#define DUK_HEAP_FLAG_DEBUGGER_PAUSED                          (1 << 3)  /* debugger is paused: talk with debug client until step/resume */
+#define DUK_HEAP_FLAG_MARKANDSWEEP_RECLIMIT_REACHED            (1U << 0)  /* mark-and-sweep marking reached a recursion limit and must use multi-pass marking */
+#define DUK_HEAP_FLAG_INTERRUPT_RUNNING                        (1U << 1)  /* executor interrupt running (used to avoid nested interrupts) */
+#define DUK_HEAP_FLAG_FINALIZER_NORESCUE                       (1U << 2)  /* heap destruction ongoing, finalizer rescue no longer possible */
+#define DUK_HEAP_FLAG_DEBUGGER_PAUSED                          (1U << 3)  /* debugger is paused: talk with debug client until step/resume */
 
 #define DUK__HEAP_HAS_FLAGS(heap,bits)               ((heap)->flags & (bits))
 #define DUK__HEAP_SET_FLAGS(heap,bits)  do { \
@@ -66,22 +66,22 @@
 /* Emergency mark-and-sweep: try extra hard, even at the cost of
  * performance.
  */
-#define DUK_MS_FLAG_EMERGENCY                (1 << 0)
+#define DUK_MS_FLAG_EMERGENCY                (1U << 0)
 
 /* Voluntary mark-and-sweep: triggered periodically. */
-#define DUK_MS_FLAG_VOLUNTARY                (1 << 1)
+#define DUK_MS_FLAG_VOLUNTARY                (1U << 1)
 
 /* Postpone rescue decisions for reachable objects with FINALIZED set.
  * Used during finalize_list processing to avoid incorrect rescue
  * decisions due to finalize_list being a reachability root.
  */
-#define DUK_MS_FLAG_POSTPONE_RESCUE          (1 << 2)
+#define DUK_MS_FLAG_POSTPONE_RESCUE          (1U << 2)
 
 /* Don't compact objects; needed during object property table resize
  * to prevent a recursive resize.  It would suffice to protect only the
  * current object being resized, but this is not yet implemented.
  */
-#define DUK_MS_FLAG_NO_OBJECT_COMPACTION     (1 << 2)
+#define DUK_MS_FLAG_NO_OBJECT_COMPACTION     (1U << 3)
 
 /*
  *  Thread switching
@@ -520,8 +520,8 @@ struct duk_heap {
 	/* XXX: make active breakpoints actual copies instead of pointers? */
 
 	/* These are for rate limiting Status notifications and transport peeking. */
-	duk_uint32_t dbg_exec_counter;          /* cumulative opcode execution count (overflows are OK) */
-	duk_uint32_t dbg_last_counter;          /* value of dbg_exec_counter when we last did a Date-based check */
+	duk_uint_t dbg_exec_counter;            /* cumulative opcode execution count (overflows are OK) */
+	duk_uint_t dbg_last_counter;            /* value of dbg_exec_counter when we last did a Date-based check */
 	duk_double_t dbg_last_time;             /* time when status/peek was last done (Date-based rate limit) */
 
 	/* Used to support single-byte stream lookahead. */

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -636,7 +636,7 @@ DUK_LOCAL void duk__sweep_stringtable(duk_heap *heap, duk_size_t *out_count_keep
  *  Sweep heap.
  */
 
-DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_int_t flags, duk_size_t *out_count_keep) {
+DUK_LOCAL void duk__sweep_heap(duk_heap *heap, duk_small_uint_t flags, duk_size_t *out_count_keep) {
 	duk_heaphdr *prev;  /* last element that was left in the heap */
 	duk_heaphdr *curr;
 	duk_heaphdr *next;

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -355,7 +355,7 @@ DUK_LOCAL DUK_INLINE void duk__refcount_refzero_hobject(duk_heap *heap, duk_hobj
 	/* This finalizer check MUST BE side effect free.  It should also be
 	 * as fast as possible because it's applied to every object freed.
 	 */
-	if (DUK_UNLIKELY(DUK_HOBJECT_HAS_FINALIZER_FAST(heap, (duk_hobject *) hdr))) {
+	if (DUK_UNLIKELY(DUK_HOBJECT_HAS_FINALIZER_FAST(heap, (duk_hobject *) hdr) != 0U)) {
 		/* Special case: FINALIZED may be set if mark-and-sweep queued
 		 * object for finalization, the finalizer was executed (and
 		 * FINALIZED set), mark-and-sweep hasn't yet processed the

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -479,7 +479,7 @@ DUK_LOCAL DUK_COLD DUK_NOINLINE void duk__strtable_resize_check(duk_heap *heap) 
 	DUK_STATS_INC(heap, stats_strtab_resize_check);
 
 	/* Prevent recursive resizing. */
-	if (DUK_UNLIKELY(heap->st_resizing)) {
+	if (DUK_UNLIKELY(heap->st_resizing != 0U)) {
 		DUK_D(DUK_DPRINT("prevent recursive strtable resize"));
 		return;
 	}
@@ -766,8 +766,8 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern(duk_heap *heap, const duk_uin
  */
 
 DUK_INTERNAL duk_hstring *duk_heap_strtable_intern_u32(duk_heap *heap, duk_uint32_t val) {
-	char buf[DUK__STRTAB_U32_MAX_STRLEN];
-	char *p;
+	duk_uint8_t buf[DUK__STRTAB_U32_MAX_STRLEN];
+	duk_uint8_t *p;
 
 	DUK_ASSERT(heap != NULL);
 

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -294,11 +294,11 @@
 /* Flags used for property attributes in duk_propdesc and packed flags.
  * Must fit into 8 bits.
  */
-#define DUK_PROPDESC_FLAG_WRITABLE              (1 << 0)    /* E5 Section 8.6.1 */
-#define DUK_PROPDESC_FLAG_ENUMERABLE            (1 << 1)    /* E5 Section 8.6.1 */
-#define DUK_PROPDESC_FLAG_CONFIGURABLE          (1 << 2)    /* E5 Section 8.6.1 */
-#define DUK_PROPDESC_FLAG_ACCESSOR              (1 << 3)    /* accessor */
-#define DUK_PROPDESC_FLAG_VIRTUAL               (1 << 4)    /* property is virtual: used in duk_propdesc, never stored
+#define DUK_PROPDESC_FLAG_WRITABLE              (1U << 0)    /* E5 Section 8.6.1 */
+#define DUK_PROPDESC_FLAG_ENUMERABLE            (1U << 1)    /* E5 Section 8.6.1 */
+#define DUK_PROPDESC_FLAG_CONFIGURABLE          (1U << 2)    /* E5 Section 8.6.1 */
+#define DUK_PROPDESC_FLAG_ACCESSOR              (1U << 3)    /* accessor */
+#define DUK_PROPDESC_FLAG_VIRTUAL               (1U << 4)    /* property is virtual: used in duk_propdesc, never stored
                                                              * (used by e.g. buffer virtual properties)
                                                              */
 #define DUK_PROPDESC_FLAGS_MASK                 (DUK_PROPDESC_FLAG_WRITABLE | \
@@ -309,7 +309,7 @@
 /* Additional flags which are passed in the same flags argument as property
  * flags but are not stored in object properties.
  */
-#define DUK_PROPDESC_FLAG_NO_OVERWRITE          (1 << 4)    /* internal define property: skip write silently if exists */
+#define DUK_PROPDESC_FLAG_NO_OVERWRITE          (1U << 4)    /* internal define property: skip write silently if exists */
 
 /* Convenience defines for property attributes. */
 #define DUK_PROPDESC_FLAGS_NONE                 0
@@ -324,8 +324,8 @@
                                                  DUK_PROPDESC_FLAG_CONFIGURABLE)
 
 /* Flags for duk_hobject_get_own_propdesc() and variants. */
-#define DUK_GETDESC_FLAG_PUSH_VALUE          (1 << 0)  /* push value to stack */
-#define DUK_GETDESC_FLAG_IGNORE_PROTOLOOP    (1 << 1)  /* don't throw for prototype loop */
+#define DUK_GETDESC_FLAG_PUSH_VALUE          (1U << 0)  /* push value to stack */
+#define DUK_GETDESC_FLAG_IGNORE_PROTOLOOP    (1U << 1)  /* don't throw for prototype loop */
 
 /*
  *  Macro for object validity check
@@ -905,7 +905,7 @@ DUK_INTERNAL_DECL void duk_hobject_resize_arraypart(duk_hthread *thr,
 /* low-level property functions */
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_find_existing_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *e_idx, duk_int_t *h_idx);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_hstring *key);
-DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *out_attrs);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_uint_t *out_attrs);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_array_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_uarridx_t i);
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_get_own_propdesc(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_propdesc *out_desc, duk_small_uint_t flags);
 
@@ -922,8 +922,8 @@ DUK_INTERNAL_DECL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key);
 
 /* internal property functions */
-#define DUK_DELPROP_FLAG_THROW  (1 << 0)
-#define DUK_DELPROP_FLAG_FORCE  (1 << 1)
+#define DUK_DELPROP_FLAG_THROW  (1U << 0)
+#define DUK_DELPROP_FLAG_FORCE  (1U << 1)
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_small_uint_t flags);
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_hasprop_raw(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);
 DUK_INTERNAL_DECL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_small_uint_t flags);

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -161,7 +161,7 @@ DUK_LOCAL void duk__sort_enum_keys_es6(duk_hthread *thr, duk_hobject *h_obj, duk
 		if (idx != idx_insert) {
 			DUK_MEMMOVE((void *) (keys + idx_insert + 1),
 			            (const void *) (keys + idx_insert),
-			            (size_t) ((idx - idx_insert) * sizeof(duk_hstring *)));
+			            ((size_t) (idx - idx_insert) * sizeof(duk_hstring *)));
 			keys[idx_insert] = h_curr;
 		}
 	}
@@ -495,11 +495,11 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_hthread *thr, duk_small_uint
 
 		if (!(enum_flags & DUK_ENUM_SORT_ARRAY_INDICES)) {
 #if defined(DUK_USE_PREFER_SIZE)
-			duk__sort_enum_keys_es6(thr, res, sort_start_index, sort_end_index);
+			duk__sort_enum_keys_es6(thr, res, (duk_int_fast32_t) sort_start_index, (duk_int_fast32_t) sort_end_index);
 #else
 			if (need_sort) {
 				DUK_DDD(DUK_DDDPRINT("need to sort"));
-				duk__sort_enum_keys_es6(thr, res, sort_start_index, sort_end_index);
+				duk__sort_enum_keys_es6(thr, res, (duk_int_fast32_t) sort_start_index, (duk_int_fast32_t) sort_end_index);
 			} else {
 				DUK_DDD(DUK_DDDPRINT("no need to sort"));
 			}
@@ -532,7 +532,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_hthread *thr, duk_small_uint
 		/* Sort to ES2015 order which works for pure array incides but
 		 * also for mixed keys.
 		 */
-		duk__sort_enum_keys_es6(thr, res, DUK__ENUM_START_INDEX, DUK_HOBJECT_GET_ENEXT(res));
+		duk__sort_enum_keys_es6(thr, res, (duk_int_fast32_t) DUK__ENUM_START_INDEX, (duk_int_fast32_t) DUK_HOBJECT_GET_ENEXT(res));
 	}
 
 #if defined(DUK_USE_ES6_PROXY)

--- a/src-input/duk_hobject_pc2line.c
+++ b/src-input/duk_hobject_pc2line.c
@@ -82,17 +82,17 @@ DUK_INTERNAL void duk_hobject_pc2line_pack(duk_hthread *thr, duk_compiler_instr 
 				duk_be_encode(be_ctx, 0, 1);
 			} else if (diff_line >= 1 && diff_line <= 4) {
 				/* 1 0 <2 bits> */
-				duk_be_encode(be_ctx, (0x02 << 2) + (diff_line - 1), 4);
+				duk_be_encode(be_ctx, (duk_uint32_t) ((0x02 << 2) + (diff_line - 1)), 4);
 			} else if (diff_line >= -0x80 && diff_line <= 0x7f) {
 				/* 1 1 0 <8 bits> */
 				DUK_ASSERT(diff_line + 0x80 >= 0 && diff_line + 0x80 <= 0xff);
-				duk_be_encode(be_ctx, (0x06 << 8) + (diff_line + 0x80), 11);
+				duk_be_encode(be_ctx, (duk_uint32_t) ((0x06 << 8) + (diff_line + 0x80)), 11);
 			} else {
 				/* 1 1 1 <32 bits>
 				 * Encode in two parts to avoid bitencode 24-bit limitation
 				 */
-				duk_be_encode(be_ctx, (0x07 << 16) + ((next_line >> 16) & 0xffffU), 19);
-				duk_be_encode(be_ctx, next_line & 0xffffU, 16);
+				duk_be_encode(be_ctx, (duk_uint32_t) ((0x07 << 16) + ((next_line >> 16) & 0xffff)), 19);
+				duk_be_encode(be_ctx, (duk_uint32_t) (next_line & 0xffff), 16);
 			}
 
 			curr_line = next_line;

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -117,7 +117,7 @@ DUK_LOCAL duk_uint32_t duk__tval_fastint_to_arr_idx(duk_tval *tv) {
 	DUK_ASSERT(DUK_TVAL_IS_FASTINT(tv));
 
 	t = DUK_TVAL_GET_FASTINT(tv);
-	if ((t & ~DUK_U64_CONSTANT(0xffffffff)) != 0) {
+	if (((duk_uint64_t) t & ~DUK_U64_CONSTANT(0xffffffff)) != 0) {
 		/* Catches >0x100000000 and negative values. */
 		return DUK__NO_ARRAY_INDEX;
 	}
@@ -560,7 +560,8 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 	DUK_DDD(DUK_DDDPRINT("using layout 1, but no need to pad e_size: %ld", (long) new_e_size));
 	new_e_size_adjusted = new_e_size;
 #elif defined(DUK_USE_HOBJECT_LAYOUT_1) && ((DUK_HOBJECT_ALIGN_TARGET == 4) || (DUK_HOBJECT_ALIGN_TARGET == 8))
-	new_e_size_adjusted = (new_e_size + DUK_HOBJECT_ALIGN_TARGET - 1) & (~(DUK_HOBJECT_ALIGN_TARGET - 1));
+	new_e_size_adjusted = (new_e_size + (duk_uint32_t) DUK_HOBJECT_ALIGN_TARGET - 1U) &
+	                      (~((duk_uint32_t) DUK_HOBJECT_ALIGN_TARGET - 1U));
 	DUK_DDD(DUK_DDDPRINT("using layout 1, and alignment target is %ld, adjusted e_size: %ld -> %ld",
 	                     (long) DUK_HOBJECT_ALIGN_TARGET, (long) new_e_size, (long) new_e_size_adjusted));
 	DUK_ASSERT(new_e_size_adjusted >= new_e_size);
@@ -757,7 +758,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 
 		/* Steal refcounts from value stack. */
 		DUK_DDD(DUK_DDDPRINT("abandon array: pop %ld key temps from valstack", (long) new_e_next));
-		duk_pop_n_nodecref_unsafe(thr, new_e_next);
+		duk_pop_n_nodecref_unsafe(thr, (duk_idx_t) new_e_next);
 	}
 
 	/*
@@ -1197,7 +1198,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_find_existing_entry(duk_heap *heap, duk_hobj
 		n = DUK_HOBJECT_GET_ENEXT(obj);
 		for (i = 0; i < n; i++) {
 			if (h_keys_base[i] == key) {
-				*e_idx = i;
+				*e_idx = (duk_int_t) i;
 				*h_idx = -1;
 				return 1;
 			}
@@ -1239,8 +1240,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_find_existing_entry(duk_heap *heap, duk_hobj
 				if (DUK_HOBJECT_E_GET_KEY(heap, obj, t) == key) {
 					DUK_DDD(DUK_DDDPRINT("lookup hit i=%ld, t=%ld -> key %p",
 					                     (long) i, (long) t, (void *) key));
-					*e_idx = t;
-					*h_idx = i;
+					*e_idx = (duk_int_t) t;
+					*h_idx = (duk_int_t) i;
 					return 1;
 				}
 				DUK_DDD(DUK_DDDPRINT("lookup miss i=%ld, t=%ld",
@@ -1276,7 +1277,7 @@ DUK_INTERNAL duk_tval *duk_hobject_find_existing_entry_tval_ptr(duk_heap *heap, 
 }
 
 /* For internal use: get non-accessor entry value and attributes */
-DUK_INTERNAL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *out_attrs) {
+DUK_INTERNAL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_uint_t *out_attrs) {
 	duk_int_t e_idx;
 	duk_int_t h_idx;
 
@@ -1322,7 +1323,7 @@ DUK_INTERNAL duk_tval *duk_hobject_find_existing_array_entry_tval_ptr(duk_heap *
  *  the entry value refcount.  A decref for the previous value is not necessary.
  */
 
-DUK_LOCAL duk_bool_t duk__alloc_entry_checked(duk_hthread *thr, duk_hobject *obj, duk_hstring *key) {
+DUK_LOCAL duk_int_t duk__hobject_alloc_entry_checked(duk_hthread *thr, duk_hobject *obj, duk_hstring *key) {
 	duk_uint32_t idx;
 
 	DUK_ASSERT(thr != NULL);
@@ -1366,7 +1367,7 @@ DUK_LOCAL duk_bool_t duk__alloc_entry_checked(duk_hthread *thr, duk_hobject *obj
 		for (;;) {
 			duk_uint32_t t = h_base[i];
 			if (t == DUK__HASH_UNUSED || t == DUK__HASH_DELETED) {
-				DUK_DDD(DUK_DDDPRINT("duk__alloc_entry_checked() inserted key into hash part, %ld -> %ld",
+				DUK_DDD(DUK_DDDPRINT("duk__hobject_alloc_entry_checked() inserted key into hash part, %ld -> %ld",
 				                     (long) i, (long) idx));
 				DUK_ASSERT_DISABLE(i >= 0);  /* unsigned */
 				DUK_ASSERT(i < DUK_HOBJECT_GET_HSIZE(obj));
@@ -1375,7 +1376,7 @@ DUK_LOCAL duk_bool_t duk__alloc_entry_checked(duk_hthread *thr, duk_hobject *obj
 				h_base[i] = idx;
 				break;
 			}
-			DUK_DDD(DUK_DDDPRINT("duk__alloc_entry_checked() miss %ld", (long) i));
+			DUK_DDD(DUK_DDDPRINT("duk__hobject_alloc_entry_checked() miss %ld", (long) i));
 			i = (i + step) & mask;
 
 			/* Guaranteed to finish (hash is larger than #props). */
@@ -1390,7 +1391,7 @@ DUK_LOCAL duk_bool_t duk__alloc_entry_checked(duk_hthread *thr, duk_hobject *obj
 	DUK_ASSERT_DISABLE(idx >= 0);
 	DUK_ASSERT(idx < DUK_HOBJECT_GET_ESIZE(obj));
 	DUK_ASSERT(idx < DUK_HOBJECT_GET_ENEXT(obj));
-	return idx;
+	return (duk_int_t) idx;
 }
 
 /*
@@ -1742,7 +1743,7 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 				out_desc->set = NULL;
 				out_desc->e_idx = -1;
 				out_desc->h_idx = -1;
-				out_desc->a_idx = arr_idx;
+				out_desc->a_idx = (duk_int_t) arr_idx;  /* XXX: limit 2G due to being signed */
 				goto prop_found;
 			}
 		}
@@ -1860,7 +1861,7 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr, duk_hobject *ob
 			 */
 			if (arr_idx < (h_bufobj->length >> h_bufobj->shift)) {
 				byte_off = arr_idx << h_bufobj->shift;  /* no wrap assuming h_bufobj->length is valid */
-				elem_size = 1 << h_bufobj->shift;
+				elem_size = (duk_small_uint_t) (1U << h_bufobj->shift);
 				if (flags & DUK_GETDESC_FLAG_PUSH_VALUE) {
 					duk_uint8_t *data;
 
@@ -2252,7 +2253,7 @@ DUK_LOCAL duk_bool_t duk__getprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 	DUK_ASSERT(idx != DUK__NO_ARRAY_INDEX);
 
 	byte_off = idx << h_bufobj->shift;  /* no wrap assuming h_bufobj->length is valid */
-	elem_size = 1 << h_bufobj->shift;
+	elem_size = (duk_small_uint_t) (1U << h_bufobj->shift);
 
 	if (h_bufobj->buf != NULL && DUK_HBUFOBJ_VALID_BYTEOFFSET_EXCL(h_bufobj, byte_off + elem_size)) {
 		data = (duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h_bufobj->buf) + h_bufobj->offset + byte_off;
@@ -2308,7 +2309,7 @@ DUK_LOCAL duk_bool_t duk__putprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 	DUK_ASSERT(idx != DUK__NO_ARRAY_INDEX);
 
 	byte_off = idx << h_bufobj->shift;  /* no wrap assuming h_bufobj->length is valid */
-	elem_size = 1 << h_bufobj->shift;
+	elem_size = (duk_small_uint_t) (1U << h_bufobj->shift);
 
 	/* Value is required to be a number in the fast path so there
 	 * are no side effects in write coercion.
@@ -3784,7 +3785,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 						DUK_ASSERT(arr_idx != DUK__NO_ARRAY_INDEX);  /* index/length check guarantees */
 						byte_off = arr_idx << h_bufobj->shift;       /* no wrap assuming h_bufobj->length is valid */
-						elem_size = 1 << h_bufobj->shift;
+						elem_size = (duk_small_uint_t) (1U << h_bufobj->shift);
 
 						/* Coerce to number before validating pointers etc so that the
 						 * number coercions in duk_hbufobj_validated_write() are
@@ -4084,7 +4085,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	 * refcount; may need a props allocation resize but doesn't
 	 * 'recheck' the valstack.
 	 */
-	e_idx = duk__alloc_entry_checked(thr, orig, key);
+	e_idx = duk__hobject_alloc_entry_checked(thr, orig, key);
 	DUK_ASSERT(e_idx >= 0);
 
 	tv = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, orig, e_idx);
@@ -4689,7 +4690,7 @@ DUK_INTERNAL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hob
 	}
 
 	DUK_DDD(DUK_DDDPRINT("property does not exist, object belongs in entry part -> allocate new entry and write value and attributes"));
-	e_idx = duk__alloc_entry_checked(thr, obj, key);  /* increases key refcount */
+	e_idx = duk__hobject_alloc_entry_checked(thr, obj, key);  /* increases key refcount */
 	DUK_ASSERT(e_idx >= 0);
 	DUK_HOBJECT_E_SET_FLAGS(thr->heap, obj, e_idx, propflags);
 	tv1 = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, e_idx);
@@ -5290,7 +5291,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_hthread *thr,
 			}
 
 			/* write to entry part */
-			e_idx = duk__alloc_entry_checked(thr, obj, key);
+			e_idx = duk__hobject_alloc_entry_checked(thr, obj, key);
 			DUK_ASSERT(e_idx >= 0);
 
 			DUK_HOBJECT_E_SET_VALUE_GETTER(thr->heap, obj, e_idx, get);
@@ -5343,7 +5344,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_hthread *thr,
 			}
 
 			/* write to entry part */
-			e_idx = duk__alloc_entry_checked(thr, obj, key);
+			e_idx = duk__hobject_alloc_entry_checked(thr, obj, key);
 			DUK_ASSERT(e_idx >= 0);
 			tv2 = DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(thr->heap, obj, e_idx);
 			DUK_TVAL_SET_TVAL(tv2, &tv);

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -14,12 +14,12 @@
  */
 
 /* Initial valstack size, roughly 0.7kiB. */
-#define DUK_VALSTACK_INITIAL_SIZE       96
+#define DUK_VALSTACK_INITIAL_SIZE       96U
 
 /* Internal extra elements assumed on function entry, always added to
  * user-defined 'extra' for e.g. the duk_check_stack() call.
  */
-#define DUK_VALSTACK_INTERNAL_EXTRA     32
+#define DUK_VALSTACK_INTERNAL_EXTRA     32U
 
 /* Number of elements guaranteed to be user accessible (in addition to call
  * arguments) on Duktape/C function entry.  This is the major public API
@@ -31,21 +31,21 @@
  *  Activation defines
  */
 
-#define DUK_ACT_FLAG_STRICT             (1 << 0)  /* function executes in strict mode */
-#define DUK_ACT_FLAG_TAILCALLED         (1 << 1)  /* activation has tail called one or more times */
-#define DUK_ACT_FLAG_CONSTRUCT          (1 << 2)  /* function executes as a constructor (called via "new") */
-#define DUK_ACT_FLAG_PREVENT_YIELD      (1 << 3)  /* activation prevents yield (native call or "new") */
-#define DUK_ACT_FLAG_DIRECT_EVAL        (1 << 4)  /* activation is a direct eval call */
-#define DUK_ACT_FLAG_CONSTRUCT_PROXY    (1 << 5)  /* activation is for Proxy 'construct' call, special return value handling */
-#define DUK_ACT_FLAG_BREAKPOINT_ACTIVE  (1 << 6)  /* activation has active breakpoint(s) */
+#define DUK_ACT_FLAG_STRICT             (1U << 0)  /* function executes in strict mode */
+#define DUK_ACT_FLAG_TAILCALLED         (1U << 1)  /* activation has tail called one or more times */
+#define DUK_ACT_FLAG_CONSTRUCT          (1U << 2)  /* function executes as a constructor (called via "new") */
+#define DUK_ACT_FLAG_PREVENT_YIELD      (1U << 3)  /* activation prevents yield (native call or "new") */
+#define DUK_ACT_FLAG_DIRECT_EVAL        (1U << 4)  /* activation is a direct eval call */
+#define DUK_ACT_FLAG_CONSTRUCT_PROXY    (1U << 5)  /* activation is for Proxy 'construct' call, special return value handling */
+#define DUK_ACT_FLAG_BREAKPOINT_ACTIVE  (1U << 6)  /* activation has active breakpoint(s) */
 
-#define DUK_ACT_GET_FUNC(act)        ((act)->func)
+#define DUK_ACT_GET_FUNC(act)           ((act)->func)
 
 /*
  *  Flags for __FILE__ / __LINE__ registered into tracedata
  */
 
-#define DUK_TB_FLAG_NOBLAME_FILELINE   (1 << 0)  /* don't report __FILE__ / __LINE__ as fileName/lineNumber */
+#define DUK_TB_FLAG_NOBLAME_FILELINE    (1U << 0)  /* don't report __FILE__ / __LINE__ as fileName/lineNumber */
 
 /*
  *  Catcher defines
@@ -60,10 +60,10 @@
 #define DUK_CAT_LABEL_BITS           24
 #define DUK_CAT_LABEL_SHIFT          8
 
-#define DUK_CAT_FLAG_CATCH_ENABLED          (1 << 4)   /* catch part will catch */
-#define DUK_CAT_FLAG_FINALLY_ENABLED        (1 << 5)   /* finally part will catch */
-#define DUK_CAT_FLAG_CATCH_BINDING_ENABLED  (1 << 6)   /* request to create catch binding */
-#define DUK_CAT_FLAG_LEXENV_ACTIVE          (1 << 7)   /* catch or with binding is currently active */
+#define DUK_CAT_FLAG_CATCH_ENABLED          (1U << 4)   /* catch part will catch */
+#define DUK_CAT_FLAG_FINALLY_ENABLED        (1U << 5)   /* finally part will catch */
+#define DUK_CAT_FLAG_CATCH_BINDING_ENABLED  (1U << 6)   /* request to create catch binding */
+#define DUK_CAT_FLAG_LEXENV_ACTIVE          (1U << 7)   /* catch or with binding is currently active */
 
 #define DUK_CAT_TYPE_UNKNOWN         0
 #define DUK_CAT_TYPE_TCF             1

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -387,13 +387,13 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 		duk_small_uint_t num;
 
 		DUK_DDD(DUK_DDDPRINT("initializing built-in object at index %ld", (long) i));
-		h = duk_known_hobject(thr, i);
+		h = duk_known_hobject(thr, (duk_idx_t) i);
 
 		t = (duk_small_uint_t) duk_bd_decode_varuint(bd);
 		if (t > 0) {
 			t--;
 			DUK_DDD(DUK_DDDPRINT("set internal prototype: built-in %ld", (long) t));
-			DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, h, duk_known_hobject(thr, t));
+			DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, h, duk_known_hobject(thr, (duk_idx_t) t));
 		} else if (DUK_HOBJECT_IS_NATFUNC(h)) {
 			/* Standard native built-ins cannot inherit from
 			 * %NativeFunctionPrototype%, they are required to
@@ -412,8 +412,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 */
 			t--;
 			DUK_DDD(DUK_DDDPRINT("set external prototype: built-in %ld", (long) t));
-			duk_dup(thr, t);
-			duk_xdef_prop_stridx(thr, i, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_NONE);
+			duk_dup(thr, (duk_idx_t) t);
+			duk_xdef_prop_stridx(thr, (duk_idx_t) i, DUK_STRIDX_PROTOTYPE, DUK_PROPDESC_FLAGS_NONE);
 		}
 
 		t = (duk_small_uint_t) duk_bd_decode_varuint(bd);
@@ -425,8 +425,8 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 */
 			t--;
 			DUK_DDD(DUK_DDDPRINT("set external constructor: built-in %ld", (long) t));
-			duk_dup(thr, t);
-			duk_xdef_prop_stridx(thr, i, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);
+			duk_dup(thr, (duk_idx_t) t);
+			duk_xdef_prop_stridx(thr, (duk_idx_t) i, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);
 		}
 
 		/* normal valued properties */
@@ -535,7 +535,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			}
 			}
 
-			duk_def_prop(thr, i, defprop_flags);
+			duk_def_prop(thr, (duk_idx_t) i, defprop_flags);
 			DUK_ASSERT_TOP(thr, DUK_NUM_ALL_BUILTINS);
 		}
 
@@ -560,7 +560,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			natidx = (duk_small_uint_t) duk_bd_decode_varuint(bd);
 
 			c_length = (duk_small_uint_t) duk_bd_decode(bd, DUK__LENGTH_PROP_BITS);
-			c_nargs = (duk_int_t) duk_bd_decode_flagged(bd, DUK__NARGS_BITS, (duk_int32_t) c_length /*def_value*/);
+			c_nargs = (duk_int_t) duk_bd_decode_flagged(bd, DUK__NARGS_BITS, (duk_uint32_t) c_length /*def_value*/);
 			if (c_nargs == DUK__NARGS_VARARGS_MARKER) {
 				c_nargs = DUK_VARARGS;
 			}
@@ -602,7 +602,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 			if (lightfunc_eligible) {
 				duk_tval tv_lfunc;
-				duk_small_uint_t lf_nargs = (c_nargs == DUK_VARARGS ? DUK_LFUNC_NARGS_VARARGS : c_nargs);
+				duk_small_uint_t lf_nargs = (duk_small_uint_t) (c_nargs == DUK_VARARGS ? DUK_LFUNC_NARGS_VARARGS : c_nargs);
 				duk_small_uint_t lf_flags = DUK_LFUNC_FLAGS_PACK(magic, c_length, lf_nargs);
 				DUK_TVAL_SET_LIGHTFUNC(&tv_lfunc, c_func, lf_flags);
 				duk_push_tval(thr, &tv_lfunc);
@@ -650,7 +650,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 			/* [ (builtin objects) name func ] */
 
-			duk_push_int(thr, c_length);
+			duk_push_uint(thr, c_length);
 			duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_C);
 
 			duk_dup_m2(thr);
@@ -675,7 +675,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			/* XXX: So far all ES builtins are 'wc' but e.g.
 			 * performance.now() should be 'wec'.
 			 */
-			duk_xdef_prop(thr, i, DUK_PROPDESC_FLAGS_WC);
+			duk_xdef_prop(thr, (duk_idx_t) i, DUK_PROPDESC_FLAGS_WC);
 
 			/* [ (builtin objects) ] */
 		}
@@ -826,7 +826,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 	DUK_DD(DUK_DDPRINT("compact built-ins"));
 	for (i = 0; i < DUK_NUM_ALL_BUILTINS; i++) {
-		duk_hobject_compact_props(thr, duk_known_hobject(thr, i));
+		duk_hobject_compact_props(thr, duk_known_hobject(thr, (duk_idx_t) i));
 	}
 
 	DUK_D(DUK_DPRINT("INITBUILTINS END"));

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -6,21 +6,21 @@
 #define DUK_JS_H_INCLUDED
 
 /* Flags for call handling.  Lowest flags must match bytecode DUK_BC_CALL_FLAG_xxx 1:1. */
-#define DUK_CALL_FLAG_TAILCALL                 (1 << 0)  /* setup for a tail call */
-#define DUK_CALL_FLAG_CONSTRUCT                (1 << 1)  /* constructor call (i.e. called as 'new Foo()') */
-#define DUK_CALL_FLAG_CALLED_AS_EVAL           (1 << 2)  /* call was made using the identifier 'eval' */
-#define DUK_CALL_FLAG_ALLOW_ECMATOECMA         (1 << 3)  /* ecma-to-ecma call with executor reuse is possible */
-#define DUK_CALL_FLAG_DIRECT_EVAL              (1 << 4)  /* call is a direct eval call */
-#define DUK_CALL_FLAG_CONSTRUCT_PROXY          (1 << 5)  /* handled via 'construct' proxy trap, check return value invariant(s) */
-#define DUK_CALL_FLAG_DEFAULT_INSTANCE_UPDATED (1 << 6)  /* prototype of 'default instance' updated, temporary flag in call handling */
+#define DUK_CALL_FLAG_TAILCALL                 (1U << 0)  /* setup for a tail call */
+#define DUK_CALL_FLAG_CONSTRUCT                (1U << 1)  /* constructor call (i.e. called as 'new Foo()') */
+#define DUK_CALL_FLAG_CALLED_AS_EVAL           (1U << 2)  /* call was made using the identifier 'eval' */
+#define DUK_CALL_FLAG_ALLOW_ECMATOECMA         (1U << 3)  /* ecma-to-ecma call with executor reuse is possible */
+#define DUK_CALL_FLAG_DIRECT_EVAL              (1U << 4)  /* call is a direct eval call */
+#define DUK_CALL_FLAG_CONSTRUCT_PROXY          (1U << 5)  /* handled via 'construct' proxy trap, check return value invariant(s) */
+#define DUK_CALL_FLAG_DEFAULT_INSTANCE_UPDATED (1U << 6)  /* prototype of 'default instance' updated, temporary flag in call handling */
 
 /* Flags for duk_js_equals_helper(). */
-#define DUK_EQUALS_FLAG_SAMEVALUE            (1 << 0)  /* use SameValue instead of non-strict equality */
-#define DUK_EQUALS_FLAG_STRICT               (1 << 1)  /* use strict equality instead of non-strict equality */
+#define DUK_EQUALS_FLAG_SAMEVALUE            (1U << 0)  /* use SameValue instead of non-strict equality */
+#define DUK_EQUALS_FLAG_STRICT               (1U << 1)  /* use strict equality instead of non-strict equality */
 
 /* Flags for duk_js_compare_helper(). */
-#define DUK_COMPARE_FLAG_NEGATE              (1 << 0)  /* negate result */
-#define DUK_COMPARE_FLAG_EVAL_LEFT_FIRST     (1 << 1)  /* eval left argument first */
+#define DUK_COMPARE_FLAG_NEGATE              (1U << 0)  /* negate result */
+#define DUK_COMPARE_FLAG_EVAL_LEFT_FIRST     (1U << 1)  /* eval left argument first */
 
 /* conversions, coercions, comparison, etc */
 DUK_INTERNAL_DECL duk_bool_t duk_js_toboolean(duk_tval *tv);
@@ -35,13 +35,13 @@ DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_string(const duk_uint8_t *s
 DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_hstring_fast_known(duk_hstring *h);
 DUK_INTERNAL_DECL duk_uarridx_t duk_js_to_arrayindex_hstring_fast(duk_hstring *h);
 #endif
-DUK_INTERNAL_DECL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_int_t flags);
+DUK_INTERNAL_DECL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_t flags);
 DUK_INTERNAL_DECL duk_small_int_t duk_js_data_compare(const duk_uint8_t *buf1, const duk_uint8_t *buf2, duk_size_t len1, duk_size_t len2);
 DUK_INTERNAL_DECL duk_small_int_t duk_js_string_compare(duk_hstring *h1, duk_hstring *h2);
 #if 0  /* unused */
 DUK_INTERNAL_DECL duk_small_int_t duk_js_buffer_compare(duk_heap *heap, duk_hbuffer *h1, duk_hbuffer *h2);
 #endif
-DUK_INTERNAL_DECL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_int_t flags);
+DUK_INTERNAL_DECL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_t flags);
 DUK_INTERNAL_DECL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y);
 DUK_INTERNAL_DECL duk_bool_t duk_js_in(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y);
 DUK_INTERNAL_DECL duk_small_uint_t duk_js_typeof_stridx(duk_tval *tv_x);
@@ -85,7 +85,7 @@ DUK_INTERNAL_DECL void duk_js_putvar_activation(duk_hthread *thr, duk_activation
 DUK_INTERNAL_DECL duk_bool_t duk_js_delvar_envrec(duk_hthread *thr, duk_hobject *env, duk_hstring *name);
 #endif
 DUK_INTERNAL_DECL duk_bool_t duk_js_delvar_activation(duk_hthread *thr, duk_activation *act, duk_hstring *name);
-DUK_INTERNAL_DECL duk_bool_t duk_js_declvar_activation(duk_hthread *thr, duk_activation *act, duk_hstring *name, duk_tval *val, duk_small_int_t prop_flags, duk_bool_t is_func_decl);
+DUK_INTERNAL_DECL duk_bool_t duk_js_declvar_activation(duk_hthread *thr, duk_activation *act, duk_hstring *name, duk_tval *val, duk_small_uint_t prop_flags, duk_bool_t is_func_decl);
 DUK_INTERNAL_DECL void duk_js_init_activation_environment_records_delayed(duk_hthread *thr, duk_activation *act);
 DUK_INTERNAL_DECL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject *env);
 DUK_INTERNAL_DECL duk_hobject *duk_create_activation_environment_record(duk_hthread *thr, duk_hobject *func, duk_size_t bottom_byteoff);

--- a/src-input/duk_js_bytecode.h
+++ b/src-input/duk_js_bytecode.h
@@ -456,23 +456,23 @@ typedef duk_uint32_t duk_instr_t;
  * but avoids shuffling in more cases.  Maybe not worth it.
  */
 /* DUK_OP_TRYCATCH flags in A. */
-#define DUK_BC_TRYCATCH_FLAG_HAVE_CATCH     (1 << 0)
-#define DUK_BC_TRYCATCH_FLAG_HAVE_FINALLY   (1 << 1)
-#define DUK_BC_TRYCATCH_FLAG_CATCH_BINDING  (1 << 2)
-#define DUK_BC_TRYCATCH_FLAG_WITH_BINDING   (1 << 3)
+#define DUK_BC_TRYCATCH_FLAG_HAVE_CATCH     (1U << 0)
+#define DUK_BC_TRYCATCH_FLAG_HAVE_FINALLY   (1U << 1)
+#define DUK_BC_TRYCATCH_FLAG_CATCH_BINDING  (1U << 2)
+#define DUK_BC_TRYCATCH_FLAG_WITH_BINDING   (1U << 3)
 
 /* DUK_OP_DECLVAR flags in A; bottom bits are reserved for propdesc flags
  * (DUK_PROPDESC_FLAG_XXX).
  */
-#define DUK_BC_DECLVAR_FLAG_FUNC_DECL       (1 << 4)  /* function declaration */
+#define DUK_BC_DECLVAR_FLAG_FUNC_DECL       (1U << 4)  /* function declaration */
 
 /* DUK_OP_CALLn flags, part of opcode field.  Three lowest bits must match
  * DUK_CALL_FLAG_xxx directly.
  */
-#define DUK_BC_CALL_FLAG_TAILCALL           (1 << 0)
-#define DUK_BC_CALL_FLAG_CONSTRUCT          (1 << 1)
-#define DUK_BC_CALL_FLAG_CALLED_AS_EVAL     (1 << 2)
-#define DUK_BC_CALL_FLAG_INDIRECT           (1 << 3)
+#define DUK_BC_CALL_FLAG_TAILCALL           (1U << 0)
+#define DUK_BC_CALL_FLAG_CONSTRUCT          (1U << 1)
+#define DUK_BC_CALL_FLAG_CALLED_AS_EVAL     (1U << 2)
+#define DUK_BC_CALL_FLAG_INDIRECT           (1U << 3)
 
 /* Misc constants and helper macros. */
 #define DUK_BC_LDINT_BIAS           (1L << 15)

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -36,13 +36,12 @@
  * Chosen so that when a regconst is cast to duk_int32_t, all consts are
  * negative values.
  */
-#define DUK_REGCONST_CONST_MARKER    0x80000000UL
+#define DUK_REGCONST_CONST_MARKER    DUK_INT32_MIN  /* = -0x80000000 */
 
-/* type to represent a reg/const reference during compilation */
-typedef duk_uint32_t duk_regconst_t;
-
-/* type to represent a straight register reference, with <0 indicating none */
-typedef duk_int32_t duk_reg_t;
+/* Type to represent a reg/const reference during compilation, with <0
+ * indicating a constant.  Some call sites also use -1 to indicate 'none'.
+ */
+typedef duk_int32_t duk_regconst_t;
 
 typedef struct {
 	duk_small_uint_t t;          /* DUK_ISPEC_XXX */
@@ -82,8 +81,8 @@ struct duk_compiler_instr {
  *  Compiler state
  */
 
-#define DUK_LABEL_FLAG_ALLOW_BREAK       (1 << 0)
-#define DUK_LABEL_FLAG_ALLOW_CONTINUE    (1 << 1)
+#define DUK_LABEL_FLAG_ALLOW_BREAK       (1U << 0)
+#define DUK_LABEL_FLAG_ALLOW_CONTINUE    (1U << 1)
 
 #define DUK_DECL_TYPE_VAR                0
 #define DUK_DECL_TYPE_FUNC               1
@@ -141,14 +140,14 @@ struct duk_compiler_func {
 	duk_idx_t varmap_idx;
 
 	/* Temp reg handling. */
-	duk_reg_t temp_first;               /* first register that is a temporary (below: variables) */
-	duk_reg_t temp_next;                /* next temporary register to allocate */
-	duk_reg_t temp_max;                 /* highest value of temp_reg (temp_max - 1 is highest used reg) */
+	duk_regconst_t temp_first;           /* first register that is a temporary (below: variables) */
+	duk_regconst_t temp_next;            /* next temporary register to allocate */
+	duk_regconst_t temp_max;             /* highest value of temp_reg (temp_max - 1 is highest used reg) */
 
 	/* Shuffle registers if large number of regs/consts. */
-	duk_reg_t shuffle1;
-	duk_reg_t shuffle2;
-	duk_reg_t shuffle3;
+	duk_regconst_t shuffle1;
+	duk_regconst_t shuffle2;
+	duk_regconst_t shuffle3;
 
 	/* Stats for current expression being parsed. */
 	duk_int_t nud_count;
@@ -164,7 +163,7 @@ struct duk_compiler_func {
 	duk_int_t with_depth;               /* with stack depth (affects identifier lookups) */
 	duk_int_t fnum_next;                /* inner function numbering */
 	duk_int_t num_formals;              /* number of formal arguments */
-	duk_reg_t reg_stmt_value;           /* register for writing value of 'non-empty' statements (global or eval code), -1 is marker */
+	duk_regconst_t reg_stmt_value;      /* register for writing value of 'non-empty' statements (global or eval code), -1 is marker */
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	duk_int_t min_line;                 /* XXX: typing (duk_hcompfunc has duk_uint32_t) */
 	duk_int_t max_line;

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -191,7 +191,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_add(duk_hthread *thr, duk_tval *tv
 	duk_replace(thr, (duk_idx_t) idx_z);  /* side effects */
 }
 
-DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_idx_t idx_z, duk_small_uint_fast_t opcode) {
+DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_uint_fast_t idx_z, duk_small_uint_fast_t opcode) {
 	/*
 	 *  Arithmetic operations other than '+' have number-only semantics
 	 *  and are implemented here.  The separate switch-case here means a
@@ -336,7 +336,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_binary_op(duk_hthread *thr, duk_tv
 
 #if defined(DUK_USE_EXEC_PREFER_SIZE)
 	duk_push_number(thr, du.d);  /* will NaN normalize result */
-	duk_replace(thr, idx_z);
+	duk_replace(thr, (duk_idx_t) idx_z);
 #else  /* DUK_USE_EXEC_PREFER_SIZE */
 	/* important to use normalized NaN with 8-byte tagged types */
 	DUK_DBLUNION_NORMALIZE_NAN_CHECK(&du);
@@ -474,7 +474,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_bitwise_binary_op(duk_hthread *thr, duk_
 }
 
 /* In-place unary operation. */
-DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx_t idx_src, duk_idx_t idx_dst, duk_small_uint_fast_t opcode) {
+DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_uint_fast_t idx_src, duk_uint_fast_t idx_dst, duk_small_uint_fast_t opcode) {
 	/*
 	 *  Arithmetic operations other than '+' have number-only semantics
 	 *  and are implemented here.  The separate switch-case here means a
@@ -489,10 +489,10 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx
 
 	DUK_ASSERT(thr != NULL);
 	DUK_ASSERT(opcode == DUK_OP_UNM || opcode == DUK_OP_UNP);
-	DUK_ASSERT(idx_src >= 0);
-	DUK_ASSERT(idx_dst >= 0);
+	DUK_ASSERT_DISABLE(idx_src >= 0);
+	DUK_ASSERT_DISABLE(idx_dst >= 0);
 
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_src);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_src);
 
 #if defined(DUK_USE_FASTINT)
 	if (DUK_TVAL_IS_FASTINT(tv)) {
@@ -506,7 +506,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx
 			 */
 			if (DUK_LIKELY(v1 != DUK_FASTINT_MIN && v1 != 0)) {
 				v2 = -v1;
-				tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+				tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 				DUK_TVAL_SET_FASTINT_UPDREF(thr, tv, v2);
 				return;
 			}
@@ -514,7 +514,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx
 			/* ToNumber() for a fastint is a no-op. */
 			DUK_ASSERT(opcode == DUK_OP_UNP);
 			v2 = v1;
-			tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+			tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 			DUK_TVAL_SET_FASTINT_UPDREF(thr, tv, v2);
 			return;
 		}
@@ -535,7 +535,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx
 		du.d = d1;
 		DUK_ASSERT(DUK_DBLUNION_IS_NORMALIZED(&du));
 #if defined(DUK_USE_FASTINT)
-		tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+		tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 		DUK_TVAL_SET_NUMBER_CHKFAST_UPDREF(thr, tv, du.d);  /* always 'fast', i.e. inlined */
 		return;
 #endif
@@ -547,7 +547,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_arith_unary_op(duk_hthread *thr, duk_idx
 	}
 
 	/* XXX: size optimize: push+replace? */
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv, du.d);
 }
 
@@ -565,7 +565,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_bitwise_not(duk_hthread *thr, duk_uint_f
 	DUK_ASSERT((duk_uint_t) idx_src < (duk_uint_t) duk_get_top(thr));
 	DUK_ASSERT((duk_uint_t) idx_dst < (duk_uint_t) duk_get_top(thr));
 
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_src);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_src);
 
 #if defined(DUK_USE_FASTINT)
 	if (DUK_TVAL_IS_FASTINT(tv)) {
@@ -581,11 +581,11 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_bitwise_not(duk_hthread *thr, duk_uint_f
 
 	/* Result is always fastint compatible. */
 	i2 = ~i1;
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 	DUK_TVAL_SET_I32_UPDREF(thr, tv, i2);  /* side effects */
 }
 
-DUK_LOCAL DUK__INLINE_PERF void duk__vm_logical_not(duk_hthread *thr, duk_idx_t idx_src, duk_idx_t idx_dst) {
+DUK_LOCAL DUK__INLINE_PERF void duk__vm_logical_not(duk_hthread *thr, duk_uint_fast_t idx_src, duk_uint_fast_t idx_dst) {
 	/*
 	 *  E5 Section 11.4.9
 	 */
@@ -603,11 +603,11 @@ DUK_LOCAL DUK__INLINE_PERF void duk__vm_logical_not(duk_hthread *thr, duk_idx_t 
 	 * we can do it efficiently.  For footprint it would be better to use
 	 * duk_js_toboolean() and then push+replace to the result slot.
 	 */
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_src);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_src);
 	res = duk_js_toboolean(tv);  /* does not modify 'tv' */
 	DUK_ASSERT(res == 0 || res == 1);
 	res ^= 1;
-	tv = DUK_GET_TVAL_POSIDX(thr, idx_dst);
+	tv = DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst);
 	/* XXX: size optimize: push+replace? */
 	DUK_TVAL_SET_BOOLEAN_UPDREF(thr, tv, res);  /* side effects */
 }
@@ -689,7 +689,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_reg_helper(duk_hthread *thr,
 	DUK_TVAL_SET_NUMBER_UPDREF(thr, tv_dst, z);  /* side effects */
 }
 
-DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr, duk_small_uint_t idx_dst, duk_tval *tv_id, duk_small_uint_t op, duk_uint_t is_strict) {
+DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr, duk_small_uint_t idx_dst, duk_tval *tv_id, duk_small_uint_t op, duk_small_uint_t is_strict) {
 	duk_activation *act;
 	duk_double_t x, y;
 	duk_hstring *name;
@@ -746,7 +746,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr,
 #if defined(DUK_USE_EXEC_PREFER_SIZE)
 	duk_replace(thr, (duk_idx_t) idx_dst);
 #else  /* DUK_USE_EXEC_PREFER_SIZE */
-	DUK__REPLACE_TO_TVPTR(thr, DUK_GET_TVAL_POSIDX(thr, idx_dst));
+	DUK__REPLACE_TO_TVPTR(thr, DUK_GET_TVAL_POSIDX(thr, (duk_idx_t) idx_dst));
 #endif  /* DUK_USE_EXEC_PREFER_SIZE */
 }
 
@@ -1188,7 +1188,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		} else {
 			/* Initial resume call. */
 			duk_small_uint_t call_flags;
-			duk_bool_t setup_rc;
+			duk_int_t setup_rc;
 
 			/* resumee: [... initial_func]  (currently actually: [initial_func]) */
 
@@ -1791,7 +1791,8 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 	}
 
 	/* XXX: remove heap->dbg_exec_counter, use heap->inst_count_interrupt instead? */
-	thr->heap->dbg_exec_counter += thr->interrupt_init;
+	DUK_ASSERT(thr->interrupt_init >= 0);
+	thr->heap->dbg_exec_counter += (duk_uint_t) thr->interrupt_init;
 	if (thr->heap->dbg_exec_counter - thr->heap->dbg_last_counter >= DUK_HEAP_DBG_RATELIMIT_OPCODES) {
 		/* Overflow of the execution counter is fine and doesn't break
 		 * anything here.
@@ -2217,9 +2218,9 @@ DUK_LOCAL DUK__NOINLINE_PERF void duk__handle_op_trycatch(duk_hthread *thr, duk_
 	 * error handling, so there's no side effect problem even if the
 	 * error value has a finalizer.
 	 */
-	duk_dup(thr, bc);  /* Stabilize value. */
-	duk_to_undefined(thr, bc);
-	duk_to_undefined(thr, bc + 1);
+	duk_dup(thr, (duk_idx_t) bc);  /* Stabilize value. */
+	duk_to_undefined(thr, (duk_idx_t) bc);
+	duk_to_undefined(thr, (duk_idx_t) (bc + 1));
 
 	/* Allocate catcher and populate it.  Doesn't have to
 	 * be fully atomic, but the catcher must be in a
@@ -2515,7 +2516,7 @@ DUK_LOCAL DUK__NOINLINE_PERF duk_small_uint_t duk__handle_op_endfin(duk_hthread 
 		                     "dismantle catcher, re-throw error",
 		                     (long) cont_type));
 
-		duk_err_setup_ljstate1(thr, (duk_small_int_t) cont_type, tv1);
+		duk_err_setup_ljstate1(thr, (duk_small_uint_t) cont_type, tv1);
 		/* No debugger Throw notify check on purpose (rethrow). */
 
 		DUK_ASSERT(thr->heap->lj.jmpbuf_ptr != NULL);  /* always in executor */
@@ -2615,7 +2616,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
 	 * target is (directly or indirectly) Reflect.construct(),
 	 * the call may change into a constructor call on the fly.
 	 */
-	rc = duk_handle_call_unprotected(thr, idx, call_flags);
+	rc = (duk_bool_t) duk_handle_call_unprotected(thr, idx, call_flags);
 	if (rc != 0) {
 		/* Ecma-to-ecma call possible, may or may not
 		 * be a tail call.  Avoid C recursion by
@@ -2667,7 +2668,9 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
 #else
 #define DUK__FUN()          ((duk_hcompfunc *) DUK_ACT_GET_FUNC((thr)->callstack_curr))
 #endif
-#define DUK__STRICT()       (DUK_HOBJECT_HAS_STRICT((duk_hobject *) DUK__FUN()))
+
+/* Strict flag. */
+#define DUK__STRICT()       ((duk_small_uint_t) DUK_HOBJECT_HAS_STRICT((duk_hobject *) DUK__FUN()))
 
 /* Reg/const access macros: these are very footprint and performance sensitive
  * so modify with care.  Arguments are sometimes evaluated multiple times which
@@ -4715,7 +4718,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 		case DUK_OP_CALL14:
 		case DUK_OP_CALL15: {
 			/* Indirect variant. */
-			duk_idx_t nargs;
+			duk_uint_fast_t nargs;
 			duk_idx_t idx;
 			duk_small_uint_t call_flags;
 #if !defined(DUK_USE_EXEC_FUN_LOCAL)
@@ -4725,12 +4728,12 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			DUK_ASSERT((DUK_OP_CALL0 & 0x0fU) == 0);
 			DUK_ASSERT((ins & DUK_BC_CALL_FLAG_INDIRECT) != 0);
 
-			nargs = (duk_idx_t) DUK_DEC_A(ins);
+			nargs = (duk_uint_fast_t) DUK_DEC_A(ins);
 			DUK__LOOKUP_INDIRECT(nargs);
 			call_flags = (ins & 0x07U) | DUK_CALL_FLAG_ALLOW_ECMATOECMA;
 			idx = (duk_idx_t) DUK_DEC_BC(ins);
 
-			if (duk__executor_handle_call(thr, idx, nargs, call_flags)) {
+			if (duk__executor_handle_call(thr, idx, (duk_idx_t) nargs, call_flags)) {
 				DUK_ASSERT(thr->ptr_curr_pc == NULL);
 				goto restart_execution;
 			}
@@ -4833,8 +4836,8 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			 */
 			do {
 				/* XXX: faster initialization (direct access or better primitives) */
-				duk_dup(thr, idx);
-				duk_dup(thr, idx + 1);
+				duk_dup(thr, (duk_idx_t) idx);
+				duk_dup(thr, (duk_idx_t) (idx + 1));
 				duk_def_prop(thr, obj_idx, DUK_DEFPROP_HAVE_VALUE |
 				                           DUK_DEFPROP_FORCE |
 				                           DUK_DEFPROP_SET_WRITABLE |
@@ -4908,7 +4911,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 				 * and finally set 'length' manually in the end (as already happens now).
 				 */
 
-				duk_dup(thr, idx);
+				duk_dup(thr, (duk_idx_t) idx);
 				duk_xdef_prop_index_wec(thr, obj_idx, arr_idx);
 
 				idx++;

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -283,7 +283,7 @@ DUK_INTERNAL duk_double_t duk_js_tointeger_number(duk_double_t x) {
 	/* NaN and Infinity have the same exponent so it's a cheap
 	 * initial check for the rare path.
 	 */
-	if (DUK_UNLIKELY(duk_double_is_nan_or_inf(x))) {
+	if (DUK_UNLIKELY(duk_double_is_nan_or_inf(x) != 0U)) {
 		if (duk_double_is_nan(x)) {
 			return 0.0;
 		} else {
@@ -518,7 +518,7 @@ DUK_LOCAL duk_bool_t duk__js_samevalue_number(duk_double_t x, duk_double_t y) {
 #endif  /* DUK_USE_PARANOID_MATH */
 }
 
-DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_int_t flags) {
+DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_t flags) {
 	duk_uint_t type_mask_x;
 	duk_uint_t type_mask_y;
 
@@ -663,14 +663,14 @@ DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, d
 	 */
 	if (type_mask_x & DUK_TYPE_MASK_BOOLEAN) {
 		DUK_ASSERT(DUK_TVAL_GET_BOOLEAN(tv_x) == 0 || DUK_TVAL_GET_BOOLEAN(tv_x) == 1);
-		duk_push_int(thr, DUK_TVAL_GET_BOOLEAN(tv_x));
+		duk_push_uint(thr, DUK_TVAL_GET_BOOLEAN(tv_x));
 		duk_push_tval(thr, tv_y);
 		goto recursive_call;
 	}
 	if (type_mask_y & DUK_TYPE_MASK_BOOLEAN) {
 		DUK_ASSERT(DUK_TVAL_GET_BOOLEAN(tv_y) == 0 || DUK_TVAL_GET_BOOLEAN(tv_y) == 1);
 		duk_push_tval(thr, tv_x);
-		duk_push_int(thr, DUK_TVAL_GET_BOOLEAN(tv_y));
+		duk_push_uint(thr, DUK_TVAL_GET_BOOLEAN(tv_y));
 		goto recursive_call;
 	}
 
@@ -895,7 +895,7 @@ DUK_LOCAL duk_bool_t duk__compare_number(duk_bool_t retval, duk_double_t d1, duk
 }
 #endif  /* DUK_USE_PARANOID_MATH */
 
-DUK_INTERNAL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_int_t flags) {
+DUK_INTERNAL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_t flags) {
 	duk_double_t d1, d2;
 	duk_small_int_t rc;
 	duk_bool_t retval;
@@ -1392,8 +1392,8 @@ DUK_INTERNAL duk_uarridx_t duk_js_to_arrayindex_hstring_fast_known(duk_hstring *
 			/* Scanning to NUL is always safe for interned strings. */
 			break;
 		}
-		DUK_ASSERT(t >= DUK_ASC_0 && t <= DUK_ASC_9);
-		res = res * 10U + (t - DUK_ASC_0);
+		DUK_ASSERT(t >= (duk_uint8_t) DUK_ASC_0 && t <= (duk_uint8_t) DUK_ASC_9);
+		res = res * 10U + (duk_uarridx_t) t - (duk_uarridx_t) DUK_ASC_0;
 	}
 	return res;
 }

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -40,7 +40,7 @@ typedef struct {
 	duk_hobject *env;
 	duk_hobject *holder;      /* for object-bound identifiers */
 	duk_tval *value;          /* for register-bound and declarative env identifiers */
-	duk_int_t attrs;          /* property attributes for identifier (relevant if value != NULL) */
+	duk_uint_t attrs;         /* property attributes for identifier (relevant if value != NULL) */
 	duk_bool_t has_this;      /* for object-bound identifiers: provide 'this' binding */
 } duk__id_lookup_result;
 
@@ -926,8 +926,8 @@ duk_bool_t duk__get_identifier_reference(duk_hthread *thr,
 
 	sanity = DUK_HOBJECT_PROTOTYPE_CHAIN_SANITY;
 	while (env != NULL) {
-		duk_small_int_t cl;
-		duk_int_t attrs;
+		duk_small_uint_t cl;
+		duk_uint_t attrs;
 
 		DUK_DDD(DUK_DDDPRINT("duk__get_identifier_reference, name=%!O, considering env=%p -> %!iO",
 		                     (duk_heaphdr *) name,
@@ -1490,7 +1490,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
                                duk_hobject *env,
                                duk_hstring *name,
                                duk_tval *val,
-                               duk_small_int_t prop_flags,
+                               duk_small_uint_t prop_flags,
                                duk_bool_t is_func_decl) {
 	duk_hobject *holder;
 	duk_bool_t parents;
@@ -1532,7 +1532,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 	if (duk__get_identifier_reference(thr, env, name, NULL, parents, &ref)) {
 		duk_int_t e_idx;
 		duk_int_t h_idx;
-		duk_small_int_t flags;
+		duk_small_uint_t flags;
 
 		/*
 		 *  Variable already declared, ignore re-declaration.
@@ -1718,7 +1718,7 @@ duk_bool_t duk_js_declvar_activation(duk_hthread *thr,
                                      duk_activation *act,
                                      duk_hstring *name,
                                      duk_tval *val,
-                                     duk_small_int_t prop_flags,
+                                     duk_small_uint_t prop_flags,
                                      duk_bool_t is_func_decl) {
 	duk_hobject *env;
 	duk_tval tv_val_copy;

--- a/src-input/duk_json.h
+++ b/src-input/duk_json.h
@@ -6,10 +6,10 @@
 #define DUK_JSON_H_INCLUDED
 
 /* Encoding/decoding flags */
-#define DUK_JSON_FLAG_ASCII_ONLY              (1 << 0)  /* escape any non-ASCII characters */
-#define DUK_JSON_FLAG_AVOID_KEY_QUOTES        (1 << 1)  /* avoid key quotes when key is an ASCII Identifier */
-#define DUK_JSON_FLAG_EXT_CUSTOM              (1 << 2)  /* extended types: custom encoding */
-#define DUK_JSON_FLAG_EXT_COMPATIBLE          (1 << 3)  /* extended types: compatible encoding */
+#define DUK_JSON_FLAG_ASCII_ONLY              (1U << 0)  /* escape any non-ASCII characters */
+#define DUK_JSON_FLAG_AVOID_KEY_QUOTES        (1U << 1)  /* avoid key quotes when key is an ASCII Identifier */
+#define DUK_JSON_FLAG_EXT_CUSTOM              (1U << 2)  /* extended types: custom encoding */
+#define DUK_JSON_FLAG_EXT_COMPATIBLE          (1U << 3)  /* extended types: compatible encoding */
 
 /* How much stack to require on entry to object/array encode */
 #define DUK_JSON_ENC_REQSTACK                 32
@@ -36,8 +36,8 @@ typedef struct {
 	duk_small_uint_t flag_ext_compatible;
 	duk_small_uint_t flag_ext_custom_or_compatible;
 #endif
-	duk_int_t recursion_depth;
-	duk_int_t recursion_limit;
+	duk_uint_t recursion_depth;
+	duk_uint_t recursion_limit;
 	duk_uint_t mask_for_undefined;      /* type bit mask: types which certainly produce 'undefined' */
 #if defined(DUK_USE_JX) || defined(DUK_USE_JC)
 	duk_small_uint_t stridx_custom_undefined;

--- a/src-input/duk_lexer.h
+++ b/src-input/duk_lexer.h
@@ -172,6 +172,8 @@ typedef void (*duk_re_range_callback)(void *user, duk_codepoint_t r1, duk_codepo
 
 #define DUK_TOK_MAXVAL                            101  /* inclusive */
 
+#define DUK_TOK_INVALID                           DUK_SMALL_UINT_MAX
+
 /* Convert heap string index to a token (reserved words) */
 #define DUK_STRIDX_TO_TOK(x)                        ((x) - DUK_STRIDX_START_RESERVED + DUK_TOK_START_RESERVED)
 
@@ -350,8 +352,8 @@ typedef void (*duk_re_range_callback)(void *user, duk_codepoint_t r1, duk_codepo
  * stale values otherwise.
  */
 struct duk_token {
-	duk_small_int_t t;            /* token type (with reserved word identification) */
-	duk_small_int_t t_nores;      /* token type (with reserved words as DUK_TOK_IDENTIFER) */
+	duk_small_uint_t t;           /* token type (with reserved word identification) */
+	duk_small_uint_t t_nores;     /* token type (with reserved words as DUK_TOK_IDENTIFER) */
 	duk_double_t num;             /* numeric value of token */
 	duk_hstring *str1;            /* string 1 of token (borrowed, stored to ctx->slot1_idx) */
 	duk_hstring *str2;            /* string 2 of token (borrowed, stored to ctx->slot2_idx) */
@@ -366,11 +368,11 @@ struct duk_token {
 
 /* A regexp token value. */
 struct duk_re_token {
-	duk_small_int_t t;           /* token type */
-	duk_small_int_t greedy;
-	duk_uint_fast32_t num;       /* numeric value (character, count) */
-	duk_uint_fast32_t qmin;
-	duk_uint_fast32_t qmax;
+	duk_small_uint_t t;          /* token type */
+	duk_small_uint_t greedy;
+	duk_uint32_t num;            /* numeric value (character, count) */
+	duk_uint32_t qmin;
+	duk_uint32_t qmax;
 };
 
 /* A structure for 'snapshotting' a point for rewinding */

--- a/src-input/duk_numconv.h
+++ b/src-input/duk_numconv.h
@@ -9,23 +9,23 @@
 /* Output a specified number of digits instead of using the shortest
  * form.  Used for toPrecision() and toFixed().
  */
-#define DUK_N2S_FLAG_FIXED_FORMAT         (1 << 0)
+#define DUK_N2S_FLAG_FIXED_FORMAT         (1U << 0)
 
 /* Force exponential format.  Used for toExponential(). */
-#define DUK_N2S_FLAG_FORCE_EXP            (1 << 1)
+#define DUK_N2S_FLAG_FORCE_EXP            (1U << 1)
 
 /* If number would need zero padding (for whole number part), use
  * exponential format instead.  E.g. if input number is 12300, 3
  * digits are generated ("123"), output "1.23e+4" instead of "12300".
  * Used for toPrecision().
  */
-#define DUK_N2S_FLAG_NO_ZERO_PAD          (1 << 2)
+#define DUK_N2S_FLAG_NO_ZERO_PAD          (1U << 2)
 
 /* Digit count indicates number of fractions (i.e. an absolute
  * digit index instead of a relative one).  Used together with
  * DUK_N2S_FLAG_FIXED_FORMAT for toFixed().
  */
-#define DUK_N2S_FLAG_FRACTION_DIGITS      (1 << 3)
+#define DUK_N2S_FLAG_FRACTION_DIGITS      (1U << 3)
 
 /*
  *  String-to-number conversion
@@ -38,57 +38,57 @@
 #define DUK_S2N_MAX_EXPONENT              1000000000
 
 /* Trim white space (= allow leading and trailing whitespace) */
-#define DUK_S2N_FLAG_TRIM_WHITE           (1 << 0)
+#define DUK_S2N_FLAG_TRIM_WHITE           (1U << 0)
 
 /* Allow exponent */
-#define DUK_S2N_FLAG_ALLOW_EXP            (1 << 1)
+#define DUK_S2N_FLAG_ALLOW_EXP            (1U << 1)
 
 /* Allow trailing garbage (e.g. treat "123foo" as "123) */
-#define DUK_S2N_FLAG_ALLOW_GARBAGE        (1 << 2)
+#define DUK_S2N_FLAG_ALLOW_GARBAGE        (1U << 2)
 
 /* Allow leading plus sign */
-#define DUK_S2N_FLAG_ALLOW_PLUS           (1 << 3)
+#define DUK_S2N_FLAG_ALLOW_PLUS           (1U << 3)
 
 /* Allow leading minus sign */
-#define DUK_S2N_FLAG_ALLOW_MINUS          (1 << 4)
+#define DUK_S2N_FLAG_ALLOW_MINUS          (1U << 4)
 
 /* Allow 'Infinity' */
-#define DUK_S2N_FLAG_ALLOW_INF            (1 << 5)
+#define DUK_S2N_FLAG_ALLOW_INF            (1U << 5)
 
 /* Allow fraction part */
-#define DUK_S2N_FLAG_ALLOW_FRAC           (1 << 6)
+#define DUK_S2N_FLAG_ALLOW_FRAC           (1U << 6)
 
 /* Allow naked fraction (e.g. ".123") */
-#define DUK_S2N_FLAG_ALLOW_NAKED_FRAC     (1 << 7)
+#define DUK_S2N_FLAG_ALLOW_NAKED_FRAC     (1U << 7)
 
 /* Allow empty fraction (e.g. "123.") */
-#define DUK_S2N_FLAG_ALLOW_EMPTY_FRAC     (1 << 8)
+#define DUK_S2N_FLAG_ALLOW_EMPTY_FRAC     (1U << 8)
 
 /* Allow empty string to be interpreted as 0 */
-#define DUK_S2N_FLAG_ALLOW_EMPTY_AS_ZERO  (1 << 9)
+#define DUK_S2N_FLAG_ALLOW_EMPTY_AS_ZERO  (1U << 9)
 
 /* Allow leading zeroes (e.g. "0123" -> "123") */
-#define DUK_S2N_FLAG_ALLOW_LEADING_ZERO   (1 << 10)
+#define DUK_S2N_FLAG_ALLOW_LEADING_ZERO   (1U << 10)
 
 /* Allow automatic detection of hex base ("0x" or "0X" prefix),
  * overrides radix argument and forces integer mode.
  */
-#define DUK_S2N_FLAG_ALLOW_AUTO_HEX_INT   (1 << 11)
+#define DUK_S2N_FLAG_ALLOW_AUTO_HEX_INT   (1U << 11)
 
 /* Allow automatic detection of legacy octal base ("0n"),
  * overrides radix argument and forces integer mode.
  */
-#define DUK_S2N_FLAG_ALLOW_AUTO_LEGACY_OCT_INT   (1 << 12)
+#define DUK_S2N_FLAG_ALLOW_AUTO_LEGACY_OCT_INT   (1U << 12)
 
 /* Allow automatic detection of ES2015 octal base ("0o123"),
  * overrides radix argument and forces integer mode.
  */
-#define DUK_S2N_FLAG_ALLOW_AUTO_OCT_INT   (1 << 13)
+#define DUK_S2N_FLAG_ALLOW_AUTO_OCT_INT   (1U << 13)
 
 /* Allow automatic detection of ES2015 binary base ("0b10001"),
  * overrides radix argument and forces integer mode.
  */
-#define DUK_S2N_FLAG_ALLOW_AUTO_BIN_INT   (1 << 14)
+#define DUK_S2N_FLAG_ALLOW_AUTO_BIN_INT   (1U << 14)
 
 /*
  *  Prototypes

--- a/src-input/duk_regexp.h
+++ b/src-input/duk_regexp.h
@@ -36,9 +36,9 @@
 #define DUK_REOP_ASSERT_NOT_WORD_BOUNDARY  19
 
 /* flags */
-#define DUK_RE_FLAG_GLOBAL                 (1 << 0)
-#define DUK_RE_FLAG_IGNORE_CASE            (1 << 1)
-#define DUK_RE_FLAG_MULTILINE              (1 << 2)
+#define DUK_RE_FLAG_GLOBAL                 (1U << 0)
+#define DUK_RE_FLAG_IGNORE_CASE            (1U << 1)
+#define DUK_RE_FLAG_MULTILINE              (1U << 2)
 
 struct duk_re_matcher_ctx {
 	duk_hthread *thr;

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -749,7 +749,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	re_ctx.bytecode = pc;
 
 	DUK_ASSERT(DUK_RE_FLAG_GLOBAL < 0x10000UL);  /* must fit into duk_small_int_t */
-	global = (duk_small_int_t) (force_global | (re_ctx.re_flags & DUK_RE_FLAG_GLOBAL));
+	global = (duk_small_int_t) (force_global | (duk_small_int_t) (re_ctx.re_flags & DUK_RE_FLAG_GLOBAL));
 
 	DUK_ASSERT(re_ctx.nsaved >= 2);
 	DUK_ASSERT((re_ctx.nsaved % 2) == 0);

--- a/src-input/duk_selftest.c
+++ b/src-input/duk_selftest.c
@@ -570,7 +570,7 @@ DUK_LOCAL duk_uint_t duk__selftest_alloc_funcs(duk_alloc_function alloc_func,
 	}
 
 	for (i = 1; i <= 256; i++) {
-		ptr = alloc_func(udata, i);
+		ptr = alloc_func(udata, (duk_size_t) i);
 		if (ptr == NULL) {
 			DUK_D(DUK_DPRINT("alloc failed, ignore"));
 			continue;  /* alloc failed, ignore */

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -228,7 +228,7 @@ typedef struct {
 #define DUK_TVAL_SET_TVAL(tv,x)              do { *(tv) = *(x); } while (0)
 
 /* getters */
-#define DUK_TVAL_GET_BOOLEAN(tv)             ((duk_small_int_t) (tv)->us[DUK_DBL_IDX_US1])
+#define DUK_TVAL_GET_BOOLEAN(tv)             ((duk_small_uint_t) (tv)->us[DUK_DBL_IDX_US1])
 #if defined(DUK_USE_FASTINT)
 #define DUK_TVAL_GET_DOUBLE(tv)              ((tv)->d)
 #define DUK_TVAL_GET_FASTINT(tv)             DUK__TVAL_GET_FASTINT((tv))
@@ -244,7 +244,7 @@ typedef struct {
 		(out_fp) = (duk_c_function) (tv)->ui[DUK_DBL_IDX_UI1]; \
 	} while (0)
 #define DUK_TVAL_GET_LIGHTFUNC_FUNCPTR(tv)   ((duk_c_function) ((tv)->ui[DUK_DBL_IDX_UI1]))
-#define DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv)     (((duk_small_int_t) (tv)->ui[DUK_DBL_IDX_UI0]) & 0xffffUL)
+#define DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv)     (((duk_small_uint_t) (tv)->ui[DUK_DBL_IDX_UI0]) & 0xffffUL)
 #define DUK_TVAL_GET_STRING(tv)              ((duk_hstring *) (tv)->vp[DUK_DBL_IDX_VP1])
 #define DUK_TVAL_GET_OBJECT(tv)              ((duk_hobject *) (tv)->vp[DUK_DBL_IDX_VP1])
 #define DUK_TVAL_GET_BUFFER(tv)              ((duk_hbuffer *) (tv)->vp[DUK_DBL_IDX_VP1])
@@ -382,7 +382,7 @@ typedef struct {
 		duk_tval *duk__tv; \
 		duk__tv = (tv); \
 		duk__tv->t = DUK_TAG_BOOLEAN; \
-		duk__tv->v.i = (val); \
+		duk__tv->v.i = (duk_small_int_t) (val); \
 	} while (0)
 
 #if defined(DUK_USE_FASTINT)
@@ -513,7 +513,7 @@ typedef struct {
 #define DUK_TVAL_SET_TVAL(tv,x)            do { *(tv) = *(x); } while (0)
 
 /* getters */
-#define DUK_TVAL_GET_BOOLEAN(tv)           ((tv)->v.i)
+#define DUK_TVAL_GET_BOOLEAN(tv)           ((duk_small_uint_t) (tv)->v.i)
 #if defined(DUK_USE_FASTINT)
 #define DUK_TVAL_GET_DOUBLE(tv)            ((tv)->v.d)
 #define DUK_TVAL_GET_FASTINT(tv)           ((tv)->v.fi)
@@ -540,7 +540,7 @@ typedef struct {
 		(out_fp) = (tv)->v.lightfunc; \
 	} while (0)
 #define DUK_TVAL_GET_LIGHTFUNC_FUNCPTR(tv) ((tv)->v.lightfunc)
-#define DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv)   ((duk_uint32_t) ((tv)->v_extra))
+#define DUK_TVAL_GET_LIGHTFUNC_FLAGS(tv)   ((duk_small_uint_t) ((tv)->v_extra))
 #define DUK_TVAL_GET_STRING(tv)            ((tv)->v.hstring)
 #define DUK_TVAL_GET_OBJECT(tv)            ((tv)->v.hobject)
 #define DUK_TVAL_GET_BUFFER(tv)            ((tv)->v.hbuffer)
@@ -605,11 +605,11 @@ DUK_INTERNAL_DECL duk_double_t duk_tval_get_number_unpacked_fastint(duk_tval *tv
 #define DUK_LFUNC_FLAGS_GET_MAGIC(lf_flags) \
 	((duk_int32_t) (duk_int8_t) (((duk_uint16_t) (lf_flags)) >> 8))
 #define DUK_LFUNC_FLAGS_GET_LENGTH(lf_flags) \
-	(((lf_flags) >> 4) & 0x0f)
+	(((lf_flags) >> 4) & 0x0fU)
 #define DUK_LFUNC_FLAGS_GET_NARGS(lf_flags) \
-	((lf_flags) & 0x0f)
+	((lf_flags) & 0x0fU)
 #define DUK_LFUNC_FLAGS_PACK(magic,length,nargs) \
-	(((magic) & 0xff) << 8) | ((length) << 4) | (nargs)
+	((((duk_small_uint_t) (magic)) & 0xffU) << 8) | ((length) << 4) | (nargs)
 
 #define DUK_LFUNC_NARGS_VARARGS             0x0f   /* varargs marker */
 #define DUK_LFUNC_NARGS_MIN                 0x00

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -1009,7 +1009,7 @@ duk_codepoint_t duk__case_transform_helper(duk_hthread *thr,
  *  Replace valstack top with case converted version.
  */
 
-DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_small_int_t uppercase) {
+DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_bool_t uppercase) {
 	duk_hstring *h_input;
 	duk_bufwriter_ctx bw_alloc;
 	duk_bufwriter_ctx *bw;

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -301,7 +301,7 @@ struct duk_bufwriter_ctx {
 #define DUK_BW_WRITE_RAW_XUTF8(thr,bw_ctx,cp) do { \
 		duk_ucodepoint_t duk__cp; \
 		duk_small_int_t duk__enc_len; \
-		duk__cp = (cp); \
+		duk__cp = (duk_ucodepoint_t) (cp); \
 		DUK_BW_ASSERT_SPACE((thr), (bw_ctx), duk_unicode_get_xutf8_length(duk__cp)); \
 		duk__enc_len = duk_unicode_encode_xutf8(duk__cp, (bw_ctx)->p); \
 		(bw_ctx)->p += duk__enc_len; \

--- a/src-input/duk_util_bitdecoder.c
+++ b/src-input/duk_util_bitdecoder.c
@@ -41,7 +41,7 @@ DUK_INTERNAL duk_uint32_t duk_bd_decode(duk_bitdecoder_ctx *ctx, duk_small_int_t
 	 * to be cleared, we just ignore them on next round.
 	 */
 	shift = ctx->currbits - bits;
-	mask = (1 << bits) - 1;
+	mask = (((duk_uint32_t) 1U) << bits) - 1U;
 	tmp = (ctx->currval >> shift) & mask;
 	ctx->currbits = shift;  /* remaining */
 

--- a/src-input/duk_util_bufwriter.c
+++ b/src-input/duk_util_bufwriter.c
@@ -133,7 +133,7 @@ DUK_INTERNAL void duk_bw_insert_raw_bytes(duk_hthread *thr, duk_bufwriter_ctx *b
 	DUK_UNREF(thr);
 
 	p_base = bw->p_base;
-	buf_sz = bw->p - p_base;
+	buf_sz = (duk_size_t) (bw->p - p_base);  /* constrained by maximum buffer size */
 	move_sz = buf_sz - dst_off;
 
 	DUK_ASSERT(p_base != NULL);  /* buffer size is >= 1 */
@@ -180,7 +180,7 @@ DUK_INTERNAL void duk_bw_insert_raw_slice(duk_hthread *thr, duk_bufwriter_ctx *b
 		src_off += len;
 	}
 
-	buf_sz = bw->p - p_base;
+	buf_sz = (duk_size_t) (bw->p - p_base);
 	move_sz = buf_sz - dst_off;
 
 	DUK_ASSERT(p_base != NULL);  /* buffer size is >= 1 */
@@ -218,7 +218,7 @@ DUK_INTERNAL duk_uint8_t *duk_bw_insert_raw_area(duk_hthread *thr, duk_bufwriter
 	DUK_UNREF(thr);
 
 	p_base = bw->p_base;
-	buf_sz = bw->p - p_base;
+	buf_sz = (duk_size_t) (bw->p - p_base);
 	move_sz = buf_sz - off;
 	p_dst = p_base + off + len;
 	p_src = p_base + off;

--- a/src-input/duk_util_misc.c
+++ b/src-input/duk_util_misc.c
@@ -369,7 +369,7 @@ DUK_INTERNAL duk_small_uint_t duk_double_signbit(duk_double_t x) {
 
 DUK_INTERNAL duk_double_t duk_double_trunc_towards_zero(duk_double_t x) {
 	/* XXX: optimize */
-	duk_small_int_t s = duk_double_signbit(x);
+	duk_small_uint_t s = duk_double_signbit(x);
 	x = DUK_FLOOR(DUK_FABS(x));  /* truncate towards zero */
 	if (s) {
 		x = -x;

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -173,35 +173,35 @@ struct duk_time_components {
 /* Number of value stack entries (in addition to actual call arguments)
  * guaranteed to be allocated on entry to a Duktape/C function.
  */
-#define DUK_API_ENTRY_STACK               64
+#define DUK_API_ENTRY_STACK               64U
 
 /* Value types, used by e.g. duk_get_type() */
-#define DUK_TYPE_MIN                      0
-#define DUK_TYPE_NONE                     0    /* no value, e.g. invalid index */
-#define DUK_TYPE_UNDEFINED                1    /* Ecmascript undefined */
-#define DUK_TYPE_NULL                     2    /* Ecmascript null */
-#define DUK_TYPE_BOOLEAN                  3    /* Ecmascript boolean: 0 or 1 */
-#define DUK_TYPE_NUMBER                   4    /* Ecmascript number: double */
-#define DUK_TYPE_STRING                   5    /* Ecmascript string: CESU-8 / extended UTF-8 encoded */
-#define DUK_TYPE_OBJECT                   6    /* Ecmascript object: includes objects, arrays, functions, threads */
-#define DUK_TYPE_BUFFER                   7    /* fixed or dynamic, garbage collected byte buffer */
-#define DUK_TYPE_POINTER                  8    /* raw void pointer */
-#define DUK_TYPE_LIGHTFUNC                9    /* lightweight function pointer */
-#define DUK_TYPE_MAX                      9
+#define DUK_TYPE_MIN                      0U
+#define DUK_TYPE_NONE                     0U    /* no value, e.g. invalid index */
+#define DUK_TYPE_UNDEFINED                1U    /* Ecmascript undefined */
+#define DUK_TYPE_NULL                     2U    /* Ecmascript null */
+#define DUK_TYPE_BOOLEAN                  3U    /* Ecmascript boolean: 0 or 1 */
+#define DUK_TYPE_NUMBER                   4U    /* Ecmascript number: double */
+#define DUK_TYPE_STRING                   5U    /* Ecmascript string: CESU-8 / extended UTF-8 encoded */
+#define DUK_TYPE_OBJECT                   6U    /* Ecmascript object: includes objects, arrays, functions, threads */
+#define DUK_TYPE_BUFFER                   7U    /* fixed or dynamic, garbage collected byte buffer */
+#define DUK_TYPE_POINTER                  8U    /* raw void pointer */
+#define DUK_TYPE_LIGHTFUNC                9U    /* lightweight function pointer */
+#define DUK_TYPE_MAX                      9U
 
 /* Value mask types, used by e.g. duk_get_type_mask() */
-#define DUK_TYPE_MASK_NONE                (1 << DUK_TYPE_NONE)
-#define DUK_TYPE_MASK_UNDEFINED           (1 << DUK_TYPE_UNDEFINED)
-#define DUK_TYPE_MASK_NULL                (1 << DUK_TYPE_NULL)
-#define DUK_TYPE_MASK_BOOLEAN             (1 << DUK_TYPE_BOOLEAN)
-#define DUK_TYPE_MASK_NUMBER              (1 << DUK_TYPE_NUMBER)
-#define DUK_TYPE_MASK_STRING              (1 << DUK_TYPE_STRING)
-#define DUK_TYPE_MASK_OBJECT              (1 << DUK_TYPE_OBJECT)
-#define DUK_TYPE_MASK_BUFFER              (1 << DUK_TYPE_BUFFER)
-#define DUK_TYPE_MASK_POINTER             (1 << DUK_TYPE_POINTER)
-#define DUK_TYPE_MASK_LIGHTFUNC           (1 << DUK_TYPE_LIGHTFUNC)
-#define DUK_TYPE_MASK_THROW               (1 << 10)  /* internal flag value: throw if mask doesn't match */
-#define DUK_TYPE_MASK_PROMOTE             (1 << 11)  /* internal flag value: promote to object if mask matches */
+#define DUK_TYPE_MASK_NONE                (1U << DUK_TYPE_NONE)
+#define DUK_TYPE_MASK_UNDEFINED           (1U << DUK_TYPE_UNDEFINED)
+#define DUK_TYPE_MASK_NULL                (1U << DUK_TYPE_NULL)
+#define DUK_TYPE_MASK_BOOLEAN             (1U << DUK_TYPE_BOOLEAN)
+#define DUK_TYPE_MASK_NUMBER              (1U << DUK_TYPE_NUMBER)
+#define DUK_TYPE_MASK_STRING              (1U << DUK_TYPE_STRING)
+#define DUK_TYPE_MASK_OBJECT              (1U << DUK_TYPE_OBJECT)
+#define DUK_TYPE_MASK_BUFFER              (1U << DUK_TYPE_BUFFER)
+#define DUK_TYPE_MASK_POINTER             (1U << DUK_TYPE_POINTER)
+#define DUK_TYPE_MASK_LIGHTFUNC           (1U << DUK_TYPE_LIGHTFUNC)
+#define DUK_TYPE_MASK_THROW               (1U << 10)  /* internal flag value: throw if mask doesn't match */
+#define DUK_TYPE_MASK_PROMOTE             (1U << 11)  /* internal flag value: promote to object if mask matches */
 
 /* Coercion hints */
 #define DUK_HINT_NONE                     0    /* prefer number, unless input is a Date, in which
@@ -211,41 +211,41 @@ struct duk_time_components {
 #define DUK_HINT_NUMBER                   2    /* prefer number */
 
 /* Enumeration flags for duk_enum() */
-#define DUK_ENUM_INCLUDE_NONENUMERABLE    (1 << 0)    /* enumerate non-numerable properties in addition to enumerable */
-#define DUK_ENUM_INCLUDE_HIDDEN           (1 << 1)    /* enumerate hidden symbols too (in Duktape 1.x called internal properties) */
-#define DUK_ENUM_INCLUDE_SYMBOLS          (1 << 2)    /* enumerate symbols */
-#define DUK_ENUM_EXCLUDE_STRINGS          (1 << 3)    /* exclude strings */
-#define DUK_ENUM_OWN_PROPERTIES_ONLY      (1 << 4)    /* don't walk prototype chain, only check own properties */
-#define DUK_ENUM_ARRAY_INDICES_ONLY       (1 << 5)    /* only enumerate array indices */
+#define DUK_ENUM_INCLUDE_NONENUMERABLE    (1U << 0)    /* enumerate non-numerable properties in addition to enumerable */
+#define DUK_ENUM_INCLUDE_HIDDEN           (1U << 1)    /* enumerate hidden symbols too (in Duktape 1.x called internal properties) */
+#define DUK_ENUM_INCLUDE_SYMBOLS          (1U << 2)    /* enumerate symbols */
+#define DUK_ENUM_EXCLUDE_STRINGS          (1U << 3)    /* exclude strings */
+#define DUK_ENUM_OWN_PROPERTIES_ONLY      (1U << 4)    /* don't walk prototype chain, only check own properties */
+#define DUK_ENUM_ARRAY_INDICES_ONLY       (1U << 5)    /* only enumerate array indices */
 /* XXX: misleading name */
-#define DUK_ENUM_SORT_ARRAY_INDICES       (1 << 6)    /* sort array indices (applied to full enumeration result, including inherited array indices); XXX: misleading name */
-#define DUK_ENUM_NO_PROXY_BEHAVIOR        (1 << 7)    /* enumerate a proxy object itself without invoking proxy behavior */
+#define DUK_ENUM_SORT_ARRAY_INDICES       (1U << 6)    /* sort array indices (applied to full enumeration result, including inherited array indices); XXX: misleading name */
+#define DUK_ENUM_NO_PROXY_BEHAVIOR        (1U << 7)    /* enumerate a proxy object itself without invoking proxy behavior */
 
 /* Compilation flags for duk_compile() and duk_eval() */
 /* DUK_COMPILE_xxx bits 0-2 are reserved for an internal 'nargs' argument.
  */
-#define DUK_COMPILE_EVAL                  (1 << 3)    /* compile eval code (instead of global code) */
-#define DUK_COMPILE_FUNCTION              (1 << 4)    /* compile function code (instead of global code) */
-#define DUK_COMPILE_STRICT                (1 << 5)    /* use strict (outer) context for global, eval, or function code */
-#define DUK_COMPILE_SHEBANG               (1 << 6)    /* allow shebang ('#! ...') comment on first line of source */
-#define DUK_COMPILE_SAFE                  (1 << 7)    /* (internal) catch compilation errors */
-#define DUK_COMPILE_NORESULT              (1 << 8)    /* (internal) omit eval result */
-#define DUK_COMPILE_NOSOURCE              (1 << 9)    /* (internal) no source string on stack */
-#define DUK_COMPILE_STRLEN                (1 << 10)   /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
-#define DUK_COMPILE_NOFILENAME            (1 << 11)   /* (internal) no filename on stack */
-#define DUK_COMPILE_FUNCEXPR              (1 << 12)   /* (internal) source is a function expression (used for Function constructor) */
+#define DUK_COMPILE_EVAL                  (1U << 3)    /* compile eval code (instead of global code) */
+#define DUK_COMPILE_FUNCTION              (1U << 4)    /* compile function code (instead of global code) */
+#define DUK_COMPILE_STRICT                (1U << 5)    /* use strict (outer) context for global, eval, or function code */
+#define DUK_COMPILE_SHEBANG               (1U << 6)    /* allow shebang ('#! ...') comment on first line of source */
+#define DUK_COMPILE_SAFE                  (1U << 7)    /* (internal) catch compilation errors */
+#define DUK_COMPILE_NORESULT              (1U << 8)    /* (internal) omit eval result */
+#define DUK_COMPILE_NOSOURCE              (1U << 9)    /* (internal) no source string on stack */
+#define DUK_COMPILE_STRLEN                (1U << 10)   /* (internal) take strlen() of src_buffer (avoids double evaluation in macro) */
+#define DUK_COMPILE_NOFILENAME            (1U << 11)   /* (internal) no filename on stack */
+#define DUK_COMPILE_FUNCEXPR              (1U << 12)   /* (internal) source is a function expression (used for Function constructor) */
 
 /* Flags for duk_def_prop() and its variants */
-#define DUK_DEFPROP_WRITABLE              (1 << 0)    /* set writable (effective if DUK_DEFPROP_HAVE_WRITABLE set) */
-#define DUK_DEFPROP_ENUMERABLE            (1 << 1)    /* set enumerable (effective if DUK_DEFPROP_HAVE_ENUMERABLE set) */
-#define DUK_DEFPROP_CONFIGURABLE          (1 << 2)    /* set configurable (effective if DUK_DEFPROP_HAVE_CONFIGURABLE set) */
-#define DUK_DEFPROP_HAVE_WRITABLE         (1 << 3)    /* set/clear writable */
-#define DUK_DEFPROP_HAVE_ENUMERABLE       (1 << 4)    /* set/clear enumerable */
-#define DUK_DEFPROP_HAVE_CONFIGURABLE     (1 << 5)    /* set/clear configurable */
-#define DUK_DEFPROP_HAVE_VALUE            (1 << 6)    /* set value (given on value stack) */
-#define DUK_DEFPROP_HAVE_GETTER           (1 << 7)    /* set getter (given on value stack) */
-#define DUK_DEFPROP_HAVE_SETTER           (1 << 8)    /* set setter (given on value stack) */
-#define DUK_DEFPROP_FORCE                 (1 << 9)    /* force change if possible, may still fail for e.g. virtual properties */
+#define DUK_DEFPROP_WRITABLE              (1U << 0)    /* set writable (effective if DUK_DEFPROP_HAVE_WRITABLE set) */
+#define DUK_DEFPROP_ENUMERABLE            (1U << 1)    /* set enumerable (effective if DUK_DEFPROP_HAVE_ENUMERABLE set) */
+#define DUK_DEFPROP_CONFIGURABLE          (1U << 2)    /* set configurable (effective if DUK_DEFPROP_HAVE_CONFIGURABLE set) */
+#define DUK_DEFPROP_HAVE_WRITABLE         (1U << 3)    /* set/clear writable */
+#define DUK_DEFPROP_HAVE_ENUMERABLE       (1U << 4)    /* set/clear enumerable */
+#define DUK_DEFPROP_HAVE_CONFIGURABLE     (1U << 5)    /* set/clear configurable */
+#define DUK_DEFPROP_HAVE_VALUE            (1U << 6)    /* set value (given on value stack) */
+#define DUK_DEFPROP_HAVE_GETTER           (1U << 7)    /* set getter (given on value stack) */
+#define DUK_DEFPROP_HAVE_SETTER           (1U << 8)    /* set setter (given on value stack) */
+#define DUK_DEFPROP_FORCE                 (1U << 9)    /* force change if possible, may still fail for e.g. virtual properties */
 #define DUK_DEFPROP_SET_WRITABLE          (DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE)
 #define DUK_DEFPROP_CLEAR_WRITABLE        DUK_DEFPROP_HAVE_WRITABLE
 #define DUK_DEFPROP_SET_ENUMERABLE        (DUK_DEFPROP_HAVE_ENUMERABLE | DUK_DEFPROP_ENUMERABLE)
@@ -254,10 +254,10 @@ struct duk_time_components {
 #define DUK_DEFPROP_CLEAR_CONFIGURABLE    DUK_DEFPROP_HAVE_CONFIGURABLE
 
 /* Flags for duk_push_thread_raw() */
-#define DUK_THREAD_NEW_GLOBAL_ENV         (1 << 0)    /* create a new global environment */
+#define DUK_THREAD_NEW_GLOBAL_ENV         (1U << 0)    /* create a new global environment */
 
 /* Flags for duk_gc() */
-#define DUK_GC_COMPACT                    (1 << 0)    /* compact heap objects */
+#define DUK_GC_COMPACT                    (1U << 0)    /* compact heap objects */
 
 /* Error codes (must be 8 bits at most, see duk_error.h) */
 #define DUK_ERR_NONE                      0    /* no error (e.g. from duk_get_error_code()) */

--- a/website/api/duk_push_boolean.yaml
+++ b/website/api/duk_push_boolean.yaml
@@ -13,7 +13,7 @@ summary: |
 example: |
   duk_push_boolean(ctx, 0);  /* -> [ ... false ] */
   duk_push_boolean(ctx, 1);  /* -> [ ... false true ] */
-  duk_push_boolean(ctx, -3);  /* -> [ ... false true true ] */
+  duk_push_boolean(ctx, 123);  /* -> [ ... false true true ] */
 
 tags:
   - stack


### PR DESCRIPTION
Add -Wsign-conversion to development Makefile (in addition to -Wall and -Wextra, and a few others). Other minor changes:

- Change duk_bool_t from signed integer to unsigned, and make integer API constants (such as flags, DUK_TYPE_xxx) unsigned to match their API type.
- Explicit wrap check for Buffer.concat().
- Refuse to unpack a >= 2G array cleanly with a RangeError rather than failing during the process.