### PR TITLE
 Replace gcc by $(CC) in extras Makefiles

### DIFF
--- a/extras/alloc-pool/Makefile
+++ b/extras/alloc-pool/Makefile
@@ -1,5 +1,6 @@
 # For manual testing; say 'make' in extras/alloc-pool and run ./test.
 
+CC=gcc
 DEFS=
 #DEFS+='-DDUK_ALLOC_POOL_DEBUG'
 
@@ -12,7 +13,7 @@ test:
 		--output-directory ./prep \
 		--option-file ./opts.yaml \
 		--fixup-line 'extern void my_fatal(const char *msg);'
-	gcc -std=c99 -Wall -Wextra -m32 -Os -otest \
+	$(CC) -std=c99 -Wall -Wextra -m32 -Os -otest \
 		-I./prep ./prep/duktape.c \
 		$(DEFS) \
 		duk_alloc_pool.c test.c \
@@ -32,7 +33,7 @@ ptrcomptest:
 		--option-file ../../config/examples/low_memory.yaml \
 		--option-file ptrcomp.yaml \
 		--fixup-file ptrcomp_fixup.h
-	gcc -std=c99 -Wall -Wextra -m32 -Os -optrcomptest \
+	$(CC) -std=c99 -Wall -Wextra -m32 -Os -optrcomptest \
 		-I. -I./prep ./prep/duktape.c \
 		$(DEFS) \
 		duk_alloc_pool.c test.c \

--- a/extras/cbor/Makefile
+++ b/extras/cbor/Makefile
@@ -1,6 +1,7 @@
 # For manual testing; say 'make' in extras/cbor.
 
 VALGRIND=valgrind
+CC=gcc
 CCOPTS=-std=c99 -Wall -Wextra -O2
 #CCOPTS+=-fsanitize=undefined
 
@@ -21,7 +22,7 @@ jsoncbor: jsoncbor.c duk_cbor.c duk_cbor.h
 		-DDUK_USE_JSON_EATWHITE_FASTPATH \
 		-DDUK_USE_JSON_QUOTESTRING_FASTPATH \
 		-DDUK_USE_JSON_STRINGIFY_FASTPATH
-	gcc $(CCOPTS) -o $@ -I./prep -I. ./prep/duktape.c duk_cbor.c jsoncbor.c -lm
+	$(CC) $(CCOPTS) -o $@ -I./prep -I. ./prep/duktape.c duk_cbor.c jsoncbor.c -lm
 
 appendix_a.json:
 	wget -O $@ https://raw.githubusercontent.com/cbor/test-vectors/master/appendix_a.json

--- a/extras/console/Makefile
+++ b/extras/console/Makefile
@@ -1,10 +1,12 @@
 # For manual testing; say 'make' in extras/console and run ./test.
 
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_console.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_console.c test.c -lm
 	./test 'console.assert(true, "not shown");'
 	./test 'console.assert(false, "shown", { foo: 123 });'
 	./test 'console.log(1, 2, 3, { foo: "bar" });'

--- a/extras/duk-v1-compat/Makefile
+++ b/extras/duk-v1-compat/Makefile
@@ -1,10 +1,12 @@
 # For manual testing; say 'make' in extras/duk-v1-compat and run ./test.
 
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_v1_compat.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_v1_compat.c test.c -lm
 	./test
 
 .PHONY: clean

--- a/extras/logging/Makefile
+++ b/extras/logging/Makefile
@@ -1,9 +1,12 @@
 # For manual testing; say 'make' in extras/logging and run ./test.
+
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -otest -I./prep ./prep/duktape.c duk_logging.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -otest -I./prep ./prep/duktape.c duk_logging.c test.c -lm
 	./test 'L = new Duktape.Logger(); L.trace("testing"); L.l = 0; L.trace("testing 2");'
 	./test 'L = new Duktape.Logger(); L.debug("testing"); L.l = 1; L.debug("testing 2");'
 	./test 'L = new Duktape.Logger(); L.info("testing");'

--- a/extras/minimal-printf/Makefile
+++ b/extras/minimal-printf/Makefile
@@ -1,5 +1,7 @@
 # Just for manual testing
+CC	= gcc
+
 .PHONY: test
 test: duk_minimal_printf.c
-	gcc -std=c99 -Wall -Wextra -fno-stack-protector -m32 -Os -fomit-frame-pointer -otest duk_minimal_printf.c test.c
+	$(CC) -std=c99 -Wall -Wextra -fno-stack-protector -m32 -Os -fomit-frame-pointer -otest duk_minimal_printf.c test.c
 	./test

--- a/extras/module-duktape/Makefile
+++ b/extras/module-duktape/Makefile
@@ -1,11 +1,13 @@
 # For manual testing; say 'make' in extras/module-duktape and run ./test.
 # There's test coverage in tests/ecmascript, so tests here are very simple.
 
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_module_duktape.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_module_duktape.c test.c -lm
 	@printf '\n'
 	./test 'assert(typeof require === "function");'
 	./test 'assert(require.name === "require");'

--- a/extras/module-node/Makefile
+++ b/extras/module-node/Makefile
@@ -1,10 +1,12 @@
 # For manual testing; say 'make' in extras/module-node and run ./test.
 
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_module_node.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -o $@ -I./prep -I. ./prep/duktape.c duk_module_node.c test.c -lm
 	@printf '\n'
 	./test 'assert(typeof require("pig") === "string", "basic require()");'
 	./test 'assert(require("cow").indexOf("pig") !== -1, "nested require()");'

--- a/extras/print-alert/Makefile
+++ b/extras/print-alert/Makefile
@@ -1,9 +1,12 @@
 # For manual testing; say 'make' in extras/print-alert and run ./test.
+
+CC	= gcc
+
 .PHONY: test
 test:
 	-rm -rf ./prep
 	python2 ../../tools/configure.py --quiet --output-directory ./prep
-	gcc -std=c99 -Wall -Wextra -otest -I./prep ./prep/duktape.c duk_print_alert.c test.c -lm
+	$(CC) -std=c99 -Wall -Wextra -otest -I./prep ./prep/duktape.c duk_print_alert.c test.c -lm
 	./test 'print("foo", "bar", 1, 2, 3)'
 	./test 'alert("foo", "bar", 1, 2, 3)'
 


### PR DESCRIPTION
All Makefiles in extra folder were using gcc instead of $(CC), fix this
to allow cross-compilation

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>