### PR TITLE
Fix some armhf -Wcast-align warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ CCOPTS_SHARED += -pedantic -ansi -std=c99 -fstrict-aliasing
 # -Wextra is very picky but catches e.g. signed/unsigned comparisons
 CCOPTS_SHARED += -Wall -Wextra -Wunused-result -Wdeclaration-after-statement -Wunused-function
 CCOPTS_SHARED += -Wcast-qual
+CCOPTS_SHARED += -Wcast-align
 CCOPTS_SHARED += -Wshadow
 CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an error
 CCOPTS_SHARED += -Wmissing-prototypes

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3239,6 +3239,8 @@ Planned
 * Fix a few casts in duk_trans_socket_windows.c to avoid errors in a C++
   build (GH-1773)
 
+* Fix harmless -Wcast-align warnings on armhf (GH-1793)
+
 * Various compiler warning fixes (GH-1788)
 
 * Add automatic workaround for union aliasing issues with FreeBSD + -m32 +

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -499,7 +499,7 @@ DUK_INTERNAL void duk_resolve_nonbound_function(duk_hthread *thr) {
 		h = DUK_TVAL_GET_OBJECT(tv);
 		DUK_ASSERT(h != NULL);
 		if (DUK_HOBJECT_HAS_BOUNDFUNC(h)) {
-			duk_push_tval(thr, &((duk_hboundfunc *) h)->target);
+			duk_push_tval(thr, &((duk_hboundfunc *) (void *) h)->target);
 			duk_replace(thr, -2);
 #if 0
 			DUK_TVAL_SET_TVAL(tv, &((duk_hboundfunc *) h)->target);

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -621,7 +621,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_constructor(duk_hthread *thr) {
 	duk_push_buffer_object(thr,
 	                       -1,
 	                       0,
-	                       DUK_HBUFFER_FIXED_GET_SIZE((duk_hbuffer_fixed *) h_buf),
+	                       DUK_HBUFFER_FIXED_GET_SIZE((duk_hbuffer_fixed *) (void *) h_buf),
 	                       DUK_BUFOBJ_UINT8ARRAY);
 	duk_push_hobject_bidx(thr, DUK_BIDX_NODEJS_BUFFER_PROTOTYPE);
 	duk_set_prototype(thr, -2);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -282,7 +282,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_hthread *thr) {
 		if (DUK_HOBJECT_HAS_BOUNDFUNC(h_target)) {
 			duk_hboundfunc *h_boundtarget;
 
-			h_boundtarget = (duk_hboundfunc *) h_target;
+			h_boundtarget = (duk_hboundfunc *) (void *) h_target;
 
 			/* The final function should always be non-bound, unless
 			 * there's a bug in the internals.  Assert for it.

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -2258,7 +2258,7 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 
 		if (DUK_HOBJECT_IS_BOUNDFUNC(h_obj)) {
 			duk_hboundfunc *h_bfun;
-			h_bfun = (duk_hboundfunc *) h_obj;
+			h_bfun = (duk_hboundfunc *) (void *) h_obj;
 
 			duk__debug_getinfo_flags_key(thr, "target");
 			duk_debug_write_tval(thr, &h_bfun->target);

--- a/src-input/duk_hbuffer.h
+++ b/src-input/duk_hbuffer.h
@@ -94,7 +94,7 @@
 #define DUK_HBUFFER_EXTERNAL_GET_SIZE(x)    DUK_HBUFFER_GET_SIZE((duk_hbuffer *) (x))
 #define DUK_HBUFFER_EXTERNAL_SET_SIZE(x,v)  DUK_HBUFFER_SET_SIZE((duk_hbuffer *) (x), (v))
 
-#define DUK_HBUFFER_FIXED_GET_DATA_PTR(heap,x)    ((duk_uint8_t *) (((duk_hbuffer_fixed *) (x)) + 1))
+#define DUK_HBUFFER_FIXED_GET_DATA_PTR(heap,x)    ((duk_uint8_t *) (((duk_hbuffer_fixed *) (void *) (x)) + 1))
 
 #if defined(DUK_USE_HEAPPTR16)
 #define DUK_HBUFFER_DYNAMIC_GET_DATA_PTR(heap,x) \
@@ -149,7 +149,7 @@
 				DUK_HBUFFER_EXTERNAL_GET_DATA_PTR((heap), (duk_hbuffer_external *) (x)) : \
 				DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((heap), (duk_hbuffer_dynamic *) (x)) \
 		) : \
-		DUK_HBUFFER_FIXED_GET_DATA_PTR((heap), (duk_hbuffer_fixed *) (x)) \
+		DUK_HBUFFER_FIXED_GET_DATA_PTR((heap), (duk_hbuffer_fixed *) (void *) (x)) \
 	)
 #else
 /* Without heap pointer compression duk_hbuffer_dynamic and duk_hbuffer_external
@@ -158,7 +158,7 @@
 #define DUK_HBUFFER_GET_DATA_PTR(heap,x)  ( \
 	DUK_HBUFFER_HAS_DYNAMIC((x)) ? \
 		DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((heap), (duk_hbuffer_dynamic *) (x)) : \
-		DUK_HBUFFER_FIXED_GET_DATA_PTR((heap), (duk_hbuffer_fixed *) (x)) \
+		DUK_HBUFFER_FIXED_GET_DATA_PTR((heap), (duk_hbuffer_fixed *) (void *) (x)) \
 	)
 #endif
 

--- a/src-input/duk_hbuffer_alloc.c
+++ b/src-input/duk_hbuffer_alloc.c
@@ -97,7 +97,7 @@ DUK_INTERNAL duk_hbuffer *duk_hbuffer_alloc(duk_heap *heap, duk_size_t size, duk
 			DUK_ASSERT(DUK_HBUFFER_DYNAMIC_GET_DATA_PTR(heap, h) == NULL);
 		}
 	} else {
-		*out_bufdata = (void *) ((duk_hbuffer_fixed *) res + 1);
+		*out_bufdata = (void *) ((duk_hbuffer_fixed *) (void *) res + 1);
 	}
 
 	DUK_HBUFFER_SET_SIZE(res, size);

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -66,7 +66,7 @@ DUK_INTERNAL void duk_free_hobject(duk_heap *heap, duk_hobject *h) {
 		 * functions in the callstack.
 		 */
 	} else if (DUK_HOBJECT_IS_BOUNDFUNC(h)) {
-		duk_hboundfunc *f = (duk_hboundfunc *) h;
+		duk_hboundfunc *f = (duk_hboundfunc *) (void *) h;
 
 		DUK_FREE(heap, f->args);
 	}

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -114,7 +114,7 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 		duk__mark_heaphdr(heap, (duk_heaphdr *) b->buf_prop);
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 	} else if (DUK_HOBJECT_IS_BOUNDFUNC(h)) {
-		duk_hboundfunc *f = (duk_hboundfunc *) h;
+		duk_hboundfunc *f = (duk_hboundfunc *) (void *) h;
 		DUK_ASSERT_HBOUNDFUNC_VALID(f);
 		duk__mark_tval(heap, &f->target);
 		duk__mark_tval(heap, &f->this_binding);

--- a/src-input/duk_heap_refcount.c
+++ b/src-input/duk_heap_refcount.c
@@ -170,7 +170,7 @@ DUK_INTERNAL void duk_hobject_refcount_finalize_norz(duk_heap *heap, duk_hobject
 		DUK_HOBJECT_DECREF_NORZ_ALLOWNULL(thr, (duk_hobject *) b->buf_prop);
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 	} else if (DUK_HOBJECT_IS_BOUNDFUNC(h)) {
-		duk_hboundfunc *f = (duk_hboundfunc *) h;
+		duk_hboundfunc *f = (duk_hboundfunc *) (void *) h;
 		DUK_ASSERT_HBOUNDFUNC_VALID(f);
 		DUK_TVAL_DECREF_NORZ(thr, &f->target);
 		DUK_TVAL_DECREF_NORZ(thr, &f->this_binding);

--- a/src-input/duk_hobject_pc2line.c
+++ b/src-input/duk_hobject_pc2line.c
@@ -229,7 +229,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_hobject_pc2line_query(duk_hthread *thr, duk_i
 	 */
 
 	duk_get_prop_stridx(thr, idx_func, DUK_STRIDX_INT_PC2LINE);
-	pc2line = (duk_hbuffer_fixed *) duk_get_hbuffer(thr, -1);
+	pc2line = (duk_hbuffer_fixed *) (void *) duk_get_hbuffer(thr, -1);
 	if (pc2line != NULL) {
 		DUK_ASSERT(!DUK_HBUFFER_HAS_DYNAMIC((duk_hbuffer *) pc2line) && !DUK_HBUFFER_HAS_EXTERNAL((duk_hbuffer *) pc2line));
 		line = duk__hobject_pc2line_query_raw(thr, pc2line, (duk_uint_fast32_t) pc);

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -568,7 +568,7 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 			duk_tval *tv_args;
 			duk_tval *tv_gap;
 
-			h_bound = (duk_hboundfunc *) func;
+			h_bound = (duk_hboundfunc *) (void *) func;
 			tv_args = h_bound->args;
 			len = h_bound->nargs;
 			DUK_ASSERT(len == 0 || tv_args != NULL);

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -772,7 +772,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx) {
 	                     (long) code_size, (long) data_size));
 
 	duk_push_fixed_buffer_nozero(thr, data_size);
-	h_data = (duk_hbuffer_fixed *) duk_known_hbuffer(thr, -1);
+	h_data = (duk_hbuffer_fixed *) (void *) duk_known_hbuffer(thr, -1);
 
 	DUK_HCOMPFUNC_SET_DATA(thr->heap, h_res, (duk_hbuffer *) h_data);
 	DUK_HEAPHDR_INCREF(thr, h_data);

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1057,7 +1057,7 @@ DUK_INTERNAL duk_bool_t duk_js_instanceof(duk_hthread *thr, duk_tval *tv_x, duk_
 	}
 
 	if (DUK_HOBJECT_HAS_BOUNDFUNC(func)) {
-		duk_push_tval(thr, &((duk_hboundfunc *) func)->target);
+		duk_push_tval(thr, &((duk_hboundfunc *) (void *) func)->target);
 		duk_replace(thr, -2);
 		func = duk_require_hobject(thr, -1);  /* lightfunc throws */
 


### PR DESCRIPTION
Fix some -Wcast-align warnings triggered on armhf target. The warnings are related to casting between different heap structs where one struct has an alignment requirement of 8 and another an alignment requirement of 4. However, all Duktape heap objects are allocated using the malloc() provider and the duk_heaphdr struct always starts directly at the pointer returned by malloc(). If alignment to 8 matters for the platform, malloc() is expected to return pointers aligned by 8 (at least if size >= 8) so that all heap objects will in fact be 8-byte aligned. The fix is to cast through void *.