### PR TITLE
Add a -fstack-usage pretty printer to get static stack information for GCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.strip
 *.pyc
 /*.gcda
+/*.su
 /_*
 /duk.*
 /duk

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,9 @@ CCOPTS_SHARED += -I./extras/print-alert
 CCOPTS_SHARED += -I./extras/console
 CCOPTS_SHARED += -I./extras/logging
 CCOPTS_SHARED += -I./extras/module-duktape
-#CCOPTS_SHARED += -m32                             # force 32-bit compilation on a 64-bit host
-#CCOPTS_SHARED += -mx32                            # force X32 compilation on a 64-bit host
+#CCOPTS_SHARED += -m32   # force 32-bit compilation on a 64-bit host
+#CCOPTS_SHARED += -mx32  # force X32 compilation on a 64-bit host
+#CCOPTS_SHARED += -fstack-usage  # enable manually, then e.g. $ make clean duk; python util/pretty_stack_usage.py duktape.su
 
 CCOPTS_NONDEBUG = $(CCOPTS_SHARED) $(CCOPTS_FEATURES)
 CCOPTS_NONDEBUG += -Os -fomit-frame-pointer -fno-stack-protector
@@ -218,6 +219,7 @@ checksetup:
 .PHONY:	clean
 clean:
 	@rm -f *.gcda
+	@rm -f *.su
 	@rm -rf dist/
 	@rm -rf prep/
 	@rm -rf site/

--- a/util/pretty_stackusage_file.py
+++ b/util/pretty_stackusage_file.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+import re
+
+def main():
+    re_line = re.compile(r'^(.*?)\s+(.*?)\s+(.*?)$')
+    with open(sys.argv[1], 'rb') as f:
+        lines = []
+        for line in f:
+            m = re_line.match(line)
+            assert(m is not None)
+            t = [ int(m.group(2)), m.group(1), m.group(3) ]
+            lines.append(t)
+
+        lines.sort()
+        for line in lines:
+            print('%5d  %s %s' % (line[0], line[1], line[2]))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Example:
- Enable -fstack-usage in Makefile manually
- $ make clean duk
- $ python util/pretty_stackusage_file.py duktape.su