### PR TITLE
Fix warnings when DUK_NORETURN not defined, add DUK_WO_NORETURN()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3231,6 +3231,11 @@ Planned
 
 * Fix some Clang warnings (GH-1777)
 
+* Fix some compilation warnings triggered when DUK_NORETURN is not defined;
+  the internal DUK_WO_NORETURN() is used to include unreachable dummy
+  statements when the noreturn attribute is not available, e.g.
+  DUK_WO_NORETURN(return 0;); (GH-1790)
+
 * Fix a few casts in duk_trans_socket_windows.c to avoid errors in a C++
   build (GH-1773)
 

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -34,6 +34,7 @@
  */
 #define DUK_CAUSE_SEGFAULT()  do { *((volatile duk_uint32_t *) NULL) = (duk_uint32_t) 0xdeadbeefUL; } while (0)
 #endif
+
 #if !defined(DUK_UNREF)
 /* Macro for suppressing warnings for potentially unreferenced variables.
  * The variables can be actually unreferenced or unreferenced in some
@@ -43,9 +44,24 @@
  */
 #define DUK_UNREF(x)  do { (void) (x); } while (0)
 #endif
-#if !defined(DUK_NORETURN)
+
+/* Fillin for DUK_NORETURN; DUK_WO_NORETURN() is used to insert dummy
+ * dummy statements after noreturn calls to silence harmless compiler
+ * warnings, e.g.:
+ *
+ *   DUK_ERROR_TYPE(thr, "aiee");
+ *   DUK_WO_NORETURN(return 0;);
+ *
+ * Statements inside DUK_WO_NORETURN() must NEVER be actually reachable,
+ * and they're only included to satisfy the compiler.
+ */
+#if defined(DUK_NORETURN)
+#define DUK_WO_NORETURN(stmt) do { } while (0)
+#else
 #define DUK_NORETURN(decl)  decl
+#define DUK_WO_NORETURN(stmt) do { stmt } while (0)
 #endif
+
 #if !defined(DUK_UNREACHABLE)
 /* Don't know how to declare unreachable point, so don't do it; this
  * may cause some spurious compilation warnings (e.g. "variable used
@@ -53,6 +69,7 @@
  */
 #define DUK_UNREACHABLE()  do { } while (0)
 #endif
+
 #if !defined(DUK_LOSE_CONST)
 /* Convert any input pointer into a "void *", losing a const qualifier.
  * This is not fully portable because casting through duk_uintptr_t may

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -94,6 +94,8 @@ Checklist for ordinary releases
 
   - Check ``make duk-clang``, covers ``-Wcast-align``
 
+  - Check compile warnings when DUK_NORETURN() is not defined
+
 * Test configure.py manually using metadata from the distributable
 
   - Ensure that Duktape compiles with e.g. ``-DDUK_USE_FASTINT`` configure

--- a/src-input/duk_api_buffer.c
+++ b/src-input/duk_api_buffer.c
@@ -14,9 +14,10 @@ DUK_EXTERNAL void *duk_resize_buffer(duk_hthread *thr, duk_idx_t idx, duk_size_t
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
 		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
-	/* maximum size check is handled by callee */
+	/* Maximum size check is handled by callee. */
 	duk_hbuffer_resize(thr, h, new_size);
 
 	return DUK_HBUFFER_DYNAMIC_GET_DATA_PTR(thr->heap, h);
