### PR TITLE
Add duk_{get,put,has,del}_prop_literal() and duk_{get,put}_global_{literal,heapptr}()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3195,8 +3195,15 @@ Planned
   useful to detect constructor calls which can already be done using
   duk_is_constructor_call() (GH-1745)
 
-* Add experimental duk_push_literal() API call which may allow e.g. better
-  lowmem behavior for string literals later on (GH-1805)
+* Add experimental API call variants for plain C literals, for example
+  duk_push_literal(ctx, "key") and duk_get_prop_literal(ctx, "propname"),
+  which may allow e.g. better performance or RAM footprint later on; calls
+  added: duk_push_literal(), duk_get_prop_literal(), duk_put_prop_literal(),
+  duk_has_prop_literal(), duk_del_prop_literal(), duk_get_global_literal(),
+  duk_put_global_literal() (GH-1805)
+
+* Add duk_get_global_heapptr() and duk_put_global_heapptr() for completeness
+  (GH-1805)
 
 * ES2015 Number constructor properties: EPSILON, MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -13,6 +13,13 @@ Main changes in this release (see RELEASES.rst for full details):
   potentially unsafe assumptions about compiler behavior for unaligned memory
   accesses and pointers (which may be an issue even on x86).
 
+* duk_xxx_literal() API call variants which take a plain C literal argument,
+  for example duk_get_prop_literal(ctx, -2, "myProperty").  The calls are
+  conceptually similar to the duk_xxx_string() variants, but can take advantage
+  of the fact that e.g. string length for a C literal can be determined at
+  compile time using sizeof("myProperty") - 1 (the -1 is for NUL termination).
+  For now the calls are experimental.
+
 Upgrading from Duktape 2.2
 ==========================
 

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -40,7 +40,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_string(duk_hthread *thr, duk_idx_t obj_idx,
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_string(thr, key);
+	(void) duk_push_string(thr, key);
 	return duk_get_prop(thr, obj_idx);
 }
 
@@ -49,9 +49,21 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_lstring(thr, key, key_len);
+	(void) duk_push_lstring(thr, key, key_len);
 	return duk_get_prop(thr, obj_idx);
 }
+
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_get_prop_literal_raw(duk_hthread *thr, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(key != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	obj_idx = duk_require_normalize_index(thr, obj_idx);
+	(void) duk_push_literal_raw(thr, key, key_len);
+	return duk_get_prop(thr, obj_idx);
+}
+#endif
 
 DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_API_ENTRY(thr);
@@ -65,7 +77,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_heapptr(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT_API_ENTRY(thr);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
+	(void) duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
 	return duk_get_prop(thr, obj_idx);
 }
 
@@ -74,7 +86,7 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx,
 	DUK_ASSERT_STRIDX_VALID(stridx);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_hstring(thr, DUK_HTHREAD_GET_STRING(thr, stridx));
+	(void) duk_push_hstring(thr, DUK_HTHREAD_GET_STRING(thr, stridx));
 	return duk_get_prop(thr, obj_idx);
 }
 
@@ -156,6 +168,18 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	return duk__put_prop_shared(thr, obj_idx, -1);
 }
 
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_put_prop_literal_raw(duk_hthread *thr, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(key != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	obj_idx = duk_normalize_index(thr, obj_idx);
+	(void) duk_push_literal_raw(thr, key, key_len);
+	return duk__put_prop_shared(thr, obj_idx, -1);
+}
+#endif
+
 DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_API_ENTRY(thr);
 
@@ -168,7 +192,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_heapptr(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT_API_ENTRY(thr);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
+	(void) duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
 	return duk__put_prop_shared(thr, obj_idx, -1);
 }
 
@@ -215,7 +239,7 @@ DUK_EXTERNAL duk_bool_t duk_del_prop_string(duk_hthread *thr, duk_idx_t obj_idx,
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_string(thr, key);
+	(void) duk_push_string(thr, key);
 	return duk_del_prop(thr, obj_idx);
 }
 
@@ -224,9 +248,21 @@ DUK_EXTERNAL duk_bool_t duk_del_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_lstring(thr, key, key_len);
+	(void) duk_push_lstring(thr, key, key_len);
 	return duk_del_prop(thr, obj_idx);
 }
+
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_del_prop_literal_raw(duk_hthread *thr, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(key != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	obj_idx = duk_require_normalize_index(thr, obj_idx);
+	(void) duk_push_literal_raw(thr, key, key_len);
+	return duk_del_prop(thr, obj_idx);
+}
+#endif
 
 DUK_EXTERNAL duk_bool_t duk_del_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_API_ENTRY(thr);
@@ -240,7 +276,7 @@ DUK_EXTERNAL duk_bool_t duk_del_prop_heapptr(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT_API_ENTRY(thr);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
+	(void) duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
 	return duk_del_prop(thr, obj_idx);
 }
 
@@ -286,7 +322,7 @@ DUK_EXTERNAL duk_bool_t duk_has_prop_string(duk_hthread *thr, duk_idx_t obj_idx,
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_string(thr, key);
+	(void) duk_push_string(thr, key);
 	return duk_has_prop(thr, obj_idx);
 }
 
@@ -295,9 +331,21 @@ DUK_EXTERNAL duk_bool_t duk_has_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT(key != NULL);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_lstring(thr, key, key_len);
+	(void) duk_push_lstring(thr, key, key_len);
 	return duk_has_prop(thr, obj_idx);
 }
