### PR TITLE
Replace 'ajduk' with 'duk-low', step 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,6 @@
 /flow
 /massif-*.out
 /ms_print.*
-/alljoyn-js
-/ajtcl
 /dukweb.js
 /debugger/jquery-ui-1.11.2.zip
 /debugger/jquery-ui-1.11.2/

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ GXXOPTS_DEBUG += -I./examples/alloc-logging -I./examples/alloc-torture -I./examp
 CCOPTS_AJDUK = -m32
 #CCOPTS_AJDUK += '-fpack-struct=1'
 CCOPTS_AJDUK += -Wno-unused-parameter -Wno-pedantic -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-result
-CCOPTS_AJDUK += -UDUK_CMDLINE_FANCY -DDUK_CMDLINE_AJSHEAP -D_POSIX_C_SOURCE=200809L
+CCOPTS_AJDUK += -UDUK_CMDLINE_FANCY -DDUK_CMDLINE_LOWMEM -D_POSIX_C_SOURCE=200809L
 CCOPTS_AJDUK += -UDUK_CMDLINE_LOGGING_SUPPORT  # extras/logger init writes to Duktape.Logger, problem with ROM build
 CCOPTS_AJDUK += -UDUK_CMDLINE_MODULE_SUPPORT  # extras/module-duktape init writes to Duktape.Logger, problem with ROM build
 
@@ -277,7 +277,6 @@ cleanall: clean
 	@rm -rf flow
 	@rm -rf 3883a2e9063b0a5f2705bdac3263577a03913c94.zip
 	@rm -rf es5-tests.zip
-	@rm -rf alljoyn-js ajtcl
 	@rm -f v1.3.5.tar.gz
 	@rm -f "references/ECMA-262 5th edition December 2009.pdf"
 	@rm -f "references/ECMA-262 5.1 edition June 2011.pdf"
@@ -457,35 +456,35 @@ dukdscanbuild: prep/debug-scanbuild
 # Command line with Alljoyn.js pool allocator, for low memory testing.
 # The pool sizes only make sense with -m32, so force that.  This forces
 # us to use barebones cmdline too.
-ajduk: alljoyn-js ajtcl linenoise prep/ajduk-nondebug
+ajduk: linenoise prep/ajduk-nondebug
 	$(CC) -o $@ \
-		-Ialljoyn-js/src -Iajtcl/inc/ -Iajtcl/src/target/linux/ -Iprep/ajduk-nondebug \
+		-Iextras/alloc-pool/ -Iprep/ajduk-nondebug \
 		$(CCOPTS_NONDEBUG) $(CCOPTS_AJDUK) \
 		prep/ajduk-nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) \
-		examples/cmdline/duk_cmdline_ajduk.c \
-		alljoyn-js/src/ajs_heap.c ajtcl/src/aj_debug.c ajtcl/src/target/linux/aj_target_util.c \
+		examples/cmdline/duk_cmdline_lowmem.c \
+		extras/alloc-pool/duk_alloc_pool.c \
 		-lm -lpthread
 	@echo "*** SUCCESS:"
 	@ls -l $@
 	-@size $@
-ajduk-rom: alljoyn-js ajtcl linenoise prep/ajduk-nondebug-rom
+ajduk-rom: linenoise prep/ajduk-nondebug-rom
 	$(CC) -o $@ \
-		-Ialljoyn-js/src -Iajtcl/inc/ -Iajtcl/src/target/linux/ -Iprep/ajduk-nondebug-rom \
+		-Iextras/alloc-pool/ -Iprep/ajduk-nondebug-rom \
 		$(CCOPTS_NONDEBUG) $(CCOPTS_AJDUK) \
 		prep/ajduk-nondebug-rom/duktape.c $(DUKTAPE_CMDLINE_SOURCES) \
-		examples/cmdline/duk_cmdline_ajduk.c \
-		alljoyn-js/src/ajs_heap.c ajtcl/src/aj_debug.c ajtcl/src/target/linux/aj_target_util.c \
+		examples/cmdline/duk_cmdline_lowmem.c \
+		extras/alloc-pool/duk_alloc_pool.c \
 		-lm -lpthread
 	@echo "*** SUCCESS:"
 	@ls -l $@
 	-@size $@
-ajduk-norefc: alljoyn-js ajtcl linenoise prep/ajduk-nondebug-norefc
+ajduk-norefc: linenoise prep/ajduk-nondebug-norefc
 	$(CC) -o $@ \
-		-Ialljoyn-js/src -Iajtcl/inc/ -Iajtcl/src/target/linux/ -Iprep/ajduk-nondebug-norefc \
+		-Iextras/alloc-pool/ -Iprep/ajduk-nondebug-norefc \
 		$(CCOPTS_NONDEBUG) $(CCOPTS_AJDUK) \
 		prep/ajduk-nondebug-norefc/duktape.c $(DUKTAPE_CMDLINE_SOURCES) \