@@ -34,6 +35,7 @@ DUK_EXTERNAL void *duk_steal_buffer(duk_hthread *thr, duk_idx_t idx, duk_size_t 
 
 	if (!(DUK_HBUFFER_HAS_DYNAMIC(h) && !DUK_HBUFFER_HAS_EXTERNAL(h))) {
 		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	/* Forget the previous allocation, setting size to 0 and alloc to
@@ -62,6 +64,7 @@ DUK_EXTERNAL void duk_config_buffer(duk_hthread *thr, duk_idx_t idx, void *ptr, 
 
 	if (!DUK_HBUFFER_HAS_EXTERNAL(h)) {
 		DUK_ERROR_TYPE(thr, DUK_STR_WRONG_BUFFER_TYPE);
+		DUK_WO_NORETURN(return;);
 	}
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(h));
 

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -748,6 +748,7 @@ DUK_EXTERNAL void duk_load_function(duk_hthread *thr) {
 
  format_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BYTECODE);
+	DUK_WO_NORETURN(return;);
 }
 
 #else  /* DUK_USE_BYTECODE_DUMP_SUPPORT */
@@ -755,11 +756,13 @@ DUK_EXTERNAL void duk_load_function(duk_hthread *thr) {
 DUK_EXTERNAL void duk_dump_function(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_load_function(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 #endif  /* DUK_USE_BYTECODE_DUMP_SUPPORT */

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -53,7 +53,7 @@ DUK_LOCAL duk_idx_t duk__call_get_idx_func(duk_hthread *thr, duk_idx_t nargs, du
 	idx_func = duk_get_top(thr) - nargs - other;
 	if (DUK_UNLIKELY((idx_func | nargs) < 0)) {  /* idx_func < 0 || nargs < 0; OR sign bits */
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		/* unreachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 	DUK_ASSERT(duk_is_valid_index(thr, idx_func));
 	return idx_func;
@@ -165,6 +165,7 @@ DUK_EXTERNAL void duk_call_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_idx_t n
 	obj_idx = duk_require_normalize_index(thr, obj_idx);  /* make absolute */
 	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	duk__call_prop_prep_stack(thr, obj_idx, nargs);
@@ -201,7 +202,7 @@ DUK_EXTERNAL duk_int_t duk_pcall(duk_hthread *thr, duk_idx_t nargs) {
 	args.nargs = nargs;
 	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
+		DUK_WO_NORETURN(return DUK_EXEC_ERROR;);
 	}
 	args.call_flags = 0;
 
@@ -236,7 +237,7 @@ DUK_INTERNAL duk_int_t duk_pcall_method_flags(duk_hthread *thr, duk_idx_t nargs,
 	args.nargs = nargs;
 	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
+		DUK_WO_NORETURN(return DUK_EXEC_ERROR;);
 	}
 	args.call_flags = call_flags;
 
@@ -277,7 +278,7 @@ DUK_EXTERNAL duk_int_t duk_pcall_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_i
 	args.nargs = nargs;
 	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
+		DUK_WO_NORETURN(return DUK_EXEC_ERROR;);
 	}
 	args.call_flags = 0;
 
@@ -313,7 +314,7 @@ DUK_EXTERNAL duk_int_t duk_safe_call(duk_hthread *thr, duk_safe_call_function fu
 		                  (long) (thr->valstack_top - thr->valstack),
 		                  (long) nrets));
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
+		DUK_WO_NORETURN(return DUK_EXEC_ERROR;);
 	}
 
 	rc = duk_handle_safe_call(thr,           /* thread */
@@ -361,7 +362,7 @@ DUK_EXTERNAL duk_int_t duk_pnew(duk_hthread *thr, duk_idx_t nargs) {
 
 	if (DUK_UNLIKELY(nargs < 0)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return DUK_EXEC_ERROR;  /* unreachable */
+		DUK_WO_NORETURN(return DUK_EXEC_ERROR;);
 	}
 
 	rc = duk_safe_call(thr, duk__pnew_helper, (void *) &nargs /*udata*/, nargs + 1 /*nargs*/, 1 /*nrets*/);
@@ -388,6 +389,7 @@ DUK_INTERNAL void duk_require_constructor_call(duk_hthread *thr) {
 
 	if (!duk_is_constructor_call(thr)) {
 		DUK_ERROR_TYPE(thr, DUK_STR_CONSTRUCT_ONLY);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -465,7 +467,7 @@ DUK_EXTERNAL duk_int_t duk_get_magic(duk_hthread *thr, duk_idx_t idx) {
 	/* fall through */
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_UNEXPECTED_TYPE);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_EXTERNAL void duk_set_magic(duk_hthread *thr, duk_idx_t idx, duk_int_t magic) {

--- a/src-input/duk_api_codec.c
+++ b/src-input/duk_api_codec.c
@@ -631,7 +631,7 @@ DUK_EXTERNAL const char *duk_base64_encode(duk_hthread *thr, duk_idx_t idx) {
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_BASE64_ENCODE_FAILED);
-	return NULL;  /* never here */
+	DUK_WO_NORETURN(return NULL;);
 }
 
 DUK_EXTERNAL void duk_base64_decode(duk_hthread *thr, duk_idx_t idx) {
@@ -668,16 +668,19 @@ DUK_EXTERNAL void duk_base64_decode(duk_hthread *thr, duk_idx_t idx) {
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_BASE64_DECODE_FAILED);
+	DUK_WO_NORETURN(return;);
 }
 #else  /* DUK_USE_BASE64_SUPPORT */
 DUK_EXTERNAL const char *duk_base64_encode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_base64_decode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_BASE64_SUPPORT */
 
@@ -823,15 +826,18 @@ DUK_EXTERNAL void duk_hex_decode(duk_hthread *thr, duk_idx_t idx) {
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_HEX_DECODE_FAILED);
+	DUK_WO_NORETURN(return;);
 }
 #else  /* DUK_USE_HEX_SUPPORT */
 DUK_EXTERNAL const char *duk_hex_encode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 DUK_EXTERNAL void duk_hex_decode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_HEX_SUPPORT */
 
@@ -890,11 +896,13 @@ DUK_EXTERNAL const char *duk_json_encode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return NULL;);
 }
 
 DUK_EXTERNAL void duk_json_decode(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_JSON_SUPPORT */

--- a/src-input/duk_api_compile.c
+++ b/src-input/duk_api_compile.c
@@ -89,6 +89,7 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_hthread *thr, void *udata) {
 		if ((flags & DUK_COMPILE_NOSOURCE) ||  /* args incorrect */
 		    (h_sourcecode == NULL)) {          /* e.g. duk_push_string_file_raw() pushed undefined */
 			DUK_ERROR_TYPE(thr, DUK_STR_NO_SOURCECODE);
+			DUK_WO_NORETURN(return 0;);
 		}
 		DUK_ASSERT(h_sourcecode != NULL);
 		comp_args->src_buffer = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_sourcecode);

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -42,6 +42,7 @@ DUK_EXTERNAL void duk_push_context_dump(duk_hthread *thr) {
 DUK_EXTERNAL void duk_push_context_dump(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_JSON_SUPPORT */
 
@@ -153,7 +154,7 @@ DUK_EXTERNAL duk_bool_t duk_debugger_notify(duk_hthread *thr, duk_idx_t nvalues)
 	top = duk_get_top(thr);
 	if (top < nvalues) {
 		DUK_ERROR_RANGE(thr, "not enough stack values for notify");
-		return ret;  /* unreachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 	if (duk_debug_is_attached(thr->heap)) {
 		duk_debug_write_notify(thr, DUK_DBG_CMD_APPNOTIFY);
@@ -220,11 +221,13 @@ DUK_EXTERNAL void duk_debugger_attach(duk_hthread *thr,
 	DUK_UNREF(detached_cb);
 	DUK_UNREF(udata);
 	DUK_ERROR_TYPE(thr, "no debugger support");
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_debugger_detach(duk_hthread *thr) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_ERROR_TYPE(thr, "no debugger support");
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_debugger_cooperate(duk_hthread *thr) {
@@ -241,7 +244,7 @@ DUK_EXTERNAL duk_bool_t duk_debugger_notify(duk_hthread *thr, duk_idx_t nvalues)
 	top = duk_get_top(thr);
 	if (top < nvalues) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
-		return 0;  /* unreachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* No debugger support, just pop values. */

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -511,11 +511,11 @@ DUK_EXTERNAL void duk_def_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_uint_t f
 
  fail_invalid_desc:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_DESCRIPTOR);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_not_callable:
 	DUK_ERROR_TYPE(thr, DUK_STR_NOT_CALLABLE);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -613,6 +613,7 @@ DUK_INTERNAL void duk_seal_freeze_raw(duk_hthread *thr, duk_idx_t obj_idx, duk_b
 
  fail_cannot_freeze:
 	DUK_ERROR_TYPE_INVALID_ARGS(thr);  /* XXX: proper error message */
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_seal(duk_hthread *thr, duk_idx_t obj_idx) {
@@ -764,7 +765,7 @@ DUK_EXTERNAL void duk_set_prototype(duk_hthread *thr, duk_idx_t idx) {
 #if defined(DUK_USE_ROM_OBJECTS)
 	if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) obj)) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);  /* XXX: "read only object"? */
-		return;
+		DUK_WO_NORETURN(return;);
 	}
 #endif
 
@@ -821,11 +822,13 @@ DUK_EXTERNAL void duk_get_finalizer(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_set_finalizer(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_UNREF(idx);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_FINALIZER_SUPPORT */

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1527,6 +1527,7 @@ DUK_EXTERNAL duk_bool_t duk_require_boolean(duk_hthread *thr, duk_idx_t idx) {
 		return ret;
 	} else {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "boolean", DUK_STR_NOT_BOOLEAN);
+		DUK_WO_NORETURN(return 0;);
 	}
 }
 
@@ -3237,12 +3238,14 @@ DUK_EXTERNAL const char *duk_to_string(duk_hthread *thr, duk_idx_t idx) {
 		DUK_ASSERT(h != NULL);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			DUK_ERROR_TYPE(thr, DUK_STR_CANNOT_STRING_COERCE_SYMBOL);
+			DUK_WO_NORETURN(goto skip_replace;);
 		} else {
 			goto skip_replace;
 		}
 #else
 		goto skip_replace;
 #endif
+		break;
 	}
 	case DUK_TAG_BUFFER: /* Go through Uint8Array.prototype.toString() for coercion. */
 	case DUK_TAG_OBJECT: {
@@ -5366,6 +5369,7 @@ DUK_EXTERNAL duk_idx_t duk_push_proxy(duk_hthread *thr, duk_uint_t proxy_flags) 
 
  fail_args:
 	DUK_ERROR_TYPE_INVALID_ARGS(thr);
+	DUK_WO_NORETURN(return 0;);
 }
 #else  /* DUK_USE_ES6_PROXY */
 DUK_EXTERNAL duk_idx_t duk_push_proxy(duk_hthread *thr, duk_uint_t proxy_flags) {

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -172,7 +172,7 @@ DUK_LOCAL duk_int_t duk__api_coerce_d2i(duk_hthread *thr, duk_idx_t idx, duk_int
 
 	if (require) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
-		/* not reachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	return def_value;
@@ -223,7 +223,7 @@ DUK_LOCAL duk_uint_t duk__api_coerce_d2ui(duk_hthread *thr, duk_idx_t idx, duk_u
 
 	if (require) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
-		/* not reachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	return def_value;
@@ -298,7 +298,7 @@ DUK_EXTERNAL duk_idx_t duk_require_normalize_index(duk_hthread *thr, duk_idx_t i
 		return (duk_idx_t) uidx;
 	}
 	DUK_ERROR_RANGE_INDEX(thr, idx);
-	return 0;  /* unreachable */
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_tval *duk_get_tval(duk_hthread *thr, duk_idx_t idx) {
@@ -374,7 +374,7 @@ DUK_INTERNAL duk_tval *duk_require_tval(duk_hthread *thr, duk_idx_t idx) {
 		return thr->valstack_bottom + uidx;
 	}
 	DUK_ERROR_RANGE_INDEX(thr, idx);
-	return NULL;
+	DUK_WO_NORETURN(return NULL;);
 }
 
 /* Non-critical. */
@@ -392,7 +392,7 @@ DUK_EXTERNAL void duk_require_valid_index(duk_hthread *thr, duk_idx_t idx) {
 
 	if (DUK_UNLIKELY(duk_normalize_index(thr, idx) < 0)) {
 		DUK_ERROR_RANGE_INDEX(thr, idx);
-		return;  /* unreachable */
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -417,6 +417,7 @@ DUK_INTERNAL duk_idx_t duk_get_top_require_min(duk_hthread *thr, duk_idx_t min_t
 	ret = (duk_idx_t) (thr->valstack_top - thr->valstack_bottom);
 	if (DUK_UNLIKELY(ret < min_top)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_WO_NORETURN(return 0;);
 	}
 	return ret;
 }
@@ -461,7 +462,7 @@ DUK_EXTERNAL void duk_set_top(duk_hthread *thr, duk_idx_t idx) {
 #else
 	if (DUK_UNLIKELY(uidx > vs_limit)) {
 		DUK_ERROR_RANGE_INDEX(thr, idx);
-		return;  /* unreachable */
+		DUK_WO_NORETURN(return;);
 	}
 #endif
 	DUK_ASSERT(uidx <= vs_limit);
@@ -644,7 +645,7 @@ DUK_EXTERNAL duk_idx_t duk_require_top_index(duk_hthread *thr) {
 	ret = (duk_idx_t) (thr->valstack_top - thr->valstack_bottom) - 1;
 	if (DUK_UNLIKELY(ret < 0)) {
 		DUK_ERROR_RANGE_INDEX(thr, -1);
-		return 0;  /* unreachable */
+		DUK_WO_NORETURN(return 0;);
 	}
 	return ret;
 }
@@ -845,6 +846,7 @@ DUK_LOCAL DUK_COLD DUK_NOINLINE duk_bool_t duk__valstack_grow(duk_hthread *thr, 
 		 */
 		if (throw_on_error) {
 			DUK_ERROR_RANGE(thr, DUK_STR_VALSTACK_LIMIT);
+			DUK_WO_NORETURN(return 0;);
 		}
 		return 0;
 	}
@@ -852,6 +854,7 @@ DUK_LOCAL DUK_COLD DUK_NOINLINE duk_bool_t duk__valstack_grow(duk_hthread *thr, 
 	if (duk__resize_valstack(thr, new_size) == 0) {
 		if (throw_on_error) {
 			DUK_ERROR_ALLOC_FAILED(thr);
+			DUK_WO_NORETURN(return 0;);
 		}
 		return 0;
 	}
@@ -1112,7 +1115,7 @@ DUK_EXTERNAL void duk_dup_top(duk_hthread *thr) {
 
 	if (DUK_UNLIKELY(thr->valstack_top - thr->valstack_bottom <= 0)) {
 		DUK_ERROR_RANGE_INDEX(thr, -1);
-		return;  /* unreachable */
+		DUK_WO_NORETURN(return;);
 	}
 	tv_from = thr->valstack_top - 1;
 	tv_to = thr->valstack_top++;
@@ -1369,14 +1372,14 @@ DUK_EXTERNAL void duk_xcopymove_raw(duk_hthread *to_thr, duk_hthread *from_thr, 
 
 	if (DUK_UNLIKELY(to_thr == from_thr)) {
 		DUK_ERROR_TYPE(to_thr, DUK_STR_INVALID_CONTEXT);
-		return;
+		DUK_WO_NORETURN(return;);
 	}
 	if (DUK_UNLIKELY((duk_uidx_t) count > (duk_uidx_t) DUK_USE_VALSTACK_LIMIT)) {
 		/* Maximum value check ensures 'nbytes' won't wrap below.
 		 * Also handles negative count.
 		 */
 		DUK_ERROR_RANGE_INVALID_COUNT(to_thr);
-		return;
+		DUK_WO_NORETURN(return;);
 	}
 	DUK_ASSERT(count >= 0);
 
@@ -1387,10 +1390,12 @@ DUK_EXTERNAL void duk_xcopymove_raw(duk_hthread *to_thr, duk_hthread *from_thr, 
 	DUK_ASSERT(to_thr->valstack_top <= to_thr->valstack_end);
 	if (DUK_UNLIKELY((duk_size_t) ((duk_uint8_t *) to_thr->valstack_end - (duk_uint8_t *) to_thr->valstack_top) < nbytes)) {
 		DUK_ERROR_RANGE_PUSH_BEYOND(to_thr);
+		DUK_WO_NORETURN(return;);
 	}
 	src = (void *) ((duk_uint8_t *) from_thr->valstack_top - nbytes);
 	if (DUK_UNLIKELY(src < (void *) from_thr->valstack_bottom)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(to_thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/* copy values (no overlap even if to_thr == from_thr; that's not
@@ -1467,6 +1472,7 @@ DUK_EXTERNAL void duk_require_undefined(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_UNDEFINED(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "undefined", DUK_STR_NOT_UNDEFINED);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -1479,6 +1485,7 @@ DUK_EXTERNAL void duk_require_null(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_NULL(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "null", DUK_STR_NOT_NULL);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -1589,6 +1596,7 @@ DUK_EXTERNAL duk_double_t duk_require_number(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_NUMBER(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "number", DUK_STR_NOT_NUMBER);
+		DUK_WO_NORETURN(return 0.0;);
 	}
 
 	ret.d = DUK_TVAL_GET_NUMBER(tv);
@@ -1820,6 +1828,7 @@ DUK_EXTERNAL void duk_require_object(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_OBJECT(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "object", DUK_STR_NOT_OBJECT);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -1871,6 +1880,7 @@ DUK_EXTERNAL void *duk_require_pointer(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_POINTER(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "pointer", DUK_STR_NOT_POINTER);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	p = DUK_TVAL_GET_POINTER(tv);  /* may be NULL */
 	return p;
@@ -1918,6 +1928,7 @@ DUK_LOCAL void *duk__get_buffer_helper(duk_hthread *thr, duk_idx_t idx, duk_size
 	} else {
 		if (throw_flag) {
 			DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "buffer", DUK_STR_NOT_BUFFER);
+			DUK_WO_NORETURN(return NULL;);
 		}
 		len = def_size;
 		ret = def_ptr;
@@ -2021,6 +2032,7 @@ DUK_INTERNAL void *duk_get_buffer_data_raw(duk_hthread *thr, duk_idx_t idx, duk_
 
 	if (throw_flag) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "buffer", DUK_STR_NOT_BUFFER);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return def_ptr;
 }
@@ -2100,6 +2112,7 @@ DUK_INTERNAL duk_hstring *duk_require_hstring(duk_hthread *thr, duk_idx_t idx) {
 	h = (duk_hstring *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_STRING);
 	if (DUK_UNLIKELY(h == NULL)) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "string", DUK_STR_NOT_STRING);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return h;
 }
@@ -2112,6 +2125,7 @@ DUK_INTERNAL duk_hstring *duk_require_hstring_notsymbol(duk_hthread *thr, duk_id
 	h = (duk_hstring *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_STRING);
 	if (DUK_UNLIKELY(h == NULL || DUK_HSTRING_HAS_SYMBOL(h))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "string", DUK_STR_NOT_STRING);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return h;
 }
@@ -2129,6 +2143,7 @@ DUK_INTERNAL duk_hobject *duk_require_hobject(duk_hthread *thr, duk_idx_t idx) {
 	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_OBJECT);
 	if (DUK_UNLIKELY(h == NULL)) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "object", DUK_STR_NOT_OBJECT);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return h;
 }
@@ -2146,6 +2161,7 @@ DUK_INTERNAL duk_hbuffer *duk_require_hbuffer(duk_hthread *thr, duk_idx_t idx) {
 	h = (duk_hbuffer *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_BUFFER);
 	if (DUK_UNLIKELY(h == NULL)) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "buffer", DUK_STR_NOT_BUFFER);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return h;
 }
@@ -2170,6 +2186,7 @@ DUK_INTERNAL duk_hthread *duk_require_hthread(duk_hthread *thr, duk_idx_t idx) {
 	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_OBJECT);
 	if (DUK_UNLIKELY(!(h != NULL && DUK_HOBJECT_IS_THREAD(h)))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "thread", DUK_STR_NOT_THREAD);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return (duk_hthread *) h;
 }
@@ -2194,6 +2211,7 @@ DUK_INTERNAL duk_hcompfunc *duk_require_hcompfunc(duk_hthread *thr, duk_idx_t id
 	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_OBJECT);
 	if (DUK_UNLIKELY(!(h != NULL && DUK_HOBJECT_IS_COMPFUNC(h)))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "compiledfunction", DUK_STR_NOT_COMPFUNC);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return (duk_hcompfunc *) h;
 }
@@ -2218,6 +2236,7 @@ DUK_INTERNAL duk_hnatfunc *duk_require_hnatfunc(duk_hthread *thr, duk_idx_t idx)
 	h = (duk_hobject *) duk__get_tagged_heaphdr_raw(thr, idx, DUK_TAG_OBJECT);
 	if (DUK_UNLIKELY(!(h != NULL && DUK_HOBJECT_IS_NATFUNC(h)))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "nativefunction", DUK_STR_NOT_NATFUNC);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return (duk_hnatfunc *) h;
 }
@@ -2276,6 +2295,7 @@ DUK_EXTERNAL duk_c_function duk_require_c_function(duk_hthread *thr, duk_idx_t i
 	ret = duk_get_c_function(thr, idx);
 	if (DUK_UNLIKELY(!ret)) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "nativefunction", DUK_STR_NOT_NATFUNC);
+		DUK_WO_NORETURN(return ret;);
 	}
 	return ret;
 }
@@ -2284,6 +2304,7 @@ DUK_EXTERNAL void duk_require_function(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 	if (DUK_UNLIKELY(!duk_is_function(thr, idx))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "function", DUK_STR_NOT_FUNCTION);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -2295,6 +2316,7 @@ DUK_INTERNAL void duk_require_constructable(duk_hthread *thr, duk_idx_t idx) {
 	h = duk_require_hobject_accept_mask(thr, idx, DUK_TYPE_MASK_LIGHTFUNC);
 	if (DUK_UNLIKELY(h != NULL && !DUK_HOBJECT_HAS_CONSTRUCTABLE(h))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "constructable", DUK_STR_NOT_CONSTRUCTABLE);
+		DUK_WO_NORETURN(return;);
 	}
 	/* Lightfuncs (h == NULL) are constructable. */
 }
@@ -2382,6 +2404,7 @@ DUK_EXTERNAL void *duk_require_heapptr(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT(tv != NULL);
 	if (DUK_UNLIKELY(!DUK_TVAL_IS_HEAP_ALLOCATED(tv))) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "heapobject", DUK_STR_UNEXPECTED_TYPE);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	ret = (void *) DUK_TVAL_GET_HEAPHDR(tv);
@@ -2415,6 +2438,7 @@ DUK_LOCAL duk_hobject *duk__get_hobject_promote_mask_raw(duk_hthread *thr, duk_i
 
 	if (type_mask & DUK_TYPE_MASK_THROW) {
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, "object", DUK_STR_NOT_OBJECT);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return NULL;
 }
@@ -2475,6 +2499,7 @@ DUK_INTERNAL duk_hobject *duk_require_hobject_with_class(duk_hthread *thr, duk_i
 		DUK_UNREF(h_class);
 
 		DUK_ERROR_REQUIRE_TYPE_INDEX(thr, idx, (const char *) DUK_HSTRING_GET_DATA(h_class), DUK_STR_UNEXPECTED_TYPE);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return h;
 }
@@ -2744,6 +2769,7 @@ DUK_EXTERNAL void duk_to_primitive(duk_hthread *thr, duk_idx_t idx, duk_int_t hi
 	}
 
 	DUK_ERROR_TYPE(thr, DUK_STR_TOPRIMITIVE_FAILED);
+	DUK_WO_NORETURN(return;);
 }
 
 /* E5 Section 9.2 */
@@ -3181,6 +3207,7 @@ DUK_INTERNAL duk_int_t duk_to_int_clamped_raw(duk_hthread *thr, duk_idx_t idx, d
 		/* coerced value is updated to value stack even when RangeError thrown */
 		if (clamped) {
 			DUK_ERROR_RANGE(thr, DUK_STR_NUMBER_OUTSIDE_RANGE);
+			DUK_WO_NORETURN(return 0;);
 		}
 	}
 
@@ -3519,6 +3546,7 @@ DUK_EXTERNAL void duk_to_object(duk_hthread *thr, duk_idx_t idx) {
 	case DUK_TAG_UNDEFINED:
 	case DUK_TAG_NULL: {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_OBJECT_COERCIBLE);
+		DUK_WO_NORETURN(return;);
 		break;
 	}
 	case DUK_TAG_BOOLEAN: {
@@ -3826,7 +3854,7 @@ DUK_EXTERNAL duk_bool_t duk_check_type_mask(duk_hthread *thr, duk_idx_t idx, duk
 	}
 	if (mask & DUK_TYPE_MASK_THROW) {
 		DUK_ERROR_TYPE(thr, DUK_STR_UNEXPECTED_TYPE);
-		DUK_UNREACHABLE();
+		DUK_WO_NORETURN(return 0;);
 	}
 	return 0;
 }
@@ -4314,6 +4342,7 @@ DUK_EXTERNAL const char *duk_push_lstring(duk_hthread *thr, const char *str, duk
 	/* Check for maximum string length */
 	if (DUK_UNLIKELY(len > DUK_HSTRING_MAX_BYTELEN)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_STRING_TOO_LONG);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	h = duk_heap_strtable_intern_checked(thr, (const duk_uint8_t *) str, (duk_uint32_t) len);
@@ -4390,6 +4419,7 @@ DUK_LOCAL void duk__push_this_helper(duk_hthread *thr, duk_small_uint_t check_ob
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_NOT_OBJECT_COERCIBLE);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_push_this(duk_hthread *thr) {
@@ -4493,7 +4523,7 @@ DUK_EXTERNAL void duk_push_thread_stash(duk_hthread *thr, duk_hthread *target_th
 	DUK_ASSERT_API_ENTRY(thr);
 	if (DUK_UNLIKELY(target_thr == NULL)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
-		return;  /* not reached */
+		DUK_WO_NORETURN(return;);
 	}
 	duk_push_hobject(thr, (duk_hobject *) target_thr);
 	duk__push_stash(thr);
@@ -4569,6 +4599,7 @@ DUK_EXTERNAL const char *duk_push_vsprintf(duk_hthread *thr, const char *fmt, va
 		sz = sz * 2;
 		if (DUK_UNLIKELY(sz >= DUK_PUSH_SPRINTF_SANITY_LIMIT)) {
 			DUK_ERROR_RANGE(thr, DUK_STR_RESULT_TOO_LONG);
+			DUK_WO_NORETURN(return NULL;);
 		}
 	}
 
@@ -4757,6 +4788,7 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_hthread *thr, duk_uint_t flags) {
 	/* important to do this *after* pushing, to make the thread reachable for gc */
 	if (DUK_UNLIKELY(!duk_hthread_init_stacks(thr->heap, obj))) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* initialize built-ins - either by copying or creating new ones */
@@ -4798,6 +4830,7 @@ DUK_INTERNAL duk_hcompfunc *duk_push_hcompfunc(duk_hthread *thr) {
 	                          DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION));
 	if (DUK_UNLIKELY(obj == NULL)) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("created compiled function object with flags: 0x%08lx", (unsigned long) obj->obj.hdr.h_flags));
@@ -4829,6 +4862,7 @@ DUK_INTERNAL duk_hboundfunc *duk_push_hboundfunc(duk_hthread *thr) {
 	                           DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_FUNCTION));
 	if (!obj) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	tv_slot = thr->valstack_top++;
@@ -4885,7 +4919,7 @@ DUK_LOCAL duk_idx_t duk__push_c_function_raw(duk_hthread *thr, duk_c_function fu
 
  api_error:
 	DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	return 0;  /* not reached */
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_EXTERNAL duk_idx_t duk_push_c_function(duk_hthread *thr, duk_c_function func, duk_int_t nargs) {
@@ -4977,7 +5011,7 @@ DUK_EXTERNAL duk_idx_t duk_push_c_lightfunc(duk_hthread *thr, duk_c_function fun
 
  api_error:
 	DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	return 0;  /* not reached */
+	DUK_WO_NORETURN(return 0;);
 }
 
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
@@ -5129,11 +5163,11 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_hthread *thr, duk_idx_t idx_buffer,
 
  range_error:
 	DUK_ERROR_RANGE(thr, DUK_STR_INVALID_ARGS);
-	return;  /* not reached */
+	DUK_WO_NORETURN(return;);
 
  arg_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_ARGS);
-	return;  /* not reached */
+	DUK_WO_NORETURN(return;);
 }
 #else  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 DUK_EXTERNAL void duk_push_buffer_object(duk_hthread *thr, duk_idx_t idx_buffer, duk_size_t byte_offset, duk_size_t byte_length, duk_uint_t flags) {
@@ -5143,6 +5177,7 @@ DUK_EXTERNAL void duk_push_buffer_object(duk_hthread *thr, duk_idx_t idx_buffer,
 	DUK_UNREF(byte_length);
 	DUK_UNREF(flags);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
@@ -5242,11 +5277,13 @@ DUK_EXTERNAL void *duk_push_buffer_raw(duk_hthread *thr, duk_size_t size, duk_sm
 	/* Check for maximum buffer length. */
 	if (DUK_UNLIKELY(size > DUK_HBUFFER_MAX_BYTELEN)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_BUFFER_TOO_LONG);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	h = duk_hbuffer_alloc(thr->heap, size, flags, &buf_data);
 	if (DUK_UNLIKELY(h == NULL)) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
 	tv_slot = thr->valstack_top;
@@ -5376,6 +5413,7 @@ DUK_EXTERNAL duk_idx_t duk_push_proxy(duk_hthread *thr, duk_uint_t proxy_flags) 
 	DUK_ASSERT_API_ENTRY(thr);
 	DUK_UNREF(proxy_flags);
 	DUK_ERROR_UNSUPPORTED(thr);
+	DUK_WO_NORETURN(return 0;);
 }
 #endif  /* DUK_USE_ES6_PROXY */
 
@@ -5673,7 +5711,7 @@ DUK_EXTERNAL void duk_pop_n(duk_hthread *thr, duk_idx_t count) {
 
 	if (DUK_UNLIKELY((duk_uidx_t) (thr->valstack_top - thr->valstack_bottom) < (duk_uidx_t) count)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
-		return;
+		DUK_WO_NORETURN(return;);
 	}
 	DUK_ASSERT(count >= 0);
 
@@ -5761,6 +5799,7 @@ DUK_EXTERNAL void duk_pop(duk_hthread *thr) {
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	if (DUK_UNLIKELY(thr->valstack_top == thr->valstack_bottom)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	duk__pop_unsafe_raw(thr);
@@ -5849,6 +5888,7 @@ DUK_EXTERNAL void duk_pop_2(duk_hthread *thr) {
 	DUK_ASSERT(thr->valstack_top >= thr->valstack_bottom);
 	if (DUK_UNLIKELY(thr->valstack_top - 2 < thr->valstack_bottom)) {
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	duk__pop_2_unsafe_raw(thr);
@@ -5906,7 +5946,7 @@ DUK_INTERNAL void duk_pack(duk_hthread *thr, duk_idx_t count) {
 	if (DUK_UNLIKELY((duk_uidx_t) count > (duk_uidx_t) top)) {
 		/* Also handles negative count. */
 		DUK_ERROR_RANGE_INVALID_COUNT(thr);
-		return;
+		DUK_WO_NORETURN(return;);
 	}
 	DUK_ASSERT(count >= 0);
 
@@ -6043,11 +6083,11 @@ DUK_INTERNAL duk_idx_t duk_unpack_array_like(duk_hthread *thr, duk_idx_t idx) {
 	}
 
 	DUK_ERROR_TYPE_INVALID_ARGS(thr);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 
  fail_over_2g:
 	DUK_ERROR_RANGE_INVALID_LENGTH(thr);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 /*
@@ -6064,6 +6104,7 @@ DUK_EXTERNAL void duk_throw_raw(duk_hthread *thr) {
 
 	if (DUK_UNLIKELY(thr->valstack_top == thr->valstack_bottom)) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/* Errors are augmented when they are created, not when they are
@@ -6127,6 +6168,7 @@ DUK_EXTERNAL void duk_error_va_raw(duk_hthread *thr, duk_errcode_t err_code, con
 
 	duk_push_error_object_va_raw(thr, err_code, filename, line, fmt, ap);
 	(void) duk_throw(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_error_raw(duk_hthread *thr, duk_errcode_t err_code, const char *filename, duk_int_t line, const char *fmt, ...) {
@@ -6138,6 +6180,7 @@ DUK_EXTERNAL void duk_error_raw(duk_hthread *thr, duk_errcode_t err_code, const 
 	duk_push_error_object_va_raw(thr, err_code, filename, line, fmt, ap);
 	va_end(ap);
 	(void) duk_throw(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 #if !defined(DUK_USE_VARIADIC_MACROS)
@@ -6156,6 +6199,7 @@ DUK_LOCAL void duk__throw_error_from_stash(duk_hthread *thr, duk_errcode_t err_c
 
 	duk_push_error_object_va_raw(thr, err_code, filename, line, fmt, ap);
 	(void) duk_throw(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 #define DUK__ERROR_STASH_SHARED(code) do { \
@@ -6163,7 +6207,7 @@ DUK_LOCAL void duk__throw_error_from_stash(duk_hthread *thr, duk_errcode_t err_c
 		va_start(ap, fmt); \
 		duk__throw_error_from_stash(thr, (code), fmt, ap); \
 		va_end(ap); \
-		/* Never reached; if return 0 here, gcc/clang will complain. */ \
+		DUK_WO_NORETURN(return 0;); \
 	} while (0)
 
 DUK_EXTERNAL duk_ret_t duk_error_stash(duk_hthread *thr, duk_errcode_t err_code, const char *fmt, ...) {

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -17,7 +17,7 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_hthread *thr, duk_idx_t count_in,
 	if (DUK_UNLIKELY(count_in <= 0)) {
 		if (count_in < 0) {
 			DUK_ERROR_RANGE_INVALID_COUNT(thr);
-			return;
+			DUK_WO_NORETURN(return;);
 		}
 		DUK_ASSERT(count_in == 0);
 		duk_push_hstring_empty(thr);
@@ -104,6 +104,7 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_hthread *thr, duk_idx_t count_in,
 
  error_overflow:
 	DUK_ERROR_RANGE(thr, DUK_STR_RESULT_TOO_LONG);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_EXTERNAL void duk_concat(duk_hthread *thr, duk_idx_t count) {
@@ -153,6 +154,7 @@ DUK_INTERNAL void duk_concat_2(duk_hthread *thr) {
 
  error_overflow:
 	DUK_ERROR_RANGE(thr, DUK_STR_RESULT_TOO_LONG);
+	DUK_WO_NORETURN(return;);
 }
 #endif  /* DUK_USE_PREFER_SIZE */
 

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -77,6 +77,7 @@ DUK_LOCAL duk_uint32_t duk__push_this_obj_len_u32_limited(duk_hthread *thr) {
 	duk_uint32_t ret = duk__push_this_obj_len_u32(thr);
 	if (DUK_UNLIKELY(ret >= 0x80000000UL)) {
 		DUK_ERROR_RANGE_INVALID_LENGTH(thr);
+		DUK_WO_NORETURN(return 0U;);
 	}
 	return ret;
 }

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -175,6 +175,7 @@ DUK_LOCAL duk_heaphdr *duk__getrequire_bufobj_this(duk_hthread *thr, duk_small_u
 
 	if (flags & DUK__BUFOBJ_FLAG_THROW) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_BUFFER);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return NULL;
 }
@@ -216,7 +217,7 @@ DUK_LOCAL duk_hbufobj *duk__require_bufobj_value(duk_hthread *thr, duk_idx_t idx
 	}
 
 	DUK_ERROR_TYPE(thr, DUK_STR_NOT_BUFFER);
-	return NULL;  /* not reachable */
+	DUK_WO_NORETURN(return NULL;);
 }
 
 DUK_LOCAL void duk__set_bufobj_buffer(duk_hthread *thr, duk_hbufobj *h_bufobj, duk_hbuffer *h_val) {
@@ -291,6 +292,7 @@ DUK_LOCAL void duk__resolve_offset_opt_length(duk_hthread *thr,
 
  fail_range:
 	DUK_ERROR_RANGE(thr, DUK_STR_INVALID_ARGS);
+	DUK_WO_NORETURN(return;);
 }
 
 /* Shared lenient buffer length clamping helper.  No negative indices, no
@@ -554,12 +556,14 @@ DUK_LOCAL duk_hbuffer *duk__hbufobj_fixed_from_argvalue(duk_hthread *thr) {
 			h_bufobj = (duk_hbufobj *) h;
 			if (DUK_UNLIKELY(h_bufobj->buf == NULL)) {
 				DUK_ERROR_TYPE_INVALID_ARGS(thr);
+				DUK_WO_NORETURN(return NULL;);
 			}
 			if (DUK_UNLIKELY(h_bufobj->offset != 0 || h_bufobj->length != DUK_HBUFFER_GET_SIZE(h_bufobj->buf))) {
 				/* No support for ArrayBuffers with slice
 				 * offset/length.
 				 */
 				DUK_ERROR_TYPE_INVALID_ARGS(thr);
+				DUK_WO_NORETURN(return NULL;);
 			}
 			duk_push_hbuffer(thr, h_bufobj->buf);
 			return h_bufobj->buf;
@@ -575,6 +579,7 @@ DUK_LOCAL duk_hbuffer *duk__hbufobj_fixed_from_argvalue(duk_hthread *thr) {
 	}
 	default:
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 
  done:

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -897,6 +897,7 @@ DUK_LOCAL duk_double_t duk__push_this_get_timeval_tzoffset(duk_hthread *thr, duk
 	h = duk_get_hobject(thr, -1);  /* XXX: getter with class check, useful in built-ins */
 	if (h == NULL || DUK_HOBJECT_GET_CLASS_NUMBER(h) != DUK_HOBJECT_CLASS_DATE) {
 		DUK_ERROR_TYPE(thr, "expected Date");
+		DUK_WO_NORETURN(return 0.0;);
 	}
 
 	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
@@ -909,6 +910,7 @@ DUK_LOCAL duk_double_t duk__push_this_get_timeval_tzoffset(duk_hthread *thr, duk
 		}
 		if (flags & DUK_DATE_FLAG_NAN_TO_RANGE_ERROR) {
 			DUK_ERROR_RANGE(thr, "Invalid Date");
+			DUK_WO_NORETURN(return 0.0;);
 		}
 	}
 	/* if no NaN handling flag, may still be NaN here, but not Inf */

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -254,6 +254,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_hthread *thr, duk__decode_context *de
 	 */
 	if (len >= (DUK_HBUFFER_MAX_BYTELEN / 3) - 3) {
 		DUK_ERROR_TYPE(thr, DUK_STR_RESULT_TOO_LONG);
+		DUK_WO_NORETURN(return 0;);
 	}
 	output = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, 3 + (3 * len));  /* used parts will be always manually written over */
 
@@ -331,7 +332,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_hthread *thr, duk__decode_context *de
 
  fail_type:
 	DUK_ERROR_TYPE(thr, DUK_STR_UTF8_DECODE_FAILED);
-	DUK_UNREACHABLE();
+	DUK_WO_NORETURN(return 0;);
 }
 
 /*
@@ -371,6 +372,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 		len = (duk_size_t) DUK_HSTRING_GET_CHARLEN(h_input);
 		if (len >= DUK_HBUFFER_MAX_BYTELEN / 3) {
 			DUK_ERROR_TYPE(thr, DUK_STR_RESULT_TOO_LONG);
+			DUK_WO_NORETURN(return 0;);
 		}
 	}
 

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -200,6 +200,7 @@ DUK_LOCAL void duk__transform_callback_encode_uri(duk__transform_context *tfm_ct
 
  uri_error:
 	DUK_ERROR_URI(tfm_ctx->thr, DUK_STR_INVALID_INPUT);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__transform_callback_decode_uri(duk__transform_context *tfm_ctx, const void *udata, duk_codepoint_t cp) {
@@ -338,6 +339,7 @@ DUK_LOCAL void duk__transform_callback_decode_uri(duk__transform_context *tfm_ct
 
  uri_error:
 	DUK_ERROR_URI(tfm_ctx->thr, DUK_STR_INVALID_INPUT);
+	DUK_WO_NORETURN(return;);
 }
 
 #if defined(DUK_USE_SECTION_B)
@@ -378,6 +380,7 @@ DUK_LOCAL void duk__transform_callback_escape(duk__transform_context *tfm_ctx, c
 
  esc_error:
 	DUK_ERROR_TYPE(tfm_ctx->thr, DUK_STR_INVALID_INPUT);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__transform_callback_unescape(duk__transform_context *tfm_ctx, const void *udata, duk_codepoint_t cp) {

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -214,6 +214,7 @@ DUK_LOCAL void duk__dec_syntax_error(duk_json_dec_ctx *js_ctx) {
 	 */
 	DUK_ERROR_FMT1(js_ctx->thr, DUK_ERR_SYNTAX_ERROR, DUK_STR_FMT_INVALID_JSON,
 	               (long) (js_ctx->p - js_ctx->p_start));
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__dec_eat_white(duk_json_dec_ctx *js_ctx) {
@@ -720,6 +721,7 @@ DUK_LOCAL void duk__dec_objarr_entry(duk_json_dec_ctx *js_ctx) {
 	DUK_ASSERT(js_ctx->recursion_depth <= js_ctx->recursion_limit);
 	if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
 		DUK_ERROR_RANGE(thr, DUK_STR_JSONDEC_RECLIMIT);
+		DUK_WO_NORETURN(return;);
 	}
 	js_ctx->recursion_depth++;
 }
@@ -1753,6 +1755,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 		if (DUK_UNLIKELY(js_ctx->visiting[i] == h_target)) {
 			DUK_DD(DUK_DDPRINT("slow path loop detect"));
 			DUK_ERROR_TYPE(thr, DUK_STR_CYCLIC_INPUT);
+			DUK_WO_NORETURN(return;);
 		}
 	}
 	if (js_ctx->recursion_depth < DUK_JSON_ENC_LOOPARRAY) {
@@ -1762,6 +1765,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 		duk_dup_top(thr);  /* -> [ ... voidp voidp ] */
 		if (duk_has_prop(thr, js_ctx->idx_loop)) {
 			DUK_ERROR_TYPE(thr, DUK_STR_CYCLIC_INPUT);
+			DUK_WO_NORETURN(return;);
 		}
 		duk_push_true(thr);  /* -> [ ... voidp true ] */
 		duk_put_prop(thr, js_ctx->idx_loop);  /* -> [ ... ] */
@@ -1773,6 +1777,7 @@ DUK_LOCAL void duk__enc_objarr_entry(duk_json_enc_ctx *js_ctx, duk_idx_t *entry_
 	DUK_ASSERT(js_ctx->recursion_depth <= js_ctx->recursion_limit);
 	if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
 		DUK_ERROR_RANGE(thr, DUK_STR_JSONENC_RECLIMIT);
+		DUK_WO_NORETURN(return;);
 	}
 	js_ctx->recursion_depth++;
 
@@ -2370,12 +2375,14 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		if (js_ctx->recursion_depth >= js_ctx->recursion_limit) {
 			DUK_DD(DUK_DDPRINT("fast path recursion limit"));
 			DUK_ERROR_RANGE(js_ctx->thr, DUK_STR_JSONDEC_RECLIMIT);
+			DUK_WO_NORETURN(return 0;);
 		}
 
 		for (i = 0, n = (duk_uint_fast32_t) js_ctx->recursion_depth; i < n; i++) {
 			if (DUK_UNLIKELY(js_ctx->visiting[i] == obj)) {
 				DUK_DD(DUK_DDPRINT("fast path loop detect"));
 				DUK_ERROR_TYPE(js_ctx->thr, DUK_STR_CYCLIC_INPUT);
+				DUK_WO_NORETURN(return 0;);
 			}
 		}
 
@@ -2756,7 +2763,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 	/* Error message doesn't matter: the error is ignored anyway. */
 	DUK_DD(DUK_DDPRINT("aborting fast path"));
 	DUK_ERROR_INTERNAL(js_ctx->thr);
-	return 0;  /* unreachable */
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_LOCAL duk_ret_t duk__json_stringify_fast(duk_hthread *thr, void *udata) {

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -23,6 +23,7 @@ DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_hthread *thr) {
 	    (DUK_HOBJECT_GET_CLASS_NUMBER(h) != DUK_HOBJECT_CLASS_NUMBER)) {
 		DUK_DDD(DUK_DDDPRINT("unacceptable this value: %!T", (duk_tval *) duk_get_tval(thr, -1)));
 		DUK_ERROR_TYPE(thr, "number expected");
+		DUK_WO_NORETURN(return 0.0;);
 	}
 	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 	DUK_ASSERT(duk_is_number(thr, -1));

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -795,6 +795,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_lookupaccessor(duk_hthread *thr) 
 
 		if (DUK_UNLIKELY(sanity-- == 0)) {
 			DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_WO_NORETURN(return 0;);
 		}
 
 		duk_get_prototype(thr, -1);

--- a/src-input/duk_bi_promise.c
+++ b/src-input/duk_bi_promise.c
@@ -8,37 +8,37 @@
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_constructor(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_all(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_race(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_reject(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_resolve(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_catch(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_promise_then(duk_hthread *thr) {
 	DUK_ERROR_TYPE(thr, "unimplemented");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 #endif  /* DUK_USE_PROMISE_BUILTIN */

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -28,6 +28,7 @@ DUK_INTERNAL void duk_proxy_ownkeys_postprocess(duk_hthread *thr, duk_hobject *h
 		h = duk_get_hstring(thr, -1);
 		if (h == NULL) {
 			DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr);
+			DUK_WO_NORETURN(return;);
 		}
 
 		if (!(flags & DUK_ENUM_INCLUDE_NONENUMERABLE)) {

--- a/src-input/duk_bi_reflect.c
+++ b/src-input/duk_bi_reflect.c
@@ -40,6 +40,7 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_get(duk_hthread *thr) {
 	if (nargs >= 3 && !duk_strict_equals(thr, 0, 2)) {
 		/* XXX: [[Get]] receiver currently unsupported */
 		DUK_ERROR_UNSUPPORTED(thr);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* [ target key receiver? ...? ] */
@@ -83,6 +84,7 @@ DUK_INTERNAL duk_ret_t duk_bi_reflect_object_set(duk_hthread *thr) {
 	if (nargs >= 4 && !duk_strict_equals(thr, 0, 3)) {
 		/* XXX: [[Set]] receiver currently unsupported */
 		DUK_ERROR_UNSUPPORTED(thr);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* [ target key value receiver? ...? ] */

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -28,6 +28,7 @@ DUK_LOCAL duk_hstring *duk__str_tostring_notregexp(duk_hthread *thr, duk_idx_t i
 
 	if (duk_get_class_number(thr, idx) == DUK_HOBJECT_CLASS_REGEXP) {
 		DUK_ERROR_TYPE_INVALID_ARGS(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	h = duk_to_hstring(thr, idx);
 	DUK_ASSERT(h != NULL);

--- a/src-input/duk_error_longjmp.c
+++ b/src-input/duk_error_longjmp.c
@@ -9,6 +9,7 @@
 DUK_NORETURN(DUK_LOCAL_DECL void duk__uncaught_minimal(duk_hthread *thr));
 DUK_LOCAL void duk__uncaught_minimal(duk_hthread *thr) {
 	(void) duk_fatal(thr, "uncaught error");
+	DUK_WO_NORETURN(return;);
 }
 #endif
 
@@ -22,6 +23,7 @@ DUK_LOCAL void duk__uncaught_readable(duk_hthread *thr) {
 	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
 	buf[sizeof(buf) - 1] = (char) 0;
 	(void) duk_fatal(thr, (const char *) buf);
+	DUK_WO_NORETURN(return;);
 }
 #endif
 
@@ -36,6 +38,7 @@ DUK_LOCAL void duk__uncaught_error_aware(duk_hthread *thr) {
 	DUK_SNPRINTF(buf, sizeof(buf), "uncaught: %s", summary);
 	buf[sizeof(buf) - 1] = (char) 0;
 	(void) duk_fatal(thr, (const char *) buf);
+	DUK_WO_NORETURN(return;);
 }
 #endif
 

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -158,5 +158,5 @@ DUK_INTERNAL void duk_error_throw_from_negative_rc(duk_hthread *thr, duk_ret_t r
 	 */
 
 	duk_error_raw(thr, -rc, NULL, 0, "error (rc %ld)", (long) rc);
-	DUK_UNREACHABLE();
+	DUK_WO_NORETURN(return;);
 }

--- a/src-input/duk_hbuffer_ops.c
+++ b/src-input/duk_hbuffer_ops.c
@@ -24,6 +24,7 @@ DUK_INTERNAL void duk_hbuffer_resize(duk_hthread *thr, duk_hbuffer_dynamic *buf,
 
 	if (new_size > DUK_HBUFFER_MAX_BYTELEN) {
 		DUK_ERROR_RANGE(thr, "buffer too long");
+		DUK_WO_NORETURN(return;);
 	}
 
 	/*
@@ -61,6 +62,7 @@ DUK_INTERNAL void duk_hbuffer_resize(duk_hthread *thr, duk_hbuffer_dynamic *buf,
 		DUK_HBUFFER_DYNAMIC_SET_DATA_PTR(thr->heap, buf, res);
 	} else {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	DUK_ASSERT(res != NULL || new_size == 0);

--- a/src-input/duk_heap_memory.c
+++ b/src-input/duk_heap_memory.c
@@ -142,7 +142,7 @@ DUK_INTERNAL void *duk_heap_mem_alloc_checked(duk_hthread *thr, duk_size_t size)
 		return res;
 	}
 	DUK_ERROR_ALLOC_FAILED(thr);
-	return NULL;
+	DUK_WO_NORETURN(return NULL;);
 }
 
 DUK_INTERNAL void *duk_heap_mem_alloc_checked_zeroed(duk_hthread *thr, duk_size_t size) {
@@ -154,7 +154,7 @@ DUK_INTERNAL void *duk_heap_mem_alloc_checked_zeroed(duk_hthread *thr, duk_size_
 		return res;
 	}
 	DUK_ERROR_ALLOC_FAILED(thr);
-	return NULL;
+	DUK_WO_NORETURN(return NULL;);
 }
 
 /*

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -305,5 +305,5 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 
  scan_error:
 	DUK_ERROR_INTERNAL(thr);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -801,6 +801,7 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern_checked(duk_hthread *thr, con
 	res = duk_heap_strtable_intern(thr->heap, str, blen);
 	if (DUK_UNLIKELY(res == NULL)) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return res;
 }
@@ -814,6 +815,7 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern_u32_checked(duk_hthread *thr,
 	res = duk_heap_strtable_intern_u32(thr->heap, val);
 	if (DUK_UNLIKELY(res == NULL)) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return res;
 }

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -214,6 +214,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc(duk_hthread *thr, duk_uint_t hobject
 	res = duk_hthread_alloc_unchecked(thr->heap, hobject_flags);
 	if (res == NULL) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	return res;
 }

--- a/src-input/duk_hobject_misc.c
+++ b/src-input/duk_hobject_misc.c
@@ -27,6 +27,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_prototype_chain_contains(duk_hthread *thr, d
 				break;
 			} else {
 				DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+				DUK_WO_NORETURN(return 0;);
 			}
 		}
 		h = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, h);

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -603,6 +603,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 
 	if (new_e_size_adjusted + new_a_size > DUK_HOBJECT_MAX_PROPERTIES) {
 		DUK_ERROR_ALLOC_FAILED(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/*
@@ -952,6 +953,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 #endif
 
 	DUK_ERROR_ALLOC_FAILED(thr);
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -2049,6 +2051,7 @@ DUK_LOCAL duk_bool_t duk__get_propdesc(duk_hthread *thr, duk_hobject *obj, duk_h
 				break;
 			} else {
 				DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+				DUK_WO_NORETURN(return 0;);
 			}
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
@@ -2384,7 +2387,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot read property %s of %s",
 		               duk_push_string_tval_readable(thr, tv_key), duk_push_string_tval_readable(thr, tv_obj));
 #endif
-		return 0;
+		DUK_WO_NORETURN(return 0;);
+		break;
 	}
 
 	case DUK_TAG_BOOLEAN: {
@@ -2540,6 +2544,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 					                 !DUK_TVAL_IS_UNDEFINED(tv_hook);
 					if (datadesc_reject || accdesc_reject) {
 						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+						DUK_WO_NORETURN(return 0;);
 					}
 
 					duk_pop_2_unsafe(thr);
@@ -2731,6 +2736,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 		 */
 		if (DUK_UNLIKELY(sanity-- == 0)) {
 			DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_WO_NORETURN(return 0;);
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
 	} while (curr != NULL);
@@ -2801,6 +2807,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			    DUK_HOBJECT_HAS_STRICT(h)) {
 				/* XXX: sufficient to check 'strict', assert for 'is function' */
 				DUK_ERROR_TYPE(thr, DUK_STR_STRICT_CALLER_READ);
+				DUK_WO_NORETURN(return 0;);
 			}
 		}
 	}
@@ -2923,6 +2930,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 					if (!((desc.flags & DUK_PROPDESC_FLAG_CONFIGURABLE) &&  /* property is configurable and */
 					      DUK_HOBJECT_HAS_EXTENSIBLE(h_target))) {          /* ... target is extensible */
 						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+						DUK_WO_NORETURN(return 0;);
 					}
 				}
 			}
@@ -3028,7 +3036,7 @@ DUK_LOCAL duk_uint32_t duk__to_new_array_length_checked(duk_hthread *thr, duk_tv
 
  fail_range:
 	DUK_ERROR_RANGE(thr, DUK_STR_INVALID_ARRAY_LENGTH);
-	return 0;  /* unreachable */
+	DUK_WO_NORETURN(return 0;);
 }
 
 /* Delete elements required by a smaller length, taking into account
@@ -3386,7 +3394,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
 		               duk_push_string_tval_readable(thr, tv_key), duk_push_string_tval_readable(thr, tv_obj));
 #endif
-		return 0;
+		DUK_WO_NORETURN(return 0;);
+		break;
 	}
 
 	case DUK_TAG_BOOLEAN: {
@@ -3523,6 +3532,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 					                 (desc.set == NULL);
 					if (datadesc_reject || accdesc_reject) {
 						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+						DUK_WO_NORETURN(return 0;);
 					}
 
 					duk_pop_2_unsafe(thr);
@@ -3822,6 +3832,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		 */
 		if (DUK_UNLIKELY(sanity-- == 0)) {
 			DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_WO_NORETURN(return 0;);
 		}
 		curr = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, curr);
 	} while (curr != NULL);
@@ -4171,6 +4182,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, proxy rejects"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+		DUK_WO_NORETURN(return 0;);
 	}
 	/* Note: no key on stack */
 	return 0;
@@ -4185,6 +4197,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 		DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot write property %s of %s",
 		               duk_push_string_tval_readable(thr, tv_key), duk_push_string_tval_readable(thr, tv_obj));
 #endif
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4193,6 +4206,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, not extensible"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_EXTENSIBLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4201,6 +4215,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, not writable"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4210,6 +4225,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, not writable"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_WRITABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	return 0;
 #endif
@@ -4218,6 +4234,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DD(DUK_DDPRINT("result: error, array length write only partially successful"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4226,6 +4243,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, accessor property without setter"));
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_SETTER_UNDEFINED);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4234,6 +4252,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_DDD(DUK_DDDPRINT("result: error, internal"));
 	if (throw_flag) {
 		DUK_ERROR_INTERNAL(thr);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_pop_unsafe(thr);  /* remove key */
 	return 0;
@@ -4394,6 +4413,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	return 0;
 }
@@ -4480,6 +4500,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 					if (desc_reject) {
 						/* unconditional */
 						DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+						DUK_WO_NORETURN(return 0;);
 					}
 				}
 				rc = 1;  /* success */
@@ -4563,12 +4584,13 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_ERROR_FMT2(thr, DUK_ERR_TYPE_ERROR, "cannot delete property %s of %s",
 	               duk_push_string_tval_readable(thr, tv_key), duk_push_string_tval_readable(thr, tv_obj));
 #endif
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 
 #if defined(DUK_USE_ES6_PROXY)
  fail_proxy_rejected:
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_set_top_unsafe(thr, entry_top);
 	return 0;
@@ -4577,6 +4599,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
  fail_not_configurable:
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	duk_set_top_unsafe(thr, entry_top);
 	return 0;
@@ -4716,7 +4739,7 @@ DUK_INTERNAL void duk_hobject_define_property_internal(duk_hthread *thr, duk_hob
  error_virtual:  /* share error message */
  error_internal:
 	DUK_ERROR_INTERNAL(thr);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -5038,6 +5061,7 @@ void duk_hobject_prepare_property_descriptor(duk_hthread *thr,
 
  type_error:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_DESCRIPTOR);
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -5919,6 +5943,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_hthread *thr,
  fail_not_extensible:
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_EXTENSIBLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	return 0;
 
@@ -5926,6 +5951,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_hthread *thr,
  fail_not_configurable:
 	if (throw_flag) {
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
+		DUK_WO_NORETURN(return 0;);
 	}
 	return 0;
 }
@@ -5981,6 +6007,7 @@ DUK_INTERNAL void duk_hobject_object_seal_freeze_helper(duk_hthread *thr, duk_ho
 	if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) obj)) {
 		DUK_DD(DUK_DDPRINT("attempt to seal/freeze a readonly object, reject"));
 		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);
+		DUK_WO_NORETURN(return;);
 	}
 #endif
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -2879,6 +2879,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_hasprop(duk_hthread *thr, duk_tval *tv_obj, 
 		/* Note: unconditional throw */
 		DUK_DDD(DUK_DDDPRINT("base object is not an object -> reject"));
 		DUK_ERROR_TYPE(thr, DUK_STR_INVALID_BASE);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* XXX: fast path for arrays? */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -409,6 +409,7 @@ DUK_LOCAL void duk__comp_recursion_increase(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(comp_ctx->recursion_depth >= 0);
 	if (comp_ctx->recursion_depth >= comp_ctx->recursion_limit) {
 		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_COMPILER_RECURSION_LIMIT);
+		DUK_WO_NORETURN(return;);
 	}
 	comp_ctx->recursion_depth++;
 }
@@ -472,6 +473,7 @@ DUK_LOCAL void duk__advance_helper(duk_compiler_ctx *comp_ctx, duk_small_int_t e
 		DUK_D(DUK_DPRINT("parse error: expect=%ld, got=%ld",
 		                 (long) expect, (long) comp_ctx->curr_token.t));
 		DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/* make current token the previous; need to fiddle with valstack "backing store" */
@@ -1174,6 +1176,7 @@ DUK_LOCAL void duk__emit(duk_compiler_ctx *comp_ctx, duk_instr_t ins) {
 
   fail_bc_limit:
 	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_BYTECODE_LIMIT);
+	DUK_WO_NORETURN(return;);
 }
 
 /* Update function min/max line from current token.  Needed to improve
@@ -1458,6 +1461,7 @@ DUK_LOCAL void duk__emit_a_b_c(duk_compiler_ctx *comp_ctx, duk_small_uint_t op_f
 
  error_outofregs:
 	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
+	DUK_WO_NORETURN(return;);
 }
 
 /* For many of the helpers below it'd be technically correct to add
@@ -1556,6 +1560,7 @@ DUK_LOCAL void duk__emit_a_bc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op_fl
 
  error_outofregs:
 	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__emit_bc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op, duk_regconst_t bc) {
@@ -1590,6 +1595,7 @@ DUK_LOCAL void duk__emit_abc(duk_compiler_ctx *comp_ctx, duk_small_uint_t op, du
 
  error_outofregs:
 	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__emit_load_int32_raw(duk_compiler_ctx *comp_ctx, duk_regconst_t reg, duk_int32_t val, duk_small_uint_t op_flags) {
@@ -1687,6 +1693,7 @@ DUK_LOCAL void duk__insert_jump_entry(duk_compiler_ctx *comp_ctx, duk_int_t jump
 
   fail_bc_limit:
 	DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_BYTECODE_LIMIT);
+	DUK_WO_NORETURN(return;);
 }
 
 /* Does not assume that jump_pc contains a DUK_OP_JUMP previously; this is intentional
@@ -1742,6 +1749,7 @@ DUK_LOCAL void duk__patch_trycatch(duk_compiler_ctx *comp_ctx, duk_int_t ldconst
 			DUK_D(DUK_DPRINT("failed to patch trycatch: flags=%ld, reg_catch=%ld, const_varname=%ld (0x%08lx)",
 			                 (long) flags, (long) reg_catch, (long) const_varname, (long) const_varname));
 			DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_REG_LIMIT);
+			DUK_WO_NORETURN(return;);
 		}
 		instr->ins |= DUK_ENC_OP_A_BC(0, 0, const_varname);
 	} else {
@@ -1933,6 +1941,7 @@ DUK_LOCAL duk_regconst_t duk__alloctemps(duk_compiler_ctx *comp_ctx, duk_small_i
 
 	if (comp_ctx->curr_func.temp_next > DUK__MAX_TEMPS) {  /* == DUK__MAX_TEMPS is OK */
 		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_TEMP_LIMIT);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* maintain highest 'used' temporary, needed to figure out nregs of function */
@@ -1992,6 +2001,7 @@ DUK_LOCAL duk_regconst_t duk__getconst(duk_compiler_ctx *comp_ctx) {
 
 	if (n > DUK__MAX_CONSTS) {
 		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_CONST_LIMIT);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("allocating new constant for %!T -> const index %ld",
@@ -2204,7 +2214,7 @@ duk_regconst_t duk__ispec_toregconst_raw(duk_compiler_ctx *comp_ctx,
 
  fail_internal:
 	DUK_ERROR_INTERNAL(thr);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_LOCAL void duk__ispec_toforcedreg(duk_compiler_ctx *comp_ctx, duk_ispec *x, duk_regconst_t forced_reg) {
@@ -2402,7 +2412,7 @@ DUK_LOCAL void duk__ivalue_toplain_raw(duk_compiler_ctx *comp_ctx, duk_ivalue *x
 	}
 
 	DUK_ERROR_INTERNAL(thr);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /* evaluate to plain value, no forced register (temp/bound reg both ok) */
@@ -2634,6 +2644,7 @@ DUK_LOCAL void duk__add_label(duk_compiler_ctx *comp_ctx, duk_hstring *h_label, 
 
 		if (li->h_label == h_label && h_label != DUK_HTHREAD_STRING_EMPTY_STRING(thr)) {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_DUPLICATE_LABEL);
+			DUK_WO_NORETURN(return;);
 		}
 	}
 
@@ -2763,6 +2774,7 @@ DUK_LOCAL void duk__lookup_active_label(duk_compiler_ctx *comp_ctx, duk_hstring 
 			 */
 			if (h_label != DUK_HTHREAD_STRING_EMPTY_STRING(thr)) {
 				DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LABEL);
+				DUK_WO_NORETURN(return;);
 			} else {
 				DUK_DDD(DUK_DDDPRINT("continue matched an empty label which does not "
 				                     "allow a continue -> continue lookup deeper in label stack"));
@@ -2772,6 +2784,7 @@ DUK_LOCAL void duk__lookup_active_label(duk_compiler_ctx *comp_ctx, duk_hstring 
 	/* XXX: match flag is awkward, rework */
 	if (!match) {
 		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LABEL);
+		DUK_WO_NORETURN(return;);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("label match: %!O -> label_id %ld, catch_depth=%ld, pc_label=%ld",
@@ -2961,6 +2974,7 @@ DUK_LOCAL void duk__nud_array_literal(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_ARRAY_LITERAL);
+	DUK_WO_NORETURN(return;);
 }
 
 typedef struct {
@@ -3244,6 +3258,7 @@ DUK_LOCAL void duk__nud_object_literal(duk_compiler_ctx *comp_ctx, duk_ivalue *r
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_OBJECT_LITERAL);
+	DUK_WO_NORETURN(return;);
 }
 
 /* Parse argument list.  Arguments are written to temps starting from
@@ -3555,6 +3570,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 
 			if (comp_ctx->curr_func.is_strict) {
 				DUK_ERROR_SYNTAX(thr, DUK_STR_CANNOT_DELETE_IDENTIFIER);
+				DUK_WO_NORETURN(return;);
 			}
 
 			DUK__SETTEMP(comp_ctx, temp_at_entry);
@@ -3719,7 +3735,7 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 	}  /* end switch */
 
 	DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
-	return;
+	DUK_WO_NORETURN(return;);
 
  unary:
 	{
@@ -3823,10 +3839,12 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 #if defined(DUK_USE_ES6)
  syntax_error_newtarget:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_NEWTARGET);
+	DUK_WO_NORETURN(return;);
 #endif
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_EXPRESSION);
+	DUK_WO_NORETURN(return;);
 }
 
 /* XXX: add flag to indicate whether caller cares about return value; this
@@ -3881,6 +3899,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 		/* NB: must accept reserved words as property name */
 		if (comp_ctx->curr_token.t_nores != DUK_TOK_IDENTIFIER) {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_EXPECTED_IDENTIFIER);
+			DUK_WO_NORETURN(return;);
 		}
 
 		res->t = DUK_IVAL_PROP;
@@ -4310,7 +4329,7 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
 	DUK_D(DUK_DPRINT("parse error: unexpected token: %ld", (long) tok));
 	DUK_ERROR_SYNTAX(thr, DUK_STR_PARSE_ERROR);
-	return;
+	DUK_WO_NORETURN(return;);
 
 #if 0
 	/* XXX: shared handling for 'duk__expr_lhs'? */
@@ -4800,11 +4819,11 @@ DUK_LOCAL void duk__expr_led(duk_compiler_ctx *comp_ctx, duk_ivalue *left, duk_i
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_EXPRESSION);
-	return;
+	DUK_WO_NORETURN(return;);
 
  syntax_error_lvalue:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_LVALUE);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL duk_small_uint_t duk__expr_lbp(duk_compiler_ctx *comp_ctx) {
@@ -4889,6 +4908,7 @@ DUK_LOCAL void duk__expr(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_small_
 		DUK_DDD(DUK_DDDPRINT("empty expression"));
 		if (!(rbp_flags & DUK__EXPR_FLAG_ALLOW_EMPTY)) {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
+			DUK_WO_NORETURN(return;);
 		}
 		duk_push_undefined(thr);
 		duk__ivalue_plain_fromstack(comp_ctx, res);
@@ -4927,6 +4947,7 @@ DUK_LOCAL void duk__exprtop(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_sma
 
 	if (!(rbp_flags & DUK__EXPR_FLAG_ALLOW_EMPTY) && duk__expr_is_empty(comp_ctx)) {
 		DUK_ERROR_SYNTAX(thr, DUK_STR_EMPTY_EXPR_NOT_ALLOWED);
+		DUK_WO_NORETURN(return;);
 	}
 }
 
@@ -5119,6 +5140,7 @@ DUK_LOCAL void duk__parse_var_decl(duk_compiler_ctx *comp_ctx, duk_ivalue *res, 
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_VAR_DECLARATION);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__parse_var_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_small_uint_t expr_flags) {
@@ -5492,6 +5514,7 @@ DUK_LOCAL void duk__parse_for_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, 
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_FOR);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__parse_switch_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_int_t pc_label_site) {
@@ -5692,6 +5715,7 @@ DUK_LOCAL void duk__parse_switch_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_SWITCH);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__parse_if_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
@@ -5829,6 +5853,7 @@ DUK_LOCAL void duk__parse_break_or_continue_stmt(duk_compiler_ctx *comp_ctx, duk
 		duk__advance(comp_ctx);
 	} else {
 		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_BREAK_CONT_LABEL);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/* Use a fast break/continue when possible.  A fast break/continue is
@@ -5870,6 +5895,7 @@ DUK_LOCAL void duk__parse_return_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *re
 	 */
 	if (!comp_ctx->curr_func.is_function) {
 		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_RETURN);
+		DUK_WO_NORETURN(return;);
 	}
 
 	if (comp_ctx->curr_token.t == DUK_TOK_SEMICOLON ||  /* explicit semi follows */
@@ -5971,6 +5997,7 @@ DUK_LOCAL void duk__parse_throw_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res
 
 	if (comp_ctx->curr_token.lineterm) {
 		DUK_ERROR_SYNTAX(comp_ctx->thr, DUK_STR_INVALID_THROW);
+		DUK_WO_NORETURN(return;);
 	}
 
 	reg_val = duk__exprtop_toreg(comp_ctx, res, DUK__BP_FOR_EXPR /*rbp_flags*/);
@@ -6210,6 +6237,7 @@ DUK_LOCAL void duk__parse_try_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) 
 
  syntax_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_TRY);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__parse_with_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
@@ -6220,6 +6248,7 @@ DUK_LOCAL void duk__parse_with_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res)
 
 	if (comp_ctx->curr_func.is_strict) {
 		DUK_ERROR_SYNTAX(comp_ctx->thr, DUK_STR_WITH_IN_STRICT_MODE);
+		DUK_WO_NORETURN(return;);
 	}
 
 	comp_ctx->curr_func.catch_depth++;
@@ -6410,6 +6439,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 			break;
 		} else {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_FUNC_STMT_NOT_ALLOWED);
+			DUK_WO_NORETURN(return;);
 		}
 		break;
 	}
@@ -6747,6 +6777,7 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 				                     "even though no lineterm present before next token)"));
 			} else {
 				DUK_ERROR_SYNTAX(thr, DUK_STR_UNTERMINATED_STMT);
+				DUK_WO_NORETURN(return;);
 			}
 		}
 	} else {
@@ -7175,13 +7206,11 @@ DUK_LOCAL void duk__init_varmap_and_prologue_for_pass2(duk_compiler_ctx *comp_ct
 
  error_outofregs:
 	DUK_ERROR_RANGE(thr, DUK_STR_REG_LIMIT);
-	DUK_UNREACHABLE();
-	return;
+	DUK_WO_NORETURN(return;);
 
  error_argname:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_ARG_NAME);
-	DUK_UNREACHABLE();
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -7433,6 +7462,7 @@ DUK_LOCAL void duk__parse_func_body(duk_compiler_ctx *comp_ctx, duk_bool_t expec
 			/* Should never happen but avoid infinite loop just in case. */
 			DUK_D(DUK_DPRINT("more than 3 compile passes needed, should never happen"));
 			DUK_ERROR_INTERNAL(thr);
+			DUK_WO_NORETURN(return;);
 		}
 		DUK_D(DUK_DPRINT("need additional round to compile function, round now %d", (int) compile_round));
 	}
@@ -7476,6 +7506,7 @@ DUK_LOCAL void duk__parse_func_body(duk_compiler_ctx *comp_ctx, duk_bool_t expec
 
  error_funcname:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_FUNC_NAME);
+	DUK_WO_NORETURN(return;);
 }
 
 /*
@@ -7524,6 +7555,7 @@ DUK_LOCAL void duk__parse_func_formals(duk_compiler_ctx *comp_ctx) {
 
 		if (comp_ctx->curr_token.t != DUK_TOK_IDENTIFIER) {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_EXPECTED_IDENTIFIER);
+			DUK_WO_NORETURN(return;);
 		}
 		DUK_ASSERT(comp_ctx->curr_token.t == DUK_TOK_IDENTIFIER);
 		DUK_ASSERT(comp_ctx->curr_token.str1 != NULL);
@@ -7589,6 +7621,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_small_ui
 			duk_to_string(thr, -1);
 		} else {
 			DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_GETSET_NAME);
+			DUK_WO_NORETURN(return;);
 		}
 		comp_ctx->curr_func.h_name = duk_known_hstring(thr, -1);  /* borrowed reference */
 	} else {
@@ -7606,6 +7639,7 @@ DUK_LOCAL void duk__parse_func_like_raw(duk_compiler_ctx *comp_ctx, duk_small_ui
 			no_advance = 1;
 			if (flags & DUK__FUNC_FLAG_DECL) {
 				DUK_ERROR_SYNTAX(thr, DUK_STR_FUNC_NAME_REQUIRED);
+				DUK_WO_NORETURN(return;);
 			}
 		}
 	}