+
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_has_prop_literal_raw(duk_hthread *thr, duk_idx_t obj_idx, const char *key, duk_size_t key_len) {
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(key != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	obj_idx = duk_require_normalize_index(thr, obj_idx);
+	(void) duk_push_literal_raw(thr, key, key_len);
+	return duk_has_prop(thr, obj_idx);
+}
+#endif
 
 DUK_EXTERNAL duk_bool_t duk_has_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_uarridx_t arr_idx) {
 	DUK_ASSERT_API_ENTRY(thr);
@@ -311,7 +359,7 @@ DUK_EXTERNAL duk_bool_t duk_has_prop_heapptr(duk_hthread *thr, duk_idx_t obj_idx
 	DUK_ASSERT_API_ENTRY(thr);
 
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
-	duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
+	(void) duk_push_heapptr(thr, ptr);  /* NULL -> 'undefined' */
 	return duk_has_prop(thr, obj_idx);
 }
 
@@ -697,6 +745,38 @@ DUK_EXTERNAL duk_bool_t duk_get_global_lstring(duk_hthread *thr, const char *key
 	return ret;
 }
 
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_get_global_literal_raw(duk_hthread *thr, const char *key, duk_size_t key_len) {
+	duk_bool_t ret;
+
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(thr, thr->builtins[DUK_BIDX_GLOBAL]);
+	ret = duk_get_prop_literal_raw(thr, -1, key, key_len);
+	duk_remove_m2(thr);
+	return ret;
+}
+#endif
+
+DUK_EXTERNAL duk_bool_t duk_get_global_heapptr(duk_hthread *thr, void *ptr) {
+	duk_bool_t ret;
+
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(thr, thr->builtins[DUK_BIDX_GLOBAL]);
+	ret = duk_get_prop_heapptr(thr, -1, ptr);
+	duk_remove_m2(thr);
+	return ret;
+}
+
+
 DUK_EXTERNAL duk_bool_t duk_put_global_string(duk_hthread *thr, const char *key) {
 	duk_bool_t ret;
 
@@ -723,6 +803,39 @@ DUK_EXTERNAL duk_bool_t duk_put_global_lstring(duk_hthread *thr, const char *key
 	duk_push_hobject(thr, thr->builtins[DUK_BIDX_GLOBAL]);
 	duk_insert(thr, -2);
 	ret = duk_put_prop_lstring(thr, -2, key, key_len);  /* [ ... global val ] -> [ ... global ] */
+	duk_pop(thr);
+	return ret;
+}
+
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL duk_bool_t duk_put_global_literal_raw(duk_hthread *thr, const char *key, duk_size_t key_len) {
+	duk_bool_t ret;
+
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+	DUK_ASSERT(key[key_len] == (char) 0);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(thr, thr->builtins[DUK_BIDX_GLOBAL]);
+	duk_insert(thr, -2);
+	ret = duk_put_prop_literal_raw(thr, -2, key, key_len);  /* [ ... global val ] -> [ ... global ] */
+	duk_pop(thr);
+	return ret;
+}
+#endif
+
+DUK_EXTERNAL duk_bool_t duk_put_global_heapptr(duk_hthread *thr, void *ptr) {
+	duk_bool_t ret;
+
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(thr->builtins[DUK_BIDX_GLOBAL] != NULL);
+
+	/* XXX: direct implementation */
+
+	duk_push_hobject(thr, thr->builtins[DUK_BIDX_GLOBAL]);
+	duk_insert(thr, -2);
+	ret = duk_put_prop_heapptr(thr, -2, ptr);  /* [ ... global val ] -> [ ... global ] */
 	duk_pop(thr);
 	return ret;
 }

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4355,6 +4355,17 @@ DUK_EXTERNAL const char *duk_push_string(duk_hthread *thr, const char *str) {
 	}
 }
 
+#if !defined(DUK_USE_PREFER_SIZE)
+DUK_EXTERNAL const char *duk_push_literal_raw(duk_hthread *thr, const char *str, duk_size_t len) {
+	DUK_ASSERT_API_ENTRY(thr);
+	DUK_ASSERT(str != NULL);
+	DUK_ASSERT(str[len] == (char) 0);
+
+	/* No difference to duk_push_lstring() for now. */
+	return duk_push_lstring(thr, str, len);
+}
+#endif
+
 DUK_EXTERNAL void duk_push_pointer(duk_hthread *thr, void *val) {
 	duk_tval *tv_slot;
 

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -559,11 +559,10 @@ DUK_EXTERNAL_DECL const char *duk_push_vsprintf(duk_context *ctx, const char *fm
  * behavior will then depend on config options.
  */
 #if defined(DUK_USE_PREFER_SIZE)
-#define duk_push_literal(ctx,cstring) \
-	duk_push_string((ctx), (cstring))
+#define duk_push_literal(ctx,cstring)  duk_push_string((ctx), (cstring))
 #else
-#define duk_push_literal(ctx,cstring) \
-	duk_push_lstring((ctx), (cstring), sizeof((cstring)) - 1)
+DUK_EXTERNAL_DECL const char *duk_push_literal_raw(duk_context *ctx, const char *str, duk_size_t len);
+#define duk_push_literal(ctx,cstring)  duk_push_literal_raw((ctx), (cstring), sizeof((cstring)) - 1U)
 #endif
 
 DUK_EXTERNAL_DECL void duk_push_this(duk_context *ctx);
@@ -899,29 +898,54 @@ DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *
 /*
  *  Property access
  *
- *  The basic function assumes key is on stack.  The _string variant takes
- *  a C string as a property name, while the _index variant takes an array
- *  index as a property name (e.g. 123 is equivalent to the key "123").
+ *  The basic function assumes key is on stack.  The _(l)string variant takes
+ *  a C string as a property name; the _literal variant takes a C literal.
+ *  The _index variant takes an array index as a property name (e.g. 123 is
+ *  equivalent to the key "123").
  */
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_get_prop_literal(ctx,obj_idx,key)  duk_get_prop_string((ctx), (obj_idx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_literal_raw(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#define duk_get_prop_literal(ctx,obj_idx,key)  duk_get_prop_literal_raw((ctx), (obj_idx), (key), sizeof((key)) - 1U)
+#endif
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop_heapptr(duk_context *ctx, duk_idx_t obj_idx, void *ptr);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_put_prop_literal(ctx,obj_idx,key)  duk_put_prop_string((ctx), (obj_idx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_literal_raw(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#define duk_put_prop_literal(ctx,obj_idx,key)  duk_put_prop_literal_raw((ctx), (obj_idx), (key), sizeof((key)) - 1U)
+#endif
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_prop_heapptr(duk_context *ctx, duk_idx_t obj_idx, void *ptr);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_del_prop_literal(ctx,obj_idx,key)  duk_del_prop_string((ctx), (obj_idx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_literal_raw(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#define duk_del_prop_literal(ctx,obj_idx,key)  duk_del_prop_literal_raw((ctx), (obj_idx), (key), sizeof((key)) - 1U)
+#endif
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_del_prop_heapptr(duk_context *ctx, duk_idx_t obj_idx, void *ptr);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop(duk_context *ctx, duk_idx_t obj_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_string(duk_context *ctx, duk_idx_t obj_idx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_lstring(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_has_prop_literal(ctx,obj_idx,key)  duk_has_prop_string((ctx), (obj_idx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_literal_raw(duk_context *ctx, duk_idx_t obj_idx, const char *key, duk_size_t key_len);
+#define duk_has_prop_literal(ctx,obj_idx,key)  duk_has_prop_literal_raw((ctx), (obj_idx), (key), sizeof((key)) - 1U)
+#endif
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_idx, duk_uarridx_t arr_idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_has_prop_heapptr(duk_context *ctx, duk_idx_t obj_idx, void *ptr);
 
@@ -930,8 +954,22 @@ DUK_EXTERNAL_DECL void duk_def_prop(duk_context *ctx, duk_idx_t obj_idx, duk_uin
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_global_string(duk_context *ctx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_get_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_get_global_literal(ctx,key)  duk_get_global_string((ctx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_get_global_literal_raw(duk_context *ctx, const char *key, duk_size_t key_len);
+#define duk_get_global_literal(ctx,key)  duk_get_global_literal_raw((ctx), (key), sizeof((key)) - 1U)
+#endif
+DUK_EXTERNAL_DECL duk_bool_t duk_get_global_heapptr(duk_context *ctx, void *ptr);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_global_string(duk_context *ctx, const char *key);
 DUK_EXTERNAL_DECL duk_bool_t duk_put_global_lstring(duk_context *ctx, const char *key, duk_size_t key_len);
+#if defined(DUK_USE_PREFER_SIZE)
+#define duk_put_global_literal(ctx,key)  duk_put_global_string((ctx), (key))
+#else
+DUK_EXTERNAL_DECL duk_bool_t duk_put_global_literal_raw(duk_context *ctx, const char *key, duk_size_t key_len);
+#define duk_put_global_literal(ctx,key)  duk_put_global_literal_raw((ctx), (key), sizeof((key)) - 1U)
+#endif
+DUK_EXTERNAL_DECL duk_bool_t duk_put_global_heapptr(duk_context *ctx, void *ptr);
 
 /*
  *  Inspection

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -61,6 +61,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_def_prop(ctx, 0, 0);
 	(void) duk_del_prop_heapptr(ctx, 0, NULL);
 	(void) duk_del_prop_index(ctx, 0, 0);
+	(void) duk_del_prop_literal(ctx, 0, "dummy");
 	(void) duk_del_prop_lstring(ctx, 0, "dummy", 0);
 	(void) duk_del_prop_string(ctx, 0, "dummy");
 	(void) duk_del_prop(ctx, 0);
@@ -100,6 +101,8 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_get_current_magic(ctx);
 	(void) duk_get_error_code(ctx, 0);
 	(void) duk_get_finalizer(ctx, 0);
+	(void) duk_get_global_heapptr(ctx, NULL);
+	(void) duk_get_global_literal(ctx, "dummy");
 	(void) duk_get_global_lstring(ctx, "dummy", 0);
 	(void) duk_get_global_string(ctx, "dummy");
 	(void) duk_get_heapptr(ctx, 0);
@@ -119,6 +122,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_get_prop_desc(ctx, 0, 0);
 	(void) duk_get_prop_heapptr(ctx, 0, NULL);
 	(void) duk_get_prop_index(ctx, 0, 0);
+	(void) duk_get_prop_literal(ctx, 0, "dummy");
 	(void) duk_get_prop_lstring(ctx, 0, "dummy", 0);
 	(void) duk_get_prop_string(ctx, 0, "dummy");
 	(void) duk_get_prop(ctx, 0);
@@ -133,6 +137,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_get_uint_default(ctx, 0, 0);
 	(void) duk_has_prop_heapptr(ctx, 0, NULL);
 	(void) duk_has_prop_index(ctx, 0, 0);
+	(void) duk_has_prop_literal(ctx, 0, "dummy");
 	(void) duk_has_prop_lstring(ctx, 0, "dummy", 0);
 	(void) duk_has_prop_string(ctx, 0, "dummy");
 	(void) duk_has_prop(ctx, 0);
@@ -256,11 +261,14 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_push_undefined(ctx);
 	(void) duk_push_vsprintf(ctx, "dummy", NULL);
 	(void) duk_put_function_list(ctx, 0, NULL);
+	(void) duk_put_global_heapptr(ctx, NULL);
+	(void) duk_put_global_literal(ctx, "dummy");
 	(void) duk_put_global_lstring(ctx, "dummy", 0);
 	(void) duk_put_global_string(ctx, "dummy");
 	(void) duk_put_number_list(ctx, 0, NULL);
 	(void) duk_put_prop_heapptr(ctx, 0, NULL);
 	(void) duk_put_prop_index(ctx, 0, 0);
+	(void) duk_put_prop_literal(ctx, 0, "dummy");
 	(void) duk_put_prop_lstring(ctx, 0, "dummy", 0);
 	(void) duk_put_prop_string(ctx, 0, "dummy");
 	(void) duk_put_prop(ctx, 0);

--- a/tests/api/test-del-prop.c
+++ b/tests/api/test-del-prop.c
@@ -98,6 +98,16 @@ delete obj.nul<NUL>key -> rc=1
 {"123":"123val","foo":"fooval","bar":"barval","undefined":"undefinedval"}
 final top: 3
 ==> rc=0, result='undefined'
+*** test_delpropliteral_a_safecall (duk_safe_call)
+delete obj.foo -> rc=1
+{"123":"123val","bar":"barval","nul\u0000key":"nulval","undefined":"undefinedval"}
+final top: 3
+==> rc=0, result='undefined'
+*** test_delpropliteral_a (duk_pcall)
+delete obj.foo -> rc=1
+{"123":"123val","bar":"barval","nul\u0000key":"nulval","undefined":"undefinedval"}
+final top: 3
+==> rc=0, result='undefined'
 *** test_delpropheapptr_a_safecall (duk_safe_call)
 delete obj.foo -> rc=1
 delete obj.nonexistent -> rc=1
@@ -546,6 +556,25 @@ static duk_ret_t test_delproplstring_a_safecall(duk_context *ctx, void *udata) {
 	return test_delproplstring_a(ctx);
 }
 
+/* duk_del_prop_literal(), success case */
+static duk_ret_t test_delpropliteral_a(duk_context *ctx) {
+	duk_ret_t rc;
+	prep(ctx);
+
+	rc = duk_del_prop_literal(ctx, 0, "foo");
+	printf("delete obj.foo -> rc=%d\n", (int) rc);
+
+	duk_json_encode(ctx, 0);
+	printf("%s\n", duk_to_string(ctx, 0));
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+static duk_ret_t test_delpropliteral_a_safecall(duk_context *ctx, void *udata) {
+	(void) udata;
+	return test_delpropliteral_a(ctx);
+}
+
 /* duk_del_prop_heapptr(), success cases */
 static duk_ret_t test_delpropheapptr_a_safecall(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
@@ -688,6 +717,9 @@ void test(duk_context *ctx) {
 
 	TEST_SAFE_CALL(test_delproplstring_a_safecall);
 	TEST_PCALL(test_delproplstring_a);
+
+	TEST_SAFE_CALL(test_delpropliteral_a_safecall);
+	TEST_PCALL(test_delpropliteral_a);
 
 	TEST_SAFE_CALL(test_delpropheapptr_a_safecall);
 	TEST_PCALL(test_delpropheapptr_a);

--- a/tests/api/test-get-global-heapptr.c
+++ b/tests/api/test-get-global-heapptr.c
@@ -1,0 +1,32 @@
+/*===
+*** test_basic (duk_safe_call)
+top: 1
+top: 2
+ret: 1
+duk_is_function: 1
+final top: 2
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+	void *ptr;
+
+	(void) udata;
+
+	(void) duk_push_string(ctx, "encodeURIComponent");
+	ptr = duk_get_heapptr(ctx, -1);
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	ret = duk_get_global_heapptr(ctx, ptr);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+	printf("duk_is_function: %ld\n", duk_is_function(ctx, -1));
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/api/test-get-global-literal.c
+++ b/tests/api/test-get-global-literal.c
@@ -1,0 +1,28 @@
+/*===
+*** test_basic (duk_safe_call)
+top: 0
+top: 1
+ret: 1
+duk_is_function: 1
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+
+	(void) udata;
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	ret = duk_get_global_literal(ctx, "encodeURIComponent");
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+	printf("duk_is_function: %ld\n", duk_is_function(ctx, -1));
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+}

--- a/tests/api/test-has-prop.c
+++ b/tests/api/test-has-prop.c
@@ -50,6 +50,19 @@ final top: 3
 ==> rc=1, result='RangeError: invalid stack index 234'
 *** test_hasproplstring_c (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_haspropliteral_a (duk_safe_call)
+obj.foo -> rc=1
+obj.nonexistent -> rc=0
+obj['123'] -> rc=1
+arr.nonexistent -> rc=0
+arr['2'] -> rc=1
+arr.length -> rc=1
+final top: 3
+==> rc=0, result='undefined'
+*** test_haspropliteral_b (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index 234'
+*** test_haspropliteral_c (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
 *** test_haspropheapptr_a (duk_safe_call)
 obj.foo -> rc=1
 obj.nonexistent -> rc=0
@@ -349,6 +362,65 @@ static duk_ret_t test_hasproplstring_c(duk_context *ctx, void *udata) {
 	return 0;
 }
 
+/* duk_has_prop_literal(), success cases */
+static duk_ret_t test_haspropliteral_a(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+
+	(void) udata;
+
+	prep(ctx);
+
+	rc = duk_has_prop_literal(ctx, 0, "foo");
+	printf("obj.foo -> rc=%d\n", (int) rc);
+
+	rc = duk_has_prop_literal(ctx, 0, "nonexistent");
+	printf("obj.nonexistent -> rc=%d\n", (int) rc);
+
+	rc = duk_has_prop_literal(ctx, 0, "123");
+	printf("obj['123'] -> rc=%d\n", (int) rc);
+
+	rc = duk_has_prop_literal(ctx, 1, "nonexistent");
+	printf("arr.nonexistent -> rc=%d\n", (int) rc);
+
+	rc = duk_has_prop_literal(ctx, 1, "2");
+	printf("arr['2'] -> rc=%d\n", (int) rc);
+
+	rc = duk_has_prop_literal(ctx, 1, "length");
+	printf("arr.length -> rc=%d\n", (int) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/* duk_has_prop_literal(), invalid index */
+static duk_ret_t test_haspropliteral_b(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+
+	(void) udata;
+
+	prep(ctx);
+
+	rc = duk_has_prop_literal(ctx, 234, "foo");
+	printf("obj.foo -> rc=%d\n", (int) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+/* duk_has_prop_literal(), DUK_INVALID_INDEX */
+static duk_ret_t test_haspropliteral_c(duk_context *ctx, void *udata) {
+	duk_ret_t rc;
+
+	(void) udata;
+
+	prep(ctx);
+
+	rc = duk_has_prop_literal(ctx, DUK_INVALID_INDEX, "foo");
+	printf("obj.foo -> rc=%d\n", (int) rc);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
 /* duk_has_prop_heapptr(), success cases */
 static duk_ret_t test_haspropheapptr_a(duk_context *ctx, void *udata) {
 	duk_ret_t rc;
@@ -453,6 +525,10 @@ void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_hasproplstring_a);
 	TEST_SAFE_CALL(test_hasproplstring_b);
 	TEST_SAFE_CALL(test_hasproplstring_c);
+
+	TEST_SAFE_CALL(test_haspropliteral_a);
+	TEST_SAFE_CALL(test_haspropliteral_b);
+	TEST_SAFE_CALL(test_haspropliteral_c);
 
 	TEST_SAFE_CALL(test_haspropheapptr_a);
 	TEST_SAFE_CALL(test_haspropheapptr_b);

--- a/tests/api/test-put-global-heapptr.c
+++ b/tests/api/test-put-global-heapptr.c
@@ -1,0 +1,64 @@
+/*===
+*** test_basic (duk_safe_call)
+top: 1
+top: 1
+ret: 1
+1.2.3
+final top: 1
+==> rc=0, result='undefined'
+*** test_nonwritable (duk_safe_call)
+top: 1
+==> rc=1, result='TypeError: not writable'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+	void *ptr;
+
+	(void) udata;
+
+	(void) duk_push_string(ctx, "myAppVersion");
+	ptr = duk_get_heapptr(ctx, -1);
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_push_string(ctx, "1.2.3");
+	ret = duk_put_global_heapptr(ctx, ptr);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+
+	duk_eval_string_noresult(ctx, "print(myAppVersion);");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nonwritable(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+	void *ptr;
+
+	(void) udata;
+
+	(void) duk_push_string(ctx, "nonWritable");
+	ptr = duk_get_heapptr(ctx, -1);
+
+	duk_eval_string_noresult(ctx,
+		"Object.defineProperty(this, 'nonWritable', "
+		"{ value: 'foo', writable: false, enumerable: false, configurable: false });"
+	);
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_push_string(ctx, "bar");
+	ret = duk_put_global_heapptr(ctx, ptr);
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+
+	duk_eval_string_noresult(ctx, "print(nonWritable);");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+	TEST_SAFE_CALL(test_nonwritable);
+}

--- a/tests/api/test-put-global-literal.c
+++ b/tests/api/test-put-global-literal.c
@@ -1,0 +1,56 @@
+/*===
+*** test_basic (duk_safe_call)
+top: 0
+top: 0
+ret: 1
+1.2.3
+final top: 0
+==> rc=0, result='undefined'
+*** test_nonwritable (duk_safe_call)
+top: 0
+==> rc=1, result='TypeError: not writable'
+===*/
+
+static duk_ret_t test_basic(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+
+	(void) udata;
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_push_string(ctx, "1.2.3");
+	ret = duk_put_global_literal(ctx, "myAppVersion");
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+
+	duk_eval_string_noresult(ctx, "print(myAppVersion);");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_nonwritable(duk_context *ctx, void *udata) {
+	duk_bool_t ret;
+
+	(void) udata;
+
+	duk_eval_string_noresult(ctx,
+		"Object.defineProperty(this, 'nonWritable', "
+		"{ value: 'foo', writable: false, enumerable: false, configurable: false });"
+	);
+
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_push_string(ctx, "bar");
+	ret = duk_put_global_literal(ctx, "nonWritable");
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	printf("ret: %ld\n", (long) ret);
+
+	duk_eval_string_noresult(ctx, "print(nonWritable);");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_basic);
+	TEST_SAFE_CALL(test_nonwritable);
+}

--- a/tests/api/test-put-prop.c
+++ b/tests/api/test-put-prop.c
@@ -108,11 +108,11 @@ eval:
 top after eval: 1
 ==> rc=1, result='TypeError: not extensible'
 *** test_putprop_shorthand_a_safecall (duk_safe_call)
-{"2001":234,"foo":123,"bar":123,"nul\u0000key":345,"heapptr":456,"stringCoerced":567,"undefined":678}
+{"2001":234,"foo":123,"bar":123,"nul\u0000key":345,"heapptr":456,"stringCoerced":567,"undefined":678,"litkey":789}
 final top: 1
 ==> rc=0, result='undefined'
 *** test_putprop_shorthand_a (duk_pcall)
-{"2001":234,"foo":123,"bar":123,"nul\u0000key":345,"heapptr":456,"stringCoerced":567,"undefined":678}
+{"2001":234,"foo":123,"bar":123,"nul\u0000key":345,"heapptr":456,"stringCoerced":567,"undefined":678,"litkey":789}
 final top: 1
 ==> rc=0, result='undefined'
 *** test_putprop_invalid_index1 (duk_safe_call)
@@ -126,6 +126,10 @@ final top: 1
 *** test_putprop_lstring_invalid_index1 (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
 *** test_putprop_lstring_invalid_index2 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_literal_invalid_index1 (duk_safe_call)
+==> rc=1, result='RangeError: invalid stack index -2147483648'
+*** test_putprop_literal_invalid_index2 (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index -2147483648'
 *** test_putprop_index_invalid_index1 (duk_safe_call)
 ==> rc=1, result='RangeError: invalid stack index 345'
@@ -406,6 +410,9 @@ static duk_ret_t test_putprop_shorthand_a(duk_context *ctx) {
 	duk_push_uint(ctx, 678);
 	duk_put_prop_heapptr(ctx, -2, NULL);
 
+	duk_push_uint(ctx, 789);
+	duk_put_prop_literal(ctx, -2, "litkey");
+
 	duk_json_encode(ctx, -1);
 	printf("%s\n", duk_to_string(ctx, -1));
 
@@ -474,6 +481,26 @@ static duk_ret_t test_putprop_lstring_invalid_index2(duk_context *ctx, void *uda
 
 	duk_push_uint(ctx, 123);
 	duk_put_prop_lstring(ctx, DUK_INVALID_INDEX, "foox", 3);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_literal_invalid_index1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_literal(ctx, 123, "foo");
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_putprop_literal_invalid_index2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_push_uint(ctx, 123);
+	duk_put_prop_literal(ctx, DUK_INVALID_INDEX, "foo");
 
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
@@ -552,6 +579,8 @@ void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_putprop_string_invalid_index2);
 	TEST_SAFE_CALL(test_putprop_lstring_invalid_index1);
 	TEST_SAFE_CALL(test_putprop_lstring_invalid_index2);
+	TEST_SAFE_CALL(test_putprop_literal_invalid_index1);
+	TEST_SAFE_CALL(test_putprop_literal_invalid_index2);
 	TEST_SAFE_CALL(test_putprop_index_invalid_index1);
 	TEST_SAFE_CALL(test_putprop_index_invalid_index2);
 	TEST_SAFE_CALL(test_putprop_heapptr_invalid_index1);

--- a/tests/perf/test-func-tostring.js
+++ b/tests/perf/test-func-tostring.js
@@ -2,19 +2,19 @@ if (typeof print !== 'function') { print = console.log; }
 
 function test() {
     var fn = function foo() {};
-    var i, t;
+    var i;
 
     for (i = 0; i < 1e6; i++) {
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
-        t = fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
+        fn.toString();
     }
 }
 

--- a/tests/perf/test-string-literal-intern.js
+++ b/tests/perf/test-string-literal-intern.js
@@ -1,0 +1,35 @@
+/*
+ *  Exercise the internal mechanism for intern checking a string literal
+ *  pushed using e.g. duk_push_literal().  The ideal test target has a lot
+ *  of literal interning and minimal other activity.  No really good target
+ *  exists now, but 'String(Buffer.prototype)' just pushes a literal and
+ *  returns.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var S = String;
+    var BP = Buffer.prototype;
+    var i;
+
+    for (i = 0; i < 1e5; i++) {
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+        S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP); S(BP);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/tests/perf/test-symbol-tostring.js
+++ b/tests/perf/test-symbol-tostring.js
@@ -1,0 +1,26 @@
+if (typeof print !== 'function') { print = console.log; }
+
+function test() {
+    var S = Symbol('foo');
+    var i;
+
+    for (i = 0; i < 1e6; i++) {
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+        String(S);
+    }
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/website/api/duk_del_prop.yaml
+++ b/website/api/duk_del_prop.yaml
@@ -66,8 +66,10 @@ tags:
   - property
 
 seealso:
+  - duk_del_prop_index
   - duk_del_prop_string
   - duk_del_prop_lstring
-  - duk_del_prop_index
+  - duk_del_prop_literal
+  - duk_del_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_del_prop_heapptr.yaml
+++ b/website/api/duk_del_prop_heapptr.yaml
@@ -26,4 +26,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_del_prop
+  - duk_del_prop_index
+  - duk_del_prop_string
+  - duk_del_prop_lstring
+  - duk_del_prop_literal
+
 introduced: 2.2.0

--- a/website/api/duk_del_prop_index.yaml
+++ b/website/api/duk_del_prop_index.yaml
@@ -26,4 +26,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_del_prop
+  - duk_del_prop_string
+  - duk_del_prop_lstring
+  - duk_del_prop_literal
+  - duk_del_prop_heapptr
+
 introduced: 1.0.0

--- a/website/api/duk_del_prop_literal.yaml
+++ b/website/api/duk_del_prop_literal.yaml
@@ -1,0 +1,31 @@
+name: duk_del_prop_literal
+
+proto: |
+  duk_bool_t duk_del_prop_literal(duk_context *ctx, duk_idx_t obj_idx, const char *key_literal);
+
+stack: |
+  [ ... obj! ... ] -> [ ... obj! ... ]
+
+summary: |
+  <p>Like <code><a href="#duk_del_prop">duk_del_prop()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  duk_bool_t rc;
+
+  rc = duk_del_prop_literal(ctx, -3, "myPropertyKey");
+  printf("delete obj.myPropertyKey -> rc=%d\n", (int) rc);
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_del_prop
+  - duk_del_prop_index
+  - duk_del_prop_string
+  - duk_del_prop_lstring
+  - duk_del_prop_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_del_prop_lstring.yaml
+++ b/website/api/duk_del_prop_lstring.yaml
@@ -20,6 +20,10 @@ tags:
   - property
 
 seealso:
+  - duk_del_prop
+  - duk_del_prop_index
   - duk_del_prop_string
+  - duk_del_prop_literal
+  - duk_del_prop_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_del_prop_string.yaml
+++ b/website/api/duk_del_prop_string.yaml
@@ -21,6 +21,10 @@ tags:
   - property
 
 seealso:
+  - duk_del_prop
+  - duk_del_prop_index
   - duk_del_prop_lstring
+  - duk_del_prop_literal
+  - duk_del_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_get_global_heapptr.yaml
+++ b/website/api/duk_get_global_heapptr.yaml
@@ -1,0 +1,27 @@
+name: duk_get_global_heapptr
+
+proto: |
+  duk_bool_t duk_get_global_heapptr(duk_context *ctx, void *ptr);
+
+stack: |
+  [ ... ] -> [ ... val! ]  (if key exists)
+  [ ... ] -> [ ... undefined! ]  (if key doesn't exist)
+
+summary: |
+  <p>Like <code><a href="#duk_get_global_string">duk_get_global_string()</a></code>,
+  but the property name is given as a Duktape heap pointer obtained e.g. using
+  <code><a href="#duk_get_heapptr">duk_get_heapptr()</a></code>.  If
+  <code>ptr</code> is NULL, <code>undefined</code> is used as the key.</p>
+
+example: |
+  (void) duk_get_global_heapptr(ctx, my_ptr_ref);
+
+tags:
+  - property
+
+seealso:
+  - duk_get_global_string
+  - duk_get_global_lstring
+  - duk_get_global_literal
+
+introduced: 2.3.0

--- a/website/api/duk_get_global_literal.yaml
+++ b/website/api/duk_get_global_literal.yaml
@@ -1,0 +1,31 @@
+name: duk_get_global_literal
+
+proto: |
+  duk_bool_t duk_get_global_literal(duk_context *ctx, const char *key_literal);
+
+stack: |
+  [ ... ] -> [ ... val! ]  (if key exists)
+  [ ... ] -> [ ... undefined! ]  (if key doesn't exist)
+
+summary: |
+  <p>Like <code><a href="#duk_get_global_string">duk_get_global_string()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  (void) duk_get_global_literal(ctx, "encodeURIComponent");
+  duk_push_string(ctx, "foo bar");
+  duk_call(ctx, 1);  /* [ ... encodeURIComponent "foo bar" ] -> [ "foo%20bar" ] */
+  printf("encoded: %s\n", duk_to_string(ctx, -1));
+  duk_pop(ctx);
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_get_global_string
+  - duk_get_global_lstring
+  - duk_get_global_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_get_global_lstring.yaml
+++ b/website/api/duk_get_global_lstring.yaml
@@ -19,7 +19,7 @@ tags:
 
 seealso:
   - duk_get_global_string
-  - duk_put_global_string
-  - duk_put_global_lstring
+  - duk_get_global_literal
+  - duk_get_global_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_get_global_string.yaml
+++ b/website/api/duk_get_global_string.yaml
@@ -32,7 +32,7 @@ tags:
 
 seealso:
   - duk_get_global_lstring
-  - duk_put_global_string
-  - duk_put_global_lstring
+  - duk_get_global_literal
+  - duk_get_global_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_get_prop.yaml
+++ b/website/api/duk_get_prop.yaml
@@ -79,9 +79,10 @@ tags:
   - property
 
 seealso:
+  - duk_get_prop_index
   - duk_get_prop_string
   - duk_get_prop_lstring
-  - duk_get_prop_index
+  - duk_get_prop_literal
   - duk_get_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_get_prop_heapptr.yaml
+++ b/website/api/duk_get_prop_heapptr.yaml
@@ -27,4 +27,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_get_prop
+  - duk_get_prop_index
+  - duk_get_prop_string
+  - duk_get_prop_lstring
+  - duk_get_prop_literal
+
 introduced: 2.2.0

--- a/website/api/duk_get_prop_index.yaml
+++ b/website/api/duk_get_prop_index.yaml
@@ -26,4 +26,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_get_prop
+  - duk_get_prop_string
+  - duk_get_prop_lstring
+  - duk_get_prop_literal
+  - duk_get_prop_heapptr
+
 introduced: 1.0.0

--- a/website/api/duk_get_prop_literal.yaml
+++ b/website/api/duk_get_prop_literal.yaml
@@ -1,0 +1,31 @@
+name: duk_get_prop_literal
+
+proto: |
+  duk_bool_t duk_get_prop_literal(duk_context *ctx, const char *key_literal);
+
+stack: |
+  [ ... obj! ... ] -> [ ... obj! ... val! ]  (if key exists)
+  [ ... obj! ... ] -> [ ... obj! ... undefined! ]  (if key doesn't exist)
+
+summary: |
+  <p>Like <code><a href="#duk_get_prop">duk_get_prop()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  (void) duk_get_prop_literal(ctx, -3, "myPropertyName");
+  printf("obj.myPropertyName = %s\n", duk_to_string(ctx, -1));
+  duk_pop(ctx);
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_get_prop
+  - duk_get_prop_index
+  - duk_get_prop_string
+  - duk_get_prop_lstring
+  - duk_get_prop_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_get_prop_lstring.yaml
+++ b/website/api/duk_get_prop_lstring.yaml
@@ -13,13 +13,17 @@ summary: |
 
 example: |
   (void) duk_get_prop_lstring(ctx, -3, "internal" "\x00" "nul", 12);
-  printf("obj.propertyName = %s\n", duk_to_string(ctx, -1));
+  printf("obj.interanl[00]nul = %s\n", duk_to_string(ctx, -1));
   duk_pop(ctx);
 
 tags:
   - property
 
 seealso:
+  - duk_get_prop
+  - duk_get_prop_index
   - duk_get_prop_string
+  - duk_get_prop_literal
+  - duk_get_prop_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_get_prop_string.yaml
+++ b/website/api/duk_get_prop_string.yaml
@@ -21,6 +21,10 @@ tags:
   - property
 
 seealso:
+  - duk_get_prop
+  - duk_get_prop_index
   - duk_get_prop_lstring
+  - duk_get_prop_literal
+  - duk_get_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_has_prop.yaml
+++ b/website/api/duk_has_prop.yaml
@@ -62,8 +62,10 @@ tags:
   - property
 
 seealso:
+  - duk_has_prop_index
   - duk_has_prop_string
   - duk_has_prop_lstring
-  - duk_has_prop_index
+  - duk_has_prop_literal
+  - duk_has_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_has_prop_heapptr.yaml
+++ b/website/api/duk_has_prop_heapptr.yaml
@@ -28,4 +28,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_has_prop
+  - duk_has_prop_index
+  - duk_has_prop_string
+  - duk_has_prop_lstring
+  - duk_has_prop_literal
+
 introduced: 2.2.0

--- a/website/api/duk_has_prop_index.yaml
+++ b/website/api/duk_has_prop_index.yaml
@@ -27,4 +27,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_has_prop
+  - duk_has_prop_string
+  - duk_has_prop_lstring
+  - duk_has_prop_literal
+  - duk_has_prop_heapptr
+
 introduced: 1.0.0

--- a/website/api/duk_has_prop_literal.yaml
+++ b/website/api/duk_has_prop_literal.yaml
@@ -1,0 +1,32 @@
+name: duk_has_prop_literal
+
+proto: |
+  duk_bool_t duk_has_prop_literal(duk_context *ctx, duk_idx_t obj_idx, const char *key_literal);
+
+stack: |
+  [ ... obj! ... ] -> [ ... obj! ... ]
+
+summary: |
+  <p>Like <code><a href="#duk_has_prop">duk_has_prop()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  if (duk_has_prop_literal(ctx, -3, "myPropertyKey");
+      printf("obj has 'myPropertyKey'\n");
+  } else {
+      printf("obj does not have 'myPropertyKey'\n");
+  }
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_has_prop
+  - duk_has_prop_index
+  - duk_has_prop_string
+  - duk_has_prop_lstring
+  - duk_has_prop_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_has_prop_lstring.yaml
+++ b/website/api/duk_has_prop_lstring.yaml
@@ -21,6 +21,10 @@ tags:
   - property
 
 seealso:
+  - duk_has_prop
+  - duk_has_prop_index
   - duk_has_prop_string
+  - duk_has_prop_literal
+  - duk_has_prop_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_has_prop_string.yaml
+++ b/website/api/duk_has_prop_string.yaml
@@ -22,6 +22,10 @@ tags:
   - property
 
 seealso:
+  - duk_has_prop
+  - duk_has_prop_index
   - duk_has_prop_lstring
+  - duk_has_prop_literal
+  - duk_has_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_push_literal.yaml
+++ b/website/api/duk_push_literal.yaml
@@ -1,7 +1,7 @@
 name: duk_push_literal
 
 proto: |
-  const char *duk_push_literal(duk_context *ctx, const char *str);
+  const char *duk_push_literal(duk_context *ctx, const char *literal_str);
 
 stack: |
   [ ... ] -> [ ... str! ]
@@ -9,29 +9,29 @@ stack: |
 summary: |
   <p>Push a C literal into the stack and return a pointer to the interned
   string data area (which may or may not be the same as the argument literal).
-  The argument <code>str</code must be a non-NULL C literal that can be
+  The argument <code>str_literal</code> must be a non-NULL C literal that can be
   operated on using e.g. <code>sizeof(str)</code>.  The data contents of the
   literal must be immutable, and the string must not contain NUL characters.
-  The <code>str</code> argument may be evaluated multiple times by the API
-  macro.  Finally, no runtime NULL pointer check is made for the
-  <code>str</code> argument so passing in a NULL causes memory unsafe
+  The <code>str_literal</code> argument may be evaluated multiple times by the
+  API macro.  Finally, no runtime NULL pointer check is made for the
+  <code>str_literal</code> argument so passing in a NULL causes memory unsafe
   behavior.</p>
 
-  <p>This call is conceptually equivalent to duk_push_(l)string(), and
+  <p>This call is conceptually equivalent to duk_push_string(), and
   only needs to be used if the minor differences in footprint or speed
   matter.  The properties of immutable literals allows minor optimizations
   in Duktape internals:</p>
   <ul>
   <li>The length of the string can be computed at compile time using
-      <code>sizeof(str) - 1</code> at the call site.</li>
-  <li>Because the string data is assumed to be immutable, the internal
-      string representation could just point to the data instead of
-      making a copy.  (This optimization is not done as of Duktape 2.3.)</li>
+      <code>sizeof(str_literal) - 1</code> at the call site.</li>
   <li>Because the string address is fixed at runtime, it could be used
       for speeding up a string table lookup for the literal.  While common,
       there's no assumption that strings are deduplicated, so there may be
       multiple addresses with the same literal.  (This optimization is not
       done as of Duktape 2.3.)</li>
+  <li>Because the string data is assumed to be immutable, the internal
+      string representation could just point to the data instead of
+      making a copy.  (This optimization is not done as of Duktape 2.3.)</li>
   </ul>
 
   <p>If input string might contain internal NUL characters, use

--- a/website/api/duk_put_global_heapptr.yaml
+++ b/website/api/duk_put_global_heapptr.yaml
@@ -1,0 +1,27 @@
+name: duk_put_global_heapptr
+
+proto: |
+  duk_bool_t duk_put_global_heapptr(duk_context *ctx, void *ptr);
+
+stack: |
+  [ ... val! ] -> [ ... ]
+
+summary: |
+  <p>Like <code><a href="#duk_put_global_string">duk_put_global_string()</a></code>,
+  but the property name is given as a Duktape heap pointer obtained e.g. using
+  <code><a href="#duk_get_heapptr">duk_get_heapptr()</a></code>.  If
+  <code>ptr</code> is NULL, <code>undefined</code> is used as the key.</p>
+
+example: |
+  duk_push_string(ctx, "1.2.3");
+  (void) duk_put_global_heapptr(ctx, my_ptr_ref);
+
+tags:
+  - property
+
+seealso:
+  - duk_put_global_string
+  - duk_put_global_lstring
+  - duk_put_global_literal
+
+introduced: 2.3.0

--- a/website/api/duk_put_global_literal.yaml
+++ b/website/api/duk_put_global_literal.yaml
@@ -1,0 +1,27 @@
+name: duk_put_global_literal
+
+proto: |
+  duk_bool_t duk_put_global_literal(duk_context *ctx, const char *key_literal);
+
+stack: |
+  [ ... val! ] -> [ ... ]
+
+summary: |
+  <p>Like <code><a href="#duk_put_global_string">duk_put_global_string()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  duk_push_string(ctx, "1.2.3");
+  (void) duk_put_global_literal(ctx, "my_app_version");
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_put_global_string
+  - duk_put_global_lstring
+  - duk_put_global_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_put_global_lstring.yaml
+++ b/website/api/duk_put_global_lstring.yaml
@@ -19,7 +19,7 @@ tags:
 
 seealso:
   - duk_put_global_string
-  - duk_get_global_string
-  - duk_get_global_lstring
+  - duk_put_global_literal
+  - duk_put_global_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_put_global_string.yaml
+++ b/website/api/duk_put_global_string.yaml
@@ -30,7 +30,7 @@ tags:
 
 seealso:
   - duk_put_global_lstring
-  - duk_get_global_string
-  - duk_get_global_lstring
+  - duk_put_global_literal
+  - duk_put_global_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_put_prop.yaml
+++ b/website/api/duk_put_prop.yaml
@@ -72,8 +72,10 @@ tags:
   - property
 
 seealso:
+  - duk_put_prop_index
   - duk_put_prop_string
   - duk_put_prop_lstring
-  - duk_put_prop_index
+  - duk_put_prop_literal
+  - duk_put_prop_heapptr
 
 introduced: 1.0.0

--- a/website/api/duk_put_prop_heapptr.yaml
+++ b/website/api/duk_put_prop_heapptr.yaml
@@ -27,4 +27,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_put_prop
+  - duk_put_prop_index
+  - duk_put_prop_string
+  - duk_put_prop_lstring
+  - duk_put_prop_literal
+
 introduced: 2.2.0

--- a/website/api/duk_put_prop_index.yaml
+++ b/website/api/duk_put_prop_index.yaml
@@ -25,4 +25,11 @@ example: |
 tags:
   - property
 
+seealso:
+  - duk_put_prop
+  - duk_put_prop_string
+  - duk_put_prop_lstring
+  - duk_put_prop_literal
+  - duk_put_prop_heapptr
+
 introduced: 1.0.0

--- a/website/api/duk_put_prop_literal.yaml
+++ b/website/api/duk_put_prop_literal.yaml
@@ -1,0 +1,32 @@
+name: duk_put_prop_literal
+
+proto: |
+  duk_bool_t duk_put_prop_literal(duk_context *ctx, duk_idx_t obj_idx, const char *key_literal);
+
+stack: |
+  [ ... obj! ... val! ] -> [ ... obj! ... ]
+
+summary: |
+  <p>Like <code><a href="#duk_put_prop">duk_put_prop()</a></code>,
+  but the property name is given as a string literal (see
+  <code><a href="#duk_push_literal">duk_push_literal()</a></code>).</p>
+
+example: |
+  duk_bool_t rc;
+
+  duk_push_string(ctx, "value");
+  rc = duk_put_prop_literal(ctx, -3, "myPropertyName");
+  printf("rc=%d\n", (int) rc);
+
+tags:
+  - property
+  - experimental
+
+seealso:
+  - duk_put_prop
+  - duk_put_prop_index
+  - duk_put_prop_string
+  - duk_put_prop_lstring
+  - duk_put_prop_heapptr
+
+introduced: 2.3.0

--- a/website/api/duk_put_prop_lstring.yaml
+++ b/website/api/duk_put_prop_lstring.yaml
@@ -21,6 +21,10 @@ tags:
   - property
 
 seealso:
+  - duk_put_prop
+  - duk_put_prop_index
   - duk_put_prop_string
+  - duk_put_prop_literal
+  - duk_put_prop_heapptr
 
 introduced: 2.0.0

--- a/website/api/duk_put_prop_string.yaml
+++ b/website/api/duk_put_prop_string.yaml
@@ -22,6 +22,10 @@ tags:
   - property
 
 seealso:
+  - duk_put_prop
+  - duk_put_prop_index
   - duk_put_prop_lstring
+  - duk_put_prop_literal
+  - duk_put_prop_heapptr
 
 introduced: 1.0.0


### PR DESCRIPTION
- [x] Add duk_{get,put,has,del}_prop_literal() API calls
- [x] Add duk_{get,put}_global_literal() API calls
- [x] Add duk_{get,put}_global_heapptr() API calls
- [x] NUL assert for duk_push_literal(), catches some API abuse
- [x] Proper ifdef's for duk_push_literal_raw() etc
- [x] Size optimized variant: map to xxx_lstring()
- [x] Testcase coverage for API calls
- [x] Update test-all-public-symbols.c test
- [x] Test size-optimized variant manually
- [x] API documentation for API calls
- [x] Migration notes
- [x] Releases entry