### PR TITLE
Add a benchmarks page placeholder

### DIFF
--- a/testrunner/run_commit_test.py
+++ b/testrunner/run_commit_test.py
@@ -934,6 +934,40 @@ def context_linux_x64_dukluv():
 
     return True
 
+def context_linux_graph_hello_size_helper(archopt):
+    cwd = os.getcwd()
+    cmd = [
+        'python2', os.path.join(cwd, 'tools', 'configure.py'),
+        '--source-directory', os.path.join(cwd, 'src-input'),
+        '--output-directory', os.path.join(cwd, 'prep'),
+        '--config-metadata', os.path.join(cwd, 'config'),
+        '--option-file', os.path.join(cwd, 'config', 'examples', 'low_memory.yaml')
+    ]
+    execute(cmd)
+    execute([
+        'gcc', '-ohello', archopt,
+        '-std=c99', '-Wall',
+        '-Os', '-fomit-frame-pointer',
+        '-flto', '-fno-asynchronous-unwind-tables',
+        '-ffunction-sections', '-Wl,--gc-sections',
+        '-fno-stack-protector',
+        '-I' + os.path.join('prep'),
+        os.path.join(cwd, 'prep', 'duktape.c'),
+        os.path.join(cwd, 'examples', 'hello', 'hello.c'),
+        '-lm'
+    ])
+    set_output_result({
+        'newsz': get_binary_size(os.path.join(cwd, 'hello'))
+    })
+    return True
+
+def context_linux_x64_graph_hello_size():
+    return context_linux_graph_hello_size_helper('-m64')
+def context_linux_x86_graph_hello_size():
+    return context_linux_graph_hello_size_helper('-m32')
+def context_linux_x32_graph_hello_size():
+    return context_linux_graph_hello_size_helper('-mx32')
+
 context_handlers = {
     # Linux
 
@@ -974,6 +1008,11 @@ context_handlers = {
     'linux-x64-gcc-stripsize-fltoetc': context_linux_x64_gcc_stripsize_fltoetc,
     'linux-x86-gcc-stripsize-fltoetc': context_linux_x86_gcc_stripsize_fltoetc,
     'linux-x32-gcc-stripsize-fltoetc': context_linux_x32_gcc_stripsize_fltoetc,
+
+    # Jobs matching previous graphs.html data points.
+    'linux-x64-graph-hello-size': context_linux_x64_graph_hello_size,
+    'linux-x86-graph-hello-size': context_linux_x86_graph_hello_size,
+    'linux-x32-graph-hello-size': context_linux_x32_graph_hello_size,
 
     'linux-x64-cpp-exceptions': context_linux_x64_cpp_exceptions,
 

--- a/util/build_benchmarks_page.py
+++ b/util/build_benchmarks_page.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+import re
+import json
+
+def main():
+    duktape_repo = '/home/duktape/duktape'
+    duktape_testrunner_repo = '/home/duktape/duktape-testrunner'
+    duktape_testclient_config = '/home/duktape/duktape-testclient-config.yaml'
+    benchmarks_template = '/home/duktape/duktape/website/benchmarks.html'
+    merge_count = 1000
+
+    # Get the hashes we're interested in, in increasing merge order.
+
+#    os.system('cd %s && git pull --rebase' % duktape_repo)
+    os.system('cd %s && git log -n %d --merges --oneline --decorate=no --pretty=format:%%H > /tmp/tmp-hashes.txt' % (duktape_repo, merge_count))
+    hashes = []
+    with open('/tmp/tmp-hashes.txt', 'rb') as f:
+        for line in f:
+            line = line.strip()
+            if line != '':
+                hashes.append(line)
+    hashes.reverse()
+    print('%d hashes found' % len(hashes))
+
+    # Get any release tags matching the hashes for annotations.
+    re_release_tag = re.compile('^v\d+\.\d+\.\d+$')
+    annotations = []
+    for x,h in enumerate(hashes):
+        os.system('git tag -l --points-at %s > /tmp/tmp-taglog.txt' % h)
+        with open('/tmp/tmp-taglog.txt', 'rb') as f:
+            for line in f:
+                line = line.strip()
+                m = re_release_tag.match(line)
+                if m is None:
+                    continue
+                annotations.append({ 'x': x, 'tag': line })
+    print(json.dumps(annotations, indent=4))
+
+    req = { 'repo_full': 'svaarala/duktape', 'sha_list': hashes }
+    with open('/tmp/tmp-request.json', 'wb') as f:
+        f.write(json.dumps(req))
+
+    os.system('cd %s && cd client-simple-node && nodejs client.js --request-uri /query-commit-simple --config %s --request-file /tmp/tmp-request.json --output-file /tmp/tmp-result.json' % (duktape_testrunner_repo, duktape_testclient_config))
+
+    with open(benchmarks_template, 'rb') as f:
+        page = f.read()
+    with open('/tmp/tmp-result.json', 'rb') as f:
+        data = json.loads(f.read())
+
+    doc = {
+        'commit_simples': data,
+        'annotations': annotations
+    }
+    doc_formatted = json.dumps(doc, indent=4)
+    page = page.replace('<!-- @DATA@ -->', \
+                        'var rawGraphData = \n' + doc_formatted + '\n')
+    with open('/tmp/benchmarks.html', 'wb') as f:
+        f.write(page)
+
+if __name__ == '__main__':
+    main()

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Duktape benchmarks</title>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<style type="text/css">
+html, body {
+	background: #ffffff;
+	color: #000000;
+	margin: 0;
+	padding: 0;
+	border: none;
+}
+h1 {
+	text-align: center;
+	margin: 0 0 10px 0;
+	padding: 20px 0px 20px 0px;
+	background: #444444;
+	color: #ffffff;
+
+	font-family: 'Droid Sans Mono', sans-serif;
+	font-size: 24pt;
+	font-weight: 400;
+	text-shadow: 3px 3px 3px #000000;
+	filter: dropshadow(color=#000000, offx=3, offy=3);
+}
+#main {
+	margin: 10px;
+}
+.duk-graph {
+	width: 95%;
+	height: 400px;
+	margin: 10px auto;
+}
+</style>
+<body>
+
+<!--
+
+    DATA SETS, injected by build scripts based on @XXX@ markup.
+
+-->
+
+<script>
+<!-- Injected by build script. -->
+<!-- @DATA@ -->
+</script>
+
+<!--
+
+    JAVASCRIPT HELPERS
+
+-->
+
+<script>
+function getDataTrace(context, name, callback) {
+    var ydata = rawGraphData.commit_simples.map(function (commit_simple) {
+        var i, n;
+        if (!commit_simple.runs) { return null; }
+        for (i = 0, n = commit_simple.runs.length; i < n; i++) {
+            var run = commit_simple.runs[i];
+            if (run.context === context && run.result) {
+                try {
+                    return callback(run.result);
+                } catch (e) {
+                    console.log('callback error, ignored:', e);
+                }
+                return null;
+            }
+        }
+        return null;
+    });
+
+    var xdata = ydata.map(function (v,i) { return i; });
+
+    var countNull = 0;
+    ydata.forEach(function (v) { if (v === null) { countNull++; } });
+
+    console.log('data for ' + context + ': ' + ydata.length + ' data points, ' + countNull + ' null');
+
+    // remove nulls
+    //ydata = ydata.map(function (v) { if (v === null) { return 0; } else { return v; } });
+
+    // trace object
+    return {
+        x: xdata,
+        y: ydata,
+        type: 'scatter',
+        name: name
+    };
+/*
+    return {
+        x: ydata,
+        type: 'histogram'
+    };
+*/
+}
+
+function detectRange(data) {
+    var min, max;
+    var i;
+
+    for (i = 0; i < data.length; i++) {
+        if (typeof data[i] !== 'number') {
+            continue;
+        }
+        if (min === void 0) {
+            min = max = data[i];
+        } else {
+            min = Math.min(min, data[i]);
+            max = Math.max(max, data[i]);
+        }
+    }
+    return [ min, max ];
+}
+
+function drawGraph(options, dataCallback) {
+    var data = options.dataCallbacks.map(function (cbspec) {
+        return getDataTrace(options.context, cbspec.traceName, cbspec.callback);
+    });
+    var annotations = [];
+    var mergeCountInitial = 200;
+    var xRange = [ data[0].x.length - mergeCountInitial, data[0].x.length ];  // initial focus on last 100 merges
+    var yRange = detectRange(data[0].y);  // initial y range from first trace
+    console.log('automatic ranges for ' + options.context + ':', xRange, yRange);
+    var layout = {
+        title: options.graphTitle,
+        xaxis: {
+            title: options.xTitle,
+            //autorange: true,
+            range: xRange,
+            tickformat: 'd'
+        },
+        yaxis: {
+            title: options.yTitle,
+            //autorange: true,
+            range: yRange,
+            //rangemode: 'tozero',
+            tickformat: 'd'
+        },
+        annotations: annotations
+    };
+    rawGraphData.annotations.forEach(function (anno) {
+        annotations.push({
+            text: anno.tag,
+            x: anno.x,
+            xref: 'x',
+            y: 0,
+            yref: 'paper'
+        })
+    });
+    console.log('data for ' + options.context + ':', data)
+    Plotly.newPlot(options.domId, data, layout);
+}
+</script>
+
+<!--
+
+    MAIN PAGE
+
+-->
+
+<h1>((o) Duktape benchmarks</h1>
+
+<div id="main">
+
+<p>Graphs are over merges to master, not individual commits.  Master HEAD is on
+the right.  Graphs implemented using
+<a href="https://plot.ly/javascript/open-source-announcement/">plotly.js</a>.</p>
+
+<div class="duk-graph" id="linux-x64-octane"></div>
+<div class="duk-graph" id="linux-x64-graph-hello-size"></div>
+<div class="duk-graph" id="linux-x86-graph-hello-size"></div>
+<div class="duk-graph" id="linux-x32-graph-hello-size"></div>
+<div class="duk-graph" id="linux-x64-gcc-minsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x86-gcc-minsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x32-gcc-minsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x64-gcc-stripsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x86-gcc-stripsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x32-gcc-stripsize-fltoetc"></div>
+<div class="duk-graph" id="linux-x64-gcc-defsize-makeduk"></div>
+<div class="duk-graph" id="linux-x64-gcc-defsize-fltoetc"></div>
+
+<script>
+[
+    'linux-x64-graph-hello-size',
+    'linux-x86-graph-hello-size',
+    'linux-x32-graph-hello-size',
+    'linux-x64-gcc-minsize-fltoetc',
+    'linux-x86-gcc-minsize-fltoetc',
+    'linux-x32-gcc-minsize-fltoetc',
+    'linux-x64-gcc-stripsize-fltoetc',
+    'linux-x86-gcc-stripsize-fltoetc',
+    'linux-x32-gcc-stripsize-fltoetc',
+    'linux-x64-gcc-defsize-makeduk',
+    'linux-x64-gcc-defsize-fltoetc'
+].forEach(function (context) {
+    drawGraph({
+        context: context,
+        domId: context,
+        graphTitle: context,
+        xTitle: 'Merge to master',
+        yTitle: 'Total bytes',
+        dataCallbacks: [
+            {
+                traceName: 'total',
+                callback: function (result) { return result.newsz.total; }
+            },
+            {
+                traceName: 'text',
+                callback: function (result) { return result.newsz.text; }
+            },
+            {
+                traceName: 'data',
+                callback: function (result) { return result.newsz.data; }
+            },
+            {
+                traceName: 'bss',
+                callback: function (result) { return result.newsz.bss; }
+            }
+        ]
+    });
+});
+
+drawGraph({
+    context: 'linux-x64-octane',
+    domId: 'linux-x64-octane',
+    graphTitle: 'linux-x64-octane',
+    xTitle: 'Merge to master',
+    yTitle: 'Score',
+    dataCallbacks: [
+        {
+            traceName: 'avg',
+            callback: function (result) { return result.score_avg; }
+        },
+        {
+            traceName: 'min',
+            callback: function (result) { return result.score_min; }
+        },
+        {
+            traceName: 'max',
+            callback: function (result) { return result.score_max; }
+        }
+    ]
+});
+</script>
+
+<!--
+
+    FUTURE WORK
+
+-->
+
+<!--
+joint footprint graph for archs
+hover data - hashes, git describe, commit message
+hello ram usage
+rom build ram usage: startup, mandel, etc
+table: largest functions
+table: 10 largest stack frames
+-->
+
+</div>  <!-- main -->
+</body>
+</html>

--- a/website/index/index.html
+++ b/website/index/index.html
@@ -70,6 +70,8 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
 <tr><td>Startup RAM</td><td>68kB</td><td>35kB</td><td>2.3kB</td></tr>
 </table>
 
+<p>See <a href="http://duktape.org/benchmarks.html">Benchmarks</a>.</p>
+
 <p>See <a href="https://github.com/svaarala/duktape/blob/master/doc/low-memory.rst#optimizing-code-footprint">GCC options</a>
 for minimizing code footprint.  Full <a href="https://github.com/svaarala/duktape/blob/master/doc/low-memory.rst">lowmem</a>
 uses "pointer compression" and ROM-based strings/objects.  ROM-based strings/objects can


### PR DESCRIPTION
Add initial version of http://duktape.org/benchmarks.html, which has interactive graphs and is directly tied into test run outputs (which are now structured JSON documents). The page is updated periodically, currently the graphs are missing a lot of data points as I had to retrigger many days worth of tests to populate it.