### PR TITLE
Fixed invalid casting in C++ build on Windows

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,6 +46,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Steven Don (https://github.com/shdon)
 * Simon Stone (https://github.com/sstone1)
 * \J. McC. (https://github.com/jmhmccr)
+* Jakub Nowakowski (https://github.com/jimvonmoon)
 
 Other contributions
 ===================

--- a/examples/debug-trans-socket/duk_trans_socket_windows.c
+++ b/examples/debug-trans-socket/duk_trans_socket_windows.c
@@ -251,7 +251,7 @@ duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length
 	 * timeout here to recover from "black hole" disconnects.
 	 */
 
-	ret = recv(client_sock, (void *) buffer, (int) length, 0);
+	ret = recv(client_sock, buffer, (int) length, 0);
 	if (ret < 0) {
 		fprintf(stderr, "%s: debug read failed, error %d, closing connection\n",
 		        __FILE__, ret);
@@ -315,7 +315,7 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 	 * timeout here to recover from "black hole" disconnects.
 	 */
 
-	ret = send(client_sock, (const void *) buffer, (int) length, 0);
+	ret = send(client_sock, buffer, (int) length, 0);
 	if (ret <= 0 || ret > (int) length) {
 		fprintf(stderr, "%s: debug write failed, ret %d, closing connection\n",
 		        __FILE__, ret);


### PR DESCRIPTION
When building `duk_trans_socket_windows.c` with a C++ compiler on Windows, I get following errors:
```
Error C2664 'int send(SOCKET,const char *,int,int)': cannot convert argument 2 from 'const void *' to 'const char *'
Error C2664 'int recv(SOCKET,char *,int,int)': cannot convert argument 2 from 'void *' to 'char *'
```
I am building with VS2017, but this error should occur with any C++ compiler.

Faulty lines are:
```cpp
ret = recv(client_sock, (void *) buffer, (int) length, 0);
// ...
ret = send(client_sock, (const void *) buffer, (int) length, 0);
```

MSDN states that Winsock's `recv()` and `send()` take their buffers as `char*`, not `void*`.
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740121(v=vs.85).aspx
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740149(v=vs.85).aspx

C++, being more strict than C, doesn't let that slide and reports errors.

Even if C++ support is not an issue, it seems reasonable to pass these buffers using their correct types.

Thanks.