### PR TITLE
Add duk_push_literal() API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3195,6 +3195,9 @@ Planned
   useful to detect constructor calls which can already be done using
   duk_is_constructor_call() (GH-1745)
 
+* Add experimental duk_push_literal() API call which may allow e.g. better
+  lowmem behavior for string literals later on (GH-1805)
+
 * ES2015 Number constructor properties: EPSILON, MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),
   parseInt(), parseFloat() (GH-1756, GH-1761)

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -32,6 +32,9 @@ Checklist for ordinary releases
 
   - Verify by running Duktape cmdline and evaluating ``Duktape.version``
 
+* Check for API calls and config options tagged experimental to see if they
+  should lose their experimental status
+
 * Check dist-files/README.rst
 
   - Update release specific release notes link

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -6366,7 +6366,7 @@ DUK_INTERNAL void duk_push_lightfunc_name_raw(duk_hthread *thr, duk_c_function f
 
 	DUK_ASSERT_API_ENTRY(thr);
 
-	duk_push_sprintf(thr, "light_");
+	duk_push_literal(thr, "light_");
 	duk_push_string_funcptr(thr, (duk_uint8_t *) &func, sizeof(func));
 	duk_push_sprintf(thr, "_%04x", (unsigned int) lf_flags);
 	duk_concat(thr, 3);
@@ -6391,9 +6391,9 @@ DUK_INTERNAL void duk_push_lightfunc_tostring(duk_hthread *thr, duk_tval *tv) {
 	DUK_ASSERT(DUK_TVAL_IS_LIGHTFUNC(tv));
 
 	DUK_TVAL_GET_LIGHTFUNC(tv, func, lf_flags);  /* read before 'tv' potentially invalidated */
-	duk_push_string(thr, "function ");
+	duk_push_literal(thr, "function ");
 	duk_push_lightfunc_name_raw(thr, func, lf_flags);
-	duk_push_string(thr, "() { [lightfunc code] }");
+	duk_push_literal(thr, "() { [lightfunc code] }");
 	duk_concat(thr, 3);
 }
 
@@ -6505,7 +6505,7 @@ DUK_LOCAL const char *duk__push_string_tval_readable(duk_hthread *thr, duk_tval 
 	/* 'tv' may be NULL */
 
 	if (tv == NULL) {
-		duk_push_string(thr, "none");
+		duk_push_literal(thr, "none");
 	} else {
 		switch (DUK_TVAL_GET_TAG(tv)) {
 		case DUK_TAG_STRING: {
@@ -6514,11 +6514,11 @@ DUK_LOCAL const char *duk__push_string_tval_readable(duk_hthread *thr, duk_tval 
 				/* XXX: string summary produces question marks
 				 * so this is not very ideal.
 				 */
-				duk_push_string(thr, "[Symbol ");
+				duk_push_literal(thr, "[Symbol ");
 				duk_push_string(thr, duk__get_symbol_type_string(h));
-				duk_push_string(thr, " ");
+				duk_push_literal(thr, " ");
 				duk__push_hstring_readable_unicode(thr, h, DUK__READABLE_STRING_MAXCHARS);
-				duk_push_string(thr, "]");
+				duk_push_literal(thr, "]");
 				duk_concat(thr, 5);
 				break;
 			}
@@ -6603,7 +6603,7 @@ DUK_INTERNAL void duk_push_symbol_descriptive_string(duk_hthread *thr, duk_hstri
 	DUK_ASSERT_API_ENTRY(thr);
 
 	/* .toString() */
-	duk_push_string(thr, "Symbol(");
+	duk_push_literal(thr, "Symbol(");
 	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h);
 	p_end = p + DUK_HSTRING_GET_BYTELEN(h);
 	DUK_ASSERT(p[0] == 0xff || (p[0] & 0xc0) == 0x80);
@@ -6619,7 +6619,7 @@ DUK_INTERNAL void duk_push_symbol_descriptive_string(duk_hthread *thr, duk_hstri
 		}
 	}
 	duk_push_lstring(thr, (const char *) p, (duk_size_t) (q - p));
-	duk_push_string(thr, ")");
+	duk_push_literal(thr, ")");
 	duk_concat(thr, 3);
 }
 

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -1191,7 +1191,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tostring(duk_hthread *thr) {
 	h_this = duk__get_bufobj_this(thr);
 	if (h_this == NULL) {
 		/* XXX: happens e.g. when evaluating: String(Buffer.prototype). */
-		duk_push_string(thr, "[object Object]");
+		duk_push_literal(thr, "[object Object]");
 		return 1;
 	}
 	DUK_ASSERT_HBUFOBJ_VALID(h_this);

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -350,7 +350,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_constructor(duk_hthread *thr) {
 }
 
 DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encoding_getter(duk_hthread *thr) {
-	duk_push_string(thr, "utf-8");
+	duk_push_literal(thr, "utf-8");
 	return 1;
 }
 
@@ -492,7 +492,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_prototype_shared_getter(duk_hthread *t
 		/* Encoding is now fixed, so _Context lookup is only needed to
 		 * validate the 'this' binding (TypeError if not TextDecoder-like).
 		 */
-		duk_push_string(thr, "utf-8");
+		duk_push_literal(thr, "utf-8");
 		break;
 	case 1:
 		duk_push_boolean(thr, dec_ctx->fatal);

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -54,7 +54,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_hthread *thr) {
 	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_NAME);
 	if (duk_is_undefined(thr, -1)) {
 		duk_pop(thr);
-		duk_push_string(thr, "Error");
+		duk_push_literal(thr, "Error");
 	} else {
 		duk_to_string(thr, -1);
 	}
@@ -84,7 +84,7 @@ DUK_INTERNAL duk_ret_t duk_bi_error_prototype_to_string(duk_hthread *thr) {
 		duk_pop(thr);
 		return 1;
 	}
-	duk_push_string(thr, ": ");
+	duk_push_literal(thr, ": ");
 	duk_insert(thr, -2);  /* ... name ': ' message */
 	duk_concat(thr, 3);
 

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -36,7 +36,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_hthread *thr) {
 		duk_push_hstring_empty(thr);
 	} else {
 		duk_insert(thr, 0);   /* [ arg1 ... argN-1 body] -> [body arg1 ... argN-1] */
-		duk_push_string(thr, ",");
+		duk_push_literal(thr, ",");
 		duk_insert(thr, 1);
 		duk_join(thr, nargs - 1);
 	}
@@ -48,11 +48,11 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_hthread *thr) {
 	/* XXX: this placeholder is not always correct, but use for now.
 	 * It will fail in corner cases; see test-dev-func-cons-args.js.
 	 */
-	duk_push_string(thr, "function(");
+	duk_push_literal(thr, "function(");
 	duk_dup_1(thr);
-	duk_push_string(thr, "){");
+	duk_push_literal(thr, "){");
 	duk_dup_0(thr);
-	duk_push_string(thr, "\n}");  /* Newline is important to handle trailing // comment. */
+	duk_push_literal(thr, "\n}");  /* Newline is important to handle trailing // comment. */
 	duk_concat(thr, 5);
 
 	/* [ body formals source ] */
@@ -70,7 +70,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_hthread *thr) {
 	               comp_flags);
 
 	/* Force .name to 'anonymous' (ES2015). */
-	duk_push_string(thr, "anonymous");
+	duk_push_literal(thr, "anonymous");
 	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_C);
 
 	func = (duk_hcompfunc *) duk_known_hobject(thr, -1);
@@ -356,7 +356,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_hthread *thr) {
 	duk_xdef_prop_stridx_thrower(thr, -1, DUK_STRIDX_LC_ARGUMENTS);
 
 	/* Function name and fileName (non-standard). */
-	duk_push_string(thr, "bound ");  /* ES2015 19.2.3.2. */
+	duk_push_literal(thr, "bound ");  /* ES2015 19.2.3.2. */
 	duk_get_prop_stridx(thr, -3, DUK_STRIDX_NAME);
 	if (!duk_is_string_notsymbol(thr, -1)) {
 		/* ES2015 has requirement to check that .name of target is a string

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -119,7 +119,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_tostring(duk_hthread *thr) {
 	/* This must be generic in ES2015 and later. */
 	DUK_ASSERT_TOP(thr, 0);
 	duk_push_this(thr);
-	duk_push_string(thr, "/");
+	duk_push_literal(thr, "/");
 	duk_get_prop_stridx(thr, 0, DUK_STRIDX_SOURCE);
 	duk_dup_m2(thr);  /* another "/" */
 	duk_get_prop_stridx(thr, 0, DUK_STRIDX_FLAGS);
@@ -183,7 +183,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_shared_getter(duk_hthread *thr) {
 		if (magic != 16 /* .source */) {
 			return 0;
 		}
-		duk_push_string(thr, "(?:)");  /* .source handled by switch-case */
+		duk_push_literal(thr, "(?:)");  /* .source handled by switch-case */
 		re_flags = 0;
 	} else {
 		DUK_DCERROR_TYPE_INVALID_ARGS(thr);

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -977,7 +977,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx) {
 		 */
 
 #if 0
-		duk_push_string(thr, "XXX");
+		duk_push_literal(thr, "XXX");
 		duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_SOURCE, DUK_PROPDESC_FLAGS_NONE);
 #endif
 	}

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -1080,7 +1080,7 @@ DUK_LOCAL void duk__create_escaped_source(duk_hthread *thr, int idx_pattern) {
 	n = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h);
 
 	if (n == 0) {
-		duk_push_string(thr, "(?:)");
+		duk_push_literal(thr, "(?:)");
 		return;
 	}
 

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -552,6 +552,20 @@ DUK_EXTERNAL_DECL void duk_push_pointer(duk_context *ctx, void *p);
 DUK_EXTERNAL_DECL const char *duk_push_sprintf(duk_context *ctx, const char *fmt, ...);
 DUK_EXTERNAL_DECL const char *duk_push_vsprintf(duk_context *ctx, const char *fmt, va_list ap);
 
+/* duk_push_literal() may evaluate its argument (a C string literal) more than
+ * once on purpose.  When speed is preferred, sizeof() avoids an unnecessary
+ * strlen() at runtime.  Sizeof("foo") == 4, so subtract 1.  The argument
+ * must be non-NULL and should not contain internal NUL characters as the
+ * behavior will then depend on config options.
+ */
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_push_literal(ctx,cstring) \
+	duk_push_string((ctx), (cstring))
+#else
+#define duk_push_literal(ctx,cstring) \
+	duk_push_lstring((ctx), (cstring), sizeof((cstring)) - 1)
+#endif
+
 DUK_EXTERNAL_DECL void duk_push_this(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_new_target(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_push_current_function(duk_context *ctx);

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -237,6 +237,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_push_heap_stash(ctx);
 	(void) duk_push_heapptr(ctx, NULL);
 	(void) duk_push_int(ctx, 0);
+	(void) duk_push_literal(ctx, "dummy");
 	(void) duk_push_lstring(ctx, "dummy", 0);
 	(void) duk_push_nan(ctx);
 	(void) duk_push_null(ctx);

--- a/tests/api/test-push-literal.c
+++ b/tests/api/test-push-literal.c
@@ -1,0 +1,86 @@
+/*
+ *  duk_push_literal()
+ */
+
+/*===
+*** test_basic (duk_safe_call)
+top: 1, string: ''
+len: 0
+top: 1, string: 'foo'
+len: 3
+top: 1, string: 'foobar'
+len: 6
+top: 1
+len: 5
+top: 1, string: 'foobar'
+return str: 'foobar'
+top: 1, string: 'foo'
+len: 7
+final top: 0
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	const char *str;
+	duk_size_t len;
+
+	(void) udata;
+
+	/* Empty. */
+	(void) duk_push_literal(ctx, "");
+	printf("top: %ld, string: '%s'\n", (long) duk_get_top(ctx), duk_get_string(ctx, -1));
+	str = duk_get_lstring(ctx, -1, &len);
+	printf("len: %ld\n", (long) len);
+	duk_pop(ctx);
+
+	/* Normal string. */
+	(void) duk_push_literal(ctx, "foo");
+	printf("top: %ld, string: '%s'\n", (long) duk_get_top(ctx), duk_get_string(ctx, -1));
+	str = duk_get_lstring(ctx, -1, &len);
+	printf("len: %ld\n", (long) len);
+	duk_pop(ctx);
+
+	/* String can be concantenated and may involve parentheses. */
+	(void) duk_push_literal(ctx, ("foo" "bar"));
+	printf("top: %ld, string: '%s'\n", (long) duk_get_top(ctx), duk_get_string(ctx, -1));
+	str = duk_get_lstring(ctx, -1, &len);
+	printf("len: %ld\n", (long) len);
+	duk_pop(ctx);
+
+	/* Literal can also be produces using symbol macros. */
+	(void) duk_push_literal(ctx, DUK_HIDDEN_SYMBOL("quux"));
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	str = duk_get_lstring(ctx, -1, &len);
+	printf("len: %ld\n", (long) len);
+	duk_pop(ctx);
+
+	/* Return value is a pointer to the interned string data.  It may
+	 * or may not be the same as the input.  Right now (Duktape 2.3)
+	 * it is always different from the input because there are no
+	 * optimizations to take advatange of the literal (e.g. referring
+	 * to it as an external string).
+	 */
+	str = duk_push_literal(ctx, ("foo" "bar"));
+	printf("top: %ld, string: '%s'\n", (long) duk_get_top(ctx), duk_get_string(ctx, -1));
+	printf("return str: '%s'\n", str);
+	duk_pop(ctx);
+
+	/* Embedded NUL.  Behavior depends on whether sizeof() is used (prefer
+	 * speed) or whether duk_push_literal() is compiled as duk_push_string()
+	 * (prefer size).  Test for default, prefer speed behavior.
+	 *
+	 * Application code SHOULD NOT make calls like this.
+	 */
+	(void) duk_push_literal(ctx, "foo" "\x00" "bar");
+	printf("top: %ld, string: '%s'\n", (long) duk_get_top(ctx), duk_get_string(ctx, -1));
+	str = duk_get_lstring(ctx, -1, &len);
+	printf("len: %ld\n", (long) len);
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/perf/test-add-string.js
+++ b/tests/perf/test-add-string.js
@@ -1,0 +1,27 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var i;
+    var x = 'foo';
+    var t;
+
+    for (i = 0; i < 1e7; i++) {
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+        t = x + 'bar';
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-func-tostring.js
+++ b/tests/perf/test-func-tostring.js
@@ -1,0 +1,26 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var fn = function foo() {};
+    var i, t;
+
+    for (i = 0; i < 1e6; i++) {
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+        t = fn.toString();
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/website/api/duk_push_literal.yaml
+++ b/website/api/duk_push_literal.yaml
@@ -1,0 +1,57 @@
+name: duk_push_literal
+
+proto: |
+  const char *duk_push_literal(duk_context *ctx, const char *str);
+
+stack: |
+  [ ... ] -> [ ... str! ]
+
+summary: |
+  <p>Push a C literal into the stack and return a pointer to the interned
+  string data area (which may or may not be the same as the argument literal).
+  The argument <code>str</code must be a non-NULL C literal that can be
+  operated on using e.g. <code>sizeof(str)</code>.  The data contents of the
+  literal must be immutable, and the string must not contain NUL characters.
+  The <code>str</code> argument may be evaluated multiple times by the API
+  macro.  Finally, no runtime NULL pointer check is made for the
+  <code>str</code> argument so passing in a NULL causes memory unsafe
+  behavior.</p>
+
+  <p>This call is conceptually equivalent to duk_push_(l)string(), and
+  only needs to be used if the minor differences in footprint or speed
+  matter.  The properties of immutable literals allows minor optimizations
+  in Duktape internals:</p>
+  <ul>
+  <li>The length of the string can be computed at compile time using
+      <code>sizeof(str) - 1</code> at the call site.</li>
+  <li>Because the string data is assumed to be immutable, the internal
+      string representation could just point to the data instead of
+      making a copy.  (This optimization is not done as of Duktape 2.3.)</li>
+  <li>Because the string address is fixed at runtime, it could be used
+      for speeding up a string table lookup for the literal.  While common,
+      there's no assumption that strings are deduplicated, so there may be
+      multiple addresses with the same literal.  (This optimization is not
+      done as of Duktape 2.3.)</li>
+  </ul>
+
+  <p>If input string might contain internal NUL characters, use
+  <code><a href="#duk_push_lstring">duk_push_lstring()</a></code> instead.
+  For <code>duk_push_literal()</code> handling of embedded NULs depends
+  on config options and calling code should never rely on the behavior.</p>
+
+example: |
+  /* Basic case. */
+  duk_push_literal(ctx, "foo");
+
+  /* Argument may involve compile time concatenation and parentheses. */
+  duk_push_literal(ctx, ("foo" "bar"));
+
+  /* Argument may also be e.g. DUK_HIDDEN_SYMBOL() which produces a literal. */
+  duk_push_literal(ctx, DUK_HIDDEN_SYMBOL("mySymbol"));
+
+tags:
+  - stack
+  - string
+  - experimental
+
+introduced: 2.3.0


### PR DESCRIPTION
Add `duk_push_literal(ctx, "foo")` which is in principle the same as `duk_push_string(ctx, "foo")` but with minor differences (the API call is similar to http://pgl.yoyo.org/luai/i/lua_pushliteral):
- The argument is assumed to be a C literal. This allows the string length to be computed at the call site as `sizeof(str) - 1` (-1 for excluding the terminating NUL).
- The string data is assumed to be immutable so in the future Duktape may just point to the string rather than making a copy in the intern. This would be nice for lowmem targets where "external strings" are already used.
- Because the literal address may be reused in subsequent intern check calls, in the future Duktape might speed up the literal -> string table lookup somehow to avoid hashing (and maybe even comparison in some approaches). For example, a soft address -> string table index (with validation before use) might be worth it.

The internals are changed to use the new API call where appropriate. The performance impact just with this change alone (in essence avoiding a strlen()) is negligible, but visible in very specific microbenchmarks.

I'm adding this as an experimental entry for now. The convenience functions like `duk_get_prop_string()` also need `xxx_literal()` counterparts for the addition to be complete.

Tasks:
- [x] Add API macro duk_push_literal()
- [x] API documentation
- [x] API testcase
- [x] Testcase coverage for return value
- [x] Perf test demonstrating the (very minor) advantage
- [x] Follow-up issues: #1806
- [x] Releases entry