### PR TITLE
Makefile whitespace trivia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,27 +31,27 @@
 # A few commands which may need to be edited.  NodeJS is sometimes found
 # as 'nodejs', sometimes as 'node'; sometimes 'node' is unrelated to NodeJS
 # so check 'nodejs' first.
-GIT:=$(shell command -v git 2>/dev/null)
-NODE:=$(shell { command -v nodejs || command -v node; } 2>/dev/null)
-WGET:=$(shell command -v wget 2>/dev/null)
-JAVA:=$(shell command -v java 2>/dev/null)
-VALGRIND:=$(shell command -v valgrind 2>/dev/null)
-PYTHON:=$(shell { command -v python2 || command -v python; } 2>/dev/null)
+GIT := $(shell command -v git 2>/dev/null)
+NODE := $(shell { command -v nodejs || command -v node; } 2>/dev/null)
+WGET := $(shell command -v wget 2>/dev/null)
+JAVA := $(shell command -v java 2>/dev/null)
+VALGRIND := $(shell command -v valgrind 2>/dev/null)
+PYTHON := $(shell { command -v python2 || command -v python; } 2>/dev/null)
 
 # Scrape version from the public header; convert from e.g. 10203 -> '1.2.3'
-DUK_VERSION:=$(shell cat src-input/duktape.h.in | grep 'define ' | grep DUK_VERSION | tr -s ' ' ' ' | cut -d ' ' -f 3 | tr -d 'L')
-DUK_MAJOR:=$(shell echo "$(DUK_VERSION) / 10000" | bc)
-DUK_MINOR:=$(shell echo "$(DUK_VERSION) % 10000 / 100" | bc)
-DUK_PATCH:=$(shell echo "$(DUK_VERSION) % 100" | bc)
-DUK_VERSION_FORMATTED:=$(DUK_MAJOR).$(DUK_MINOR).$(DUK_PATCH)
-GIT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
-GIT_DESCRIBE:=$(shell git describe --always --dirty)
+DUK_VERSION := $(shell cat src-input/duktape.h.in | grep 'define ' | grep DUK_VERSION | tr -s ' ' ' ' | cut -d ' ' -f 3 | tr -d 'L')
+DUK_MAJOR := $(shell echo "$(DUK_VERSION) / 10000" | bc)
+DUK_MINOR := $(shell echo "$(DUK_VERSION) % 10000 / 100" | bc)
+DUK_PATCH := $(shell echo "$(DUK_VERSION) % 100" | bc)
+DUK_VERSION_FORMATTED := $(DUK_MAJOR).$(DUK_MINOR).$(DUK_PATCH)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_DESCRIBE := $(shell git describe --always --dirty)
 ifeq ($(GIT_BRANCH),master)
-GIT_INFO:=$(GIT_DESCRIBE)
+GIT_INFO := $(GIT_DESCRIBE)
 else
-GIT_INFO:=$(GIT_DESCRIBE)-$(GIT_BRANCH)
+GIT_INFO := $(GIT_DESCRIBE)-$(GIT_BRANCH)
 endif
-BUILD_DATETIME:=$(shell date +%Y%m%d%H%M%S)
+BUILD_DATETIME := $(shell date +%Y%m%d%H%M%S)
 
 # Source lists.
 DUKTAPE_CMDLINE_SOURCES = \
@@ -76,33 +76,33 @@ LINENOISE_SOURCES = linenoise/linenoise.c
 endif
 
 # Configure.py options for a few configuration profiles needed.
