### PR TITLE
Footprint optimize -fsanitize=undefined fixes

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3231,7 +3231,8 @@ Planned
 
 * Fix some Clang warnings by avoiding undefined behavior by default, define
   DUK_USE_ALLOW_UNDEFINED_BEHAVIOR to reduce the explicit undefined behavior
-  checks for better footprint/performance (GH-1777, GH-1795, GH-1796, GH-1797)
+  checks for better footprint/performance (GH-1777, GH-1795, GH-1796, GH-1797,
+  GH-1798)
 
 * Fix some compilation warnings triggered when DUK_NORETURN is not defined;
   the internal DUK_WO_NORETURN() is used to include unreachable dummy

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -74,9 +74,10 @@ DUK_LOCAL duk_uint8_t *duk__dump_hbuffer_raw(duk_hthread *thr, duk_uint8_t *p, d
 	DUK_ASSERT(len <= 0xffffffffUL);  /* buffer limits */
 	tmp32 = (duk_uint32_t) len;
 	DUK_RAW_WRITE_U32_BE(p, tmp32);
-	duk_memcpy((void *) p,
-	           (const void *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h),
-	           len);
+	/* When len == 0, buffer data pointer may be NULL. */
+	duk_memcpy_unsafe((void *) p,
+	                  (const void *) DUK_HBUFFER_GET_DATA_PTR(thr->heap, h),
+	                  len);
 	p += len;
 	return p;
 }
