### PR TITLE
More cleanups for -fsanitize=undefined warning fixes

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3231,7 +3231,7 @@ Planned
 
 * Fix some Clang warnings by avoiding undefined behavior by default, define
   DUK_USE_ALLOW_UNDEFINED_BEHAVIOR to reduce the explicit undefined behavior
-  checks for better footprint/performance (GH-1777, GH-1795, GH-1796)
+  checks for better footprint/performance (GH-1777, GH-1795, GH-1796, GH-1797)
 
 * Fix some compilation warnings triggered when DUK_NORETURN is not defined;
   the internal DUK_WO_NORETURN() is used to include unreachable dummy

--- a/config/examples/performance_sensitive.yaml
+++ b/config/examples/performance_sensitive.yaml
@@ -3,6 +3,12 @@
 
 # You should choose the fastest setjmp/longjmp for your platform.
 
+# With the vast majority of compilers some of the 'undefined behavior'
+# assumptions are fine, and produce smaller and faster code, so enable
+# by default for performance oriented targets.  You may need to disable
+# this for some compilers.
+DUK_USE_ALLOW_UNDEFINED_BEHAVIOR: true
+
 DUK_USE_PREFER_SIZE: false
 DUK_USE_PACKED_TVAL: false  # packed duk_tval slower in most cases
 DUK_USE_FASTINT: true

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -37,7 +37,7 @@ from Duktape v2.2.x.  Note the following:
   For many compilers the undefined behavior assumptions in Duktape source
   are fine, and you can remove the extra overhead by enabling the
   DUK_USE_ALLOW_UNDEFINED_BEHAVIOR option in configure.py (this option is
-  enabled in the low_memory.yaml example configuration).  Note, however,
-  that recent gcc/clang versions are optimizing around undefined behavior so
-  while relying on undefined behavior may work in one version, it may break
-  with newer compiler versions.
+  enabled in the low_memory.yaml and performance_sensitive.yaml example
+  configurations).  Note, however, that recent gcc/clang versions are
+  optimizing around undefined behavior so while relying on undefined behavior
+  may work in one version, it may break with newer compiler versions.

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -40,7 +40,7 @@ DUK_LOCAL duk_uint8_t *duk__load_buffer_raw(duk_hthread *thr, duk_uint8_t *p) {
 	len = DUK_RAW_READ_U32_BE(p);
 	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, (duk_size_t) len);
 	DUK_ASSERT(buf != NULL);
-	DUK_MEMCPY((void *) buf, (const void *) p, (size_t) len);
+	duk_memcpy((void *) buf, (const void *) p, (size_t) len);
 	p += len;
 	return p;
 }