-CONFIGOPTS_NONDEBUG=--option-file util/makeduk_base.yaml
-CONFIGOPTS_NONDEBUG_SCANBUILD=--option-file util/makeduk_base.yaml --option-file util/makeduk_scanbuild.yaml
-CONFIGOPTS_NONDEBUG_PERF=--option-file config/examples/performance_sensitive.yaml
-CONFIGOPTS_NONDEBUG_SIZE=--option-file config/examples/low_memory.yaml
-CONFIGOPTS_NONDEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
-CONFIGOPTS_NONDEBUG_DUKLOW=--option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h
-CONFIGOPTS_DEBUG_DUKLOW=$(CONFIGOPTS_NONDEBUG_DUKLOW) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
-CONFIGOPTS_NONDEBUG_DUKLOW_ROM=--rom-support --rom-auto-lightfunc --option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h --builtin-file util/example_user_builtins1.yaml --builtin-file util/example_user_builtins2.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX -UDUK_USE_DEBUG
-CONFIGOPTS_DEBUG_DUKLOW_ROM=$(CONFIGOPTS_NONDEBUG_DUKLOW_ROM) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
-CONFIGOPTS_NONDEBUG_DUKLOW_NOREFC=--option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h -UDUK_USE_REFERENCE_COUNTING -UDUK_USE_DOUBLE_LINKED_HEAP
-CONFIGOPTS_DEBUG_DUKLOW_NOREFC=$(CONFIGOPTS_NONDEBUG_DUKLOW_NOREFC) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
-CONFIGOPTS_DEBUG=--option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml
-CONFIGOPTS_DEBUG_SCANBUILD=--option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml --option-file util/makeduk_scanbuild.yaml
-CONFIGOPTS_DEBUG_ROM=--rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
-CONFIGOPTS_EMDUK=-UDUK_USE_FASTINT -UDUK_USE_PACKED_TVAL
-CONFIGOPTS_DUKWEB=--option-file util/dukweb_base.yaml --fixup-file util/dukweb_fixup.h
+CONFIGOPTS_NONDEBUG = --option-file util/makeduk_base.yaml
+CONFIGOPTS_NONDEBUG_SCANBUILD = --option-file util/makeduk_base.yaml --option-file util/makeduk_scanbuild.yaml
+CONFIGOPTS_NONDEBUG_PERF = --option-file config/examples/performance_sensitive.yaml
+CONFIGOPTS_NONDEBUG_SIZE = --option-file config/examples/low_memory.yaml
+CONFIGOPTS_NONDEBUG_ROM = --rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
+CONFIGOPTS_NONDEBUG_DUKLOW = --option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h
+CONFIGOPTS_DEBUG_DUKLOW = $(CONFIGOPTS_NONDEBUG_DUKLOW) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
+CONFIGOPTS_NONDEBUG_DUKLOW_ROM = --rom-support --rom-auto-lightfunc --option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h --builtin-file util/example_user_builtins1.yaml --builtin-file util/example_user_builtins2.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX -UDUK_USE_DEBUG
+CONFIGOPTS_DEBUG_DUKLOW_ROM = $(CONFIGOPTS_NONDEBUG_DUKLOW_ROM) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
+CONFIGOPTS_NONDEBUG_DUKLOW_NOREFC = --option-file config/examples/low_memory.yaml --option-file util/makeduk_duklow.yaml --fixup-file util/makeduk_duklow_fixup.h -UDUK_USE_REFERENCE_COUNTING -UDUK_USE_DOUBLE_LINKED_HEAP
+CONFIGOPTS_DEBUG_DUKLOW_NOREFC = $(CONFIGOPTS_NONDEBUG_DUKLOW_NOREFC) -DDUK_USE_ASSERTIONS -DDUK_USE_SELF_TESTS
+CONFIGOPTS_DEBUG = --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml
+CONFIGOPTS_DEBUG_SCANBUILD = --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml --option-file util/makeduk_scanbuild.yaml
+CONFIGOPTS_DEBUG_ROM = --rom-support --rom-auto-lightfunc --option-file util/makeduk_base.yaml --option-file util/makeduk_debug.yaml -DDUK_USE_ROM_STRINGS -DDUK_USE_ROM_OBJECTS -DDUK_USE_ROM_GLOBAL_INHERIT -UDUK_USE_HSTRING_ARRIDX
+CONFIGOPTS_EMDUK = -UDUK_USE_FASTINT -UDUK_USE_PACKED_TVAL
+CONFIGOPTS_DUKWEB = --option-file util/dukweb_base.yaml --fixup-file util/dukweb_fixup.h
 
 # Profile guided optimization test set.
