### PR TITLE
Fix debugger pause handling for StepOver and StepInto + tailcall

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3096,9 +3096,8 @@ Planned
   below the current call, leading potentially to a smaller reserve than
   requested (GH-1536)
 
-* Fix incorrect pausing by debugger StepOut command when current function has
-  a tail return; previously execution would pause on exit to tailcall target
-  (GH-1684, GH-1685)
+* Fix incorrect pausing by debugger StepOut, StepOver, and StepInto commands
+  when stepping over a tail call (GH-1684, GH-1685, GH-1726, GH-1734)
 
 * Fix duk_hbufobj assert in shared slice() handling (GH-1506)
 

--- a/tests/ecmascript/test-dev-debugger-step-tailcall.js
+++ b/tests/ecmascript/test-dev-debugger-step-tailcall.js
@@ -1,7 +1,13 @@
 /*
- *  Test illustrating GH-1684.
+ *  Test illustrating GH-1684 and GH-1726.
  *
- *  Run with debugger attached, and StepOut from test1 and test2.
+ *  Run with debugger attached, and:
+ *
+ *  - StepOut from test1 and test2.
+ *
+ *  - StepOver the 'return' statement in test1 and test2.
+ *
+ *  - StepInto anotherFunction in test1 and test2.
  */
 
 /*===


### PR DESCRIPTION
Fixes #1726.