### PR TITLE
Address 'defined but not used' warning

### DIFF
--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -23,10 +23,12 @@ DUK_LOCAL void duk__convert_systime_to_ularge(const SYSTEMTIME *st, ULARGE_INTEG
 	}
 }
 
+#if defined(DUK_USE_DATE_NOW_WINDOWS_SUBMS)
 DUK_LOCAL void duk__convert_filetime_to_ularge(const FILETIME *ft, ULARGE_INTEGER *res) {
 	res->LowPart = ft->dwLowDateTime;
 	res->HighPart = ft->dwHighDateTime;
 }
+#endif  /* DUK_USE_DATE_NOW_WINDOWS_SUBMS */
 
 DUK_LOCAL void duk__set_systime_jan1970(SYSTEMTIME *st) {
 	DUK_MEMZERO((void *) st, sizeof(*st));


### PR DESCRIPTION
In duk_bi_date_windows.c, the function `duk__convert_filetime_to_ularge`
is a static function called only from `duk_bi_date_get_now_windows_subms`,
which is wrapped in a `#define`.

This change wraps `duk__convert_filetime_to_ularge` in the same `#define`
to prevent compiler warnings about unused functions.