### PR TITLE
Remove license.spdx from dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -976,7 +976,7 @@ doc/%.html: doc/%.txt
 # Source distributable for end users.
 dist:
 	@make codepolicycheck
-	$(PYTHON) util/dist.py --create-spdx
+	$(PYTHON) util/dist.py
 .PHONY:	dist-src
 dist-src:	dist
 	rm -rf duktape-$(DUK_VERSION_FORMATTED)

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3060,6 +3060,8 @@ Planned
 * Add assertion coverage for catching calls into Duktape API from debug
   transport calls (read, peek, etc) (GH-1681)
 
+* Remove license.spdx from the distributable (GH-1741)
+
 * Fix incorrect handling of register bound unary operation target for
   unary minus, unary plus, and bitwise NOT (GH-1623, GH-1624)
 


### PR DESCRIPTION
Remove the license.spdx file because: (1) I'm no longer aware of active consumers of the license, (2) the license is created as custom RDF statements and there's no validation for the result. To be added back once there's more interest.