### PR TITLE
CBOR extra improvements, add CBOR to dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ DUKTAPE_CMDLINE_SOURCES = \
 	extras/print-alert/duk_print_alert.c \
 	extras/console/duk_console.c \
 	extras/logging/duk_logging.c \
-	extras/module-duktape/duk_module_duktape.c
+	extras/module-duktape/duk_module_duktape.c \
+	extras/cbor/duk_cbor.c
 ifdef SYSTEMROOT  # Windows
 DUKTAPE_CMDLINE_SOURCES += examples/debug-trans-socket/duk_trans_socket_windows.c
 else
@@ -108,6 +109,7 @@ CCOPTS_SHARED += -DDUK_CMDLINE_PRINTALERT_SUPPORT
 CCOPTS_SHARED += -DDUK_CMDLINE_CONSOLE_SUPPORT
 CCOPTS_SHARED += -DDUK_CMDLINE_LOGGING_SUPPORT
 CCOPTS_SHARED += -DDUK_CMDLINE_MODULE_SUPPORT
+CCOPTS_SHARED += -DDUK_CMDLINE_CBOR_SUPPORT
 ifdef SYSTEMROOT  # Windows
 # Skip fancy (linenoise)
 else
@@ -143,6 +145,7 @@ CCOPTS_SHARED += -I./extras/print-alert
 CCOPTS_SHARED += -I./extras/console
 CCOPTS_SHARED += -I./extras/logging
 CCOPTS_SHARED += -I./extras/module-duktape
+CCOPTS_SHARED += -I./extras/cbor
 #CCOPTS_SHARED += -m32   # force 32-bit compilation on a 64-bit host
 #CCOPTS_SHARED += -mx32  # force X32 compilation on a 64-bit host
 #CCOPTS_SHARED += -fstack-usage  # enable manually, then e.g. $ make clean duk; python util/pretty_stack_usage.py duktape.su
@@ -164,9 +167,9 @@ CLANG_CCOPTS_NONDEBUG += -Wcomma
 GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -Wunused-function
 GXXOPTS_SHARED += -DDUK_CMDLINE_PRINTALERT_SUPPORT
 GXXOPTS_NONDEBUG = $(GXXOPTS_SHARED) -Os -fomit-frame-pointer
-GXXOPTS_NONDEBUG += -I./examples/alloc-logging -I./examples/alloc-torture -I./examples/alloc-hybrid -I./extras/print-alert -I./extras/console -I./extras/logging -I./extras/module-duktape
+GXXOPTS_NONDEBUG += -I./examples/alloc-logging -I./examples/alloc-torture -I./examples/alloc-hybrid -I./extras/print-alert -I./extras/console -I./extras/logging -I./extras/module-duktape -I./extras/cbor
 GXXOPTS_DEBUG = $(GXXOPTS_SHARED) -O0 -g -ggdb
-GXXOPTS_DEBUG += -I./examples/alloc-logging -I./examples/alloc-torture -I./examples/alloc-hybrid -I./extras/print-alert -I./extras/console -I./extras/logging -I./extras/module-duktape
+GXXOPTS_DEBUG += -I./examples/alloc-logging -I./examples/alloc-torture -I./examples/alloc-hybrid -I./extras/print-alert -I./extras/console -I./extras/logging -I./extras/module-duktape -I./extras/cbor
 
 CCOPTS_DUKLOW = -m32
 CCOPTS_DUKLOW += -flto -fno-asynchronous-unwind-tables -ffunction-sections -Wl,--gc-sections

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3218,6 +3218,8 @@ Planned
 * Add a duk_uint64_t to duk_hbuffer_fixed forced alignment union trick just
   in case double and uint64_t alignment requirements differ (GH-1799)
 
+* Add a CBOR encoder/decoder as an extra (GH-1781, GH-1800, GH-1801)
+
 * Fix debugger StepOver behavior when a tailcall happens in a nested
   function (not the function where stepping started from) (GH-1786, GH-1787)
 

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -12,6 +12,9 @@
  *  - To enable Duktape.Logger, define DUK_CMDLINE_LOGGING_SUPPORT
  *    and add extras/logging/duk_logging.c to compilation.
  *
+ *  - To enable CBOR, define DUK_CMDLINE_CBOR_SUPPORT and add
+ *    extras/cbor/duk_cbor.c to compilation.
+ *
  *  - To enable Duktape 1.x module loading support (require(),
  *    Duktape.modSearch() etc), define DUK_CMDLINE_MODULE_SUPPORT and add
  *    extras/module-duktape/duk_module_duktape.c to compilation.
