### PR TITLE
Fix StepOver a nested tailcall

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3201,6 +3201,9 @@ Planned
 
 * Add C++ name mangling wrappers (extern "C") for extras (GH-1780, GH-1782)
 
+* Fix debugger StepOver behavior when a tailcall happens in a nested
+  function (not the function where stepping started from) (GH-1786, GH-1787)
+
 * Fix trailing single line comment handling for Function constructor;
   new Function('return "foo" //') previously failed with SyntaxError
   (GH-1757)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1507,9 +1507,10 @@ DUK_LOCAL duk_small_uint_t duk__call_setup_act_attempt_tailcall(duk_hthread *thr
 	 *    - Disable StepOut processing for the activation unwind because
 	 *      we reuse the activation, see:
 	 *      https://github.com/svaarala/duktape/issues/1684.
-	 *    - Disable line change pause flag permanently (if set) because
-	 *      it would no longer be relevant, see:
-	 *      https://github.com/svaarala/duktape/issues/1726.
+	 *    - Disable line change pause flag permanently if act == dbg_pause_act
+	 *      (if set) because it would no longer be relevant, see:
+	 *      https://github.com/svaarala/duktape/issues/1726,
+	 *      https://github.com/svaarala/duktape/issues/1786.
 	 *    - Check for function entry (e.g. StepInto) pause flag here, because
 	 *      the executor pause check won't trigger due to shared activation, see:
 	 *      https://github.com/svaarala/duktape/issues/1726.
@@ -1530,9 +1531,12 @@ DUK_LOCAL duk_small_uint_t duk__call_setup_act_attempt_tailcall(duk_hthread *thr
 	DUK_ASSERT(thr->callstack_top > 0);
 	DUK_ASSERT(thr->callstack_curr != NULL);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
+	if (act == thr->heap->dbg_pause_act) {
+		thr->heap->dbg_pause_flags &= ~DUK_PAUSE_FLAG_LINE_CHANGE;
+	}
+
 	prev_pause_act = thr->heap->dbg_pause_act;
 	thr->heap->dbg_pause_act = NULL;
-	thr->heap->dbg_pause_flags &= ~DUK_PAUSE_FLAG_LINE_CHANGE;
 	if (thr->heap->dbg_pause_flags & DUK_PAUSE_FLAG_FUNC_ENTRY) {
 		DUK_D(DUK_DPRINT("PAUSE TRIGGERED by function entry (tailcall)"));
 		duk_debug_set_paused(thr->heap);

--- a/tests/ecmascript/test-dev-debugger-step-tailcall.js
+++ b/tests/ecmascript/test-dev-debugger-step-tailcall.js
@@ -1,6 +1,15 @@
 /*
- *  Test illustrating GH-1684 and GH-1726.
- *
+ *  Test illustrating GH-1684, GH-1726, GH1786.
+ */
+
+/*===
+entered test1
+entered anotherFunction
+entered test2
+entered anotherFunction
+===*/
+
+/*
  *  Run with debugger attached, and:
  *
  *  - StepOut from test1 and test2.
@@ -9,14 +18,6 @@
  *
  *  - StepInto anotherFunction in test1 and test2.
  */
-
-/*===
-entered test1
-entered anotherFunction
-entered test2
-entered anotherFunction
-done
-===*/
 
 function anotherFunction() {
     var ret;
@@ -44,5 +45,37 @@ try {
 } catch (e) {
     print(e.stack || e);
 }
+
+/*===
+before bar
+after bar
+===*/
+
+/*
+ *  Nested case.  The tailcall in a nested call (not occurring in the
+ *  function where stepping starts) shouldn't affect line pausing.
+ */
+
+function foo() {
+    return 1;
+}
+function bar() {
+    return foo();
+}
+function test() {
+    print('before bar');
+    bar();  // step over this
+    print('after bar');
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+done
+===*/
 
 print('done');


### PR DESCRIPTION
Fix for a debugger regression in 2.2.0: StepOver a call which does a nested tailcall causes #1786:

- [x] Draft fix for root cause
- [x] Clean up fix
- [x] Check if a simpler fix suffices: don't add a duk_activation flag, but only clear the "pause on line" flag if doing a tailcall *and* the current activation matches dbg_pause_act
- [x] Manual testcase
- [x] Releases entry

Fixes #1786.