@@ -7758,6 +7792,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
 
 	if (fnum > DUK__MAX_FUNCS) {
 		DUK_ERROR_RANGE(comp_ctx->thr, DUK_STR_FUNC_LIMIT);
+		DUK_WO_NORETURN(return 0;);
 	}
 
 	/* array writes autoincrement length */
@@ -7977,6 +8012,7 @@ DUK_INTERNAL void duk_js_compile(duk_hthread *thr, const duk_uint8_t *src_buffer
 	if (safe_rc != DUK_EXEC_SUCCESS) {
 		DUK_D(DUK_DPRINT("compilation failed: %!T", duk_get_tval(thr, -1)));
 		(void) duk_throw(thr);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/* [ ... template ] */

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1208,6 +1208,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 				 * executor which can be quite misleading.
 				 */
 				DUK_ERROR_INTERNAL(thr);
+				DUK_WO_NORETURN(return 0;);
 			}
 
 			DUK_ASSERT(resumee->resumer == NULL);
@@ -1444,8 +1445,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 	 * infinite loop in this catchpoint.
 	 */
 	DUK_ERROR_INTERNAL(thr);
-	DUK_UNREACHABLE();
-	return retval;
+	DUK_WO_NORETURN(return 0;);
 }
 
 /* Handle a BREAK/CONTINUE opcode.  Avoid using longjmp() for BREAK/CONTINUE
@@ -1509,7 +1509,7 @@ DUK_LOCAL DUK__NOINLINE_PERF void duk__handle_break_or_continue(duk_hthread *thr
 	/* Should never happen, but be robust. */
 	DUK_D(DUK_DPRINT("-> break/continue not caught by anything in the current function (should never happen), throw internal error"));
 	DUK_ERROR_INTERNAL(thr);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /* Handle a RETURN opcode.  Avoid using longjmp() for return handling because
@@ -1662,7 +1662,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 #else
 	/* Without coroutine support this case should never happen. */
 	DUK_ERROR_INTERNAL(thr);
