### PR TITLE
Clarify develoment version numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,10 @@ Branch policy
 Versioning
 ----------
 
-Duktape uses [Semantic Versioning](http://semver.org/).
+Duktape uses [Semantic Versioning](http://semver.org/) for official
+releases.  Builds from Duktape repo are not official releases and don't
+follow strict semver, mainly because `DUK_VERSION` needs to have some
+compromise value that won't be strictly semver conforming.
 Because Duktape tracks the latest Ecmascript specification versions,
 compliance fixes are made in minor versions even when they are technically
 not backwards compatible.  See

--- a/website/guide/versioning.html
+++ b/website/guide/versioning.html
@@ -2,7 +2,8 @@
 
 <h2 id="semantic-versioning">Semantic versioning</h2>
 
-<p>Duktape follows <a href="http://semver.org/">Semantic Versioning</a>:</p>
+<p>Duktape follows <a href="http://semver.org/">Semantic Versioning</a> for
+official releases:</p>
 <ul>
 <li>Major version changes when API incompatible changes are made.</li>
 <li>Minor version changes when backwards-compatible functional changes are made.</li>
@@ -58,6 +59,9 @@
 <li>Config options won't change in an incompatible manner.</li>
 </ul>
 
+<p>Development builds made from Duktape repo are not official releases and
+don't follow strict semantic versioning.</p>
+
 <h2 id="experimental-features">Experimental features</h2>
 
 <p>Some new features and API calls are marked <b>experimental</b> which means
@@ -73,31 +77,29 @@ becomes a fully supported feature.</p>
 
 <p>Releases use the form <i>(major).(minor).(patch)</i>, e.g. <b>1.0.3</b>.</p>
 
-<p>Development pre-releases use the form <i>(major).(minor).(patch)-alpha.(number)</i>,
-e.g. <b>1.3.0-alpha.2</b>.  The form <i>0.(minor).0</i> was used for development
-pre-releases before the 1.0 release.</p>
-
 <h2>DUK_VERSION and Duktape.version</h2>
 
 <p><code>DUK_VERSION</code> and <code>Duktape.version</code> provide version
 identification using a single number computed as:
 <code>(major * 10000 + minor * 100 + patch)</code>,
-then subtracting one for development pre-releases.</p>
+then subtracting one for development builds (not official releases) made from
+Duktape repo.</p>
 
-<p>Note the limitations for development pre-releases:</p>
+<p>Note the limitations for development builds:</p>
 <ul>
-<li>Development pre-releases for the same release are not distinguished from
-    one another: for example, both 1.3.0-alpha.1 and 1.3.0-alpha.2 are
-    identified as 10299.</li>
-<li>Development pre-releases for patch releases are not distinguished from the
-    previous patch release: for example, 1.3.3-alpha.6 and 1.3.2 are both
-    identified as 10302.</li>
+<li>Development builds for the same upcoming release are not distinguished from
+    one another: for example, all builds from master prior to 1.3.0 release
+    are identified as 10299.</li>
+<li>Development builds for patch releases are not distinguished from the
+    previous patch release: for example, a development build after 1.3.2 but
+    before 1.3.3 is identified as 10302.</li>
 </ul>
 
-<p>Development pre-releases shouldn't be used in production, but the current
+<p>Development builds shouldn't be used in production, but the current
 <code>DUK_VERSION</code> and <code>Duktape.version</code> number provides
-a useful approximation for version comparison: an alpha release will compare
-smaller than the actual release, but higher (or equal) than a previous release.</p>
+a useful approximation for version comparison: a development build will
+compare smaller than the actual release, but higher (or equal) than a
+previous release.</p>
 
 <h2 id="versioning-examples">Examples</h2>
 
@@ -105,20 +107,16 @@ smaller than the actual release, but higher (or equal) than a previous release.<
 <table>
 <tr>
 <th>Version</th>
-<th>Pre-release?</th>
 <th>DUK_VERSION &amp;<br />Duktape.version</th>
 <th>Notes</th>
 </tr>
-<tr><td>0.12.0</td><td>yes</td><td>1200</td><td>Pre-release before 1.0 release.</td></tr>
-<tr><td>1.0.0</td><td>no</td><td>10000</td><td></td></tr>
-<tr><td>1.3.0-alpha.1</td><td>yes</td><td>10299</td><td>Identified like 1.2.99, first 1.3.0 development pre-release.</td></tr>
-<tr><td>1.3.0-alpha.2</td><td>yes</td><td>10299</td><td>Identified like 1.2.99, no difference to 1.3.0-alpha.1.</td></tr>
-<tr><td>1.3.0</td><td>no</td><td>10300</td><td></td></tr>
-<tr><td>1.3.2</td><td>no</td><td>10302</td><td></td></tr>
-<tr><td>1.3.3-alpha.6</td><td>yes</td><td>10302</td><td>Identified like 1.3.2, no difference to 1.3.2 release.</td></tr>
-<tr><td>1.3.3</td><td>no</td><td>10303</td><td></td></tr>
-<tr><td>2.0.0-alpha.3</td><td>yes</td><td>19999</td><td>Identified like 1.99.99.</td></tr>
-<tr><td>2.0.0</td><td>no</td><td>20000</td><td></td></tr>
+<tr><td>0.12.0</td><td>1200</td><td>Development build before 1.0 release.</td></tr>
+<tr><td>1.0.0</td><td>10000</td><td></td></tr>
+<tr><td>1.2.99</td><td>10299</td><td>Development build before 1.3 release.</td></tr>
+<tr><td>1.3.0</td><td>10300</td><td></td></tr>
+<tr><td>1.3.2</td><td>10302</td><td></td></tr>
+<tr><td>1.3.3</td><td>10303</td><td></td></tr>
+<tr><td>2.0.0</td><td>20000</td><td></td></tr>
 </table>
 
 <h2 id="version-maintenance">Maintenance of stable versions</h2>


### PR DESCRIPTION
- Remove obsolete text related to alpha versions: no alpha versions have been releases (after initial stable release) and it's better to avoid them entirely because DUK_VERSION cannot reflect them in a semver compliant way.
- Clarify that development builds from Duktape repo are not official releases and don't follow strict semver. Doing so would be impossible because DUK_VERSION needs to have some useful value that is necessarily some kind of compromise and will break one or more strict semver requirements.
- Use the term development build rather than prerelease to make the distinction clearer.