### PR TITLE
Add narrow workaround for FreeBSD clang aliasing

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3197,6 +3197,12 @@ Planned
   new Function('return "foo" //') previously failed with SyntaxError
   (GH-1757)
 
+* Add automatic workaround for union aliasing issues with FreeBSD + -m32 +
+  Clang prior to 5.0; the aliasing issues cause packed duk_tval to work
+  incorrectly (see
+  https://github.com/svaarala/duktape/blob/master/misc/clang_aliasing.c),
+  and the workaround is to use unpacked duk_tval prior to Clang 5.0 (GH-1764)
+
 3.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/config/architectures/architecture_x86.h.in
+++ b/config/architectures/architecture_x86.h.in
@@ -8,4 +8,13 @@
 #if !defined(DUK_USE_ALIGN_BY)
 #define DUK_USE_ALIGN_BY 1
 #endif
+
 #define DUK_USE_PACKED_TVAL
+
+/* FreeBSD, -m32, and clang prior to 5.0 has union aliasing issues which
+ * break duk_tval copying.  Disable packed duk_tval automatically.
+ */
+#if defined(DUK_F_FREEBSD) && defined(DUK_F_X86) && \
+    defined(__clang__) && defined(__clang_major__) && (__clang_major__ < 5)
+#undef DUK_USE_PACKED_TVAL
+#endif

--- a/config/header-snippets/packed_tval_fillin.h.in
+++ b/config/header-snippets/packed_tval_fillin.h.in
@@ -35,6 +35,6 @@
 #if defined(DUK_F_PACKED_TVAL_POSSIBLE)
 #define DUK_USE_PACKED_TVAL
 #endif
-
 #undef DUK_F_PACKED_TVAL_POSSIBLE
+
 #endif  /* DUK_F_PACKED_TVAL_PROVIDED */


### PR DESCRIPTION
Rough solution to make FreeBSD + -m32 + clang prior to 5.0 to avoid clang aliasing issues automatically. This avoids unnecessary segfaults due to broken union assignments etc. Though they are detectable with -DDUK_USE_SELF_TESTS, it takes some diagnosis to figure them out.