-PGO_TEST_SET=\
+PGO_TEST_SET = \
 	tests/ecmascript/test-dev-mandel2-func.js \
 	tests/ecmascript/test-dev-totp.js \
 	tests/perf/test-fib.js \
 	tests/ecmascript/test-regexp-ipv6-regexp.js
 
 # Compiler setup for Linux.
-CC	= gcc
-GXX	= g++
+CC = gcc
+GXX = g++
 
 CCOPTS_SHARED =
 CCOPTS_SHARED += -DDUK_CMDLINE_PRINTALERT_SUPPORT
@@ -203,18 +203,18 @@ endif
 #
 # Reducing the TOTAL_MEMORY and TOTAL_STACK values is useful if you run
 # Duktape cmdline with resource limits (i.e. "duk -r test.js").
-#EMCCOPTS=-s TOTAL_MEMORY=2097152 -s TOTAL_STACK=524288 --memory-init-file 0
-EMCCOPTS=-O2 -std=c99 -Wall --memory-init-file 0
-EMCCOPTS_DUKVM=-O2 -std=c99 -Wall --memory-init-file 0 -DEMSCRIPTEN
-EMCCOPTS_DUKWEB_EXPORT=-s EXPORTED_FUNCTIONS='["_dukweb_is_open", "_dukweb_open","_dukweb_close","_dukweb_eval"]'
-EMDUKOPTS=-s TOTAL_MEMORY=268435456 -DDUK_CMDLINE_PRINTALERT_SUPPORT
-EMDUKOPTS+=-DEMSCRIPTEN  # enable stdin workaround in duk_cmdline.c
+#EMCCOPTS = -s TOTAL_MEMORY=2097152 -s TOTAL_STACK=524288 --memory-init-file 0
+EMCCOPTS = -O2 -std=c99 -Wall --memory-init-file 0
+EMCCOPTS_DUKVM = -O2 -std=c99 -Wall --memory-init-file 0 -DEMSCRIPTEN
+EMCCOPTS_DUKWEB_EXPORT = -s EXPORTED_FUNCTIONS='["_dukweb_is_open", "_dukweb_open","_dukweb_close","_dukweb_eval"]'
+EMDUKOPTS = -s TOTAL_MEMORY=268435456 -DDUK_CMDLINE_PRINTALERT_SUPPORT
+EMDUKOPTS += -DEMSCRIPTEN  # enable stdin workaround in duk_cmdline.c
 
 # Mandelbrot test, base-64 encoded.