-		examples/cmdline/duk_cmdline_ajduk.c \
-		alljoyn-js/src/ajs_heap.c ajtcl/src/aj_debug.c ajtcl/src/target/linux/aj_target_util.c \
+		examples/cmdline/duk_cmdline_lowmem.c \
+		extras/alloc-pool/duk_alloc_pool.c \
 		-lm -lpthread
 	@echo "*** SUCCESS:"
 	@ls -l $@
@@ -886,16 +885,7 @@ dtrace4linux:
 flow:
 	# https://github.com/facebook/flow
 	$(GIT) clone --depth 1 https://github.com/facebook/flow.git
-alljoyn-js:
-	# https://git.allseenalliance.org/cgit/core/alljoyn-js.git/
-	# no --depth 1 ("dumb http transport does not support --depth")
-	$(GIT) clone https://git.allseenalliance.org/gerrit/core/alljoyn-js.git
-ajtcl:
-	# https://git.allseenalliance.org/cgit/core/ajtcl.git/
-	# no --depth 1 ("dumb http transport does not support --depth")
-	$(GIT) clone https://git.allseenalliance.org/gerrit/core/ajtcl.git/
-	ln -s . ajtcl/inc/ajtcl  # workaround for #include <ajtcl/xxx.h>
-	ln -s . ajtcl/src/target/linux/ajtcl
+
 # Duktape binary releases are in a separate repo.
 duktape-releases:
 	$(GIT) clone https://github.com/svaarala/duktape-releases.git

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -380,7 +380,7 @@ The following may be appropriate when even less memory is available
 
   - When using pointer compression you need to add support for compressing
     ROM strings, see ``doc/objects-in-code-section.rst`` and a concrete
-    example in ``examples/cmdline/duk_cmdline_ajduk.c``.
+    example in ``examples/cmdline/duk_cmdline_lowmem.c``.
 
   - See ``doc/objects-in-code-section.rst`` for technical details and
     current limitations.
@@ -431,7 +431,7 @@ When ROM object/string support is enabled, pointer compression and
 decompression must support ROM pointer compression.  This is done by
 reserving a range of 16-bit compressed pointer values to represent
 ROM pointers, and to use a ROM pointer table to compress/decompress
-ROM pointers.  See ``examples/cmdline/duk_cmdline_ajduk.c`` for an
+ROM pointers.  See ``examples/cmdline/duk_cmdline_lowmem.c`` for an
 example.
 
 External string strategies (DUK_USE_EXTSTR_INTERN_CHECK)
@@ -469,7 +469,7 @@ scraping strings from C and Ecmascript code using regexps:
 
 There are concrete examples for some external string strategies in:
 
-* ``dist/examples/cmdline/duk_cmdline_ajduk.c``
+* ``dist/examples/cmdline/duk_cmdline_lowmem.c``
 
 Tuning pool sizes for a pool-based memory allocator
 ===================================================

--- a/doc/objects-in-code-section.rst
+++ b/doc/objects-in-code-section.rst
@@ -280,4 +280,4 @@ objects using the user-supplied compression macros.  This poses a few issues:
 For now the approach is based on that ROM pointer table; the integration with
 user code is not (yet) very clean, see:
 
-* ``examples/cmdline/duk_cmdline_ajduk.c``
+* ``examples/cmdline/duk_cmdline_lowmem.c``

