### PR TITLE
Fix armhf -Wcast-align warnings from Clang and GCC

### DIFF
--- a/src-input/duk_heaphdr.h
+++ b/src-input/duk_heaphdr.h
@@ -32,6 +32,9 @@
 
 /* XXX: macro for shared header fields (avoids some padding issues) */
 
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_MSVC_PRAGMA)
+#pragma pack(push, 8)
+#endif
 struct duk_heaphdr {
 	duk_uint32_t h_flags;
 
@@ -77,7 +80,16 @@ struct duk_heaphdr {
 #if defined(DUK_USE_HEAPPTR16)
 	duk_uint16_t h_extra16;
 #endif
-};
+}
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_GCC_ATTR)
+__attribute__ ((aligned (8)))
+#elif (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_CLANG_ATTR)
+__attribute__ ((aligned (8)))
+#endif
+;
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_MSVC_PRAGMA)
+#pragma pack(pop)
+#endif
 
 struct duk_heaphdr_string {
 	/* 16 bits would be enough for shared heaphdr flags and duk_hstring

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -165,6 +165,9 @@
  *  Misc
  */
 
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_MSVC_PRAGMA)
+#pragma pack(push, 8)
+#endif
 struct duk_hstring {
 	/* Smaller heaphdr than for other objects, because strings are held
 	 * in string intern table which requires no link pointers.  Much of
@@ -209,7 +212,16 @@ struct duk_hstring {
 	 *  for strings, but fields above should guarantee alignment-by-4
 	 *  (but not alignment-by-8).
 	 */
-};
+}
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_GCC_ATTR)
+__attribute__ ((aligned (8)))
+#elif (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_CLANG_ATTR)
+__attribute__ ((aligned (8)))
+#endif
+;
+#if (DUK_USE_ALIGN_BY == 8) && defined(DUK_USE_PACK_MSVC_PRAGMA)
+#pragma pack(pop)
+#endif
 
 /* The external string struct is defined even when the feature is inactive. */
 struct duk_hstring_external {


### PR DESCRIPTION
These warnings stem from the fact that the double type has 8 byte
alignment on armhf.

The following is from Clang (one of a number of similar warnings):

    content/handlers/javascript/duktape/duktape.c:13390:28: error:
    cast from 'duk_hbuffer *' (aka 'struct duk_hbuffer *')
    to 'duk_hbuffer_fixed *' (aka 'struct duk_hbuffer_fixed *')
    increases required alignment from 4 to 8 [-Werror,-Wcast-align]

This happens because `struct duk_hbuffer_fixed` contains a double in
the union.

The following has a similar cause (again, there are many of these
warnings):

    content/handlers/javascript/duktape/duktape.c:14588:25: error:
    cast from 'duk_hobject *' (aka 'struct duk_hobject *')
    to 'duk_hboundfunc *' (aka 'struct duk_hboundfunc *')
    increases required alignment from 4 to 8 [-Werror,-Wcast-align]

It happens because `struct duk_hboundfunc` contains a `duk_tval`,
and `duk_tval` whihc is a `struct duk_tval_struct`, which contains
a double in the union.

Since all these structures have a `struct duk_heaphdr` at the
start, giving that structure 8-byte alignment fixes the above
warnings.

However, it introduces warnings of the following form:

    content/handlers/javascript/duktape/duktape.c:48342:33: error:
    cast from 'duk_hstring *' (aka 'struct duk_hstring *')
    to 'duk_heaphdr *' (aka 'struct duk_heaphdr *')
    increases required alignment from 4 to 8 [-Werror,-Wcast-align]

Giving `struct duk_hstring` the same 8-byte alignment fixes
all the warnings when building on armhf with both GCC and Clang
with -Wcast-align.