-	return DUK__RETHAND_FINISHED;  /* not executed */
+	DUK_WO_NORETURN(return 0;);
 #endif
 }
 
@@ -1961,6 +1961,7 @@ DUK_LOCAL DUK__NOINLINE_PERF DUK_COLD duk_small_uint_t duk__executor_interrupt(d
 		thr->interrupt_counter = 0;
 		DUK_HEAP_CLEAR_INTERRUPT_RUNNING(thr->heap);
 		DUK_ERROR_RANGE(thr, "execution timeout");
+		DUK_WO_NORETURN(return 0;);
 	}
 #endif  /* DUK_USE_EXEC_TIMEOUT_CHECK */
 
@@ -2748,6 +2749,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
 #if defined(DUK_USE_VERBOSE_EXECUTOR_ERRORS)
 #define DUK__INTERNAL_ERROR(msg)  do { \
 		DUK_ERROR_ERROR(thr, (msg)); \
+		DUK_WO_NORETURN(return;); \
 	} while (0)
 #else
 #define DUK__INTERNAL_ERROR(msg)  do { \
@@ -2922,6 +2924,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 			try {
 				DUK_ASSERT(heap->curr_thread != NULL);
 				DUK_ERROR_FMT1(heap->curr_thread, DUK_ERR_TYPE_ERROR, "caught invalid c++ std::exception '%s' (perhaps thrown by user code)", what);
+				DUK_WO_NORETURN(return;);
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ std::exception"));
 				DUK_UNREF(exc);
@@ -2936,6 +2939,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 			try {
 				DUK_ASSERT(heap->curr_thread != NULL);
 				DUK_ERROR_TYPE(heap->curr_thread, "caught invalid c++ exception (perhaps thrown by user code)");
+				DUK_WO_NORETURN(return;);
 			} catch (duk_internal_exception exc) {
 				DUK_D(DUK_DPRINT("caught api error thrown from unexpected c++ exception"));
 				DUK_UNREF(exc);
@@ -2948,7 +2952,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 #endif
 	}
 
-	DUK_UNREACHABLE();
+	DUK_WO_NORETURN(return;);
 }
 
 /* Inner executor, performance critical. */
