### PR TITLE
Add duk_push_new_target() API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3190,6 +3190,11 @@ Planned
 2.3.0 (XXXX-XX-XX)
 ------------------
 
+* Add duk_push_new_target() to allow C code to access new.target; at present
+  this is for completeness because without actual class support it's only
+  useful to detect constructor calls which can already be done using
+  duk_is_constructor_call() (GH-1745)
+
 * ES2015 Number constructor properties: EPSILON, MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),
   parseInt(), parseFloat() (GH-1756, GH-1761)

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4452,6 +4452,23 @@ DUK_INTERNAL duk_tval *duk_get_borrowed_this_tval(duk_hthread *thr) {
 	return thr->valstack_bottom - 1;
 }
 
+DUK_EXTERNAL void duk_push_new_target(duk_hthread *thr) {
+	duk_activation *act;
+
+	DUK_ASSERT_API_ENTRY(thr);
+
+	act = thr->callstack_curr;
+	if (act != NULL && (act->flags & DUK_ACT_FLAG_CONSTRUCT) != 0) {
+		/* Because C functions don't have a lexical scope, new.target
+		 * at present, without class support, is just the current
+		 * function if it was called as a constructor.
+		 */
+		duk_push_tval(thr, &act->tv_func);
+	} else {
+		duk_push_undefined(thr);
+	}
+}
+
 DUK_EXTERNAL void duk_push_current_function(duk_hthread *thr) {
 	duk_activation *act;
 

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -5020,40 +5020,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 
 #if defined(DUK_USE_ES6)
 		case DUK_OP_NEWTARGET: {
-			/* https://www.ecma-international.org/ecma-262/6.0/#sec-meta-properties-runtime-semantics-evaluation
-			 * https://www.ecma-international.org/ecma-262/6.0/#sec-getnewtarget
-			 *
-			 * No newTarget support now, so as a first approximation
-			 * use the resolved (non-bound) target function.
-			 */
-			/* XXX: C API: push_new_target()? */
-			duk_activation *act;
-
-			act = thr->callstack_curr;
-			DUK_ASSERT(act != NULL);
-
-			/* Check CONSTRUCT flag from current function, or if running
-			 * direct eval, from a non-direct-eval parent (with possibly
-			 * more than one nested direct eval).  An alternative to this
-			 * would be to store [[NewTarget]] as a hidden symbol of the
-			 * lexical scope, and then just look up that variable.
-			 */
-			for (;;) {
-				if (act == NULL) {
-					duk_push_undefined(thr);
-					break;
-				}
-				if (act->flags & DUK_ACT_FLAG_CONSTRUCT) {
-					duk_push_tval(thr, &act->tv_func);
-					break;
-				} else if (act->flags & DUK_ACT_FLAG_DIRECT_EVAL) {
-					act = act->parent;
-				} else {
-					duk_push_undefined(thr);
-					break;
-				}
-			}
-
+			duk_push_new_target(thr);
 			DUK__REPLACE_TOP_BC_BREAK();
 		}
 #endif  /* DUK_USE_ES6 */

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -553,6 +553,7 @@ DUK_EXTERNAL_DECL const char *duk_push_sprintf(duk_context *ctx, const char *fmt
 DUK_EXTERNAL_DECL const char *duk_push_vsprintf(duk_context *ctx, const char *fmt, va_list ap);
 
 DUK_EXTERNAL_DECL void duk_push_this(duk_context *ctx);
+DUK_EXTERNAL_DECL void duk_push_new_target(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_current_function(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_current_thread(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_global_object(duk_context *ctx);

--- a/tests/api/test-push-new-target.c
+++ b/tests/api/test-push-new-target.c
@@ -1,0 +1,60 @@
+/*
+ *  duk_push_new_target()
+ */
+
+/*===
+push with empty callstack, top 1, result type is 'undefined': 1
+duk_is_constructor_call: 0
+duk_is_undefined() for new.target: 1
+duk_is_object() for new.target: 0
+duk_is_callable() for new.target: 0
+duk_get_c_function(): NULL
+final top: 1
+duk_is_constructor_call: 1
+duk_is_undefined() for new.target: 0
+duk_is_object() for new.target: 1
+duk_is_callable() for new.target: 1
+duk_get_c_function(): matches my_func: 1
+final top: 1
+final top: 0
+===*/
+
+static duk_ret_t my_func(duk_context *ctx) {
+	duk_c_function func;
+
+	printf("duk_is_constructor_call: %ld\n", (long) duk_is_constructor_call(ctx));
+	duk_push_new_target(ctx);
+	printf("duk_is_undefined() for new.target: %ld\n", duk_is_undefined(ctx, -1));
+	printf("duk_is_object() for new.target: %ld\n", duk_is_object(ctx, -1));
+	printf("duk_is_callable() for new.target: %ld\n", duk_is_callable(ctx, -1));
+
+	func = duk_get_c_function(ctx, -1);
+	if (func != NULL) {
+		printf("duk_get_c_function(): matches my_func: %ld\n", (long) (func == my_func ? 1 : 0));
+	} else {
+		printf("duk_get_c_function(): NULL\n");
+	}
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	/* Push with empty callstack. */
+	duk_push_new_target(ctx);
+	printf("push with empty callstack, top %ld, result type is 'undefined': %ld\n",
+	       (long) duk_get_top(ctx), (long) duk_is_undefined(ctx, -1));
+	duk_pop(ctx);
+
+	/* Push from normal call. */
+	duk_push_c_function(ctx, my_func, 0);
+	duk_call(ctx, 0);
+	duk_pop(ctx);
+
+	/* Push from constructor call. */
+	duk_push_c_function(ctx, my_func, 0);
+	duk_new(ctx, 0);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+}

--- a/website/api/duk_push_new_target.yaml
+++ b/website/api/duk_push_new_target.yaml
@@ -1,0 +1,22 @@
+name: duk_push_new_target
+
+proto: |
+  void duk_push_new_target(duk_context *ctx);
+
+stack: |
+  [ ... ] -> [ ... undefined! ]  (if no current function or not a constructor call)
+  [ ... ] -> [ ... func! ]  (if current function call is a constructor call)
+
+summary: |
+  <p>Push the equivalent of <code>new.target</code> for the currently running
+  function to the stack.  The value pushed is <code>undefined</code> if the
+  current call is not a constructor call, or if the call stack is empty.</p>
+
+example: |
+  duk_push_new_target(ctx);
+
+tags:
+  - stack
+  - function
+
+introduced: 2.3.0


### PR DESCRIPTION
At present, without class support, the API call is in essence just duk_push_current_function() with a pre-check that we've been called as a constructor. But later on `new.target` and current function may be different.

- [x] Add API call
- [x] API tests
- [x] API documentation
- [x] Releases entry