### PR TITLE
Fix duk_hboundfunc->args memory leak

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2990,7 +2990,7 @@ Planned
 
 * Add an internal type for representing bound functions (duk_hboundfunc) and
   "collapse" bound function chains so that the target of a duk_hboundfunc is
-  always a non-bound function (GH-1503, GH-1507)
+  always a non-bound function (GH-1503, GH-1507, GH-1748)
 
 * Make call stack and value stack limits configurable via config options
   (DUK_USE_CALLSTACK_LIMIT, DUK_USE_VALSTACK_LIMIT) (GH-1526)

--- a/src-input/duk_hboundfunc.h
+++ b/src-input/duk_hboundfunc.h
@@ -33,7 +33,7 @@ struct duk_hboundfunc {
 	duk_tval this_binding;
 
 	/* Arguments to prepend. */
-	duk_tval *args;
+	duk_tval *args;  /* Separate allocation. */
 	duk_idx_t nargs;
 };
 

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -65,7 +65,12 @@ DUK_INTERNAL void duk_free_hobject(duk_heap *heap, duk_hobject *h) {
 		 * to be unwound to update the 'caller' properties of
 		 * functions in the callstack.
 		 */
+	} else if (DUK_HOBJECT_IS_BOUNDFUNC(h)) {
+		duk_hboundfunc *f = (duk_hboundfunc *) h;
+
+		DUK_FREE(heap, f->args);
 	}
+
 	DUK_FREE(heap, (void *) h);
 }
 


### PR DESCRIPTION
The bug was introduced in duk_hboundfunc rework after 2.1.0 release, so it's present in master but unreleased. Found in 2.2.0 release stress tests.