@@ -4972,7 +4976,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 
 		case DUK_OP_INVLHS: {
 			DUK_ERROR_REFERENCE(thr, DUK_STR_INVALID_LVALUE);
-			DUK_UNREACHABLE();
+			DUK_WO_NORETURN(return;);
 			break;
 		}
 
@@ -5007,6 +5011,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 
 		case DUK_OP_INVALID: {
 			DUK_ERROR_FMT1(thr, DUK_ERR_ERROR, "INVALID opcode (%ld)", (long) DUK_DEC_ABC(ins));
+			DUK_WO_NORETURN(return;);
 			break;
 		}
 
@@ -5147,10 +5152,11 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 		continue;
 #endif
 	}
-	DUK_UNREACHABLE();
+	DUK_WO_NORETURN(return;);
 
 #if !defined(DUK_USE_VERBOSE_EXECUTOR_ERRORS)
  internal_error:
 	DUK_ERROR_INTERNAL(thr);
+	DUK_WO_NORETURN(return;);
 #endif
 }

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -217,6 +217,7 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_SYMBOL(h))) {
 			DUK_ERROR_TYPE(thr, DUK_STR_CANNOT_NUMBER_COERCE_SYMBOL);
+			DUK_WO_NORETURN(return 0.0;);
 		}
 		duk_push_hstring(thr, h);
 		return duk__tonumber_string_raw(thr);
