### PR TITLE
Replace gcc by $(CC) in Makefile.sharedlibrary and other dist Makefiles

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,6 +48,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * \J. McC. (https://github.com/jmhmccr)
 * Jakub Nowakowski (https://github.com/jimvonmoon)
 * Tommy Nguyen (https://github.com/tn0502)
+* Fabrice Fontaine (https://github.com/ffontaine)
 
 Other contributions
 ===================

--- a/dist-files/Makefile.codepage
+++ b/dist-files/Makefile.codepage
@@ -1,4 +1,6 @@
+CC	= gcc
+
 codepage:
-	gcc -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
+	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
 		src/duktape.c examples/codepage-conv/duk_codepage_conv.c \
 		examples/codepage-conv/test.c -lm

--- a/dist-files/Makefile.eval
+++ b/dist-files/Makefile.eval
@@ -2,6 +2,8 @@
 #  Example Makefile for building the eval example
 #
 
+CC	= gcc
+
 eval:
-	gcc -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
+	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
 		src/duktape.c examples/eval/eval.c -lm

--- a/dist-files/Makefile.eventloop
+++ b/dist-files/Makefile.eventloop
@@ -2,12 +2,14 @@
 #  Example Makefile for building the eventloop example
 #
 
+CC	= gcc
+
 evloop:
 	@echo "NOTE: The eventloop is example is intended to be used on Linux"
 	@echo "      or other common UNIX variants.  It is not fully portable."
 	@echo ""
 
-	gcc -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
+	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
 		examples/eventloop/main.c \
 		examples/eventloop/c_eventloop.c \
 		examples/eventloop/poll.c \

--- a/dist-files/Makefile.jxpretty
+++ b/dist-files/Makefile.jxpretty
@@ -2,7 +2,9 @@
 #  Example Makefile for building the jxpretty example
 #
 
+CC	= gcc
+
 jxpretty:
-	gcc -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
+	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
 		src/duktape.c examples/jxpretty/jxpretty.c \
 		-lm

--- a/dist-files/Makefile.sandbox
+++ b/dist-files/Makefile.sandbox
@@ -2,6 +2,8 @@
 #  Example Makefile for building the sandbox example
 #
 
+CC	= gcc
+
 sandbox:
-	gcc -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
+	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
 		src/duktape.c examples/sandbox/sandbox.c -lm

--- a/dist-files/Makefile.sharedlibrary
+++ b/dist-files/Makefile.sharedlibrary
@@ -36,6 +36,8 @@ INSTALL_PREFIX=/usr/local
 DUKTAPE_SRCDIR=./src
 #DUKTAPE_SRCDIR=./src-noline
 
+CC=gcc
+
 .PHONY: all
 all: libduktape.so.$(REAL_VERSION) libduktaped.so.$(REAL_VERSION)
 
@@ -44,11 +46,11 @@ all: libduktape.so.$(REAL_VERSION) libduktaped.so.$(REAL_VERSION)
 # to $INSTALL_PREFIX/include on installation.
 
 libduktape.so.$(REAL_VERSION):
-	gcc -shared -fPIC -Wall -Wextra -Os -Wl,-soname,libduktape.so.$(SONAME_VERSION) \
+	$(CC) -shared -fPIC -Wall -Wextra -Os -Wl,-soname,libduktape.so.$(SONAME_VERSION) \
 		-o $@ $(DUKTAPE_SRCDIR)/duktape.c
 
 libduktaped.so.$(REAL_VERSION):
-	gcc -shared -fPIC -g -Wall -Wextra -Os -Wl,-soname,libduktaped.so.$(SONAME_VERSION) \
+	$(CC) -shared -fPIC -g -Wall -Wextra -Os -Wl,-soname,libduktaped.so.$(SONAME_VERSION) \
 		-o $@ $(DUKTAPE_SRCDIR)/duktape.c
 
 # Symlinks depend on platform conventions.
@@ -68,4 +70,4 @@ install: libduktape.so.$(REAL_VERSION) libduktaped.so.$(REAL_VERSION)
 #CCOPTS=-I/usr/local/include -L/usr/local/lib
 CCOPTS=-I./examples/cmdline
 duk:
-	gcc $(CCOPTS) -Wall -Wextra -Os -o $@ ./examples/cmdline/duk_cmdline.c -lduktape -lm
+	$(CC) $(CCOPTS) -Wall -Wextra -Os -o $@ ./examples/cmdline/duk_cmdline.c -lduktape -lm


### PR DESCRIPTION
This patch will allow cross-compilation

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>