### PR TITLE
Use align-by-8 on all platforms by default

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3194,6 +3194,11 @@ Planned
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),
   parseInt(), parseFloat() (GH-1756, GH-1761)
 
+* Assume only natural alignment (DUK_USE_ALIGN_BY=8) on all platforms to
+  minimize compiler assumptions regarding unaligned accesses (which can be
+  an issue even on x86); applications working with a low memory target may
+  want to force DUK_USE_ALIGN_BY in configuration (GH-1783, GH-1784)
+
 * Fix trailing single line comment handling for Function constructor;
   new Function('return "foo" //') previously failed with SyntaxError
   (GH-1757)

--- a/config/architectures/architecture_arm32.h.in
+++ b/config/architectures/architecture_arm32.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "arm32"
 /* Byte order varies, so rely on autodetect. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 4
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_arm64.h.in
+++ b/config/architectures/architecture_arm64.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "arm64"
 /* Byte order varies, so rely on autodetect. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_emscripten.h.in
+++ b/config/architectures/architecture_emscripten.h.in
@@ -2,7 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_m68k.h.in
+++ b/config/architectures/architecture_m68k.h.in
@@ -2,7 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 3
 #endif
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_mips32.h.in
+++ b/config/architectures/architecture_mips32.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "mips32"
 /* MIPS byte order varies so rely on autodetection. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_mips64.h.in
+++ b/config/architectures/architecture_mips64.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "mips64"
 /* MIPS byte order varies so rely on autodetection. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_powerpc32.h.in
+++ b/config/architectures/architecture_powerpc32.h.in
@@ -2,7 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 3
 #endif
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_powerpc64.h.in
+++ b/config/architectures/architecture_powerpc64.h.in
@@ -2,7 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 3
 #endif
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_sparc32.h.in
+++ b/config/architectures/architecture_sparc32.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "sparc32"
 /* SPARC byte order varies so rely on autodetection. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_sparc64.h.in
+++ b/config/architectures/architecture_sparc64.h.in
@@ -1,6 +1,3 @@
 #define DUK_USE_ARCH_STRING "sparc64"
 /* SPARC byte order varies so rely on autodetection. */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 8
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_superh.h.in
+++ b/config/architectures/architecture_superh.h.in
@@ -1,9 +1,3 @@
 #define DUK_USE_ARCH_STRING "sh"
 /* Byte order varies, rely on autodetection. */
-/* Based on 'make checkalign' there are no alignment requirements on
- * Linux SH4, but align by 4 is probably a good basic default.
- */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 4
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_x32.h.in
+++ b/config/architectures/architecture_x32.h.in
@@ -2,10 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
- */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
-#endif
 #define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_x64.h.in
+++ b/config/architectures/architecture_x64.h.in
@@ -2,10 +2,4 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
- */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
-#endif
 #undef DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_x86.h.in
+++ b/config/architectures/architecture_x86.h.in
@@ -2,12 +2,6 @@
 #if !defined(DUK_USE_BYTEORDER)
 #define DUK_USE_BYTEORDER 1
 #endif
-/* XXX: This is technically not guaranteed because it's possible to configure
- * an x86 to require aligned accesses with Alignment Check (AC) flag.
- */
-#if !defined(DUK_USE_ALIGN_BY)
-#define DUK_USE_ALIGN_BY 1
-#endif
 
 #define DUK_USE_PACKED_TVAL
 

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -11,6 +11,10 @@
 #   - Does not enable ROM string/object support by default, enable manually
 #
 
+# Consider switching alignment to align-by-1 or align-by-4 for more compact
+# memory layout if the architecture supports it.
+#DUK_USE_ALIGN_BY: 1
+
 DUK_USE_PREFER_SIZE: true
 DUK_USE_EXEC_PREFER_SIZE: true
 DUK_USE_FAST_REFCOUNT_DEFAULT: false

--- a/config/header-snippets/alignment_fillin.h.in
+++ b/config/header-snippets/alignment_fillin.h.in
@@ -3,10 +3,13 @@
  *
  *  Assume unaligned accesses are not supported unless specifically allowed
  *  in the target platform.  Some platforms may support unaligned accesses
- *  but alignment to 4 or 8 may still be desirable.
+ *  but alignment to 4 or 8 may still be desirable.  Note that unaligned
+ *  accesses (and even pointers) relative to natural alignment (regardless
+ *  of target alignment) are technically undefined behavior and thus
+ *  compiler/architecture specific.
  */
 
-/* If not provided, use safe default for alignment. */
+/* If not forced, use safe default for alignment. */
 #if !defined(DUK_USE_ALIGN_BY)
 #define DUK_USE_ALIGN_BY 8
 #endif

--- a/doc/low-memory.rst
+++ b/doc/low-memory.rst
@@ -174,6 +174,10 @@ NOTE: This list is not exhaustive, see ``config/examples/low_memory.yaml``.
   increases heap header size, it also reduces memory usage fluctuation
   which is often more important than absolute footprint.
 
+* By default Duktape uses natural alignment, which in practice translates
+  to ``DUK_USE_ALIGN_BY=8``.  If the target can use lower alignment,
+  consider forcing alignment to 4 or 1.
+
 * If the target has a shallow C stack, you may want to limit C stack
   recursion, see:
 

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -1,0 +1,27 @@
+=========================
+Duktape 2.3 release notes
+=========================
+
+Release overview
+================
+
+Main changes in this release (see RELEASES.rst for full details):
+
+* TBD.
+
+* DUK_USE_ALIGN_BY now always defaults to 8 (natural alignment) to avoid any
+  potentially unsafe assumptions about compiler behavior for unaligned memory
+  accesses and pointers (which may be an issue even on x86).
+
+Upgrading from Duktape 2.2
+==========================
+
+No action (other than recompiling) should be needed for most users to upgrade
+from Duktape v2.2.x.  Note the following:
+
+* TBD.
+
+* If you're working with a low memory target or any other target where memory
+  usage matters, you may want to force DUK_USE_ALIGN_BY to a lower value
+  (4 or 1) to reduce memory overhead.  For most targets the memory overhead
+  is not important.


### PR DESCRIPTION
Fixes #1783. Tasks:
- [x] Remove all alignment forcing from architecture files, rely on align-by-8 default fillin (one can still force alignment via configure.py)
- [x] Releases entry
- [x] 2.3 migration notes: need to force if memory usage matters and lower alignment is possible
- [x] Low memory documentation note

This also means that x86/x64 will switch from `duk_hobject` property layout 1 to 2.