@@ -67,6 +70,9 @@
 #endif
 #if defined(DUK_CMDLINE_MODULE_SUPPORT)
 #include "duk_module_duktape.h"
+#endif
+#if defined(DUK_CMDLINE_CBOR_SUPPORT)
+#include "duk_cbor.h"
 #endif
 #if defined(DUK_CMDLINE_FILEIO)
 #include <errno.h>
@@ -1162,6 +1168,11 @@ static duk_context *create_duktape_heap(int alloc_provider, int debugger, int lo
 	/* Register require() (removed in Duktape 2.x). */
 #if defined(DUK_CMDLINE_MODULE_SUPPORT)
 	duk_module_duktape_init(ctx);
+#endif
+
+	/* Register CBOR. */
+#if defined(DUK_CMDLINE_CBOR_SUPPORT)
+	duk_cbor_init(ctx, 0 /*flags*/);
 #endif
 
 	/* Trivial readFile/writeFile bindings for testing. */

--- a/extras/cbor/Makefile
+++ b/extras/cbor/Makefile
@@ -1,6 +1,9 @@
 # For manual testing; say 'make' in extras/cbor.
 
 VALGRIND=valgrind
+CCOPTS=-std=c99 -Wall -Wextra -O2
+#CCOPTS+=-fsanitize=undefined
+
 .PHONY: all
 all: clean jsoncbor test-runs
 
@@ -8,6 +11,7 @@ all: clean jsoncbor test-runs
 clean:
 	-rm -rf ./prep
 	-rm -f jsoncbor
+	-rm -f appendix_a.json
 
 jsoncbor: jsoncbor.c duk_cbor.c duk_cbor.h
 	-rm -rf ./prep
@@ -17,44 +21,20 @@ jsoncbor: jsoncbor.c duk_cbor.c duk_cbor.h
 		-DDUK_USE_JSON_EATWHITE_FASTPATH \
 		-DDUK_USE_JSON_QUOTESTRING_FASTPATH \
 		-DDUK_USE_JSON_STRINGIFY_FASTPATH
-	gcc -std=c99 -Wall -Wextra -O2 -o $@ -I./prep -I. \
-		./prep/duktape.c duk_cbor.c jsoncbor.c -lm
+	gcc $(CCOPTS) -o $@ -I./prep -I. ./prep/duktape.c duk_cbor.c jsoncbor.c -lm
+
+appendix_a.json:
+	wget -O $@ https://raw.githubusercontent.com/cbor/test-vectors/master/appendix_a.json
 
 .PHONY: test-runs
 test-runs: jsoncbor \
 	enc-primitives enc-number enc-buffer enc-string enc-array enc-object enc-half-float enc-float enc-misc \
-	dec-half-float dec-half-float
+	dec-half-float dec-half-float dec-array dec-object
 
-.PHONY: dec-misc
-dec-misc: jsoncbor
-	python -c 'import sys; sys.stdout.write("\xa1cfoocbar")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xa1cfoocbar")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\xa1\xa0\xa0")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xa1\xa0\xa0")'| $(VALGRIND) -q ./jsoncbor -d  # object key, gets string coerced in JSON output
-	python -c 'import sys; sys.stdout.write("\x7f\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x7f\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x7f`````````````````````````````````````````````````````````````````````````````````````````````````````````\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x7f`````````````````````````````````````````````````````````````````````````````````````````````````````````\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x7fcfoo\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x7fcfoo\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x7fcfoocbaraqau`auax\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x7fcfoocbaraqau`auax\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x5f\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x5f\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x5f@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x5f@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x5fCfoo\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x5fCfoo\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\x5fCfooCbarAqAu@AuAx\xff")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\x5fCfooCbarAqAu@AuAx\xff")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\xc0cfoo")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xc0cfoo")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\xc0\xc1cfoo")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xc0\xc1cfoo")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\xc0\xd7cfoo")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xc0\xd7cfoo")'| $(VALGRIND) -q ./jsoncbor -d
-	python -c 'import sys; sys.stdout.write("\xc0\xd8\xffcfoo")'| python cbordecode.py
-	python -c 'import sys; sys.stdout.write("\xc0\xd8\xffcfoo")'| $(VALGRIND) -q ./jsoncbor -d
+.PHONY: test-vectors
+test-vectors: appendix_a.json
+	echo "Expects 'duk' to exist in local directory for now..."
+	./duk run_testvectors.js
 
 .PHONY: dec-half-float
 dec-half-float: jsoncbor
@@ -115,6 +95,48 @@ dec-half-float: jsoncbor
 	python -c 'import sys; sys.stdout.write("\xf9\x7f\x12")'| $(VALGRIND) -q ./jsoncbor -d
 	python -c 'import sys; sys.stdout.write("\xf9\xff\x12")'| python cbordecode.py
 	python -c 'import sys; sys.stdout.write("\xf9\xff\x12")'| $(VALGRIND) -q ./jsoncbor -d
+
+.PHONY: dec-array
+dec-array: jsoncbor
+	python -c 'import sys; sys.stdout.write("\x9f\x01\x02\x03\x9f\xff\x04\x80\x80\x9f\x10\x11\xff\x84\x04\x03\x02\x01\xff")' | python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x9f\x01\x02\x03\x9f\xff\x04\x80\x80\x9f\x10\x11\xff\x84\x04\x03\x02\x01\xff")' | $(VALGRIND) -q ./jsoncbor -d
+
+.PHONY: dec-object
+dec-object: jsoncbor
+	python -c 'import sys; sys.stdout.write("\xbf\x63foo\x63bar\x63bar\xa0\x64quux\xbf\xff\x63baz\xa2\x61a\x61b\x61c\x61d\x65quuux\xbf\x61x\x61y\x61z\x61w\xff\xff")' | python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xbf\x63foo\x63bar\x63bar\xa0\x64quux\xbf\xff\x63baz\xa2\x61a\x61b\x61c\x61d\x65quuux\xbf\x61x\x61y\x61z\x61w\xff\xff")' | $(VALGRIND) -q ./jsoncbor -d
+
+.PHONY: dec-misc
+dec-misc: jsoncbor
+	python -c 'import sys; sys.stdout.write("\xa1cfoocbar")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xa1cfoocbar")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\xa1\xa0\xa0")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xa1\xa0\xa0")'| $(VALGRIND) -q ./jsoncbor -d  # object key, gets string coerced in JSON output
+	python -c 'import sys; sys.stdout.write("\x7f\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x7f\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x7f`````````````````````````````````````````````````````````````````````````````````````````````````````````\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x7f`````````````````````````````````````````````````````````````````````````````````````````````````````````\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x7fcfoo\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x7fcfoo\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x7fcfoocbaraqau`auax\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x7fcfoocbaraqau`auax\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x5f\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x5f\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x5f@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x5f@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x5fCfoo\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x5fCfoo\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\x5fCfooCbarAqAu@AuAx\xff")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\x5fCfooCbarAqAu@AuAx\xff")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\xc0cfoo")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xc0cfoo")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\xc0\xc1cfoo")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xc0\xc1cfoo")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\xc0\xd7cfoo")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xc0\xd7cfoo")'| $(VALGRIND) -q ./jsoncbor -d
+	python -c 'import sys; sys.stdout.write("\xc0\xd8\xffcfoo")'| python cbordecode.py
+	python -c 'import sys; sys.stdout.write("\xc0\xd8\xffcfoo")'| $(VALGRIND) -q ./jsoncbor -d
+
 
 .PHONY: enc-primitives
 enc-primitives: jsoncbor

--- a/extras/cbor/README.rst
+++ b/extras/cbor/README.rst
@@ -8,7 +8,16 @@ Overview
 C functions to encode/decode values in CBOR format, and a simple command
 line utility to convert between JSON and CBOR.
 
-Basic usage of the conversion tool::
+To integrate CBOR into your application:
+
+* Call ``duk_cbor_encode()`` and ``duk_cbor_decode()`` directly if a C API
+  is enough.
+
+* Call ``duk_cbor_init()`` to register a global ``CBOR`` object with
+  Ecmascript bindings ``CBOR.encode()`` and ``CBOR.decode()``, roughly
+  matching https://github.com/paroga/cbor-js.
+
+Basic usage of the ``jsoncbor`` conversion tool::
 
     $ make jsoncbor
     [...]
@@ -48,8 +57,6 @@ Future work
 - Decode test cases, also for cases we don't produce.
 - https://datatracker.ietf.org/doc/draft-jroatch-cbor-tags/?include_text=1
   could be used for typed arrays.
-- Half-float encoding and decoding.
-- Single precision encoding when no precision lost.
 - 64-bit integer encoding.
 - Better 64-bit integer decoding (workaround for non-64-bit targets).
 - Objects with non-string keys, could be represented as a Map.

--- a/extras/cbor/definite_and_indefinite_arrays.py
+++ b/extras/cbor/definite_and_indefinite_arrays.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python2
-import sys
-
-x = '\x9f' + ( '\x01' + '\x02' + '\x03' + '\x9f\xff' + '\x04' + '\x80' + '\x80' + \
-    '\x9f\x10\x11\xff' + '\x84\x04\x03\x02\x01' ) + '\xff'
-sys.stdout.write(x)

--- a/extras/cbor/definite_and_indefinite_maps.py
+++ b/extras/cbor/definite_and_indefinite_maps.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python2
-import sys
-
-x = '\xbf' + ( '\x63foo\x63bar' + '\x63bar\xa0' + '\x64quux\xbf\xff' + \
-    '\x63baz\xa2\x61a\x61b\x61c\x61d' + '\x65quuux\xbf\x61x\x61y\x61z\x61w\xff' ) + \
-    '\xff'
-sys.stdout.write(x)

--- a/extras/cbor/duk_cbor.h
+++ b/extras/cbor/duk_cbor.h
@@ -1,10 +1,15 @@
 #if !defined(DUK_CBOR_H_INCLUDED)
 #define DUK_CBOR_H_INCLUDED
 
+#include "duktape.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
+/* No flags at present. */
+
+extern void duk_cbor_init(duk_context *ctx, duk_uint_t flags);
 extern void duk_cbor_encode(duk_context *ctx, duk_idx_t idx, duk_uint_t encode_flags);
 extern void duk_cbor_decode(duk_context *ctx, duk_idx_t idx, duk_uint_t decode_flags);
 

--- a/extras/cbor/run_testvectors.js
+++ b/extras/cbor/run_testvectors.js
@@ -1,0 +1,30 @@
+var testvectors = JSON.parse(new TextDecoder().decode(readFile('appendix_a.json')));
+
+// Very rudimentary for now, just dump useful information about decode
+// results and (simple, unstructured) comparison to expected.  This is
+// only useful for manually inspecting the results right now.
+
+testvectors.forEach(function (test, idx) {
+    print('===', idx, '->', Duktape.enc('jx', test));
+
+    var cbor = Duktape.dec('base64', test.cbor);
+    try {
+        var dec = CBOR.decode(cbor);
+    } catch (e) {
+        print('decode failed: ' + e);
+        return;
+    }
+
+    print('dec (jx): ' + Duktape.enc('jx', dec));
+
+    if (dec !== test.decoded) {
+        print('decoded compare failed');
+    }
+    if (test.roundtrip) {
+        var enc = CBOR.encode(dec);
+        print('re-enc: ' + Duktape.enc('hex', enc));
+        if (Duktape.enc('base64', cbor) !== Duktape.enc('base64', enc)) {
+            print('roundtrip failed');
+        }
+    }
+});

--- a/util/dist.py
+++ b/util/dist.py
@@ -137,6 +137,7 @@ def create_dist_directories(dist):
     mkdir(os.path.join(dist, 'extras', 'module-duktape'))
     mkdir(os.path.join(dist, 'extras', 'module-node'))
     mkdir(os.path.join(dist, 'extras', 'alloc-pool'))
+    mkdir(os.path.join(dist, 'extras', 'cbor'))
     mkdir(os.path.join(dist, 'polyfills'))
     #mkdir(os.path.join(dist, 'doc'))  # Empty, so omit
     mkdir(os.path.join(dist, 'licenses'))
@@ -705,6 +706,16 @@ def main():
         'Makefile',
         'test.c'
     ], os.path.join('extras', 'alloc-pool'), os.path.join(dist, 'extras', 'alloc-pool'))
+
+    copy_files([
+        'README.rst',
+        'cbordecode.py',
+        'duk_cbor.c',
+        'duk_cbor.h',
+        'jsoncbor.c',
+        'run_testvectors.js',
+        'Makefile'
+    ], os.path.join('extras', 'cbor'), os.path.join(dist, 'extras', 'cbor'))
 
     copy_files([
         'Makefile.cmdline',


### PR DESCRIPTION
Final changes for initial inclusion into extras:

- [x] Fix some wrap and out-of-range cast cases
- [x] Minor footprint optimization
- [x] Remove a few unnecessary test Python scripts (inline to Makefile)
- [x] Test vectors: https://github.com/cbor/test-vectors/blob/master/appendix_a.json, executed manually
- [x] JS API:https://github.com/paroga/cbor-js
- [x] Add CBOR extra to dist
- [x] Add CBOR binding to 'duk' built from repo Makefile
- [x] Releases entry

Several shortcomings remain, e.g. tests are not actually automatic but rather rely on manual inspection and footprint is still somewhat large (~5kB).