-MAND_BASE64=dyA9IDgwOyBoID0gNDA7IGl0ZXIgPSAxMDA7IGZvciAoaSA9IDA7IGkgLSBoOyBpICs9IDEpIHsgeTAgPSAoaSAvIGgpICogNC4wIC0gMi4wOyByZXMgPSBbXTsgZm9yIChqID0gMDsgaiAtIHc7IGogKz0gMSkgeyB4MCA9IChqIC8gdykgKiA0LjAgLSAyLjA7IHh4ID0gMDsgeXkgPSAwOyBjID0gIiMiOyBmb3IgKGsgPSAwOyBrIC0gaXRlcjsgayArPSAxKSB7IHh4MiA9IHh4Knh4OyB5eTIgPSB5eSp5eTsgaWYgKE1hdGgubWF4KDAsIDQuMCAtICh4eDIgKyB5eTIpKSkgeyB5eSA9IDIqeHgqeXkgKyB5MDsgeHggPSB4eDIgLSB5eTIgKyB4MDsgfSBlbHNlIHsgYyA9ICIuIjsgYnJlYWs7IH0gfSByZXNbcmVzLmxlbmd0aF0gPSBjOyB9IHByaW50KHJlcy5qb2luKCIiKSk7IH0K
+MAND_BASE64 = dyA9IDgwOyBoID0gNDA7IGl0ZXIgPSAxMDA7IGZvciAoaSA9IDA7IGkgLSBoOyBpICs9IDEpIHsgeTAgPSAoaSAvIGgpICogNC4wIC0gMi4wOyByZXMgPSBbXTsgZm9yIChqID0gMDsgaiAtIHc7IGogKz0gMSkgeyB4MCA9IChqIC8gdykgKiA0LjAgLSAyLjA7IHh4ID0gMDsgeXkgPSAwOyBjID0gIiMiOyBmb3IgKGsgPSAwOyBrIC0gaXRlcjsgayArPSAxKSB7IHh4MiA9IHh4Knh4OyB5eTIgPSB5eSp5eTsgaWYgKE1hdGgubWF4KDAsIDQuMCAtICh4eDIgKyB5eTIpKSkgeyB5eSA9IDIqeHgqeXkgKyB5MDsgeHggPSB4eDIgLSB5eTIgKyB4MDsgfSBlbHNlIHsgYyA9ICIuIjsgYnJlYWs7IH0gfSByZXNbcmVzLmxlbmd0aF0gPSBjOyB9IHByaW50KHJlcy5qb2luKCIiKSk7IH0K
 
 # Options for runtests.js.
-RUNTESTSOPTS=--prep-test-path util/prep_test.py --minify-uglifyjs2 UglifyJS2/bin/uglifyjs --util-include-path tests/ecmascript --known-issues doc/testcase-known-issues.yaml
+RUNTESTSOPTS = --prep-test-path util/prep_test.py --minify-uglifyjs2 UglifyJS2/bin/uglifyjs --util-include-path tests/ecmascript --known-issues doc/testcase-known-issues.yaml
 
 # Compile 'duk' only by default
 .PHONY:	all

--- a/dist-files/Makefile.cmdline
+++ b/dist-files/Makefile.cmdline
@@ -8,10 +8,10 @@ DUKTAPE_SOURCES = src/duktape.c
 CMDLINE_SOURCES = \
 	examples/cmdline/duk_cmdline.c
 
-CC	= gcc
-CCOPTS	= -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CC = gcc
+CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
 CCOPTS += -I./examples/cmdline -I./src   # duktape.h and duk_config.h must be in include path
-CCLIBS	= -lm
+CCLIBS = -lm
 
 # Enable print() and alert() for command line using an optional extra module.
 CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
@@ -33,13 +33,13 @@ CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.c
 # will cause some harmless compilation warnings.
 #CCOPTS += -DDUK_CMDLINE_FANCY -I./linenoise
 #CMDLINE_SOURCES += linenoise/linenoise.c
-#duk:	linenoise
+#duk: linenoise
 
 # Use the tools/configure.py utility to modify Duktape default configuration:
 # http://duktape.org/guide.html#compiling
 # http://wiki.duktape.org/Configuring.html
 
-duk:	$(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)
+duk: $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)
 	$(CC) -o $@ $(DEFINES) $(CCOPTS) $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) $(CCLIBS)
 
 linenoise/linenoise.c: linenoise

--- a/dist-files/Makefile.codepage
+++ b/dist-files/Makefile.codepage
@@ -1,4 +1,4 @@
-CC	= gcc
+CC = gcc
 
 codepage:
 	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \

--- a/dist-files/Makefile.dukdebug
+++ b/dist-files/Makefile.dukdebug
@@ -10,11 +10,11 @@ CMDLINE_SOURCES = \
 	examples/cmdline/duk_cmdline.c \
 	examples/debug-trans-socket/duk_trans_socket_unix.c
 