@@ -55,7 +55,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_hstring_raw(duk_uint8_t *p, duk_hstring *h) {
 	DUK_ASSERT(len <= 0xffffffffUL);  /* string limits */
 	tmp32 = (duk_uint32_t) len;
 	DUK_RAW_WRITE_U32_BE(p, tmp32);
-	DUK_MEMCPY((void *) p,
+	duk_memcpy((void *) p,
 	           (const void *) DUK_HSTRING_GET_DATA(h),
 	           len);
 	p += len;
@@ -74,7 +74,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_hbuffer_raw(duk_hthread *thr, duk_uint8_t *p, d
 	DUK_ASSERT(len <= 0xffffffffUL);  /* buffer limits */
 	tmp32 = (duk_uint32_t) len;
 	DUK_RAW_WRITE_U32_BE(p, tmp32);
-	DUK_MEMCPY((void *) p,
+	duk_memcpy((void *) p,
 	           (const void *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h),
 	           len);
 	p += len;
@@ -288,7 +288,7 @@ static duk_uint8_t *duk__dump_func(duk_hthread *thr, duk_hcompfunc *func, duk_bu
 	ins_end = DUK_HCOMPFUNC_GET_CODE_END(thr->heap, func);
 	DUK_ASSERT((duk_size_t) (ins_end - ins) == (duk_size_t) count_instr);
 #if defined(DUK_USE_INTEGER_BE)
-	DUK_MEMCPY((void *) p, (const void *) ins, (size_t) (ins_end - ins));
+	duk_memcpy((void *) p, (const void *) ins, (size_t) (ins_end - ins));
 	p += (size_t) (ins_end - ins);
 #else
 	while (ins != ins_end) {
@@ -474,7 +474,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	DUK__ASSERT_LEFT(count_instr * sizeof(duk_instr_t));
 #if defined(DUK_USE_INTEGER_BE)
 	q = fun_data + sizeof(duk_tval) * count_const + sizeof(duk_hobject *) * count_funcs;
-	DUK_MEMCPY((void *) q,
+	duk_memcpy((void *) q,
 	           (const void *) p,
 	           sizeof(duk_instr_t) * count_instr);
 	p += sizeof(duk_instr_t) * count_instr;
@@ -539,15 +539,12 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	DUK_ASSERT((count_const == 0 && count_funcs == 0) || tv1 != NULL);
 
 	q = fun_data;
-	if (count_const > 0) {
-		/* Explicit zero size check to avoid NULL 'tv1'. */
-		DUK_MEMCPY((void *) q, (const void *) tv1, sizeof(duk_tval) * count_const);
-		for (n = count_const; n > 0; n--) {
-			DUK_TVAL_INCREF_FAST(thr, (duk_tval *) (void *) q);  /* no side effects */
-			q += sizeof(duk_tval);
-		}
-		tv1 += count_const;
+	duk_memcpy((void *) q, (const void *) tv1, sizeof(duk_tval) * count_const);
+	for (n = count_const; n > 0; n--) {
+		DUK_TVAL_INCREF_FAST(thr, (duk_tval *) (void *) q);  /* no side effects */
+		q += sizeof(duk_tval);
 	}
+	tv1 += count_const;
 
 	DUK_HCOMPFUNC_SET_FUNCS(thr->heap, h_fun, (duk_hobject **) (void *) q);
 	for (n = count_funcs; n > 0; n--) {

--- a/src-input/duk_api_heap.c
+++ b/src-input/duk_api_heap.c
@@ -105,7 +105,7 @@ DUK_EXTERNAL void duk_suspend(duk_hthread *thr, duk_thread_state *state) {
 	duk_push_tval(thr, &lj->value2);
 
 	/* XXX: creating_error == 0 is asserted above, so no need to store. */
-	DUK_MEMCPY((void *) &snapshot->lj, (const void *) lj, sizeof(duk_ljstate));
+	duk_memcpy((void *) &snapshot->lj, (const void *) lj, sizeof(duk_ljstate));
 	snapshot->creating_error = heap->creating_error;
 	snapshot->curr_thread = heap->curr_thread;
 	snapshot->call_recursion_depth = heap->call_recursion_depth;
@@ -135,7 +135,7 @@ DUK_EXTERNAL void duk_resume(duk_hthread *thr, const duk_thread_state *state) {
 
 	heap = thr->heap;
 
-	DUK_MEMCPY((void *) &heap->lj, (const void *) &snapshot->lj, sizeof(duk_ljstate));
+	duk_memcpy((void *) &heap->lj, (const void *) &snapshot->lj, sizeof(duk_ljstate));
 	heap->creating_error = snapshot->creating_error;
 	heap->curr_thread = snapshot->curr_thread;
 	heap->call_recursion_depth = snapshot->call_recursion_depth;

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -66,7 +66,7 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 
 	/* Assume two's complement and set everything to -1. */
-	DUK_MEMSET((void *) &vals, (int) 0xff, sizeof(vals));
+	duk_memset((void *) &vals, (int) 0xff, sizeof(vals));
 	DUK_ASSERT(vals[DUK__IDX_TYPE] == -1);  /* spot check one */
 
 	tv = duk_get_tval_or_unused(thr, idx);

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -73,11 +73,11 @@ DUK_LOCAL void duk__concat_and_join_helper(duk_hthread *thr, duk_idx_t count_in,
 	for (i = count; i >= 1; i--) {
 		if (is_join && i != count) {
 			h = duk_require_hstring(thr, -((duk_idx_t) count) - 2);  /* extra -1 for buffer */
-			DUK_MEMCPY(buf + idx, DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+			duk_memcpy(buf + idx, DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
 			idx += DUK_HSTRING_GET_BYTELEN(h);
 		}
 		h = duk_require_hstring(thr, -((duk_idx_t) i) - 1);  /* extra -1 for buffer */
-		DUK_MEMCPY(buf + idx, DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+		duk_memcpy(buf + idx, DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
 		idx += DUK_HSTRING_GET_BYTELEN(h);
 	}
 
@@ -142,8 +142,8 @@ DUK_INTERNAL void duk_concat_2(duk_hthread *thr) {
 	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, len);
 	DUK_ASSERT(buf != NULL);
 
-	DUK_MEMCPY((void *) buf, (const void *) DUK_HSTRING_GET_DATA(h1), (size_t) len1);
-	DUK_MEMCPY((void *) (buf + len1), (const void *) DUK_HSTRING_GET_DATA(h2), (size_t) len2);
+	duk_memcpy((void *) buf, (const void *) DUK_HSTRING_GET_DATA(h1), (size_t) len1);
+	duk_memcpy((void *) (buf + len1), (const void *) DUK_HSTRING_GET_DATA(h2), (size_t) len2);
 	(void) duk_buffer_to_string(thr, -1);  /* Safe if inputs are safe. */
 
 	/* [ ... str1 str2 buf ] */

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -443,7 +443,7 @@ DUK_INTERNAL void duk_hbufobj_push_uint8array_from_plain(duk_hthread *thr, duk_h
 DUK_INTERNAL void duk_hbufobj_push_validated_read(duk_hthread *thr, duk_hbufobj *h_bufobj, duk_uint8_t *p, duk_small_uint_t elem_size) {
 	duk_double_union du;
 
-	DUK_MEMCPY((void *) du.uc, (const void *) p, (size_t) elem_size);
+	duk_memcpy((void *) du.uc, (const void *) p, (size_t) elem_size);
 
 	switch (h_bufobj->elem_type) {
 	case DUK_HBUFOBJ_ELEM_UINT8:
@@ -524,7 +524,7 @@ DUK_INTERNAL void duk_hbufobj_validated_write(duk_hthread *thr, duk_hbufobj *h_b
 		DUK_UNREACHABLE();
 	}
 
-	DUK_MEMCPY((void *) p, (const void *) du.uc, (size_t) elem_size);
+	duk_memcpy((void *) p, (const void *) du.uc, (size_t) elem_size);
 }
 
 /* Helper to create a fixed buffer from argument value at index 0.
@@ -953,7 +953,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_constructor(duk_hthread *thr) {
 		DUK_DDD(DUK_DDDPRINT("using memcpy: p_src=%p, p_dst=%p, byte_length=%ld",
 		                     (void *) p_src, (void *) p_dst, (long) byte_length));
 
-		DUK_MEMCPY((void *) p_dst, (const void *) p_src, (size_t) byte_length);
+		duk_memcpy((void *) p_dst, (const void *) p_src, (size_t) byte_length);
 		break;
 	}
 	case 1: {
@@ -1220,7 +1220,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tostring(duk_hthread *thr) {
 	 */
 
 	DUK_ASSERT(DUK_HBUFOBJ_VALID_BYTEOFFSET_EXCL(h_this, (duk_size_t) start_offset + slice_length));
-	DUK_MEMCPY((void *) buf_slice,
+	duk_memcpy((void *) buf_slice,
 	           (const void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + start_offset),
 	           (size_t) slice_length);
 
@@ -1384,7 +1384,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_fill(duk_hthread *thr) {
 		/* Handle single character fills as memset() even when
 		 * the fill data comes from a one-char argument.
 		 */
-		DUK_MEMSET((void *) p, (int) fill_str_ptr[0], (size_t) fill_length);
+		duk_memset((void *) p, (int) fill_str_ptr[0], (size_t) fill_length);
 	} else if (fill_str_len > 1) {
 		duk_size_t i, n, t;
 
@@ -1435,7 +1435,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_write(duk_hthread *thr) {
 
 	if (DUK_HBUFOBJ_VALID_SLICE(h_this)) {
 		/* Cannot overlap. */
-		DUK_MEMCPY((void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + offset),
+		duk_memcpy((void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + offset),
 		           (const void *) str_data,
 		           (size_t) length);
 	} else {
@@ -1533,7 +1533,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_copy(duk_hthread *thr) {
 		/* Must use memmove() because copy area may overlap (source and target
 		 * buffer may be the same, or from different slices.
 		 */
-		DUK_MEMMOVE((void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_bufarg) + target_ustart),
+		duk_memmove((void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_bufarg) + target_ustart),
 		            (const void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + source_ustart),
 		            (size_t) copy_size);
 	} else {
@@ -1721,7 +1721,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_hthread *thr) {
 			DUK_ASSERT(src_length == dst_length);
 
 			DUK_DDD(DUK_DDDPRINT("fast path: able to use memmove() because views are compatible"));
-			DUK_MEMMOVE((void *) p_dst_base, (const void *) p_src_base, (size_t) dst_length);
+			duk_memmove((void *) p_dst_base, (const void *) p_src_base, (size_t) dst_length);
 			return 0;
 		}
 		DUK_DDD(DUK_DDDPRINT("fast path: views are not compatible with a byte copy, copy by item"));
@@ -1764,7 +1764,7 @@ DUK_INTERNAL duk_ret_t duk_bi_typedarray_set(duk_hthread *thr) {
 			DUK_DDD(DUK_DDDPRINT("there is overlap, make a copy of the source"));
 			p_src_copy = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, src_length);
 			DUK_ASSERT(p_src_copy != NULL);
-			DUK_MEMCPY((void *) p_src_copy, (const void *) p_src_base, (size_t) src_length);
+			duk_memcpy((void *) p_src_copy, (const void *) p_src_base, (size_t) src_length);
 
 			p_src_base = p_src_copy;  /* use p_src_base from now on */
 		}
@@ -1891,7 +1891,7 @@ DUK_LOCAL void duk__arraybuffer_plain_slice(duk_hthread *thr, duk_hbuffer *h_val
 	DUK_ASSERT(p_copy != NULL);
 	copy_length = slice_length;
 
-	DUK_MEMCPY((void *) p_copy,
+	duk_memcpy((void *) p_copy,
 	           (const void *) ((duk_uint8_t *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h_val) + start_offset),
 	           copy_length);
 }
@@ -2015,7 +2015,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_slice_shared(duk_hthread *thr) {
 		 * is left as zero.
 		 */
 		copy_length = DUK_HBUFOBJ_CLAMP_BYTELENGTH(h_this, slice_length);
-		DUK_MEMCPY((void *) p_copy,
+		duk_memcpy((void *) p_copy,
 		           (const void *) (DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this) + start_offset),
 		           copy_length);
 
@@ -2209,7 +2209,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_concat(duk_hthread *thr) {
 
 		if (h_bufobj->buf != NULL &&
 		    DUK_HBUFOBJ_VALID_SLICE(h_bufobj)) {
-			DUK_MEMCPY((void *) p,
+			duk_memcpy((void *) p,
 			           (const void *) DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_bufobj),
 			           copy_size);
 		} else {
@@ -2361,7 +2361,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_hthread *thr) {
 		if (offset + 2U > check_length) {
 			goto fail_bounds;
 		}
-		DUK_MEMCPY((void *) du.uc, (const void *) (buf + offset), 2);
+		duk_memcpy((void *) du.uc, (const void *) (buf + offset), 2);
 		tmp = du.us[0];
 		if (endswap) {
 			tmp = DUK_BSWAP16(tmp);
@@ -2378,7 +2378,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_hthread *thr) {
 		if (offset + 4U > check_length) {
 			goto fail_bounds;
 		}
-		DUK_MEMCPY((void *) du.uc, (const void *) (buf + offset), 4);
+		duk_memcpy((void *) du.uc, (const void *) (buf + offset), 4);
 		tmp = du.ui[0];
 		if (endswap) {
 			tmp = DUK_BSWAP32(tmp);
@@ -2395,7 +2395,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_hthread *thr) {
 		if (offset + 4U > check_length) {
 			goto fail_bounds;
 		}
-		DUK_MEMCPY((void *) du.uc, (const void *) (buf + offset), 4);
+		duk_memcpy((void *) du.uc, (const void *) (buf + offset), 4);
 		if (endswap) {
 			tmp = du.ui[0];
 			tmp = DUK_BSWAP32(tmp);
@@ -2408,7 +2408,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_readfield(duk_hthread *thr) {
 		if (offset + 8U > check_length) {
 			goto fail_bounds;
 		}
-		DUK_MEMCPY((void *) du.uc, (const void *) (buf + offset), 8);
+		duk_memcpy((void *) du.uc, (const void *) (buf + offset), 8);
 		if (endswap) {
 			DUK_DBLUNION_BSWAP64(&du);
 		}
@@ -2646,7 +2646,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_hthread *thr) {
 		}
 		du.us[0] = tmp;
 		/* sign doesn't matter when writing */
-		DUK_MEMCPY((void *) (buf + offset), (const void *) du.uc, 2);
+		duk_memcpy((void *) (buf + offset), (const void *) du.uc, 2);
 		break;
 	}
 	case DUK__FLD_32BIT: {
@@ -2660,7 +2660,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_hthread *thr) {
 		}
 		du.ui[0] = tmp;
 		/* sign doesn't matter when writing */
-		DUK_MEMCPY((void *) (buf + offset), (const void *) du.uc, 4);
+		duk_memcpy((void *) (buf + offset), (const void *) du.uc, 4);
 		break;
 	}
 	case DUK__FLD_FLOAT: {
@@ -2675,7 +2675,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_hthread *thr) {
 			du.ui[0] = tmp;
 		}
 		/* sign doesn't matter when writing */
-		DUK_MEMCPY((void *) (buf + offset), (const void *) du.uc, 4);
+		duk_memcpy((void *) (buf + offset), (const void *) du.uc, 4);
 		break;
 	}
 	case DUK__FLD_DOUBLE: {
@@ -2687,7 +2687,7 @@ DUK_INTERNAL duk_ret_t duk_bi_buffer_writefield(duk_hthread *thr) {
 			DUK_DBLUNION_BSWAP64(&du);
 		}
 		/* sign doesn't matter when writing */
-		DUK_MEMCPY((void *) (buf + offset), (const void *) du.uc, 8);
+		duk_memcpy((void *) (buf + offset), (const void *) du.uc, 8);
 		break;
 	}
 	case DUK__FLD_VARINT: {

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -200,7 +200,7 @@ DUK_LOCAL duk_bool_t duk__parse_string_iso8601_subset(duk_hthread *thr, const ch
 	duk_small_uint_t i;
 
 	/* During parsing, month and day are one-based; set defaults here. */
-	DUK_MEMZERO(parts, sizeof(parts));
+	duk_memzero(parts, sizeof(parts));
 	DUK_ASSERT(parts[DUK_DATE_IDX_YEAR] == 0);  /* don't care value, year is mandatory */
 	parts[DUK_DATE_IDX_MONTH] = 1;
 	parts[DUK_DATE_IDX_DAY] = 1;

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -132,7 +132,7 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 	t = (time_t) (d / 1000.0);
 	DUK_DDD(DUK_DDDPRINT("timeval: %lf -> time_t %ld", (double) d, (long) t));
 
-	DUK_MEMZERO((void *) tms, sizeof(struct tm) * 2);
+	duk_memzero((void *) tms, sizeof(struct tm) * 2);
 
 #if defined(DUK_USE_DATE_TZO_GMTIME_R)
 	(void) gmtime_r(&t, &tms[0]);
@@ -142,9 +142,9 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 	(void) localtime_s(&t, &tms[1]);
 #elif defined(DUK_USE_DATE_TZO_GMTIME)
 	tm_ptr = gmtime(&t);
-	DUK_MEMCPY((void *) &tms[0], tm_ptr, sizeof(struct tm));
+	duk_memcpy((void *) &tms[0], tm_ptr, sizeof(struct tm));
 	tm_ptr = localtime(&t);
-	DUK_MEMCPY((void *) &tms[1], tm_ptr, sizeof(struct tm));
+	duk_memcpy((void *) &tms[1], tm_ptr, sizeof(struct tm));
 #else
 #error internal error
 #endif
@@ -205,13 +205,13 @@ DUK_INTERNAL duk_bool_t duk_bi_date_parse_string_strptime(duk_hthread *thr, cons
 
 	/* Copy to buffer with slack to avoid Valgrind gripes from strptime. */
 	DUK_ASSERT(str != NULL);
-	DUK_MEMZERO(buf, sizeof(buf));  /* valgrind whine without this */
+	duk_memzero(buf, sizeof(buf));  /* valgrind whine without this */
 	DUK_SNPRINTF(buf, sizeof(buf), "%s", (const char *) str);
 	buf[sizeof(buf) - 1] = (char) 0;
 
 	DUK_DDD(DUK_DDDPRINT("parsing: '%s'", (const char *) buf));
 
-	DUK_MEMZERO(&tm, sizeof(tm));
+	duk_memzero(&tm, sizeof(tm));
 	if (strptime((const char *) buf, "%c", &tm) != NULL) {
 		DUK_DDD(DUK_DDDPRINT("before mktime: tm={sec:%ld,min:%ld,hour:%ld,mday:%ld,mon:%ld,year:%ld,"
 		                     "wday:%ld,yday:%ld,isdst:%ld}",
@@ -242,7 +242,7 @@ DUK_INTERNAL duk_bool_t duk_bi_date_parse_string_getdate(duk_hthread *thr, const
 	 * convenient for an embeddable interpreter.
 	 */
 
-	DUK_MEMZERO(&tm, sizeof(struct tm));
+	duk_memzero(&tm, sizeof(struct tm));
 	rc = (duk_small_int_t) getdate_r(str, &tm);
 	DUK_DDD(DUK_DDDPRINT("getdate_r() -> %ld", (long) rc));
 
@@ -284,7 +284,7 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_
 		return 0;
 	}
 
-	DUK_MEMZERO(&tm, sizeof(tm));
+	duk_memzero(&tm, sizeof(tm));
 	tm.tm_sec = parts[DUK_DATE_IDX_SECOND];
 	tm.tm_min = parts[DUK_DATE_IDX_MINUTE];
 	tm.tm_hour = parts[DUK_DATE_IDX_HOUR];
@@ -294,7 +294,7 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_
 	tm.tm_wday = parts[DUK_DATE_IDX_WEEKDAY];
 	tm.tm_isdst = 0;
 
-	DUK_MEMZERO(buf, sizeof(buf));
+	duk_memzero(buf, sizeof(buf));
 	if ((flags & DUK_DATE_FLAG_TOSTRING_DATE) && (flags & DUK_DATE_FLAG_TOSTRING_TIME)) {
 		fmt = "%c";
 	} else if (flags & DUK_DATE_FLAG_TOSTRING_DATE) {

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -31,7 +31,7 @@ DUK_LOCAL void duk__convert_filetime_to_ularge(const FILETIME *ft, ULARGE_INTEGE
 #endif  /* DUK_USE_DATE_NOW_WINDOWS_SUBMS */
 
 DUK_LOCAL void duk__set_systime_jan1970(SYSTEMTIME *st) {
-	DUK_MEMZERO((void *) st, sizeof(*st));
+	duk_memzero((void *) st, sizeof(*st));
 	st->wYear = 1970;
 	st->wMonth = 1;
 	st->wDayOfWeek = 4;  /* not sure whether or not needed; Thursday */

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -630,7 +630,7 @@ DUK_LOCAL void duk__dec_buffer(duk_json_dec_ctx *js_ctx) {
 	src_len = (duk_size_t) (p - js_ctx->p);
 	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, src_len);
 	DUK_ASSERT(buf != NULL);
-	DUK_MEMCPY((void *) buf, (const void *) js_ctx->p, src_len);
+	duk_memcpy((void *) buf, (const void *) js_ctx->p, src_len);
 	duk_hex_decode(thr, -1);
 
 	js_ctx->p = p + 1;  /* skip '|' */
@@ -1437,7 +1437,7 @@ DUK_LOCAL duk_uint8_t *duk__enc_buffer_data_hex(const duk_uint8_t *src, duk_size
 
 	/* Unlike in duk_hex_encode() 'dst' is not necessarily aligned by 2.
 	 * For platforms where unaligned accesses are not allowed, shift 'dst'
-	 * ahead by 1 byte to get alignment and then DUK_MEMMOVE() the result
+	 * ahead by 1 byte to get alignment and then duk_memmove() the result
 	 * in place.  The faster encoding loop makes up the difference.
 	 * There's always space for one extra byte because a terminator always
 	 * follows the hex data and that's been accounted for by the caller.
@@ -1470,7 +1470,7 @@ DUK_LOCAL duk_uint8_t *duk__enc_buffer_data_hex(const duk_uint8_t *src, duk_size
 #if !defined(DUK_USE_UNALIGNED_ACCESSES_POSSIBLE)
 	if (shift_dst) {
 		q--;
-		DUK_MEMMOVE((void *) dst, (const void *) (dst + 1), 2 * len_safe);
+		duk_memmove((void *) dst, (const void *) (dst + 1), 2 * len_safe);
 		DUK_ASSERT(dst + 2 * len_safe == q);
 	}
 #endif
@@ -1546,7 +1546,7 @@ DUK_LOCAL void duk__enc_buffer_data(duk_json_enc_ctx *js_ctx, duk_uint8_t *buf_d
 #if defined(DUK_USE_JC)
 	{
 		DUK_ASSERT(js_ctx->flag_ext_compatible);
-		DUK_MEMCPY((void *) q, (const void *) "{\"_buf\":\"", 9);  /* len: 9 */
+		duk_memcpy((void *) q, (const void *) "{\"_buf\":\"", 9);  /* len: 9 */
 		q += 9;
 		q = duk__enc_buffer_data_hex(buf_data, buf_len, q);
 		*q++ = DUK_ASC_DOUBLEQUOTE;
@@ -1619,7 +1619,7 @@ DUK_LOCAL void duk__enc_pointer(duk_json_enc_ctx *js_ctx, void *ptr) {
 	DUK_ASSERT(js_ctx->flag_ext_custom || js_ctx->flag_ext_compatible);  /* caller checks */
 	DUK_ASSERT(js_ctx->flag_ext_custom_or_compatible);
 
-	DUK_MEMZERO(buf, sizeof(buf));
+	duk_memzero(buf, sizeof(buf));
 
 	/* The #if defined() clutter here needs to handle the three
 	 * cases: (1) JX+JC, (2) JX only, (3) JC only.
@@ -1709,21 +1709,21 @@ DUK_LOCAL void duk__enc_newline_indent(duk_json_enc_ctx *js_ctx, duk_uint_t dept
 	p = DUK_BW_ENSURE_GETPTR(js_ctx->thr, &js_ctx->bw, need_bytes);
 	p_start = p;
 
-	DUK_MEMCPY((void *) p, (const void *) gap_data, (size_t) gap_len);
+	duk_memcpy((void *) p, (const void *) gap_data, (size_t) gap_len);
 	p += gap_len;
 	avail_bytes = gap_len;
 	DUK_ASSERT(need_bytes >= gap_len);
 	need_bytes -= gap_len;
 
 	while (need_bytes >= avail_bytes) {
-		DUK_MEMCPY((void *) p, (const void *) p_start, (size_t) avail_bytes);
+		duk_memcpy((void *) p, (const void *) p_start, (size_t) avail_bytes);
 		p += avail_bytes;
 		need_bytes -= avail_bytes;
 		avail_bytes <<= 1;
 	}
 
 	DUK_ASSERT(need_bytes < avail_bytes);  /* need_bytes may be zero */
-	DUK_MEMCPY((void *) p, (const void *) p_start, (size_t) need_bytes);
+	duk_memcpy((void *) p, (const void *) p_start, (size_t) need_bytes);
 	p += need_bytes;
 	/*avail_bytes += need_bytes*/
 
@@ -2812,7 +2812,7 @@ void duk_bi_json_parse_helper(duk_hthread *thr,
 	                     (unsigned long) flags,
 	                     (long) duk_get_top(thr)));
 
-	DUK_MEMZERO(&js_ctx_alloc, sizeof(js_ctx_alloc));
+	duk_memzero(&js_ctx_alloc, sizeof(js_ctx_alloc));
 	js_ctx->thr = thr;
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	/* nothing now */
@@ -2922,7 +2922,7 @@ void duk_bi_json_stringify_helper(duk_hthread *thr,
 	 *  Context init
 	 */
 
-	DUK_MEMZERO(&js_ctx_alloc, sizeof(js_ctx_alloc));
+	duk_memzero(&js_ctx_alloc, sizeof(js_ctx_alloc));
 	js_ctx->thr = thr;
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	js_ctx->h_replacer = NULL;

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -81,8 +81,8 @@ DUK_LOCAL duk_int_t duk__str_search_shared(duk_hthread *thr, duk_hstring *h_this
 		 */
 
 		if ((t == firstbyte) && ((duk_size_t) (p_end - p) >= (duk_size_t) q_blen)) {
-			DUK_ASSERT(q_blen > 0);  /* no issues with memcmp() zero size, even if broken */
-			if (DUK_MEMCMP((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
+			DUK_ASSERT(q_blen > 0);
+			if (duk_memcmp((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 				return cpos;
 			}
 		}
@@ -684,7 +684,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 
 			while (p <= p_end) {
 				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
-				if (DUK_MEMCMP((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
+				if (duk_memcmp((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 					duk_dup_0(thr);
 					h_match = duk_known_hstring(thr, -1);
 #if defined(DUK_USE_REGEXP_SUPPORT)
@@ -1065,7 +1065,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 			while (p <= p_end) {
 				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
 				DUK_ASSERT(q_blen > 0);  /* no issues with empty memcmp() */
-				if (DUK_MEMCMP((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
+				if (duk_memcmp((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 					/* never an empty match, so step 13.c.iii can't be triggered */
 					goto found;
 				}
@@ -1383,7 +1383,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 #if defined(DUK_USE_PREFER_SIZE)
 	p = buf;
 	while (count-- > 0) {
-		DUK_MEMCPY((void *) p, (const void *) src, input_blen);  /* copy size may be zero */
+		duk_memcpy((void *) p, (const void *) src, input_blen);  /* copy size may be zero */
 		p += input_blen;
 	}
 #else  /* DUK_USE_PREFER_SIZE */
@@ -1402,10 +1402,10 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 			/* If result_len is zero, this case is taken and does
 			 * a zero size copy.
 			 */
-			DUK_MEMCPY((void *) p, (const void *) src, remain);
+			duk_memcpy((void *) p, (const void *) src, remain);
 			break;
 		} else {
-			DUK_MEMCPY((void *) p, (const void *) src, copy_size);
+			duk_memcpy((void *) p, (const void *) src, copy_size);
 			p += copy_size;
 		}
 
@@ -1460,8 +1460,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_locale_compare(duk_hthread *thr) 
 	h2_len = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h2);
 	prefix_len = (h1_len <= h2_len ? h1_len : h2_len);
 
-	/* Zero size compare not an issue with DUK_MEMCMP. */
-	rc = (duk_small_int_t) DUK_MEMCMP((const void *) DUK_HSTRING_GET_DATA(h1),
+	rc = (duk_small_int_t) duk_memcmp((const void *) DUK_HSTRING_GET_DATA(h1),
 	                                  (const void *) DUK_HSTRING_GET_DATA(h2),
 	                                  (size_t) prefix_len);
 
@@ -1542,7 +1541,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_startswith_endswith(duk_hthread *
 	result = 0;
 	if (p_cmp_start >= DUK_HSTRING_GET_DATA(h) &&
 	    (duk_size_t) (p_cmp_start - (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h)) + blen_search <= DUK_HSTRING_GET_BYTELEN(h)) {
-		if (DUK_MEMCMP((const void *) p_cmp_start,
+		if (duk_memcmp((const void *) p_cmp_start,
 		               (const void *) DUK_HSTRING_GET_DATA(h_search),
 		               (size_t) blen_search) == 0) {
 			result = 1;

--- a/src-input/duk_debug_fixedbuffer.c
+++ b/src-input/duk_debug_fixedbuffer.c
@@ -18,7 +18,7 @@ DUK_INTERNAL void duk_fb_put_bytes(duk_fixedbuffer *fb, const duk_uint8_t *buffe
 	} else {
 		copylen = length;
 	}
-	DUK_MEMCPY(fb->buffer + fb->offset, buffer, copylen);
+	duk_memcpy(fb->buffer + fb->offset, buffer, copylen);
 	fb->offset += copylen;
 }
 

--- a/src-input/duk_debug_macros.c
+++ b/src-input/duk_debug_macros.c
@@ -33,7 +33,7 @@ DUK_INTERNAL void duk_debug_log(duk_int_t level, const char *file, duk_int_t lin
 
 	va_start(ap, fmt);
 
-	DUK_MEMZERO((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
+	duk_memzero((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
 	duk_debug_vsnprintf(buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
 
 	arg_level = (long) level;
@@ -64,7 +64,7 @@ DUK_INTERNAL void duk_debug_log(const char *fmt, ...) {
 
 	va_start(ap, fmt);
 
-	DUK_MEMZERO((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
+	duk_memzero((void *) buf, (size_t) DUK__DEBUG_BUFSIZE);
 	duk_debug_vsnprintf(buf, DUK__DEBUG_BUFSIZE - 1, fmt, ap);
 
 	arg_level = (long) duk_debug_level_stash;

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -821,7 +821,7 @@ DUK_INTERNAL duk_int_t duk_debug_vsnprintf(char *str, duk_size_t size, const cha
 	const char *p_end = p + DUK_STRLEN(format);
 	duk_int_t retval;
 
-	DUK_MEMZERO(&fb, sizeof(fb));
+	duk_memzero(&fb, sizeof(fb));
 	fb.buffer = (duk_uint8_t *) str;
 	fb.length = size;
 	fb.offset = 0;
@@ -846,7 +846,7 @@ DUK_INTERNAL duk_int_t duk_debug_vsnprintf(char *str, duk_size_t size, const cha
 		 *  understand.  See man 3 printf.
 		 */
 
-		DUK_MEMZERO(&st, sizeof(st));
+		duk_memzero(&st, sizeof(st));
 		st.fb = &fb;
 		st.depth = 0;
 		st.depth_limit = 1;
@@ -913,8 +913,8 @@ DUK_INTERNAL duk_int_t duk_debug_vsnprintf(char *str, duk_size_t size, const cha
 					/* format is too large, abort */
 					goto format_error;
 				}
-				DUK_MEMZERO(fmtbuf, sizeof(fmtbuf));
-				DUK_MEMCPY(fmtbuf, p_begfmt, fmtlen);
+				duk_memzero(fmtbuf, sizeof(fmtbuf));
+				duk_memcpy(fmtbuf, p_begfmt, fmtlen);
 
 				/* assume exactly 1 arg, which is why '*' is forbidden; arg size still
 				 * depends on type though.
@@ -1019,7 +1019,7 @@ DUK_INTERNAL void duk_debug_format_funcptr(char *buf, duk_size_t buf_size, duk_u
 	duk_uint8_t *p = (duk_uint8_t *) buf;
 	duk_uint8_t *p_end = (duk_uint8_t *) (buf + buf_size - 1);
 
-	DUK_MEMZERO(buf, buf_size);
+	duk_memzero(buf, buf_size);
 
 	for (i = 0; i < fptr_size; i++) {
 		duk_int_t left = (duk_int_t) (p_end - p);

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -346,7 +346,7 @@ DUK_INTERNAL void duk_debug_read_bytes(duk_hthread *thr, duk_uint8_t *data, duk_
 	return;
 
  fail:
-	DUK_MEMZERO((void *) data, (size_t) length);
+	duk_memzero((void *) data, (size_t) length);
 }
 
 DUK_INTERNAL duk_uint8_t duk_debug_read_byte(duk_hthread *thr) {
@@ -959,7 +959,7 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 		                   (unsigned int) du2.uc[4], (unsigned int) du2.uc[5],
 		                   (unsigned int) du2.uc[6], (unsigned int) du2.uc[7]));
 
-		if (DUK_MEMCMP((const void *) du1.uc, (const void *) du2.uc, sizeof(du1.uc)) == 0) {
+		if (duk_memcmp((const void *) du1.uc, (const void *) du2.uc, sizeof(du1.uc)) == 0) {
 			duk_debug_write_int(thr, i32);
 		} else {
 			DUK_DBLUNION_DOUBLE_HTON(&du1);
@@ -2831,11 +2831,10 @@ DUK_INTERNAL duk_bool_t duk_debug_remove_breakpoint(duk_hthread *thr, duk_small_
 	DUK_ASSERT(h != NULL);
 
 	move_size = sizeof(duk_breakpoint) * (heap->dbg_breakpoint_count - breakpoint_index - 1);
-	if (move_size > 0) {
-		DUK_MEMMOVE((void *) b,
-		            (const void *) (b + 1),
-		            (size_t) move_size);
-	}
+	duk_memmove((void *) b,
+	            (const void *) (b + 1),
+	            (size_t) move_size);
+
 	heap->dbg_breakpoint_count--;
 	heap->dbg_breakpoints_active[0] = (duk_breakpoint *) NULL;
 

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -423,7 +423,7 @@
 
 #if defined(DUK_USE_ASSERTIONS)
 #define DUK_ASSERT_SET_GARBAGE(ptr,size) do { \
-		DUK_MEMSET((void *) (ptr), 0x5a, size); \
+		duk_memset((void *) (ptr), 0x5a, size); \
 	} while (0)
 #else
 #define DUK_ASSERT_SET_GARBAGE(ptr,size) do {} while (0)

--- a/src-input/duk_hbuffer_alloc.c
+++ b/src-input/duk_hbuffer_alloc.c
@@ -47,10 +47,10 @@ DUK_INTERNAL duk_hbuffer *duk_hbuffer_alloc(duk_heap *heap, duk_size_t size, duk
 
 	/* zero everything unless requested not to do so */
 #if defined(DUK_USE_ZERO_BUFFER_DATA)
-	DUK_MEMZERO((void *) res,
+	duk_memzero((void *) res,
 	            (flags & DUK_BUF_FLAG_NOZERO) ? header_size : alloc_size);
 #else
-	DUK_MEMZERO((void *) res, header_size);
+	duk_memzero((void *) res, header_size);
 #endif
 
 	if (flags & DUK_BUF_FLAG_EXTERNAL) {

--- a/src-input/duk_hbuffer_ops.c
+++ b/src-input/duk_hbuffer_ops.c
@@ -53,7 +53,7 @@ DUK_INTERNAL void duk_hbuffer_resize(duk_hthread *thr, duk_hbuffer_dynamic *buf,
 		if (new_size > prev_size) {
 			DUK_ASSERT(new_size - prev_size > 0);
 #if defined(DUK_USE_ZERO_BUFFER_DATA)
-			DUK_MEMZERO((void *) ((char *) res + prev_size),
+			duk_memzero((void *) ((char *) res + prev_size),
 			            (duk_size_t) (new_size - prev_size));
 #endif
 		}

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -464,7 +464,7 @@ DUK_LOCAL duk_bool_t duk__init_heap_strings(duk_heap *heap) {
 	duk_bitdecoder_ctx *bd = &bd_ctx;  /* convenience */
 	duk_small_uint_t i;
 
-	DUK_MEMZERO(&bd_ctx, sizeof(bd_ctx));
+	duk_memzero(&bd_ctx, sizeof(bd_ctx));
 	bd->data = (const duk_uint8_t *) duk_strings_data;
 	bd->length = (duk_size_t) DUK_STRDATA_DATA_LENGTH;
 
@@ -894,7 +894,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	 *  Zero the struct, and start initializing roughly in order
 	 */
 
-	DUK_MEMZERO(res, sizeof(*res));
+	duk_memzero(res, sizeof(*res));
 #if defined(DUK_USE_ASSERTIONS)
 	res->heap_initializing = 1;
 #endif
@@ -1030,7 +1030,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 
 #if defined(DUK_USE_STRTAB_PTRCOMP)
 	/* zero assumption */
-	DUK_MEMZERO(res->strtable16, sizeof(duk_uint16_t) * st_initsize);
+	duk_memzero(res->strtable16, sizeof(duk_uint16_t) * st_initsize);
 #else
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	{
@@ -1040,7 +1040,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	        }
 	}
 #else
-	DUK_MEMZERO(res->strtable, sizeof(duk_hstring *) * st_initsize);
+	duk_memzero(res->strtable, sizeof(duk_hstring *) * st_initsize);
 #endif  /* DUK_USE_EXPLICIT_NULL_INIT */
 #endif  /* DUK_USE_STRTAB_PTRCOMP */
 
@@ -1128,7 +1128,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	{
 		duk_uint64_t tmp_u64;
 		tmp_u64 = 0;
-		DUK_MEMCPY((void *) &tmp_u64,
+		duk_memcpy((void *) &tmp_u64,
 		           (const void *) &res,
 		           (size_t) (sizeof(void *) >= sizeof(duk_uint64_t) ? sizeof(duk_uint64_t) : sizeof(void *)));
 		res->rnd_state[1] ^= tmp_u64;

--- a/src-input/duk_heap_memory.c
+++ b/src-input/duk_heap_memory.c
@@ -128,7 +128,7 @@ DUK_INTERNAL void *duk_heap_mem_alloc_zeroed(duk_heap *heap, duk_size_t size) {
 	res = DUK_ALLOC(heap, size);
 	if (DUK_LIKELY(res != NULL)) {
 		/* assume memset with zero size is OK */
-		DUK_MEMZERO(res, size);
+		duk_memzero(res, size);
 	}
 	return res;
 }

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -284,7 +284,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 			duk_strcache tmp;
 
 			tmp = *sce;
-			DUK_MEMMOVE((void *) (&heap->strcache[1]),
+			duk_memmove((void *) (&heap->strcache[1]),
 			            (const void *) (&heap->strcache[0]),
 			            (size_t) (((char *) sce) - ((char *) &heap->strcache[0])));
 			heap->strcache[0] = tmp;

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -54,7 +54,7 @@ DUK_INTERNAL void duk_heap_strtable_dump(duk_heap *heap) {
 		return;
 	}
 
-	DUK_MEMZERO((void *) count_len, sizeof(count_len));
+	duk_memzero((void *) count_len, sizeof(count_len));
 	for (i = 0; i < heap->st_size; i++) {
 		h = DUK__HEAPPTR_DEC16(heap, strtable[i]);
 		count_chain = 0;
@@ -166,7 +166,7 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 		if (DUK_UNLIKELY(res == NULL)) {
 			goto alloc_error;
 		}
-		DUK_MEMZERO(res, sizeof(duk_hstring_external));
+		duk_memzero(res, sizeof(duk_hstring_external));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 		DUK_HEAPHDR_STRING_INIT_NULLS(&res->hdr);
 #endif
@@ -186,14 +186,14 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 		if (DUK_UNLIKELY(res == NULL)) {
 			goto alloc_error;
 		}
-		DUK_MEMZERO(res, sizeof(duk_hstring));
+		duk_memzero(res, sizeof(duk_hstring));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 		DUK_HEAPHDR_STRING_INIT_NULLS(&res->hdr);
 #endif
 		DUK_HEAPHDR_SET_TYPE_AND_FLAGS(&res->hdr, DUK_HTYPE_STRING, 0);
 
 		data_tmp = (duk_uint8_t *) (res + 1);
-		DUK_MEMCPY(data_tmp, str, blen);
+		duk_memcpy(data_tmp, str, blen);
 		data_tmp[blen] = (duk_uint8_t) 0;
 		data = (const duk_uint8_t *) data_tmp;
 	}
@@ -690,7 +690,7 @@ DUK_LOCAL duk_hstring *duk__strtab_romstring_lookup(duk_heap *heap, const duk_ui
 	while (curr != NULL) {
 		if (strhash == DUK_HSTRING_GET_HASH(curr) &&
 		    blen == DUK_HSTRING_GET_BYTELEN(curr) &&
-		    DUK_MEMCMP((const void *) str, (const void *) DUK_HSTRING_GET_DATA(curr), blen) == 0) {
+		    duk_memcmp((const void *) str, (const void *) DUK_HSTRING_GET_DATA(curr), blen) == 0) {
 			DUK_DDD(DUK_DDDPRINT("intern check: rom string: %!O, computed hash 0x%08lx, rom hash 0x%08lx",
 			                     curr, (unsigned long) strhash, (unsigned long) DUK_HSTRING_GET_HASH(curr)));
 			return curr;

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -130,7 +130,7 @@ DUK_INTERNAL duk_hboundfunc *duk_hboundfunc_alloc(duk_heap *heap, duk_uint_t hob
 	if (!res) {
 		return NULL;
 	}
-	DUK_MEMZERO(res, sizeof(duk_hboundfunc));
+	duk_memzero(res, sizeof(duk_hboundfunc));
 
 	duk__init_object_parts(heap, hobject_flags, &res->obj);
 
@@ -172,7 +172,7 @@ DUK_INTERNAL duk_hthread *duk_hthread_alloc_unchecked(duk_heap *heap, duk_uint_t
 	if (DUK_UNLIKELY(res == NULL)) {
 		return NULL;
 	}
-	DUK_MEMZERO(res, sizeof(duk_hthread));
+	duk_memzero(res, sizeof(duk_hthread));
 
 	duk__init_object_parts(heap, hobject_flags, &res->obj);
 

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -159,7 +159,7 @@ DUK_LOCAL void duk__sort_enum_keys_es6(duk_hthread *thr, duk_hobject *h_obj, duk
 		 * are very often in order already.
 		 */
 		if (idx != idx_insert) {
-			DUK_MEMMOVE((void *) (keys + idx_insert + 1),
+			duk_memmove((void *) (keys + idx_insert + 1),
 			            (const void *) (keys + idx_insert),
 			            ((size_t) (idx - idx_insert) * sizeof(duk_hstring *)));
 			keys[idx_insert] = h_curr;

--- a/src-input/duk_hobject_pc2line.c
+++ b/src-input/duk_hobject_pc2line.c
@@ -58,7 +58,7 @@ DUK_INTERNAL void duk_hobject_pc2line_pack(duk_hthread *thr, duk_compiler_instr 
 		                     (long) hdr[hdr_index + 1]));
 #endif
 
-		DUK_MEMZERO(be_ctx, sizeof(*be_ctx));
+		duk_memzero(be_ctx, sizeof(*be_ctx));
 		be_ctx->data = ((duk_uint8_t *) hdr) + curr_offset;
 		be_ctx->length = (duk_size_t) DUK_PC2LINE_MAX_DIFF_LENGTH;
 
@@ -169,7 +169,7 @@ DUK_LOCAL duk_uint_fast32_t duk__hobject_pc2line_query_raw(duk_hthread *thr, duk
 	 *  Iterate the bitstream (line diffs) until PC is reached
 	 */
 
-	DUK_MEMZERO(bd_ctx, sizeof(*bd_ctx));
+	duk_memzero(bd_ctx, sizeof(*bd_ctx));
 	bd_ctx->data = ((duk_uint8_t *) hdr) + start_offset;
 	bd_ctx->length = (duk_size_t) (DUK_HBUFFER_FIXED_GET_SIZE(buf) - start_offset);
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -807,18 +807,14 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 	} else {
 		array_copy_size = sizeof(duk_tval) * new_a_size;
 	}
-	if (array_copy_size > 0) {
-		/* Avoid zero copy with an invalid pointer.  If obj->p is NULL,
-		 * the 'new_a' pointer will be invalid which is not allowed even
-		 * when copy size is zero.
-		 */
-		DUK_ASSERT(new_a != NULL);
-		DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, obj) != NULL);
-		DUK_ASSERT(DUK_HOBJECT_GET_ASIZE(obj) > 0);
-		DUK_MEMCPY((void *) new_a,
-		           (const void *) DUK_HOBJECT_A_GET_BASE(thr->heap, obj),
-		           array_copy_size);
-	}
+
+	DUK_ASSERT(new_a != NULL || array_copy_size == 0U);
+	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, obj) != NULL || array_copy_size == 0U);
+	DUK_ASSERT(DUK_HOBJECT_GET_ASIZE(obj) > 0 || array_copy_size == 0U);
+	duk_memcpy((void *) new_a,
+	           (const void *) DUK_HOBJECT_A_GET_BASE(thr->heap, obj),
+	           array_copy_size);
+
 	for (i = DUK_HOBJECT_GET_ASIZE(obj); i < new_a_size; i++) {
 		duk_tval *tv = &new_a[i];
 		DUK_TVAL_SET_UNUSED(tv);
@@ -843,7 +839,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 
 		/* fill new_h with u32 0xff = UNUSED */
 		DUK_ASSERT(new_h_size > 0);
-		DUK_MEMSET(new_h, 0xff, sizeof(duk_uint32_t) * new_h_size);
+		duk_memset(new_h, 0xff, sizeof(duk_uint32_t) * new_h_size);
 
 		DUK_ASSERT(new_e_next <= new_h_size);  /* equality not actually possible */
 
@@ -1431,7 +1427,7 @@ DUK_INTERNAL duk_hstring *duk_hobject_get_internal_value_string(duk_heap *heap, 
 	/* This is not strictly necessary, but avoids compiler warnings; e.g.
 	 * gcc won't reliably detect that no uninitialized data is read below.
 	 */
-	DUK_MEMZERO((void *) &tv, sizeof(duk_tval));
+	duk_memzero((void *) &tv, sizeof(duk_tval));
 
 	if (duk_hobject_get_internal_value(heap, obj, &tv)) {
 		duk_hstring *h;

--- a/src-input/duk_hstring_misc.c
+++ b/src-input/duk_hstring_misc.c
@@ -189,7 +189,7 @@ DUK_INTERNAL duk_bool_t duk_hstring_equals_ascii_cstring(duk_hstring *h, const c
 	if (len != DUK_HSTRING_GET_BYTELEN(h)) {
 		return 0;
 	}
-	if (DUK_MEMCMP((const void *) cstr, (const void *) DUK_HSTRING_GET_DATA(h), len) == 0) {
+	if (duk_memcmp((const void *) cstr, (const void *) DUK_HSTRING_GET_DATA(h), len) == 0) {
 		return 1;
 	}
 	return 0;

--- a/src-input/duk_hthread_alloc.c
+++ b/src-input/duk_hthread_alloc.c
@@ -30,7 +30,7 @@ DUK_INTERNAL duk_bool_t duk_hthread_init_stacks(duk_heap *heap, duk_hthread *thr
 	if (!thr->valstack) {
 		goto fail;
 	}
-	DUK_MEMZERO(thr->valstack, alloc_size);
+	duk_memzero(thr->valstack, alloc_size);
 	thr->valstack_end = thr->valstack + DUK_VALSTACK_API_ENTRY_MINIMUM;
 	thr->valstack_alloc_end = thr->valstack + DUK_VALSTACK_INITIAL_SIZE;
 	thr->valstack_bottom = thr->valstack;

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -75,7 +75,7 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	props = DUK_ALLOC_CHECKED(thr, alloc_size);
 	DUK_ASSERT(props != NULL);
 	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal) != NULL);
-	DUK_MEMCPY((void *) props, (const void *) DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal), alloc_size);
+	duk_memcpy((void *) props, (const void *) DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal), alloc_size);
 
 	/* XXX: keep property attributes or tweak them here?
 	 * Properties will now be non-configurable even when they're
@@ -202,7 +202,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 
 	DUK_D(DUK_DPRINT("INITBUILTINS BEGIN: DUK_NUM_BUILTINS=%d, DUK_NUM_BUILTINS_ALL=%d", (int) DUK_NUM_BUILTINS, (int) DUK_NUM_ALL_BUILTINS));
 
-	DUK_MEMZERO(&bd_ctx, sizeof(bd_ctx));
+	duk_memzero(&bd_ctx, sizeof(bd_ctx));
 	bd->data = (const duk_uint8_t *) duk_builtins_data;
 	bd->length = (duk_size_t) DUK_BUILTINS_DATA_LENGTH;
 

--- a/src-input/duk_hthread_stacks.c
+++ b/src-input/duk_hthread_stacks.c
@@ -392,8 +392,8 @@ DUK_INTERNAL void duk_hthread_valstack_torture_realloc(duk_hthread *thr) {
 	/* Use DUK_ALLOC_RAW() to avoid side effects. */
 	new_ptr = (duk_tval *) DUK_ALLOC_RAW(thr->heap, alloc_size);
 	if (new_ptr != NULL) {
-		DUK_MEMCPY((void *) new_ptr, (const void *) thr->valstack, alloc_size);
-		DUK_MEMSET((void *) thr->valstack, 0x55, alloc_size);
+		duk_memcpy((void *) new_ptr, (const void *) thr->valstack, alloc_size);
+		duk_memset((void *) thr->valstack, 0x55, alloc_size);
 		DUK_FREE_CHECKED(thr, (void *) thr->valstack);
 		thr->valstack = new_ptr;
 		thr->valstack_alloc_end = (duk_tval *) ((duk_uint8_t *) new_ptr + alloc_end_off);

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -477,7 +477,7 @@ DUK_LOCAL void duk__advance_helper(duk_compiler_ctx *comp_ctx, duk_small_int_t e
 	}
 
 	/* make current token the previous; need to fiddle with valstack "backing store" */
-	DUK_MEMCPY(&comp_ctx->prev_token, &comp_ctx->curr_token, sizeof(duk_token));
+	duk_memcpy(&comp_ctx->prev_token, &comp_ctx->curr_token, sizeof(duk_token));
 	duk_copy(thr, comp_ctx->tok11_idx, comp_ctx->tok21_idx);
 	duk_copy(thr, comp_ctx->tok12_idx, comp_ctx->tok22_idx);
 
@@ -525,7 +525,7 @@ DUK_LOCAL void duk__init_func_valstack_slots(duk_compiler_ctx *comp_ctx) {
 
 	entry_top = duk_get_top(thr);
 
-	DUK_MEMZERO(func, sizeof(*func));  /* intentional overlap with earlier memzero */
+	duk_memzero(func, sizeof(*func));  /* intentional overlap with earlier memzero */
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	func->h_name = NULL;
 	func->h_consts = NULL;
@@ -4891,7 +4891,7 @@ DUK_LOCAL void duk__expr(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_small_
 	                     (long) rbp_flags, (long) rbp, (long) comp_ctx->curr_func.allow_in,
 	                     (long) comp_ctx->curr_func.paren_level));
 
-	DUK_MEMZERO(&tmp_alloc, sizeof(tmp_alloc));
+	duk_memzero(&tmp_alloc, sizeof(tmp_alloc));
 	tmp->x1.valstack_idx = duk_get_top(thr);
 	tmp->x2.valstack_idx = tmp->x1.valstack_idx + 1;
 	duk_push_undefined(thr);
@@ -6843,7 +6843,7 @@ DUK_LOCAL void duk__parse_stmts(duk_compiler_ctx *comp_ctx, duk_bool_t allow_sou
 	 * for nested functions (which may occur inside expressions).
 	 */
 
-	DUK_MEMZERO(&res_alloc, sizeof(res_alloc));
+	duk_memzero(&res_alloc, sizeof(res_alloc));
 	res->t = DUK_IVAL_PLAIN;
 	res->x1.t = DUK_ISPEC_VALUE;
 	res->x1.valstack_idx = duk_get_top(thr);
@@ -7751,9 +7751,9 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
 	DUK_DDD(DUK_DDDPRINT("before func: entry_top=%ld, curr_tok.start_offset=%ld",
 	                     (long) entry_top, (long) comp_ctx->curr_token.start_offset));
 
-	DUK_MEMCPY(&old_func, &comp_ctx->curr_func, sizeof(duk_compiler_func));
+	duk_memcpy(&old_func, &comp_ctx->curr_func, sizeof(duk_compiler_func));
 
-	DUK_MEMZERO(&comp_ctx->curr_func, sizeof(duk_compiler_func));
+	duk_memzero(&comp_ctx->curr_func, sizeof(duk_compiler_func));
 	duk__init_func_valstack_slots(comp_ctx);
 	DUK_ASSERT(comp_ctx->curr_func.num_formals == 0);
 
@@ -7820,7 +7820,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
 	} else {
 		duk_set_top(thr, entry_top);
 	}
-	DUK_MEMCPY((void *) &comp_ctx->curr_func, (void *) &old_func, sizeof(duk_compiler_func));
+	duk_memcpy((void *) &comp_ctx->curr_func, (void *) &old_func, sizeof(duk_compiler_func));
 
 	return fnum;
 }
@@ -7998,7 +7998,7 @@ DUK_INTERNAL void duk_js_compile(duk_hthread *thr, const duk_uint8_t *src_buffer
 	DUK_ASSERT(src_buffer != NULL);
 
 	/* preinitialize lexer state partially */
-	DUK_MEMZERO(&comp_stk, sizeof(comp_stk));
+	duk_memzero(&comp_stk, sizeof(comp_stk));
 	comp_stk.flags = flags;
 	DUK_LEXER_INITCTX(&comp_stk.comp_ctx_alloc.lex);
 	comp_stk.comp_ctx_alloc.lex.input = src_buffer;

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -50,7 +50,7 @@ DUK_LOCAL void duk__push_tvals_incref_only(duk_hthread *thr, duk_tval *tv_src, d
 
 	tv_dst = thr->valstack_top;
 	copy_size = sizeof(duk_tval) * count;
-	DUK_MEMCPY((void *) tv_dst, (const void *) tv_src, copy_size);
+	duk_memcpy((void *) tv_dst, (const void *) tv_src, copy_size);
 	for (i = 0; i < count; i++) {
 		DUK_TVAL_INCREF(thr, tv_dst);
 		tv_dst++;

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -726,10 +726,10 @@ DUK_INTERNAL duk_small_int_t duk_js_data_compare(const duk_uint8_t *buf1, const 
 
 	prefix_len = (len1 <= len2 ? len1 : len2);
 
-	/* DUK_MEMCMP() is guaranteed to return zero (equal) for zero length
+	/* duk_memcmp() is guaranteed to return zero (equal) for zero length
 	 * inputs so no zero length check is needed.
 	 */
-	rc = DUK_MEMCMP((const void *) buf1,
+	rc = duk_memcmp((const void *) buf1,
 	                (const void *) buf2,
 	                (size_t) prefix_len);
 

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -336,7 +336,7 @@ DUK_LOCAL void duk__advance_bytes(duk_lexer_ctx *lex_ctx, duk_small_uint_t count
 		/* Not enough data to provide a full window, so "scroll" window to
 		 * start of buffer and fill up the rest.
 		 */
-		DUK_MEMMOVE((void *) lex_ctx->buffer,
+		duk_memmove((void *) lex_ctx->buffer,
 		            (const void *) lex_ctx->window,
 		            (size_t) avail_bytes);
 		lex_ctx->window = lex_ctx->buffer;
@@ -487,7 +487,7 @@ DUK_LOCAL void duk__advance_bytes(duk_lexer_ctx *lex_ctx, duk_small_uint_t count
 	/* Zero 'count' is also allowed to make call sites easier. */
 
 	keep_bytes = DUK_LEXER_WINDOW_SIZE * sizeof(duk_lexer_codepoint) - count_bytes;
-	DUK_MEMMOVE((void *) lex_ctx->window,
+	duk_memmove((void *) lex_ctx->window,
 	            (const void *) ((duk_uint8_t *) lex_ctx->window + count_bytes),
 	            (size_t) keep_bytes);
 
@@ -576,7 +576,7 @@ DUK_LOCAL duk_hstring *duk__internbuffer(duk_lexer_ctx *lex_ctx, duk_idx_t valst
 DUK_INTERNAL void duk_lexer_initctx(duk_lexer_ctx *lex_ctx) {
 	DUK_ASSERT(lex_ctx != NULL);
 
-	DUK_MEMZERO(lex_ctx, sizeof(*lex_ctx));
+	duk_memzero(lex_ctx, sizeof(*lex_ctx));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 #if defined(DUK_USE_LEXER_SLIDING_WINDOW)
 	lex_ctx->window = NULL;
@@ -1834,7 +1834,7 @@ DUK_INTERNAL void duk_lexer_parse_re_token(duk_lexer_ctx *lex_ctx, duk_re_token 
 		goto fail_token_limit;
 	}
 
-	DUK_MEMZERO(out_token, sizeof(*out_token));
+	duk_memzero(out_token, sizeof(*out_token));
 
 	x = DUK__L0();
 	y = DUK__L1();

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -133,10 +133,8 @@ DUK_LOCAL void duk__bi_copy(duk__bigint *x, duk__bigint *y) {
 
 	n = y->n;
 	x->n = n;
-	if (n == 0) {
-		return;
-	}
-	DUK_MEMCPY((void *) x->v, (const void *) y->v, (size_t) (sizeof(duk_uint32_t) * (size_t) n));
+	/* No need to special case n == 0. */
+	duk_memcpy((void *) x->v, (const void *) y->v, (size_t) (sizeof(duk_uint32_t) * (size_t) n));
 }
 
 DUK_LOCAL void duk__bi_set_small(duk__bigint *x, duk_uint32_t v) {
@@ -412,7 +410,7 @@ DUK_LOCAL void duk__bi_mul(duk__bigint *x, duk__bigint *y, duk__bigint *z) {
 		return;
 	}
 
-	DUK_MEMZERO((void *) x->v, (size_t) (sizeof(duk_uint32_t) * (size_t) nx));
+	duk_memzero((void *) x->v, (size_t) (sizeof(duk_uint32_t) * (size_t) nx));
 	x->n = nx;
 
 	nz = z->n;
@@ -562,7 +560,7 @@ DUK_LOCAL void duk__bi_twoexp(duk__bigint *x, duk_small_int_t y) {
 	n = (y / 32) + 1;
 	DUK_ASSERT(n > 0);
 	r = y % 32;
-	DUK_MEMZERO((void *) x->v, sizeof(duk_uint32_t) * (size_t) n);
+	duk_memzero((void *) x->v, sizeof(duk_uint32_t) * (size_t) n);
 	x->n = n;
 	x->v[n - 1] = (((duk_uint32_t) 1) << r);
 }
@@ -698,7 +696,7 @@ DUK_LOCAL duk_size_t duk__dragon4_format_uint32(duk_uint8_t *buf, duk_uint32_t x
 	}
 	len = (duk_size_t) ((buf + 32) - p);
 
-	DUK_MEMMOVE((void *) buf, (const void *) p, (size_t) len);
+	duk_memmove((void *) buf, (const void *) p, (size_t) len);
 
 	return len;
 }
@@ -1101,7 +1099,7 @@ DUK_LOCAL void duk__dragon4_generate(duk__numconv_stringify_ctx *nc_ctx) {
 	{
 		duk_uint8_t buf[2048];
 		duk_small_int_t i, t;
-		DUK_MEMZERO(buf, sizeof(buf));
+		duk_memzero(buf, sizeof(buf));
 		for (i = 0; i < nc_ctx->count; i++) {
 			t = nc_ctx->digits[i];
 			if (t < 0 || t > 36) {
@@ -1166,7 +1164,7 @@ DUK_LOCAL duk_small_int_t duk__dragon4_fixed_format_round(duk__numconv_stringify
 			*p = 0;
 			if (p == &nc_ctx->digits[0]) {
 				DUK_DDD(DUK_DDDPRINT("carry propagated to first digit -> special case handling"));
-				DUK_MEMMOVE((void *) (&nc_ctx->digits[1]),
+				duk_memmove((void *) (&nc_ctx->digits[1]),
 				            (const void *) (&nc_ctx->digits[0]),
 				            (size_t) (sizeof(char) * (size_t) nc_ctx->count));
 				nc_ctx->digits[0] = 1;  /* don't increase 'count' */
@@ -1411,7 +1409,7 @@ DUK_LOCAL void duk__dragon4_ctx_to_double(duk__numconv_stringify_ctx *nc_ctx, du
 	 * (perhaps because the low part is set (seemingly) conditionally in a
 	 * loop), so this is here to avoid the bogus warning.
 	 */
-	DUK_MEMZERO((void *) &u, sizeof(u));
+	duk_memzero((void *) &u, sizeof(u));
 
 	/*
 	 *  Figure out how generated digits match up with the mantissa,
@@ -1626,7 +1624,7 @@ DUK_INTERNAL void duk_numconv_stringify(duk_hthread *thr, duk_small_int_t radix,
 	 * is 1-2 kilobytes and nothing should rely on it being zeroed.
 	 */
 #if 0
-	DUK_MEMZERO((void *) nc_ctx, sizeof(*nc_ctx));  /* slow init, do only for slow path cases */
+	duk_memzero((void *) nc_ctx, sizeof(*nc_ctx));  /* slow init, do only for slow path cases */
 #endif
 
 	nc_ctx->is_s2n = 0;
@@ -1666,7 +1664,7 @@ DUK_INTERNAL void duk_numconv_stringify(duk_hthread *thr, duk_small_int_t radix,
 		}
 		DUK_DDD(DUK_DDDPRINT("count=%ld", (long) count));
 		DUK_ASSERT(count >= 1);
-		DUK_MEMZERO((void *) nc_ctx->digits, (size_t) count);
+		duk_memzero((void *) nc_ctx->digits, (size_t) count);
 		nc_ctx->count = count;
 		nc_ctx->k = 1;  /* 0.000... */
 		neg = 0;

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -1160,7 +1160,7 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 
 	/* [ ... pattern flags escaped_source buffer ] */
 
-	DUK_MEMZERO(&re_ctx, sizeof(re_ctx));
+	duk_memzero(&re_ctx, sizeof(re_ctx));
 	DUK_LEXER_INITCTX(&re_ctx.lex);  /* duplicate zeroing, expect for (possible) NULL inits */
 	re_ctx.thr = thr;
 	re_ctx.lex.thr = thr;

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -503,14 +503,14 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 			range_save = (duk_uint8_t **) duk_push_fixed_buffer_nozero(re_ctx->thr,
 			                                                           sizeof(duk_uint8_t *) * idx_count);
 			DUK_ASSERT(range_save != NULL);
-			DUK_MEMCPY(range_save, re_ctx->saved + idx_start, sizeof(duk_uint8_t *) * idx_count);
+			duk_memcpy(range_save, re_ctx->saved + idx_start, sizeof(duk_uint8_t *) * idx_count);
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 			idx_end = idx_start + idx_count;
 			for (idx = idx_start; idx < idx_end; idx++) {
 				re_ctx->saved[idx] = NULL;
 			}
 #else
-			DUK_MEMZERO((void *) (re_ctx->saved + idx_start), sizeof(duk_uint8_t *) * idx_count);
+			duk_memzero((void *) (re_ctx->saved + idx_start), sizeof(duk_uint8_t *) * idx_count);
 #endif
 
 			sub_sp = duk__match_regexp(re_ctx, pc, sp);
@@ -528,7 +528,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 			DUK_DDD(DUK_DDDPRINT("fail: restore wiped/resaved values [%ld,%ld] (captures [%ld,%ld])",
 			                     (long) idx_start, (long) (idx_start + idx_count - 1),
 			                     (long) (idx_start / 2), (long) ((idx_start + idx_count - 1) / 2)));
-			DUK_MEMCPY((void *) (re_ctx->saved + idx_start),
+			duk_memcpy((void *) (re_ctx->saved + idx_start),
 			           (const void *) range_save,
 			           sizeof(duk_uint8_t *) * idx_count);
 			duk_pop_unsafe(re_ctx->thr);
@@ -560,7 +560,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 			full_save = (duk_uint8_t **) duk_push_fixed_buffer_nozero(re_ctx->thr,
 			                                                          sizeof(duk_uint8_t *) * re_ctx->nsaved);
 			DUK_ASSERT(full_save != NULL);
-			DUK_MEMCPY(full_save, re_ctx->saved, sizeof(duk_uint8_t *) * re_ctx->nsaved);
+			duk_memcpy(full_save, re_ctx->saved, sizeof(duk_uint8_t *) * re_ctx->nsaved);
 
 			skip = duk__bc_get_i32(re_ctx, &pc);
 			sub_sp = duk__match_regexp(re_ctx, pc, sp);
@@ -585,7 +585,7 @@ DUK_LOCAL const duk_uint8_t *duk__match_regexp(duk_re_matcher_ctx *re_ctx, const
 
 		 lookahead_fail:
 			/* fail: restore saves */
-			DUK_MEMCPY((void *) re_ctx->saved,
+			duk_memcpy((void *) re_ctx->saved,
 			           (const void *) full_save,
 			           sizeof(duk_uint8_t *) * re_ctx->nsaved);
 			duk_pop_unsafe(re_ctx->thr);
@@ -733,7 +733,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 
 	/* [ ... re_obj input bc ] */
 
-	DUK_MEMZERO(&re_ctx, sizeof(re_ctx));
+	duk_memzero(&re_ctx, sizeof(re_ctx));
 
 	re_ctx.thr = thr;
 	re_ctx.input = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
@@ -770,7 +770,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 #elif defined(DUK_USE_ZERO_BUFFER_DATA)
 	/* buffer is automatically zeroed */
 #else
-	DUK_MEMZERO((void *) p_buf, sizeof(duk_uint8_t *) * re_ctx.nsaved);
+	duk_memzero((void *) p_buf, sizeof(duk_uint8_t *) * re_ctx.nsaved);
 #endif
 
 	DUK_DDD(DUK_DDDPRINT("regexp ctx initialized, flags=0x%08lx, nsaved=%ld, recursion_limit=%ld, steps_limit=%ld",

--- a/src-input/duk_selftest.c
+++ b/src-input/duk_selftest.c
@@ -23,13 +23,13 @@ typedef union {
 	} while (0)
 
 #define DUK__DBLUNION_CMP_TRUE(a,b)  do { \
-		if (DUK_MEMCMP((const void *) (a), (const void *) (b), sizeof(duk__test_double_union)) != 0) { \
+		if (duk_memcmp((const void *) (a), (const void *) (b), sizeof(duk__test_double_union)) != 0) { \
 			DUK__FAILED("double union compares false (expected true)"); \
 		} \
 	} while (0)
 
 #define DUK__DBLUNION_CMP_FALSE(a,b)  do { \
-		if (DUK_MEMCMP((const void *) (a), (const void *) (b), sizeof(duk__test_double_union)) == 0) { \
+		if (duk_memcmp((const void *) (a), (const void *) (b), sizeof(duk__test_double_union)) == 0) { \
 			DUK__FAILED("double union compares true (expected false)"); \
 		} \
 	} while (0)
@@ -338,7 +338,7 @@ DUK_LOCAL duk_uint_t duk__selftest_double_rounding(void) {
 	 */
 	DUK__DOUBLE_INIT(&a, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
 	DUK__DOUBLE_INIT(&b, 0x3c, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
-	DUK_MEMSET((void *) &c, 0, sizeof(c));
+	duk_memset((void *) &c, 0, sizeof(c));
 	c.d = a.d + b.d;
 	if (!DUK__DOUBLE_COMPARE(&c, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)) {
 		DUK_D(DUK_DPRINT("broken result (native endiannesss): %02x %02x %02x %02x %02x %02x %02x %02x",
@@ -358,7 +358,7 @@ DUK_LOCAL duk_uint_t duk__selftest_double_rounding(void) {
 	 */
 	DUK__DOUBLE_INIT(&a, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01);
 	DUK__DOUBLE_INIT(&b, 0x3c, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
-	DUK_MEMSET((void *) &c, 0, sizeof(c));
+	duk_memset((void *) &c, 0, sizeof(c));
 	c.d = a.d + b.d;
 	if (!DUK__DOUBLE_COMPARE(&c, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02)) {
 		DUK_D(DUK_DPRINT("broken result (native endiannesss): %02x %02x %02x %02x %02x %02x %02x %02x",

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -429,7 +429,7 @@ DUK_LOCAL duk_small_int_t duk__uni_range_match(const duk_uint8_t *unitab, duk_si
 	duk_bitdecoder_ctx bd_ctx;
 	duk_codepoint_t prev_re;
 
-	DUK_MEMZERO(&bd_ctx, sizeof(bd_ctx));
+	duk_memzero(&bd_ctx, sizeof(bd_ctx));
 	bd_ctx.data = (const duk_uint8_t *) unitab;
 	bd_ctx.length = (duk_size_t) unilen;
 
@@ -981,7 +981,7 @@ duk_codepoint_t duk__case_transform_helper(duk_hthread *thr,
 	}
 
 	/* 1:1 or special conversions, but not locale/context specific: script generated rules */
-	DUK_MEMZERO(&bd_ctx, sizeof(bd_ctx));
+	duk_memzero(&bd_ctx, sizeof(bd_ctx));
 	if (uppercase) {
 		bd_ctx.data = (const duk_uint8_t *) duk_unicode_caseconv_uc;
 		bd_ctx.length = (duk_size_t) sizeof(duk_unicode_caseconv_uc);

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -320,7 +320,7 @@ struct duk_bufwriter_ctx {
 		duk_size_t duk__valsz; \
 		duk__valptr = (const void *) (valptr); \
 		duk__valsz = (duk_size_t) (valsz); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
+		duk_memcpy((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
 		(bw_ctx)->p += duk__valsz; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_CSTRING(thr,bw_ctx,val) do { \
@@ -328,31 +328,31 @@ struct duk_bufwriter_ctx {
 		duk_size_t duk__val_len; \
 		duk__val = (const duk_uint8_t *) (val); \
 		duk__val_len = DUK_STRLEN((const char *) duk__val); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HSTRING(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_GET_SIZE((val)); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER_FIXED(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_FIXED_GET_SIZE((val)); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER_DYNAMIC(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_DYNAMIC_GET_SIZE((val)); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 
@@ -431,35 +431,35 @@ struct duk_bufwriter_ctx {
 		duk__val = (const duk_uint8_t *) (val); \
 		duk__val_len = DUK_STRLEN((const char *) duk__val); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HSTRING(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER_FIXED(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_FIXED_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER_DYNAMIC(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_DYNAMIC_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		DUK_MEMCPY((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 
@@ -543,7 +543,10 @@ DUK_INTERNAL_DECL void duk_byteswap_bytes(duk_uint8_t *p, duk_small_uint_t len);
 #endif
 
 DUK_INTERNAL_DECL void duk_memcpy(void *dst, const void *src, duk_size_t len);
+DUK_INTERNAL_DECL void duk_memmove(void *dst, const void *src, duk_size_t len);
 DUK_INTERNAL_DECL duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len);
+DUK_INTERNAL_DECL void duk_memset(void *s, duk_small_int_t c, duk_size_t len);
+DUK_INTERNAL_DECL void duk_memzero(void *s, duk_size_t len);
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32_nonegzero(duk_double_t x, duk_int32_t *ival);
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32(duk_double_t x, duk_int32_t *ival);

--- a/src-input/duk_util_bufwriter.c
+++ b/src-input/duk_util_bufwriter.c
@@ -105,7 +105,7 @@ DUK_INTERNAL void duk_bw_write_raw_slice(duk_hthread *thr, duk_bufwriter_ctx *bw
 	DUK_UNREF(thr);
 
 	p_base = bw->p_base;
-	DUK_MEMCPY((void *) bw->p,
+	duk_memcpy((void *) bw->p,
 	           (const void *) (p_base + src_off),
 	           (size_t) len);
 	bw->p += len;
@@ -137,10 +137,10 @@ DUK_INTERNAL void duk_bw_insert_raw_bytes(duk_hthread *thr, duk_bufwriter_ctx *b
 	move_sz = buf_sz - dst_off;
 
 	DUK_ASSERT(p_base != NULL);  /* buffer size is >= 1 */
-	DUK_MEMMOVE((void *) (p_base + dst_off + len),
+	duk_memmove((void *) (p_base + dst_off + len),
 	            (const void *) (p_base + dst_off),
 	            (size_t) move_sz);
-	DUK_MEMCPY((void *) (p_base + dst_off),
+	duk_memcpy((void *) (p_base + dst_off),
 	           (const void *) buf,
 	           (size_t) len);
 	bw->p += len;
@@ -184,10 +184,10 @@ DUK_INTERNAL void duk_bw_insert_raw_slice(duk_hthread *thr, duk_bufwriter_ctx *b
 	move_sz = buf_sz - dst_off;
 
 	DUK_ASSERT(p_base != NULL);  /* buffer size is >= 1 */
-	DUK_MEMMOVE((void *) (p_base + dst_off + len),
+	duk_memmove((void *) (p_base + dst_off + len),
 	            (const void *) (p_base + dst_off),
 	            (size_t) move_sz);
-	DUK_MEMCPY((void *) (p_base + dst_off),
+	duk_memcpy((void *) (p_base + dst_off),
 	           (const void *) (p_base + src_off),
 	           (size_t) len);
 	bw->p += len;
@@ -222,7 +222,7 @@ DUK_INTERNAL duk_uint8_t *duk_bw_insert_raw_area(duk_hthread *thr, duk_bufwriter
 	move_sz = buf_sz - off;
 	p_dst = p_base + off + len;
 	p_src = p_base + off;
-	DUK_MEMMOVE((void *) p_dst, (const void *) p_src, (size_t) move_sz);
+	duk_memmove((void *) p_dst, (const void *) p_src, (size_t) move_sz);
 	return p_src;  /* point to start of 'reserved area' */
 }
 
@@ -253,7 +253,7 @@ DUK_INTERNAL void duk_bw_remove_raw_slice(duk_hthread *thr, duk_bufwriter_ctx *b
 	p_dst = p_base + off;
 	p_src = p_dst + len;
 	move_sz = (duk_size_t) (bw->p - p_src);
-	DUK_MEMMOVE((void *) p_dst,
+	duk_memmove((void *) p_dst,
 	            (const void *) p_src,
 	            (size_t) move_sz);
 	bw->p -= len;
@@ -276,7 +276,7 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_uint16_t duk_raw_read_u16_be(duk_uint8_t **p)
 		duk_uint16_t x;
 	} u;
 
-	DUK_MEMCPY((void *) u.b, (const void *) (*p), (size_t) 2);
+	duk_memcpy((void *) u.b, (const void *) (*p), (size_t) 2);
 	u.x = DUK_NTOH16(u.x);
 	*p += 2;
 	return u.x;
@@ -288,7 +288,7 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_uint32_t duk_raw_read_u32_be(duk_uint8_t **p)
 		duk_uint32_t x;
 	} u;
 
-	DUK_MEMCPY((void *) u.b, (const void *) (*p), (size_t) 4);
+	duk_memcpy((void *) u.b, (const void *) (*p), (size_t) 4);
 	u.x = DUK_NTOH32(u.x);
 	*p += 4;
 	return u.x;
@@ -301,10 +301,10 @@ DUK_INTERNAL DUK_ALWAYS_INLINE duk_double_t duk_raw_read_double_be(duk_uint8_t *
 		duk_uint32_t x;
 	} u;
 
-	DUK_MEMCPY((void *) u.b, (const void *) (*p), (size_t) 4);
+	duk_memcpy((void *) u.b, (const void *) (*p), (size_t) 4);
 	u.x = DUK_NTOH32(u.x);
 	du.ui[DUK_DBL_IDX_UI0] = u.x;
-	DUK_MEMCPY((void *) u.b, (const void *) (*p + 4), (size_t) 4);
+	duk_memcpy((void *) u.b, (const void *) (*p + 4), (size_t) 4);
 	u.x = DUK_NTOH32(u.x);
 	du.ui[DUK_DBL_IDX_UI1] = u.x;
 	*p += 8;
@@ -319,7 +319,7 @@ DUK_INTERNAL DUK_ALWAYS_INLINE void duk_raw_write_u16_be(duk_uint8_t **p, duk_ui
 	} u;
 
 	u.x = DUK_HTON16(val);
-	DUK_MEMCPY((void *) (*p), (const void *) u.b, (size_t) 2);
+	duk_memcpy((void *) (*p), (const void *) u.b, (size_t) 2);
 	*p += 2;
 }
 
@@ -330,7 +330,7 @@ DUK_INTERNAL DUK_ALWAYS_INLINE void duk_raw_write_u32_be(duk_uint8_t **p, duk_ui
 	} u;
 
 	u.x = DUK_HTON32(val);
-	DUK_MEMCPY((void *) (*p), (const void *) u.b, (size_t) 4);
+	duk_memcpy((void *) (*p), (const void *) u.b, (size_t) 4);
 	*p += 4;
 }
 
@@ -344,9 +344,9 @@ DUK_INTERNAL DUK_ALWAYS_INLINE void duk_raw_write_double_be(duk_uint8_t **p, duk
 	du.d = val;
 	u.x = du.ui[DUK_DBL_IDX_UI0];
 	u.x = DUK_HTON32(u.x);
-	DUK_MEMCPY((void *) (*p), (const void *) u.b, (size_t) 4);
+	duk_memcpy((void *) (*p), (const void *) u.b, (size_t) 4);
 	u.x = du.ui[DUK_DBL_IDX_UI1];
 	u.x = DUK_HTON32(u.x);
-	DUK_MEMCPY((void *) (*p + 4), (const void *) u.b, (size_t) 4);
+	duk_memcpy((void *) (*p + 4), (const void *) u.b, (size_t) 4);
 	*p += 8;
 }

--- a/src-input/duk_util_memory.c
+++ b/src-input/duk_util_memory.c
@@ -14,17 +14,54 @@ DUK_INTERNAL void duk_memcpy(void *dst, const void *src, duk_size_t len) {
 	if (DUK_UNLIKELY(len == 0U)) {
 		return;
 	}
+	DUK_ASSERT(src != NULL);
+	DUK_ASSERT(dst != NULL);
+#else
+	DUK_ASSERT(src != NULL || len == 0U);
+	DUK_ASSERT(dst != NULL || len == 0U);
 #endif
 
-	(void) DUK_MEMCPY(dst, src, len);
+	(void) DUK_MEMCPY(dst, src, (size_t) len);
+}
+
+DUK_INTERNAL void duk_memmove(void *dst, const void *src, duk_size_t len) {
+#if !defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
+	if (DUK_UNLIKELY(len == 0U)) {
+		return;
+	}
+	DUK_ASSERT(src != NULL);
+	DUK_ASSERT(dst != NULL);
+#else
+	DUK_ASSERT(src != NULL || len == 0U);
+	DUK_ASSERT(dst != NULL || len == 0U);
+#endif
+
+	(void) DUK_MEMMOVE(dst, src, (size_t) len);
 }
 
 DUK_INTERNAL duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len) {
+	duk_small_int_t ret;
+
 #if !defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
 	if (DUK_UNLIKELY(len == 0U)) {
 		return 0;
 	}
+	DUK_ASSERT(s1 != NULL);
+	DUK_ASSERT(s2 != NULL);
+#else
+	DUK_ASSERT(s1 != NULL || len == 0U);
+	DUK_ASSERT(s2 != NULL || len == 0U);
 #endif
 
-	return (duk_small_int_t) DUK_MEMCMP(s1, s2, len);
+	ret = (duk_small_int_t) DUK_MEMCMP(s1, s2, (size_t) len);
+	DUK_ASSERT(ret == 0 || len > 0);  /* If len == 0, must compare equal. */
+	return ret;
+}
+
+DUK_INTERNAL void duk_memset(void *s, duk_small_int_t c, duk_size_t len) {
+	(void) DUK_MEMSET(s, (int) c, (size_t) len);
+}
+
+DUK_INTERNAL void duk_memzero(void *s, duk_size_t len) {
+	(void) DUK_MEMZERO(s, (size_t) len);
 }

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -132,6 +132,13 @@ rejected_plain_identifiers_list = [
 
     # avoid in internals, use duk_hthread exclusively (except in duktape.h.in)
     'duk_context',
+
+    # avoid in internal, except for duk_util_memory.c
+    'DUK_MEMCPY',
+    'DUK_MEMMOVE',
+    'DUK_MEMCMP',
+    'DUK_MEMSET',
+    'DUK_MEMZERO'
 ]
 rejected_plain_identifiers = {}
 for id in rejected_plain_identifiers_list:
@@ -301,6 +308,8 @@ def checkIdentifiers(lines, idx, filename):
         if rejected_plain_identifiers.has_key(m.group(0)):
             if m.group(0) in [ 'duk_context' ] and bn == 'duktape.h.in':
                 continue  # duk_context allowed in public API header
+            if m.group(0) in [ 'DUK_MEMCPY', 'DUK_MEMMOVE', 'DUK_MEMCMP', 'DUK_MEMSET', 'DUK_MEMZERO' ] and bn == 'duk_util_memory.c':
+                continue
             if not excludePlain:
                 raise Exception('invalid identifier %r (perhaps plain)' % m.group(0))
 


### PR DESCRIPTION
Use duk_memcmp() etc wrappers from all call sites so that zero-size cases are handled uniformly. Also, if the target has no issues with zero-size cases the checks can be uniformly dropped from one place as well. Remove a few explicit zero size call site checks as they should now be unnecessary.

This has too large a footprint impact (+1kB) so a follow-up will add duk_memcpy_unsafe() for the cases where portability is actually in doubt.