### PR TITLE
Fix bug in GETPROPC special marker value detection

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -2937,7 +2937,7 @@ Planned
 
 * Improve error message for property-based call TypeError (e.g. foo.noSuch()),
   error message now includes the key for easier debugging (GH-1627, GH-1630,
-  GH-1631, GH-1644, GH-1645)
+  GH-1631, GH-1644, GH-1645, GH-1750)
 
 * Add duk_{get,put,has,del}_prop_heapptr() API calls for faster property
   manipulation when a borrowed heap pointer (typically string) is available

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1318,7 +1318,7 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_hthread *th
 	 * (which would be dangerous).
 	 */
 	if (DUK_TVAL_IS_OBJECT(tv_func)) {
-		if (duk_hobject_find_existing_entry_tval_ptr(thr->heap, DUK_TVAL_GET_OBJECT(tv_func), DUK_HTHREAD_STRING_INT_VALUE(thr)) != NULL) {
+		if (duk_hobject_find_existing_entry_tval_ptr(thr->heap, DUK_TVAL_GET_OBJECT(tv_func), DUK_HTHREAD_STRING_INT_TARGET(thr)) != NULL) {
 			duk_push_tval(thr, tv_func);
 			(void) duk_throw(thr);
 		}
@@ -2829,8 +2829,10 @@ DUK_INTERNAL DUK_NOINLINE DUK_COLD void duk_call_setup_propcall_error(duk_hthrea
 	 * - Call argument evaluation
 	 * - Callability check and error thrown.
 	 *
-	 * A hidden symbol on the error object pushed here is used by
+	 * A hidden Symbol on the error object pushed here is used by
 	 * call handling to figure out the error is to be thrown as is.
+	 * It is CRITICAL that the hidden Symbol can never occur on a
+	 * user visible object that may get thrown.
 	 */
 
 #if defined(DUK_USE_PARANOID_ERRORS)
@@ -2846,7 +2848,7 @@ DUK_INTERNAL DUK_NOINLINE DUK_COLD void duk_call_setup_propcall_error(duk_hthrea
 #endif
 
 	duk_push_true(thr);
-	duk_put_prop_stridx(thr, -2, DUK_STRIDX_INT_VALUE);  /* Marker property, reuse _Value. */
+	duk_put_prop_stridx(thr, -2, DUK_STRIDX_INT_TARGET);  /* Marker property, reuse _Target. */
 
 	/* [ <nregs> propValue <variable> error ] */
 	duk_replace(thr, entry_top - 1);

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -759,6 +759,17 @@ strings:
   - str: "pointer"
     duktape: true
 
+  # GETPROPC delayed error, can use any shared hidden Symbol that can never
+  # occur in used visible values (which may be thrown and thus trigger special
+  # handling).  At present, use _Target which is only used by enumerator
+  # objects and nothing user visible.
+  - str:
+      type: symbol
+      variant: hidden
+      string: "Target"
+    duktape: true
+    internal: true
+
   # internal property for primitive value (Boolean, Number, String)
   - str:
       type: symbol

--- a/tests/ecmascript/test-bug-getpropc-value-detect.js
+++ b/tests/ecmascript/test-bug-getpropc-value-detect.js
@@ -1,0 +1,43 @@
+/*
+ *  Unreleased bug between 2.1.0 and 2.2.0 release where GETPROPC special
+ *  handling caused e.g. new String()() to unintentionally work.  Caught
+ *  with test262.
+ */
+
+/*===
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError
+===*/
+
+try {
+    new Boolean(true)();
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    new Number(1)();
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    new String('1')();
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    new String()();
+} catch (e) {
+    print(e.name);
+}
+
+try {
+    new this();  // global object
+} catch (e) {
+    print(e.name);
+}


### PR DESCRIPTION
Fix a bug in GETPROPC special marker value detection, detected using test262. The bug is unreleased (not present in 2.1.0) but exists in master prior to 2.2.0 release.