@@ -1161,6 +1162,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 
 	if (DUK_UNLIKELY(sanity == 0)) {
 		DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+		DUK_WO_NORETURN(return 0;);
 	}
 	DUK_UNREACHABLE();
 
@@ -1178,12 +1180,12 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 
  error_invalid_rval:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_INSTANCEOF_RVAL);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
  error_invalid_rval_noproto:
 	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_INSTANCEOF_RVAL_NOPROTO);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 #endif
 }
 

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -1057,6 +1057,7 @@ duk_bool_t duk__get_identifier_reference(duk_hthread *thr,
 
                 if (DUK_UNLIKELY(sanity-- == 0)) {
                         DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+			DUK_WO_NORETURN(return 0;);
                 }
 		env = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, env);
 	}
@@ -1196,6 +1197,7 @@ duk_bool_t duk__getvar_helper(duk_hthread *thr,
 			DUK_ERROR_FMT1(thr, DUK_ERR_REFERENCE_ERROR,
 			               "identifier '%s' undefined",
 			               (const char *) DUK_HSTRING_GET_DATA(name));
+			DUK_WO_NORETURN(return 0;);
 		}
 
 		return 0;
@@ -1320,6 +1322,7 @@ void duk__putvar_helper(duk_hthread *thr,
 		DUK_ERROR_FMT1(thr, DUK_ERR_REFERENCE_ERROR,
 		               "identifier '%s' undefined",
 		               (const char *) DUK_HSTRING_GET_DATA(name));
+		DUK_WO_NORETURN(return;);
 	}
 
 	DUK_DDD(DUK_DDDPRINT("identifier binding not found, not strict => set to global"));