-CC	= gcc
-CCOPTS	= -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CC = gcc
+CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
 CCOPTS += -I./prep -I./examples/cmdline -I./examples/debug-trans-socket
 CCOPTS += -DDUK_CMDLINE_DEBUGGER_SUPPORT     # enable --debugger in ./duk
-CCLIBS	= -lm
+CCLIBS = -lm
 
 # Enable a few optional modules.
 CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
@@ -28,7 +28,7 @@ CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.c
 
 # Use tools/configure.py to prepare Duktape config header and sources with
 # custom configuration.
-duk:	$(CMDLINE_SOURCES)
+duk: $(CMDLINE_SOURCES)
 	@rm -rf prep
 	python2 tools/configure.py \
 		--source-directory src-input \

--- a/dist-files/Makefile.eval
+++ b/dist-files/Makefile.eval
@@ -2,7 +2,7 @@
 #  Example Makefile for building the eval example
 #
 
-CC	= gcc
+CC = gcc
 
 eval:
 	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \

--- a/dist-files/Makefile.eventloop
+++ b/dist-files/Makefile.eventloop
@@ -2,7 +2,7 @@
 #  Example Makefile for building the eventloop example
 #
 
-CC	= gcc
+CC = gcc
 
 evloop:
 	@echo "NOTE: The eventloop is example is intended to be used on Linux"

--- a/dist-files/Makefile.hello
+++ b/dist-files/Makefile.hello
@@ -13,10 +13,10 @@ DUKTAPE_SOURCES = src/duktape.c
 # Compiler options are quite flexible.  GCC versions have a significant impact
 # on the size of -Os code, e.g. gcc-4.6 is much worse than gcc-4.5.
 
-CC	= gcc
-CCOPTS	= -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CC = gcc
+CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
 CCOPTS += -I./src  # for combined sources
-CCLIBS	= -lm
+CCLIBS = -lm
 DEFINES =
 
 # If you want a 32-bit build on a 64-bit host
@@ -28,5 +28,5 @@ DEFINES =
 
 # For debugging, use -O0 -g -ggdb, and don't add -fomit-frame-pointer
 
-hello:	$(DUKTAPE_SOURCES) examples/hello/hello.c
+hello: $(DUKTAPE_SOURCES) examples/hello/hello.c
 	$(CC) -o $@ $(DEFINES) $(CCOPTS) $(DUKTAPE_SOURCES) examples/hello/hello.c $(CCLIBS)

--- a/dist-files/Makefile.jxpretty
+++ b/dist-files/Makefile.jxpretty
@@ -2,7 +2,7 @@
 #  Example Makefile for building the jxpretty example
 #
 
-CC	= gcc
+CC = gcc
 
 jxpretty:
 	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \

--- a/dist-files/Makefile.sandbox
+++ b/dist-files/Makefile.sandbox
@@ -2,7 +2,7 @@
 #  Example Makefile for building the sandbox example
 #
 
-CC	= gcc
+CC = gcc
 
 sandbox:
 	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \

--- a/dist-files/Makefile.sharedlibrary
+++ b/dist-files/Makefile.sharedlibrary
@@ -24,19 +24,19 @@
 # convention is to set soname version to (100*MAJOR + MINOR), e.g. 104 for
 # Duktape 1.4.x, so that it gets automatically bumped for major and minor
 # releases (potentially binary incompatible), but not for patch releases.
-DUK_VERSION=@DUK_VERSION@
-SONAME_VERSION=@SONAME_VERSION@
-REAL_VERSION=$(SONAME_VERSION).$(DUK_VERSION)
+DUK_VERSION = @DUK_VERSION@
+SONAME_VERSION = @SONAME_VERSION@
+REAL_VERSION = $(SONAME_VERSION).$(DUK_VERSION)
 
 # Change to actual path for actual distribution packaging.
-INSTALL_PREFIX=/usr/local
+INSTALL_PREFIX = /usr/local
 
 # The 'noline' variant may be more appropriate for some distributions; it
 # doesn't have #line directives in the combined source.
