### PR TITLE
Improve duk instanceof no prototype error

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3003,6 +3003,9 @@ Planned
 * Make error message summary strings longer (32 -> 96 character) to better
   capture error messages for e.g. uncaught errors (GH-1653)
 
+* Improve error message for instanceof and duk_instanceof() when rval has
+  no .prototype property, which is common for Duktape/C functions (GH-1725)
+
 * Add an explicit buffer size wrap check for Buffer.concat() (GH-1688)
 
 * Reject an attempt to unpack an array with >= 2G elements cleanly with a

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3063,6 +3063,9 @@ Planned
 * Fix potential segfault in debugger GetHeapObjInfo command, caused by
   key/mask list being out of sync (GH-1540)
 
+* Fix dangling pointer in instanceof/duk_instanceof() when rval .prototype is
+  a virtualized property coming from a getter or a Proxy trap (GH-1725)
+
 * Fix Reflect.construct() handling for four or more arguments (GH-1517,
   GH-1518)
 

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -67,6 +67,8 @@
 #define DUK_STR_NO_SOURCECODE                    "no sourcecode"
 #define DUK_STR_RESULT_TOO_LONG                  "result too long"
 #define DUK_STR_INVALID_CFUNC_RC                 "invalid C function rc"
+#define DUK_STR_INVALID_INSTANCEOF_RVAL          "invalid instanceof rval"
+#define DUK_STR_INVALID_INSTANCEOF_RVAL_NOPROTO  "instanceof rval has no .prototype"
 
 /* JSON */
 #define DUK_STR_FMT_PTR                          "%p"

--- a/tests/api/test-instanceof-no-prototype.c
+++ b/tests/api/test-instanceof-no-prototype.c
@@ -1,0 +1,45 @@
+/*
+ *  duk_instanceof() error message when right side argument has no .prototype
+ *  property, which is common for Duktape/C constructor functions.
+ */
+
+/*===
+*** test_ecma (duk_safe_call)
+==> rc=1, result='TypeError: instanceof rval has no .prototype'
+*** test_c (duk_safe_call)
+==> rc=1, result='TypeError: instanceof rval has no .prototype'
+===*/
+
+static duk_ret_t test_ecma(duk_context *ctx) {
+	duk_eval_string(ctx,
+		"(function () {\n"
+		"    function Constructor() {}\n"
+		"    Constructor.prototype = void 0;\n"
+		"    print({} instanceof Constructor);\n"
+		"})()");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t my_constructor(duk_context *ctx) {
+	(void) ctx;
+	return 0;
+}
+
+static duk_ret_t test_c(duk_context *ctx) {
+	duk_bool_t rc;
+
+	duk_push_c_function(ctx, my_constructor, 0);
+	duk_push_object(ctx);
+	rc = duk_instanceof(ctx, -1, -2);  /* {} instanceof my_constructor */
+	printf("duk_instanceof() -> rc=%ld\n", (long) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_ecma);
+	TEST_SAFE_CALL(test_c);
+}


### PR DESCRIPTION
When doing `{} instanceof Constructor` and Constructor has no `.prototype` property, the current error message ("invalid instanceof rval") is correct but not very informative. Because this situation happens frequently with Duktape/C constructor functions (which don't have a .prototype by default), improve the error message. See #1604.

Also fixes a potentially dangling pointer: the instanceof rval `.prototype` was looked up, the duk_hobject pointer was assigned to a variable, and the `.prototype` value was then popped off. This works as long as the `.prototype` is a concrete property, but it might also be a getter (or Proxy trap backed). Tagged security because a dangling pointer may cause memory unsafe behavior.