--- a/extras/alloc-pool/duk_alloc_pool.c
+++ b/extras/alloc-pool/duk_alloc_pool.c
@@ -159,7 +159,7 @@ void *duk_alloc_pool_init(char *buffer,
 #endif
 
 	for (i = 0; i < num_pools; i++) {
-		n = states[i].count;
+		n = (int) states[i].count;
 		if (n > 0) {
 			states[i].first = (duk_pool_free *) p;
 			for (j = 0; j < n; j++) {

--- a/util/dist.py
+++ b/util/dist.py
@@ -521,7 +521,7 @@ def main():
     copy_files([
         'README.rst',
         'duk_cmdline.c',
-        'duk_cmdline_ajduk.c'
+        'duk_cmdline_lowmem.c'
     ], os.path.join('examples', 'cmdline'), os.path.join(dist, 'examples', 'cmdline'))
 
     copy_files([

--- a/util/makeduk_ajduk.yaml
+++ b/util/makeduk_ajduk.yaml
@@ -4,7 +4,7 @@
 #DUK_USE_DOUBLE_LINKED_HEAP: false
 
 DUK_USE_ALIGN_BY: 4
-DUK_USE_ASSERTIONS: true
+#DUK_USE_ASSERTIONS: true
 DUK_USE_LIGHTFUNC_BUILTINS: true
 DUK_USE_REFCOUNT16: true
 DUK_USE_REFCOUNT32: false
@@ -23,23 +23,23 @@ DUK_USE_STRTAB_RESIZE_CHECK_MASK: 63
 DUK_USE_STRTAB_PTRCOMP: true
 DUK_USE_HEAPPTR16: true
 DUK_USE_HEAPPTR_ENC16:
-  verbatim: "#define DUK_USE_HEAPPTR_ENC16(ud,p) ajsheap_enc16((ud),(p))"
+  verbatim: "#define DUK_USE_HEAPPTR_ENC16(ud,p) lowmem_enc16((ud),(p))"
 DUK_USE_HEAPPTR_DEC16:
-  verbatim: "#define DUK_USE_HEAPPTR_DEC16(ud,x) ajsheap_dec16((ud),(x))"
+  verbatim: "#define DUK_USE_HEAPPTR_DEC16(ud,x) lowmem_dec16((ud),(x))"
 #DUK_USE_EXTSTR_INTERN_CHECK:
-#  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) ajsheap_extstr_check_1((ptr),(len))"
+#  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) lowmem_extstr_check_1((ptr),(len))"
 #DUK_USE_EXTSTR_FREE:
-#  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) ajsheap_extstr_free_1((ptr))"
+#  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) lowmem_extstr_free_1((ptr))"
 DUK_USE_EXTSTR_INTERN_CHECK:
-  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) ajsheap_extstr_check_2((ptr),(len))"
+  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) lowmem_extstr_check_2((ptr),(len))"
 DUK_USE_EXTSTR_FREE:
-  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) ajsheap_extstr_free_2((ptr))"
+  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) lowmem_extstr_free_2((ptr))"
 #DUK_USE_EXTSTR_INTERN_CHECK:
-#  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) ajsheap_extstr_check_3((ptr),(len))"
+#  verbatim: "#define DUK_USE_EXTSTR_INTERN_CHECK(ud,ptr,len) lowmem_extstr_check_3((ptr),(len))"
 #DUK_USE_EXTSTR_FREE:
-#  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) ajsheap_extstr_free_3((ptr))"
+#  verbatim: "#define DUK_USE_EXTSTR_FREE(ud,ptr) lowmem_extstr_free_3((ptr))"
 DUK_USE_EXEC_TIMEOUT_CHECK:
-  verbatim: "#define DUK_USE_EXEC_TIMEOUT_CHECK(udata) ajsheap_exec_timeout_check(udata)"
+  verbatim: "#define DUK_USE_EXEC_TIMEOUT_CHECK(udata) lowmem_exec_timeout_check(udata)"
 #DUK_USE_ROM_STRINGS: true
 #DUK_USE_ROM_OBJECTS: true
 #DUK_USE_ROM_GLOBAL_INHERIT: true

--- a/util/makeduk_ajduk_fixup.h
+++ b/util/makeduk_ajduk_fixup.h
@@ -1,12 +1,12 @@
 /* Ajduk fixups. */
 
-extern uint8_t *ajsheap_ram;
-extern duk_uint16_t ajsheap_enc16(void *ud, void *p);
-extern void *ajsheap_dec16(void *ud, duk_uint16_t x);
-extern const void *ajsheap_extstr_check_1(const void *ptr, duk_size_t len);
-extern const void *ajsheap_extstr_check_2(const void *ptr, duk_size_t len);
-extern const void *ajsheap_extstr_check_3(const void *ptr, duk_size_t len);
-extern void ajsheap_extstr_free_1(const void *ptr);
-extern void ajsheap_extstr_free_2(const void *ptr);
-extern void ajsheap_extstr_free_3(const void *ptr);
-extern duk_bool_t ajsheap_exec_timeout_check(void *udata);
+extern uint8_t *lowmem_ram;
+extern duk_uint16_t lowmem_enc16(void *ud, void *p);
+extern void *lowmem_dec16(void *ud, duk_uint16_t x);
+extern const void *lowmem_extstr_check_1(const void *ptr, duk_size_t len);
+extern const void *lowmem_extstr_check_2(const void *ptr, duk_size_t len);
+extern const void *lowmem_extstr_check_3(const void *ptr, duk_size_t len);
+extern void lowmem_extstr_free_1(const void *ptr);
+extern void lowmem_extstr_free_2(const void *ptr);
+extern void lowmem_extstr_free_3(const void *ptr);
+extern duk_bool_t lowmem_exec_timeout_check(void *udata);


### PR DESCRIPTION
Replace ajduk with duk-low, which uses extras/alloc-pool instead of relying on ajtcl and alljoyn-js which are now unnecessary external dependencies. First step in the process: remove dependency on ajtcl and alljoyn-js, rename a few files, etc.