@@ -288,7 +289,7 @@ static duk_uint8_t *duk__dump_func(duk_hthread *thr, duk_hcompfunc *func, duk_bu
 	ins_end = DUK_HCOMPFUNC_GET_CODE_END(thr->heap, func);
 	DUK_ASSERT((duk_size_t) (ins_end - ins) == (duk_size_t) count_instr);
 #if defined(DUK_USE_INTEGER_BE)
-	duk_memcpy((void *) p, (const void *) ins, (size_t) (ins_end - ins));
+	duk_memcpy_unsafe((void *) p, (const void *) ins, (size_t) (ins_end - ins));
 	p += (size_t) (ins_end - ins);
 #else
 	while (ins != ins_end) {

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -1392,8 +1392,8 @@ DUK_EXTERNAL void duk_xcopymove_raw(duk_hthread *to_thr, duk_hthread *from_thr, 
 		DUK_WO_NORETURN(return;);
 	}
 
-	/* copy values (no overlap even if to_thr == from_thr; that's not
-	 * allowed now anyway)
+	/* Copy values (no overlap even if to_thr == from_thr; that's not
+	 * allowed now anyway).
 	 */
 	DUK_ASSERT(nbytes > 0);
 	duk_memcpy((void *) to_thr->valstack_top, (const void *) src, (size_t) nbytes);
@@ -3417,7 +3417,8 @@ DUK_EXTERNAL void *duk_to_buffer_raw(duk_hthread *thr, duk_idx_t idx, duk_size_t
 	}
 
 	dst_data = (duk_uint8_t *) duk_push_buffer(thr, src_size, (mode == DUK_BUF_MODE_DYNAMIC) /*dynamic*/);
-	duk_memcpy((void *) dst_data, (const void *) src_data, (size_t) src_size);
+	/* dst_data may be NULL if size is zero. */
+	duk_memcpy_unsafe((void *) dst_data, (const void *) src_data, (size_t) src_size);
 
 	duk_replace(thr, idx);
  skip_copy:
@@ -5293,6 +5294,7 @@ DUK_INTERNAL void *duk_push_fixed_buffer_zero(duk_hthread *thr, duk_size_t len) 
 	DUK_ASSERT_API_ENTRY(thr);
 
 	ptr = duk_push_buffer_raw(thr, len, 0);
+	DUK_ASSERT(ptr != NULL);
 #if !defined(DUK_USE_ZERO_BUFFER_DATA)
 	/* ES2015 requires zeroing even when DUK_USE_ZERO_BUFFER_DATA
 	 * is not set.
@@ -5952,7 +5954,7 @@ DUK_INTERNAL void duk_pack(duk_hthread *thr, duk_idx_t count) {
 	 * any refcount updates: net refcount changes are zero.
 	 */
 	tv_src = thr->valstack_top - count - 1;
-	duk_memcpy((void *) tv_dst, (const void *) tv_src, (size_t) count * sizeof(duk_tval));
+	duk_memcpy_unsafe((void *) tv_dst, (const void *) tv_src, (size_t) count * sizeof(duk_tval));
 
 	/* Overwrite result array to final value stack location and wipe
 	 * the rest; no refcount operations needed.
@@ -6614,7 +6616,7 @@ DUK_INTERNAL void duk_copy_tvals_incref(duk_hthread *thr, duk_tval *tv_dst, duk_
 	DUK_UNREF(thr);
 	DUK_ASSERT(count * sizeof(duk_tval) >= count);  /* no wrap */
 
-	duk_memcpy((void *) tv_dst, (const void *) tv_src, count * sizeof(duk_tval));
+	duk_memcpy_unsafe((void *) tv_dst, (const void *) tv_src, count * sizeof(duk_tval));
 
 	tv = tv_dst;
 	while (count-- > 0) {

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -1378,12 +1378,14 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 
 	/* Temporary fixed buffer, later converted to string. */
 	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, result_len);
+	DUK_ASSERT(buf != NULL);
 	src = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
+	DUK_ASSERT(src != NULL);
 
 #if defined(DUK_USE_PREFER_SIZE)
 	p = buf;
 	while (count-- > 0) {
-		duk_memcpy((void *) p, (const void *) src, input_blen);  /* copy size may be zero */
+		duk_memcpy((void *) p, (const void *) src, input_blen);  /* copy size may be zero, but pointers are valid */
 		p += input_blen;
 	}
 #else  /* DUK_USE_PREFER_SIZE */
@@ -1400,7 +1402,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 		                     (long) result_len));
 		if (remain <= copy_size) {
 			/* If result_len is zero, this case is taken and does
-			 * a zero size copy.
+			 * a zero size copy (with valid pointers).
 			 */
 			duk_memcpy((void *) p, (const void *) src, remain);
 			break;

--- a/src-input/duk_bi_symbol.c
+++ b/src-input/duk_bi_symbol.c
@@ -37,9 +37,10 @@ DUK_INTERNAL duk_ret_t duk_bi_symbol_constructor_shared(duk_hthread *thr) {
 	 *   +1    0xff after unique suffix for symbols with undefined description
 	 */
 	buf = (duk_uint8_t *) duk_push_fixed_buffer(thr, 1 + len + 1 + 17 + 1);
+	DUK_ASSERT(buf != NULL);
 	p = buf + 1;
 	DUK_ASSERT(desc != NULL || len == 0);  /* may be NULL if len is 0 */
-	duk_memcpy((void *) p, (const void *) desc, len);
+	duk_memcpy_unsafe((void *) p, (const void *) desc, len);
 	p += len;
 	if (magic == 0) {
 		/* Symbol(): create unique symbol.  Use two 32-bit values

--- a/src-input/duk_debug_fixedbuffer.c
+++ b/src-input/duk_debug_fixedbuffer.c
@@ -18,7 +18,7 @@ DUK_INTERNAL void duk_fb_put_bytes(duk_fixedbuffer *fb, const duk_uint8_t *buffe
 	} else {
 		copylen = length;
 	}
-	duk_memcpy(fb->buffer + fb->offset, buffer, copylen);
+	duk_memcpy_unsafe(fb->buffer + fb->offset, buffer, copylen);
 	fb->offset += copylen;
 }
 

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -1019,6 +1019,7 @@ DUK_INTERNAL void duk_debug_format_funcptr(char *buf, duk_size_t buf_size, duk_u
 	duk_uint8_t *p = (duk_uint8_t *) buf;
 	duk_uint8_t *p_end = (duk_uint8_t *) (buf + buf_size - 1);
 
+	DUK_ASSERT(buf != NULL);
 	duk_memzero(buf, buf_size);
 
 	for (i = 0; i < fptr_size; i++) {

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -309,6 +309,7 @@ DUK_INTERNAL void duk_debug_read_bytes(duk_hthread *thr, duk_uint8_t *data, duk_
 	DUK_ASSERT(thr != NULL);
 	heap = thr->heap;
 	DUK_ASSERT(heap != NULL);
+	DUK_ASSERT(data != NULL);
 
 	if (heap->dbg_read_cb == NULL) {
 		DUK_D(DUK_DPRINT("attempt to read %ld bytes in detached state, return zero data", (long) length));

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -423,7 +423,7 @@
 
 #if defined(DUK_USE_ASSERTIONS)
 #define DUK_ASSERT_SET_GARBAGE(ptr,size) do { \
-		duk_memset((void *) (ptr), 0x5a, size); \
+		duk_memset_unsafe((void *) (ptr), 0x5a, size); \
 	} while (0)
 #else
 #define DUK_ASSERT_SET_GARBAGE(ptr,size) do {} while (0)

--- a/src-input/duk_hbufobj.h
+++ b/src-input/duk_hbufobj.h
@@ -47,7 +47,8 @@
 	} while (0)
 
 /* Get the current data pointer (caller must ensure buf != NULL) as a
- * duk_uint8_t ptr.
+ * duk_uint8_t ptr.  Note that the result may be NULL if the underlying
+ * buffer has zero size and is not a fixed buffer.
  */
 #define DUK_HBUFOBJ_GET_SLICE_BASE(heap,h) \
 	(DUK_ASSERT_EXPR((h) != NULL), DUK_ASSERT_EXPR((h)->buf != NULL), \

--- a/src-input/duk_heap_memory.c
+++ b/src-input/duk_heap_memory.c
@@ -127,7 +127,6 @@ DUK_INTERNAL void *duk_heap_mem_alloc_zeroed(duk_heap *heap, duk_size_t size) {
 
 	res = DUK_ALLOC(heap, size);
 	if (DUK_LIKELY(res != NULL)) {
-		/* assume memset with zero size is OK */
 		duk_memzero(res, size);
 	}
 	return res;

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -690,7 +690,7 @@ DUK_LOCAL duk_hstring *duk__strtab_romstring_lookup(duk_heap *heap, const duk_ui
 	while (curr != NULL) {
 		if (strhash == DUK_HSTRING_GET_HASH(curr) &&
 		    blen == DUK_HSTRING_GET_BYTELEN(curr) &&
-		    duk_memcmp((const void *) str, (const void *) DUK_HSTRING_GET_DATA(curr), blen) == 0) {
+		    duk_memcmp_unsafe((const void *) str, (const void *) DUK_HSTRING_GET_DATA(curr), blen) == 0) {
 			DUK_DDD(DUK_DDDPRINT("intern check: rom string: %!O, computed hash 0x%08lx, rom hash 0x%08lx",
 			                     curr, (unsigned long) strhash, (unsigned long) DUK_HSTRING_GET_HASH(curr)));
 			return curr;
@@ -710,6 +710,7 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern(duk_heap *heap, const duk_uin
 
 	/* Preliminaries. */
 
+	/* XXX: maybe just require 'str != NULL' even for zero size? */
 	DUK_ASSERT(heap != NULL);
 	DUK_ASSERT(blen == 0 || str != NULL);
 	DUK_ASSERT(blen <= DUK_HSTRING_MAX_BYTELEN);  /* Caller is responsible for ensuring this. */
@@ -728,7 +729,7 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern(duk_heap *heap, const duk_uin
 	while (h != NULL) {
 		if (DUK_HSTRING_GET_HASH(h) == strhash &&
 		    DUK_HSTRING_GET_BYTELEN(h) == blen &&
-		    duk_memcmp((const void *) str, (const void *) DUK_HSTRING_GET_DATA(h), (size_t) blen) == 0) {
+		    duk_memcmp_unsafe((const void *) str, (const void *) DUK_HSTRING_GET_DATA(h), (size_t) blen) == 0) {
 			/* Found existing entry. */
 			DUK_STATS_INC(heap, stats_strtab_intern_hit);
 			return h;

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -811,9 +811,9 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 	DUK_ASSERT(new_a != NULL || array_copy_size == 0U);
 	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, obj) != NULL || array_copy_size == 0U);
 	DUK_ASSERT(DUK_HOBJECT_GET_ASIZE(obj) > 0 || array_copy_size == 0U);
-	duk_memcpy((void *) new_a,
-	           (const void *) DUK_HOBJECT_A_GET_BASE(thr->heap, obj),
-	           array_copy_size);
+	duk_memcpy_unsafe((void *) new_a,
+	                  (const void *) DUK_HOBJECT_A_GET_BASE(thr->heap, obj),
+	                  array_copy_size);
 
 	for (i = DUK_HOBJECT_GET_ASIZE(obj); i < new_a_size; i++) {
 		duk_tval *tv = &new_a[i];

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -727,11 +727,11 @@ DUK_INTERNAL duk_small_int_t duk_js_data_compare(const duk_uint8_t *buf1, const 
 	prefix_len = (len1 <= len2 ? len1 : len2);
 
 	/* duk_memcmp() is guaranteed to return zero (equal) for zero length
-	 * inputs so no zero length check is needed.
+	 * inputs.
 	 */
-	rc = duk_memcmp((const void *) buf1,
-	                (const void *) buf2,
-	                (size_t) prefix_len);
+	rc = duk_memcmp_unsafe((const void *) buf1,
+	                       (const void *) buf2,
+	                       (size_t) prefix_len);
 
 	if (rc < 0) {
 		return -1;

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -674,6 +674,7 @@ DUK_LOCAL duk_size_t duk__dragon4_format_uint32(duk_uint8_t *buf, duk_uint32_t x
 	duk_small_int_t dig;
 	duk_uint32_t t;
 
+	DUK_ASSERT(buf != NULL);
 	DUK_ASSERT(radix >= 2 && radix <= 36);
 
 	/* A 32-bit unsigned integer formats to at most 32 digits (the

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -315,12 +315,13 @@ struct duk_bufwriter_ctx {
 		(bw_ctx)->p += duk__enc_len; \
 	} while (0)
 /* XXX: add temporary duk__p pointer here too; sharing */
+/* XXX: avoid unsafe variants */
 #define DUK_BW_WRITE_RAW_BYTES(thr,bw_ctx,valptr,valsz) do { \
 		const void *duk__valptr; \
 		duk_size_t duk__valsz; \
 		duk__valptr = (const void *) (valptr); \
 		duk__valsz = (duk_size_t) (valsz); \
-		duk_memcpy((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
 		(bw_ctx)->p += duk__valsz; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_CSTRING(thr,bw_ctx,val) do { \
@@ -328,31 +329,31 @@ struct duk_bufwriter_ctx {
 		duk_size_t duk__val_len; \
 		duk__val = (const duk_uint8_t *) (val); \
 		duk__val_len = DUK_STRLEN((const char *) duk__val); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HSTRING(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_GET_SIZE((val)); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER_FIXED(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_FIXED_GET_SIZE((val)); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER_DYNAMIC(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_DYNAMIC_GET_SIZE((val)); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 
@@ -416,13 +417,14 @@ struct duk_bufwriter_ctx {
 		DUK_BW_WRITE_RAW_CESU8((thr), (bw_ctx), (cp)); \
 	} while (0)
 /* XXX: add temporary duk__p pointer here too; sharing */
+/* XXX: avoid unsafe */
 #define DUK_BW_WRITE_ENSURE_BYTES(thr,bw_ctx,valptr,valsz) do { \
 		const void *duk__valptr; \
 		duk_size_t duk__valsz; \
 		duk__valptr = (const void *) (valptr); \
 		duk__valsz = (duk_size_t) (valsz); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__valsz); \
-		duk_memcpy((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), duk__valptr, duk__valsz); \
 		(bw_ctx)->p += duk__valsz; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_CSTRING(thr,bw_ctx,val) do { \
@@ -431,35 +433,35 @@ struct duk_bufwriter_ctx {
 		duk__val = (const duk_uint8_t *) (val); \
 		duk__val_len = DUK_STRLEN((const char *) duk__val); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) duk__val, duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HSTRING(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER_FIXED(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_FIXED_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_FIXED_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER_DYNAMIC(thr,bw_ctx,val) do { \
 		duk_size_t duk__val_len; \
 		duk__val_len = DUK_HBUFFER_DYNAMIC_GET_SIZE((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HBUFFER_DYNAMIC_GET_DATA_PTR((thr)->heap, (val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 
@@ -542,11 +544,126 @@ DUK_INTERNAL_DECL void duk_raw_write_double_be(duk_uint8_t **p, duk_double_t val
 DUK_INTERNAL_DECL void duk_byteswap_bytes(duk_uint8_t *p, duk_small_uint_t len);
 #endif
 
-DUK_INTERNAL_DECL void duk_memcpy(void *dst, const void *src, duk_size_t len);
-DUK_INTERNAL_DECL void duk_memmove(void *dst, const void *src, duk_size_t len);
+/* memcpy(), memmove() etc wrappers.  The plain variants like duk_memcpy()
+ * assume C99+ and 'src' and 'dst' pointers must be non-NULL even when the
+ * operation size is zero.  The unsafe variants like duk_memcpy_safe() deal
+ * with the zero size case explicitly, and allow NULL pointers in that case
+ * (which is undefined behavior in C99+).  For the majority of actual targets
+ * a NULL pointer with a zero length is fine in practice.  These wrappers are
+ * macros to force inlining; because there are hundreds of call sites, even a
+ * few extra bytes per call site adds up to ~1kB footprint.
+ */
+#if defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
+#define duk_memcpy(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		DUK_ASSERT(duk__src != NULL || duk__len == 0U); \
+		(void) DUK_MEMCPY(duk__dst, duk__src, (size_t) duk__len); \
+	} while (0)
+#define duk_memcpy_unsafe(dst,src,len)  duk_memcpy((dst), (src), (len))
+#define duk_memmove(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		DUK_ASSERT(duk__src != NULL || duk__len == 0U); \
+		(void) DUK_MEMMOVE(duk__dst, duk__src, (size_t) duk__len); \
+	} while (0)
+#define duk_memmove_unsafe(dst,src,len)  duk_memmove((dst), (src), (len))
+#define duk_memset(dst,val,len)  do { \
+		void *duk__dst = (dst); \
+		duk_small_int_t duk__val = (val); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		(void) DUK_MEMSET(duk__dst, duk__val, (size_t) duk__len); \
+	} while (0)
+#define duk_memset_unsafe(dst,val,len)  duk_memset((dst), (val), (len))
+#define duk_memzero(dst,len)  do { \
+		void *duk__dst = (dst); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		(void) DUK_MEMZERO(duk__dst, (size_t) duk__len); \
+	} while (0)
+#define duk_memzero_unsafe(dst,len)  duk_memzero((dst), (len))
+#else  /* DUK_USE_ALLOW_UNDEFINED_BEHAVIOR */
+#define duk_memcpy(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL); \
+		DUK_ASSERT(duk__src != NULL); \
+		(void) DUK_MEMCPY(duk__dst, duk__src, (size_t) duk__len); \
+	} while (0)
+#define duk_memcpy_unsafe(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		DUK_ASSERT(duk__src != NULL || duk__len == 0U); \
+		if (DUK_LIKELY(duk__len > 0U)) { \
+			DUK_ASSERT(duk__dst != NULL); \
+			DUK_ASSERT(duk__src != NULL); \
+			(void) DUK_MEMCPY(duk__dst, duk__src, (size_t) duk__len); \
+		} \
+	} while (0)
+#define duk_memmove(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL); \
+		DUK_ASSERT(duk__src != NULL); \
+		(void) DUK_MEMMOVE(duk__dst, duk__src, (size_t) duk__len); \
+	} while (0)
+#define duk_memmove_unsafe(dst,src,len)  do { \
+		void *duk__dst = (dst); \
+		const void *duk__src = (src); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		DUK_ASSERT(duk__src != NULL || duk__len == 0U); \
+		if (DUK_LIKELY(duk__len > 0U)) { \
+			DUK_ASSERT(duk__dst != NULL); \
+			DUK_ASSERT(duk__src != NULL); \
+			(void) DUK_MEMMOVE(duk__dst, duk__src, (size_t) duk__len); \
+		} \
+	} while (0)
+#define duk_memset(dst,val,len)  do { \
+		void *duk__dst = (dst); \
+		duk_small_int_t duk__val = (val); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL); \
+		(void) DUK_MEMSET(duk__dst, duk__val, (size_t) duk__len); \
+	} while (0)
+#define duk_memset_unsafe(dst,val,len)  do { \
+		void *duk__dst = (dst); \
+		duk_small_int_t duk__val = (val); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		if (DUK_LIKELY(duk__len > 0U)) { \
+			DUK_ASSERT(duk__dst != NULL); \
+			(void) DUK_MEMSET(duk__dst, duk__val, (size_t) duk__len); \
+		} \
+	} while (0)
+#define duk_memzero(dst,len)  do { \
+		void *duk__dst = (dst); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL); \
+		(void) DUK_MEMZERO(duk__dst, (size_t) duk__len); \
+	} while (0)
+#define duk_memzero_unsafe(dst,len)  do { \
+		void *duk__dst = (dst); \
+		duk_size_t duk__len = (len); \
+		DUK_ASSERT(duk__dst != NULL || duk__len == 0U); \
+		if (DUK_LIKELY(duk__len > 0U)) { \
+			DUK_ASSERT(duk__dst != NULL); \
+			(void) DUK_MEMZERO(duk__dst, (size_t) duk__len); \
+		} \
+	} while (0)
+#endif  /* DUK_USE_ALLOW_UNDEFINED_BEHAVIOR */
+
 DUK_INTERNAL_DECL duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len);
-DUK_INTERNAL_DECL void duk_memset(void *s, duk_small_int_t c, duk_size_t len);
-DUK_INTERNAL_DECL void duk_memzero(void *s, duk_size_t len);
+DUK_INTERNAL_DECL duk_small_int_t duk_memcmp_unsafe(const void *s1, const void *s2, duk_size_t len);
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32_nonegzero(duk_double_t x, duk_int32_t *ival);
 DUK_INTERNAL_DECL duk_bool_t duk_is_whole_get_int32(duk_double_t x, duk_int32_t *ival);

--- a/src-input/duk_util_cast.c
+++ b/src-input/duk_util_cast.c
@@ -144,12 +144,17 @@ DUK_INTERNAL duk_float_t duk_double_to_float_t(duk_double_t x) {
 		} else {
 			return (duk_float_t) DUK__FLOAT_MAX;
 		}
-	} else {
-		/* This assumes double NaN -> float NaN is
-		 * considered "in range".
-		 */
+	} else if (DUK_ISNAN(x)) {
+		/* Assumes double NaN -> float NaN considered "in range". */
 		DUK_ASSERT(DUK_ISNAN(x));
 		return (duk_float_t) x;
+	} else {
+		/* Out-of-range, rounds to +/- Infinity. */
+		if (x < 0.0) {
+			return (duk_float_t) -DUK_DOUBLE_INFINITY;
+		} else {
+			return (duk_float_t) DUK_DOUBLE_INFINITY;
+		}
 	}
 #endif
 }

--- a/src-input/duk_util_memory.c
+++ b/src-input/duk_util_memory.c
@@ -1,67 +1,36 @@
 /*
- *  Memcpy() etc.
+ *  Memory utils.
  */
 
 #include "duk_internal.h"
 
-DUK_INTERNAL void duk_memcpy(void *dst, const void *src, duk_size_t len) {
-#if !defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
-	/* For portability reasons both 'src' and 'dst' must be valid and
-	 * non-NULL even if len is zero.  Check for that explicitly to avoid
-	 * depending on platform specific behavior.  For the vast majority of
-	 * actual targets a NULL pointer with a zero length is fine.
-	 */
-	if (DUK_UNLIKELY(len == 0U)) {
-		return;
-	}
-	DUK_ASSERT(src != NULL);
-	DUK_ASSERT(dst != NULL);
-#else
-	DUK_ASSERT(src != NULL || len == 0U);
-	DUK_ASSERT(dst != NULL || len == 0U);
-#endif
-
-	(void) DUK_MEMCPY(dst, src, (size_t) len);
+#if defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
+DUK_INTERNAL DUK_INLINE duk_small_int_t duk_memcmp_unsafe(const void *s1, const void *s2, duk_size_t len) {
+	DUK_ASSERT(s1 != NULL || len == 0U);
+	DUK_ASSERT(s2 != NULL || len == 0U);
+	return DUK_MEMCMP(s1, s2, (size_t) len);
 }
 
-DUK_INTERNAL void duk_memmove(void *dst, const void *src, duk_size_t len) {
-#if !defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
-	if (DUK_UNLIKELY(len == 0U)) {
-		return;
-	}
-	DUK_ASSERT(src != NULL);
-	DUK_ASSERT(dst != NULL);
-#else
-	DUK_ASSERT(src != NULL || len == 0U);
-	DUK_ASSERT(dst != NULL || len == 0U);
-#endif
-
-	(void) DUK_MEMMOVE(dst, src, (size_t) len);
+DUK_INTERNAL DUK_INLINE duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len) {
+	DUK_ASSERT(s1 != NULL);
+	DUK_ASSERT(s2 != NULL);
+	return DUK_MEMCMP(s1, s2, (size_t) len);
 }
-
-DUK_INTERNAL duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len) {
-	duk_small_int_t ret;
-
-#if !defined(DUK_USE_ALLOW_UNDEFINED_BEHAVIOR)
+#else  /* DUK_USE_ALLOW_UNDEFINED_BEHAVIOR */
+DUK_INTERNAL DUK_INLINE duk_small_int_t duk_memcmp_unsafe(const void *s1, const void *s2, duk_size_t len) {
+	DUK_ASSERT(s1 != NULL || len == 0U);
+	DUK_ASSERT(s2 != NULL || len == 0U);
 	if (DUK_UNLIKELY(len == 0U)) {
 		return 0;
 	}
 	DUK_ASSERT(s1 != NULL);
 	DUK_ASSERT(s2 != NULL);
-#else
-	DUK_ASSERT(s1 != NULL || len == 0U);
-	DUK_ASSERT(s2 != NULL || len == 0U);
-#endif
-
-	ret = (duk_small_int_t) DUK_MEMCMP(s1, s2, (size_t) len);
-	DUK_ASSERT(ret == 0 || len > 0);  /* If len == 0, must compare equal. */
-	return ret;
+	return duk_memcmp(s1, s2, len);
 }
 
-DUK_INTERNAL void duk_memset(void *s, duk_small_int_t c, duk_size_t len) {
-	(void) DUK_MEMSET(s, (int) c, (size_t) len);
+DUK_INTERNAL DUK_INLINE duk_small_int_t duk_memcmp(const void *s1, const void *s2, duk_size_t len) {
+	DUK_ASSERT(s1 != NULL);
+	DUK_ASSERT(s2 != NULL);
+	return DUK_MEMCMP(s1, s2, (size_t) len);
 }
-
-DUK_INTERNAL void duk_memzero(void *s, duk_size_t len) {
-	(void) DUK_MEMZERO(s, (size_t) len);
-}
+#endif  /* DUK_USE_ALLOW_UNDEFINED_BEHAVIOR */

--- a/util/check_code_policy.py
+++ b/util/check_code_policy.py
@@ -308,7 +308,8 @@ def checkIdentifiers(lines, idx, filename):
         if rejected_plain_identifiers.has_key(m.group(0)):
             if m.group(0) in [ 'duk_context' ] and bn == 'duktape.h.in':
                 continue  # duk_context allowed in public API header
-            if m.group(0) in [ 'DUK_MEMCPY', 'DUK_MEMMOVE', 'DUK_MEMCMP', 'DUK_MEMSET', 'DUK_MEMZERO' ] and bn == 'duk_util_memory.c':
+            if m.group(0) in [ 'DUK_MEMCPY', 'DUK_MEMMOVE', 'DUK_MEMCMP', 'DUK_MEMSET', 'DUK_MEMZERO' ] and \
+               bn in [ 'duk_util_memory.c', 'duk_util.h' ]:
                 continue
             if not excludePlain:
                 raise Exception('invalid identifier %r (perhaps plain)' % m.group(0))


### PR DESCRIPTION
Footprint optimize -fsanitize=undefined fixes: use duk_memcmp() in C99+ safe contexts and duk_memcmp_unsafe() in unsafe contexts, and change the wrappers to macros. This matters because there are hundreds of call sites, and even a few bytes per call site adds up quickly (the difference is around 0.9kB here).

Also fix a bug in double-to-float cast which caused a sanitize warning.