@@ -1710,7 +1713,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
  fail_existing_attributes:
  fail_not_extensible:
 	DUK_ERROR_TYPE(thr, "declaration failed");
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_INTERNAL

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -313,6 +313,7 @@ DUK_LOCAL void duk__fill_lexer_buffer(duk_lexer_ctx *lex_ctx, duk_small_uint_t s
 	lex_ctx->input_line = input_line;
 
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_SOURCE_DECODE_FAILED);
+	DUK_WO_NORETURN(return;);
 }
 
 DUK_LOCAL void duk__advance_bytes(duk_lexer_ctx *lex_ctx, duk_small_uint_t count_bytes) {
@@ -473,7 +474,7 @@ DUK_LOCAL duk_codepoint_t duk__read_char(duk_lexer_ctx *lex_ctx) {
  error_clipped:   /* clipped codepoint */
  error_encoding:  /* invalid codepoint encoding or codepoint */
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_SOURCE_DECODE_FAILED);
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 DUK_LOCAL void duk__advance_bytes(duk_lexer_ctx *lex_ctx, duk_small_uint_t count_bytes) {
@@ -937,11 +938,11 @@ DUK_LOCAL void duk__lexer_parse_string_literal(duk_lexer_ctx *lex_ctx, duk_token
 
  fail_escape:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_ESCAPE);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_unterminated:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_UNTERMINATED_STRING);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 /* Skip to end-of-line (or end-of-file), used for single line comments. */
@@ -1785,32 +1786,32 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 
  fail_token_limit:
 	DUK_ERROR_RANGE(lex_ctx->thr, DUK_STR_TOKEN_LIMIT);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_token:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_TOKEN);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_number_literal:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_NUMBER_LITERAL);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_escape:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_ESCAPE);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_unterm_regexp:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_UNTERMINATED_REGEXP);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_unterm_comment:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_UNTERMINATED_COMMENT);
