### PR TITLE
Misc test coverage improvements for property API calls

### DIFF
--- a/tests/api/test-del-prop.c
+++ b/tests/api/test-del-prop.c
@@ -122,6 +122,16 @@ final top: 3
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
 *** test_delpropheapptr_c (duk_pcall)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_delpropheapptr_d_safecall (duk_safe_call)
+toString() called
+delete obj.foo -> rc=1
+final top: 3
+==> rc=0, result='undefined'
+*** test_delpropheapptr_d (duk_pcall)
+toString() called
+delete obj.foo -> rc=1
+final top: 3
+==> rc=0, result='undefined'
 ===*/
 
 static void prep(duk_context *ctx) {
@@ -617,6 +627,28 @@ static duk_ret_t test_delpropheapptr_c(duk_context *ctx) {
 	return test_delpropheapptr_c_safecall(ctx, NULL);
 }
 
+/* duk_del_prop_heapptr(), non-string heapptr */
+static duk_ret_t test_delpropheapptr_d_safecall(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+	void *ptr;
+
+	(void) udata;
+
+	prep(ctx);
+
+	duk_eval_string(ctx, "({ toString: function () { print('toString() called'); return 'foo'; } })");
+	ptr = duk_require_heapptr(ctx, -1);
+	rc = duk_del_prop_heapptr(ctx, 0, ptr);
+	printf("delete obj.foo -> rc=%d\n", (int) rc);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+static duk_ret_t test_delpropheapptr_d(duk_context *ctx) {
+	return test_delpropheapptr_d_safecall(ctx, NULL);
+}
+
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_delprop_a_safecall);
 	TEST_SAFE_CALL(test_delprop_b_safecall);
@@ -663,4 +695,6 @@ void test(duk_context *ctx) {
 	TEST_PCALL(test_delpropheapptr_b);
 	TEST_SAFE_CALL(test_delpropheapptr_c_safecall);
 	TEST_PCALL(test_delpropheapptr_c);
+	TEST_SAFE_CALL(test_delpropheapptr_d_safecall);
+	TEST_PCALL(test_delpropheapptr_d);
 }

--- a/tests/api/test-get-prop.c
+++ b/tests/api/test-get-prop.c
@@ -70,6 +70,11 @@ final top: 3
 ==> rc=1, result='RangeError: invalid stack index 234'
 *** test_getpropheapptr_c (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_getpropheapptr_d (duk_safe_call)
+toString() called
+obj.foo -> rc=1, result='fooval'
+final top: 3
+==> rc=0, result='undefined'
 ===*/
 
 static void prep(duk_context *ctx) {
@@ -505,6 +510,26 @@ static duk_ret_t test_getpropheapptr_c(duk_context *ctx, void *udata) {
 	return 0;
 }
 
+/* duk_get_prop_heapptr(), non-string heapptr */
+static duk_ret_t test_getpropheapptr_d(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+	void *ptr;
+
+	(void) udata;
+
+	prep(ctx);
+
+	duk_eval_string(ctx, "({ toString: function () { print('toString() called'); return 'foo'; } })");
+	ptr = duk_require_heapptr(ctx, -1);
+	rc = duk_get_prop_heapptr(ctx, 0, ptr);
+	printf("obj.foo -> rc=%d, result='%s'\n", (int) rc, duk_to_string(ctx, -1));
+	duk_pop(ctx);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_getprop_a);
 	TEST_SAFE_CALL(test_getprop_b);
@@ -527,4 +552,5 @@ void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_getpropheapptr_a);
 	TEST_SAFE_CALL(test_getpropheapptr_b);
 	TEST_SAFE_CALL(test_getpropheapptr_c);
+	TEST_SAFE_CALL(test_getpropheapptr_d);
 }

--- a/tests/api/test-has-prop.c
+++ b/tests/api/test-has-prop.c
@@ -60,6 +60,11 @@ final top: 3
 ==> rc=1, result='RangeError: invalid stack index 234'
 *** test_haspropheapptr_c (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_haspropheapptr_d (duk_safe_call)
+toString() called
+obj.foo -> rc=1
+final top: 3
+==> rc=0, result='undefined'
 ===*/
 
 static void prep(duk_context *ctx) {
@@ -411,6 +416,25 @@ static duk_ret_t test_haspropheapptr_c(duk_context *ctx, void *udata) {
 	return 0;
 }
 
+/* duk_has_prop_lstring(), non-string heapptr */
+static duk_ret_t test_haspropheapptr_d(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+	void *ptr;
+
+	(void) udata;
+
+	prep(ctx);
+
+	duk_eval_string(ctx, "({ toString: function () { print('toString() called'); return 'foo'; } })");
+	ptr = duk_require_heapptr(ctx, -1);
+	rc = duk_has_prop_heapptr(ctx, 0, ptr);
+	printf("obj.foo -> rc=%d\n", (int) rc);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_hasprop_a);
 	TEST_SAFE_CALL(test_hasprop_b);
@@ -433,4 +457,5 @@ void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_haspropheapptr_a);
 	TEST_SAFE_CALL(test_haspropheapptr_b);
 	TEST_SAFE_CALL(test_haspropheapptr_c);
+	TEST_SAFE_CALL(test_haspropheapptr_d);
 }

--- a/tests/api/test-put-prop.c
+++ b/tests/api/test-put-prop.c
@@ -115,6 +115,26 @@ final top: 1
 {"2001":234,"foo":123,"bar":123,"nul\u0000key":345,"heapptr":456,"stringCoerced":567,"undefined":678}
 final top: 1
 ==> rc=0, result='undefined'
+*** test_putprop_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index 234'
+*** test_putprop_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_string_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_string_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_lstring_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_lstring_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_index_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index 345'
+*** test_putprop_index_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_heapptr_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index 456'
+*** test_putprop_heapptr_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
 ===*/
 
 /* Test property writing API call.
@@ -397,6 +417,113 @@ static duk_ret_t test_putprop_shorthand_a_safecall(duk_context *ctx, void *udata
 	return test_putprop_shorthand_a(ctx);
 }
 
+static duk_ret_t test_putprop_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_string(ctx, "foo");
+	duk_push_uint(ctx, 123);
+	duk_put_prop(ctx, 234);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_string(ctx, "foo");
+	duk_push_uint(ctx, 123);
+	duk_put_prop(ctx, DUK_INVALID_INDEX);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_string_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_string(ctx, -2, "foo");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_string_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_string(ctx, DUK_INVALID_INDEX, "foo");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_lstring_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_lstring(ctx, 123, "foox", 3);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_lstring_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_lstring(ctx, DUK_INVALID_INDEX, "foox", 3);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_index_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_index(ctx, 345, 1001U);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_index_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_index(ctx, DUK_INVALID_INDEX, 1001U);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_heapptr_invalid_index1(duk_context *ctx, void *udata) {
+	void *ptr;
+
+	(void) udata;
+
+	duk_push_string(ctx, "foo");
+	ptr = duk_get_heapptr(ctx, -1);
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_heapptr(ctx, 456, ptr);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_heapptr_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_heapptr(ctx, DUK_INVALID_INDEX, NULL);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
 #define  TEST(func)  do { \
 		TEST_SAFE_CALL(func ## _safecall); \
 		TEST_PCALL(func); \
@@ -404,7 +531,6 @@ static duk_ret_t test_putprop_shorthand_a_safecall(duk_context *ctx, void *udata
 
 void test(duk_context *ctx) {
 	/* Cases where own property already exists. */
-
 	TEST(test_ex_writable);
 	TEST(test_ex_nonwritable);
 	TEST(test_ex_accessor_wo_setter);
@@ -413,10 +539,21 @@ void test(duk_context *ctx) {
 	/* Cases where no own property, possibly ancestor
 	 * property of same name.
 	 */
-
 	TEST(test_new_extensible);
 	TEST(test_new_not_extensible);
 
 	/* Shorthands. */
 	TEST(test_putprop_shorthand_a);
+
+	/* Invalid index. */
+	TEST_SAFE_CALL(test_putprop_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_invalid_index2);
+	TEST_SAFE_CALL(test_putprop_string_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_string_invalid_index2);
+	TEST_SAFE_CALL(test_putprop_lstring_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_lstring_invalid_index2);
+	TEST_SAFE_CALL(test_putprop_index_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_index_invalid_index2);
+	TEST_SAFE_CALL(test_putprop_heapptr_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_heapptr_invalid_index2);
 }


### PR DESCRIPTION
- [x] Test coverage for non-string heapptr (only in duk_put_prop_heapptr() now)
- [x] Test coverage for invalid index and duk_put_prop_xxx()
