### PR TITLE
Fix DUK_BOOL_MIN/MAX for unsigned duk_bool_t

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3198,6 +3198,8 @@ Planned
   new Function('return "foo" //') previously failed with SyntaxError
   (GH-1757)
 
+* Fix DUK_BOOL_{MIN,MAX} defines for unsigned duk_bool_t (GH-1769)
+
 * Add automatic workaround for union aliasing issues with FreeBSD + -m32 +
   Clang prior to 5.0; the aliasing issues cause packed duk_tval to work
   incorrectly (see

--- a/config/header-snippets/types2.h.in
+++ b/config/header-snippets/types2.h.in
@@ -55,8 +55,8 @@ typedef duk_uint_fast16_t duk_small_uint_fast_t;
 
 /* Boolean values are represented with the platform 'unsigned int'. */
 typedef duk_small_uint_t duk_bool_t;
-#define DUK_BOOL_MIN              DUK_SMALL_INT_MIN
-#define DUK_BOOL_MAX              DUK_SMALL_INT_MAX
+#define DUK_BOOL_MIN              DUK_SMALL_UINT_MIN
+#define DUK_BOOL_MAX              DUK_SMALL_UINT_MAX
 
 /* Index values must have at least 32-bit signed range. */
 typedef duk_int_t duk_idx_t;


### PR DESCRIPTION
The min/max defines where left untouched when duk_bool_t was changed to unsigned. In practice this should cause no issues: Duktape internals don't reference the limits and they're just defined for completeness. Fixes #1766.