-DUKTAPE_SRCDIR=./src
-#DUKTAPE_SRCDIR=./src-noline
+DUKTAPE_SRCDIR = ./src
+#DUKTAPE_SRCDIR = ./src-noline
 
-CC=gcc
+CC = gcc
 
 .PHONY: all
 all: libduktape.so.$(REAL_VERSION) libduktaped.so.$(REAL_VERSION)
@@ -67,7 +67,7 @@ install: libduktape.so.$(REAL_VERSION) libduktaped.so.$(REAL_VERSION)
 
 # Note: assumes /usr/local/include/ and /usr/local/lib/ are in include/link
 # path which may not be the case for all distributions.
-#CCOPTS=-I/usr/local/include -L/usr/local/lib
-CCOPTS=-I./examples/cmdline
+#CCOPTS = -I/usr/local/include -L/usr/local/lib
+CCOPTS = -I./examples/cmdline
 duk:
 	$(CC) $(CCOPTS) -Wall -Wextra -Os -o $@ ./examples/cmdline/duk_cmdline.c -lduktape -lm

--- a/extras/alloc-pool/Makefile
+++ b/extras/alloc-pool/Makefile
@@ -1,8 +1,8 @@
 # For manual testing; say 'make' in extras/alloc-pool and run ./test.
 
-CC=gcc
-DEFS=
-#DEFS+='-DDUK_ALLOC_POOL_DEBUG'
+CC = gcc
+DEFS =
+#DEFS += '-DDUK_ALLOC_POOL_DEBUG'
 
 .PHONY: test
 test:

--- a/extras/cbor/Makefile
+++ b/extras/cbor/Makefile
@@ -1,9 +1,9 @@
 # For manual testing; say 'make' in extras/cbor.
 
-VALGRIND=valgrind
-CC=gcc
-CCOPTS=-std=c99 -Wall -Wextra -O2
-#CCOPTS+=-fsanitize=undefined
+VALGRIND = valgrind
+CC = gcc
+CCOPTS = -std=c99 -Wall -Wextra -O2
+#CCOPTS += -fsanitize=undefined
 
 .PHONY: all
 all: clean jsoncbor test-runs

--- a/extras/console/Makefile
+++ b/extras/console/Makefile
@@ -1,6 +1,6 @@
 # For manual testing; say 'make' in extras/console and run ./test.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:

--- a/extras/duk-v1-compat/Makefile
+++ b/extras/duk-v1-compat/Makefile
@@ -1,6 +1,6 @@
 # For manual testing; say 'make' in extras/duk-v1-compat and run ./test.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:

--- a/extras/logging/Makefile
+++ b/extras/logging/Makefile
@@ -1,6 +1,6 @@
 # For manual testing; say 'make' in extras/logging and run ./test.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:

--- a/extras/minimal-printf/Makefile
+++ b/extras/minimal-printf/Makefile
@@ -1,5 +1,5 @@
 # Just for manual testing
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test: duk_minimal_printf.c

--- a/extras/module-duktape/Makefile
+++ b/extras/module-duktape/Makefile
@@ -1,7 +1,7 @@
 # For manual testing; say 'make' in extras/module-duktape and run ./test.
 # There's test coverage in tests/ecmascript, so tests here are very simple.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:

--- a/extras/module-node/Makefile
+++ b/extras/module-node/Makefile
@@ -1,6 +1,6 @@
 # For manual testing; say 'make' in extras/module-node and run ./test.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:

--- a/extras/print-alert/Makefile
+++ b/extras/print-alert/Makefile
@@ -1,6 +1,6 @@
 # For manual testing; say 'make' in extras/print-alert and run ./test.
 
-CC	= gcc
+CC = gcc
 
 .PHONY: test
 test:


### PR DESCRIPTION
- Use `CC = gcc`, `FOO := bar`, etc throughout: single space between operator, no tabs.
- Use space for dependencies, not tab.