### PR TITLE
Add a uint64_t to duk_hbuffer_fixed union align trick

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3215,6 +3215,9 @@ Planned
 
 * Add C++ name mangling wrappers (extern "C") for extras (GH-1780, GH-1782)
 
+* Add a duk_uint64_t to duk_hbuffer_fixed forced alignment union trick just
+  in case double and uint64_t alignment requirements differ (GH-1799)
+
 * Fix debugger StepOver behavior when a tailcall happens in a nested
   function (not the function where stepping started from) (GH-1786, GH-1787)
 

--- a/src-input/duk_hbuffer.h
+++ b/src-input/duk_hbuffer.h
@@ -232,7 +232,10 @@ struct duk_hbuffer_fixed {
 #if (DUK_USE_ALIGN_BY == 4)
 		duk_uint32_t dummy_for_align4;
 #elif (DUK_USE_ALIGN_BY == 8)
-		duk_double_t dummy_for_align8;
+		duk_double_t dummy_for_align8_1;
+#if defined(DUK_USE_64BIT_OPS)
+		duk_uint64_t dummy_for_align8_2;
+#endif
 #elif (DUK_USE_ALIGN_BY == 1)
 		/* no extra padding */
 #else


### PR DESCRIPTION
Include a 64-bit integer (when available) in addition to an IEEE double in the portable duk_hbuffer_fixed union-based align trick, just in case double and uint64_t have different alignment in packing. In practice this doesn't matter on the main compilers because pragmas are used to force struct packing in any case, so this is more or less for completeness.