### PR TITLE
Add Number.{parseInt,parseFloat} from ES2015

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3190,6 +3190,9 @@ Planned
 2.3.0 (XXXX-XX-XX)
 ------------------
 
+* ES2015 Number built-in bindings: Number.parseInt(), Number.parseFloat()
+  (GH-1756)
+
 * Fix trailing single line comment handling for Function constructor;
   new Function('return "foo" //') previously failed with SyntaxError
   (GH-1757)

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -417,15 +417,13 @@ objects:
         present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "parseInt"
         value:
-          type: function
-          native: duk_bi_global_object_parse_int
-          length: 2
+          type: object
+          id: bi_parse_int
         present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "parseFloat"
         value:
-          type: function
-          native: duk_bi_global_object_parse_float
-          length: 1
+          type: object
+          id: bi_parse_float
         present_if: DUK_USE_GLOBAL_BUILTIN
       - key: "isNaN"
         value:
@@ -513,6 +511,34 @@ objects:
         attributes: "wec"
         performance_api: true
         present_if: DUK_USE_PERFORMANCE_BUILTIN
+
+  - id: bi_parse_int
+    class: Function
+    internal_prototype: bi_function_prototype
+    native: duk_bi_global_object_parse_int
+    callable: true
+    constructable: false
+    bidx: false
+    present_if: DUK_USE_OBJECT_BUILTIN
+
+    properties:
+      - key: "length"
+        value: 2
+        attributes: "c"
+
+  - id: bi_parse_float
+    class: Function
+    internal_prototype: bi_function_prototype
+    native: duk_bi_global_object_parse_float
+    callable: true
+    constructable: false
+    bidx: false
+    present_if: DUK_USE_OBJECT_BUILTIN
+
+    properties:
+      - key: "length"
+        value: 1
+        attributes: "c"
 
   - id: bi_global_env
     class: ObjEnv
@@ -1496,6 +1522,19 @@ objects:
           type: double
           bytes: "fff0000000000000"  # DBL_NEGATIVE_INFINITY
         attributes: ""
+
+      - key: "parseInt"  # Must map to the exactly same object as global parseInt()
+        value:
+          type: object
+          id: bi_parse_int
+        es6: true
+        present_if: DUK_USE_ES6
+      - key: "parseFloat"  # Must map to the exactly same object as global parseFloat()
+        value:
+          type: object
+          id: bi_parse_float
+        es6: true
+        present_if: DUK_USE_ES6
 
   - id: bi_number_prototype
     class: Number

--- a/tests/ecmascript/test-bi-number-parsefloat.js
+++ b/tests/ecmascript/test-bi-number-parsefloat.js
@@ -1,0 +1,18 @@
+/*===
+function
+true
+object
+true
+false
+true
+done
+===*/
+
+print(typeof Number.parseFloat);
+print(Number.parseFloat === parseFloat);
+var pd = Object.getOwnPropertyDescriptor(Number, 'parseFloat');
+print(typeof pd);
+print(pd.writable);
+print(pd.enumerable);
+print(pd.configurable);
+print('done');

--- a/tests/ecmascript/test-bi-number-parseint.js
+++ b/tests/ecmascript/test-bi-number-parseint.js
@@ -1,0 +1,18 @@
+/*===
+function
+true
+object
+true
+false
+true
+done
+===*/
+
+print(typeof Number.parseInt);
+print(Number.parseInt === parseInt);
+var pd = Object.getOwnPropertyDescriptor(Number, 'parseInt');
+print(typeof pd);
+print(pd.writable);
+print(pd.enumerable);
+print(pd.configurable);
+print('done');


### PR DESCRIPTION
Add Number.parseInt() and Number.parseFloat() from ES2015.  They must map to the exact same objects as global parseInt() and parseFloat().

Tasks:
- [x] Add the bindings
- [x] Testcase coverage
- [x] Releases entry