-	return;
+	DUK_WO_NORETURN(return;);
 
 #if !defined(DUK_USE_REGEXP_SUPPORT)
  fail_regexp_support:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_REGEXP_SUPPORT_DISABLED);
-	return;
+	DUK_WO_NORETURN(return;);
 #endif
 }
 
@@ -2158,24 +2159,24 @@ DUK_INTERNAL void duk_lexer_parse_re_token(duk_lexer_ctx *lex_ctx, duk_re_token 
 
  fail_token_limit:
 	DUK_ERROR_RANGE(lex_ctx->thr, DUK_STR_TOKEN_LIMIT);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_escape:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_REGEXP_ESCAPE);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_group:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_REGEXP_GROUP);
-	return;
+	DUK_WO_NORETURN(return;);
 
 #if !defined(DUK_USE_ES6_REGEXP_SYNTAX)
  fail_invalid_char:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_REGEXP_CHARACTER);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_quantifier:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_QUANTIFIER);
-	return;
+	DUK_WO_NORETURN(return;);
 #endif
 }
 
@@ -2424,15 +2425,15 @@ DUK_INTERNAL void duk_lexer_parse_re_ranges(duk_lexer_ctx *lex_ctx, duk_re_range
 
  fail_escape:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_REGEXP_ESCAPE);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_range:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_RANGE);
-	return;
+	DUK_WO_NORETURN(return;);
 
  fail_unterm_charclass:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_UNTERMINATED_CHARCLASS);
-	return;
+	DUK_WO_NORETURN(return;);
 }
 
 #endif  /* DUK_USE_REGEXP_SUPPORT */

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -740,6 +740,7 @@ DUK_LOCAL duk_codepoint_t duk__lexer_parse_escape(duk_lexer_ctx *lex_ctx, duk_bo
 
  fail_escape:
 	DUK_ERROR_SYNTAX(lex_ctx->thr, DUK_STR_INVALID_ESCAPE);
+	DUK_WO_NORETURN(return 0;);
 }
 
 /* Parse legacy octal escape of the form \N{1,3}, e.g. \0, \5, \0377.  Maximum

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -2259,5 +2259,5 @@ DUK_INTERNAL void duk_numconv_parse(duk_hthread *thr, duk_small_int_t radix, duk
  parse_explimit_error:
 	DUK_DDD(DUK_DDDPRINT("parse failed, internal error, can't return a value"));
 	DUK_ERROR_RANGE(thr, "exponent too large");
-	return;
+	DUK_WO_NORETURN(return;);
 }

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -524,6 +524,7 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 
 	if (re_ctx->recursion_depth >= re_ctx->recursion_limit) {
 		DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_COMPILER_RECURSION_LIMIT);
+		DUK_WO_NORETURN(return;);
 	}
 	re_ctx->recursion_depth++;
 
@@ -597,9 +598,11 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 		case DUK_RETOK_QUANTIFIER: {
 			if (atom_start_offset < 0) {
 				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_INVALID_QUANTIFIER_NO_ATOM);
+				DUK_WO_NORETURN(return;);
 			}
 			if (re_ctx->curr_token.qmin > re_ctx->curr_token.qmax) {
 				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_INVALID_QUANTIFIER_VALUES);
+				DUK_WO_NORETURN(return;);
 			}
 			if (atom_char_length >= 0) {
 				/*
@@ -668,6 +671,7 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 				              re_ctx->curr_token.qmin : re_ctx->curr_token.qmax;
 				if (atom_copies > DUK_RE_MAX_ATOM_COPIES) {
 					DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_QUANTIFIER_TOO_MANY_COPIES);
+					DUK_WO_NORETURN(return;);
 				}
 
 				/* wipe the capture range made by the atom (if any) */
@@ -931,17 +935,20 @@ DUK_LOCAL void duk__parse_disjunction(duk_re_compiler_ctx *re_ctx, duk_bool_t ex
 		case DUK_RETOK_ATOM_END_GROUP: {
 			if (expect_eof) {
 				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_CLOSING_PAREN);
+				DUK_WO_NORETURN(return;);
 			}
 			goto done;
 		}
 		case DUK_RETOK_EOF: {
 			if (!expect_eof) {
 				DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_END_OF_PATTERN);
+				DUK_WO_NORETURN(return;);
 			}
 			goto done;
 		}
 		default: {
 			DUK_ERROR_SYNTAX(re_ctx->thr, DUK_STR_UNEXPECTED_REGEXP_TOKEN);
+			DUK_WO_NORETURN(return;);
 		}
 		}
 
@@ -1036,7 +1043,7 @@ DUK_LOCAL duk_uint32_t duk__parse_regexp_flags(duk_hthread *thr, duk_hstring *h)
 
  flags_error:
 	DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_REGEXP_FLAGS);
-	return 0;  /* never here */
+	DUK_WO_NORETURN(return 0U;);
 }
 
 /*
@@ -1200,6 +1207,7 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 
 	if (re_ctx.highest_backref > re_ctx.captures) {
 		DUK_ERROR_SYNTAX(thr, DUK_STR_INVALID_BACKREFS);
+		DUK_WO_NORETURN(return;);
 	}
 
 	/*

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -68,7 +68,7 @@ DUK_LOCAL const duk_uint8_t *duk__utf8_backtrack(duk_hthread *thr, const duk_uin
 
  fail:
 	DUK_ERROR_INTERNAL(thr);
-	return NULL;  /* never here */
+	DUK_WO_NORETURN(return NULL;);
 }
 
 DUK_LOCAL const duk_uint8_t *duk__utf8_advance(duk_hthread *thr, const duk_uint8_t **ptr, const duk_uint8_t *ptr_start, const duk_uint8_t *ptr_end, duk_uint_fast32_t count) {
@@ -99,7 +99,7 @@ DUK_LOCAL const duk_uint8_t *duk__utf8_advance(duk_hthread *thr, const duk_uint8
 
  fail:
 	DUK_ERROR_INTERNAL(thr);
-	return NULL;  /* never here */
+	DUK_WO_NORETURN(return NULL;);
 }
 
 /*
@@ -148,6 +148,7 @@ DUK_LOCAL duk_codepoint_t duk__inp_get_prev_cp(duk_re_matcher_ctx *re_ctx, const
 DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_uint8_t *pc, const duk_uint8_t *sp) {
 	if (re_ctx->recursion_depth >= re_ctx->recursion_limit) {
 		DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_EXECUTOR_RECURSION_LIMIT);
+		DUK_WO_NORETURN(return NULL;);
 	}
 	re_ctx->recursion_depth++;
 
@@ -156,6 +157,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 
 		if (re_ctx->steps_count >= re_ctx->steps_limit) {
 			DUK_ERROR_RANGE(re_ctx->thr, DUK_STR_REGEXP_EXECUTOR_STEP_LIMIT);
+			DUK_WO_NORETURN(return NULL;);
 		}
 		re_ctx->steps_count++;
 
@@ -665,7 +667,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 
  internal_error:
 	DUK_ERROR_INTERNAL(re_ctx->thr);
-	return NULL;  /* never here */
+	DUK_WO_NORETURN(return NULL;);
 }
 
 /*

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -280,8 +280,7 @@ DUK_INTERNAL duk_ucodepoint_t duk_unicode_decode_xutf8_checked(duk_hthread *thr,
 		return cp;
 	}
 	DUK_ERROR_INTERNAL(thr);
-	DUK_UNREACHABLE();
-	return 0;
+	DUK_WO_NORETURN(return 0;);
 }
 
 /* Compute (extended) utf-8 length without codepoint encoding validation,

--- a/src-input/duk_util_bufwriter.c
+++ b/src-input/duk_util_bufwriter.c
@@ -62,7 +62,7 @@ DUK_INTERNAL duk_uint8_t *duk_bw_resize(duk_hthread *thr, duk_bufwriter_ctx *bw_
 	if (DUK_UNLIKELY(new_sz < curr_off)) {
 		/* overflow */
 		DUK_ERROR_RANGE(thr, DUK_STR_BUFFER_TOO_LONG);
-		return NULL;  /* not reachable */
+		DUK_WO_NORETURN(return NULL;);
 	}
 #if 0  /* for manual torture testing: tight allocation, useful with valgrind */
 	new_sz = curr_off + sz;


### PR DESCRIPTION
Add an internal DUK_WO_NORETURN() macro which provides statements that are only included when a noreturn attribute (DUK_NORETURN) is unavailable. This allows the error throw in:
```
DUK_INTERNAL duk_bool_t duk_something(duk_hthread *thr) {
    /* ... */
    if (something) {
        DUK_ERROR_TYPE(thr, "aiee");
        DUK_WO_NORETURN(return 0;);
    }
}
```

to compile as the following with DUK_NORETURN defined:

```c
    if (something) {
        DUK_ERROR_TYPE(thr, "aiee");
    }
```

and as the following when it isn't defined:

```c
    if (something) {
        DUK_ERROR_TYPE(thr, "aiee");
        return 0;
    }
```

In the latter case the 'return 0;' is never actually reached, but without a noreturn attribute (not available in many compilers) the compiler won't know it. Without a return statement the compiler will then sometimes warn about using uninitialized variables, etc. On the other hand, including the return statement always may cause warnings about unreachable code with other compilers when the noreturn attribute is available.