### PR TITLE
Initial implementation of C API literal pinning and literal intern cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,7 @@ clean:
 	@rm -f dukweb.js
 	@rm -rf /tmp/dukweb-test/
 	@rm -f massif-*.out
+	@rm -f literal_intern_test
 
 .PHONY: cleanall
 cleanall: clean
@@ -584,6 +585,11 @@ dukweb.js: emscripten prep/dukweb
 		-Iprep/dukweb prep/dukweb/duktape.c dukweb/dukweb.c -o dukweb.js
 	cat dukweb/dukweb_extra.js >> dukweb.js
 	@wc dukweb.js
+literal_intern_test: prep/nondebug misc/literal_intern_test.c
+	$(CC) -o $@ -std=c99 -O2 -fstrict-aliasing -Wall -Wextra \
+		-Iprep/nondebug prep/nondebug/duktape.c misc/literal_intern_test.c -lm
+literalinterntest: literal_intern_test
+	bash -c 'for i in 0 1 2 3 10 11 12 13 20 21 22 23; do echo; echo "*** $$i ***"; echo; for j in 1 2 3 4 5; do time ./literal_intern_test $$i; sleep 10; done; done'
 
 # Miscellaneous dumps.
 .PHONY: dump-public

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3197,13 +3197,23 @@ Planned
 
 * Add experimental API call variants for plain C literals, for example
   duk_push_literal(ctx, "key") and duk_get_prop_literal(ctx, "propname"),
-  which may allow e.g. better performance or RAM footprint later on; calls
-  added: duk_push_literal(), duk_get_prop_literal(), duk_put_prop_literal(),
-  duk_has_prop_literal(), duk_del_prop_literal(), duk_get_global_literal(),
-  duk_put_global_literal() (GH-1805)
+  which allow e.g. better performance; calls added: duk_push_literal(),
+  duk_get_prop_literal(), duk_put_prop_literal(), duk_has_prop_literal(),
+  duk_del_prop_literal(), duk_get_global_literal(), duk_put_global_literal()
+  (GH-1805)
 
 * Add duk_get_global_heapptr() and duk_put_global_heapptr() for completeness
   (GH-1805)
+
+* Automatically pin strings accessed using the C literal API call variants
+  such as duk_get_prop_literal(ctx, "propname") so that the strings are only
+  freed on heap destruction; this behavior can be disabled by disabling
+  DUK_USE_LITCACHE_SIZE in configure.py (GH-1813)
+
+* Add a lookup cache for C literals to speed up string table lookups when
+  using API call variants such as duk_get_prop_literal(ctx, "propname");
+  the cache relies on literals being pinned, and can be disabled by disabling
+  DUK_USE_LITCACHE_SIZE in configure.py (GH-1813)
 
 * ES2015 Number constructor properties: EPSILON, MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),

--- a/config/config-options/DUK_USE_LITCACHE_SIZE.yaml
+++ b/config/config-options/DUK_USE_LITCACHE_SIZE.yaml
@@ -1,0 +1,25 @@
+define: DUK_USE_LITCACHE_SIZE
+introduced: 2.3.0
+default: 256
+tags:
+  - performance
+  - lowmemory
+description: >
+  Size of the literal cache, which maps C literal memory addresses into
+  pinned duk_hstring heap object addresses.  The cache is used when
+  application code calls one of the duk_xxx_literal() API call variants,
+  such as duk_push_literal() or duk_get_prop_literal(), to speed up the
+  string intern check for the literal.  In successful cases this caching
+  makes using duk_xxx_literal() almost as fast as using borrowed heap
+  pointers with duk_xxx_heapptr().
+
+  When this option is defined, duk_hstrings related to literals encountered
+  in duk_xxx_literal() API calls are automatically pinned for the lifetime of
+  the heap.  This accomplishes two things.  First, it avoids the need for
+  any form of cache invalidation for the literal cache.  Second, it avoids
+  string table traffic (i.e. freeing and reallocating) for literals which are
+  likely to occur again and again.  However, the downside is that some strings
+  that may occur only temporarily will remain pinned.  You can avoid this by
+  simply using e.g. duk_xxx_string() when dealing with such strings.
+
+  The literal cache size must be a power of two (2^N).

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -71,6 +71,9 @@ DUK_USE_STRTAB_GROW_LIMIT: 65536       # -""-
 DUK_USE_STRTAB_RESIZE_CHECK_MASK: 255  # -""-
 #DUK_USE_STRTAB_PTRCOMP: true  # sometimes useful with pointer compression
 
+# Disable literal pinning and litcache.
+DUK_USE_LITCACHE_SIZE: false
+
 DUK_USE_HSTRING_ARRIDX: false
 DUK_USE_HSTRING_LAZY_CLEN: false  # non-lazy charlen is smaller
 

--- a/config/examples/performance_sensitive.yaml
+++ b/config/examples/performance_sensitive.yaml
@@ -14,6 +14,7 @@ DUK_USE_PACKED_TVAL: false  # packed duk_tval slower in most cases
 DUK_USE_FASTINT: true
 DUK_USE_VALSTACK_UNSAFE: true
 DUK_USE_FAST_REFCOUNT_DEFAULT: true
+
 DUK_USE_JSON_STRINGIFY_FASTPATH: true  # not fully portable right now
 DUK_USE_JSON_QUOTESTRING_FASTPATH: true
 DUK_USE_JSON_DECSTRING_FASTPATH: true
@@ -25,8 +26,13 @@ DUK_USE_IDCHAR_FASTPATH: true
 DUK_USE_ARRAY_PROP_FASTPATH: true
 DUK_USE_ARRAY_FASTPATH: true
 DUK_USE_INTERRUPT_COUNTER: false
+
 DUK_USE_DEBUGGER_SUPPORT: false
+
 DUK_USE_STRHASH_DENSE: false
 DUK_USE_STRHASH_SKIP_SHIFT: 5  # may be able to reduce
 #DUK_USE_EXEC_FUN_LOCAL: false  # test both values, marginal benefit
+
+DUK_USE_LITCACHE_SIZE: 1024
+
 DUK_USE_REGEXP_CANON_WORKAROUND: true  # high footprint impact (128kB), enabled until a better solution

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -18,6 +18,9 @@ Main changes in this release (see RELEASES.rst for full details):
   conceptually similar to the duk_xxx_string() variants, but can take advantage
   of the fact that e.g. string length for a C literal can be determined at
   compile time using sizeof("myProperty") - 1 (the -1 is for NUL termination).
+  Literal strings used by application code are also automatically pinned for
+  the duration of the heap, and a small lookup cache makes mapping a C literal
+  to a heap string object quite fast (almost as fast as using a heapptr).
   For now the calls are experimental.
 
 Upgrading from Duktape 2.2
@@ -27,6 +30,22 @@ No action (other than recompiling) should be needed for most users to upgrade
 from Duktape v2.2.x.  Note the following:
 
 * TBD.
+
+* If performance matters, you might consider using duk_xxx_literal() variants
+  in place of duk_xxx_string() variants when the argument is a C literal.
+  With literal pinning and the literal lookup cache this improves property
+  access performance around 20% with minimal application changes.  Make sure
+  that the arguments are C literals, e.g. duk_get_prop_literal(ctx, "mykey")
+  and not pointers to strings like duk_get_prop_literal(ctx, strptr).
+
+* If you're using the duk_xxx_heapptr() API call variants, you might consider
+  switching to the duk_xxx_literal() variants.  They are less error prone, and
+  with literal pinning and the literal lookup cache almost as fast as using a
+  borrowed heap pointer.
+
+* If you're working with a low memory target or any other target where memory
+  usage matters, you may want to ensure UDK_USE_LITCACHE_SIZE is undefined in
+  configure.py configuration (this is included in low_memory.yaml base config).
 
 * If you're working with a low memory target or any other target where memory
   usage matters, you may want to force DUK_USE_ALIGN_BY to a lower value

--- a/misc/literal_intern_test.c
+++ b/misc/literal_intern_test.c
@@ -1,0 +1,385 @@
+/*
+ *  Rough performance test for comparing the difference between xxx_string(),
+ *  xxx_lstring(), xxx_literal(), and xxx_heapptr() in application code.
+ */
+
+#include "duktape.h"
+
+int main(int argc, const char *argv[]) {
+	duk_context *ctx;
+	int i;
+	int mode;
+	void *hptr1;
+	void *hptr2;
+	void *hptr3;
+	void *hptr4;
+	void *hptr5;
+	void *hptr6;
+	void *hptr7;
+	void *hptr8;
+	void *hptr9;
+	void *hptr10;
+
+	if (argc < 2) {
+		return 1;
+	}
+	mode = atoi(argv[1]);
+
+	ctx = duk_create_heap_default();
+
+	duk_push_object(ctx);
+
+	/* Push the strings we're dealing with, get their heapptrs, and keep
+	 * them reachable throughout the test.  This is necessary for the
+	 * heapptr test to work.  But we also want this so that the strings
+	 * won't be freed and reallocated repeatedly during the test.  That
+	 * might happen in real application code too, but this test focuses
+	 * on the differences between the intern checks only, assuming the
+	 * string itself is already in the string table.
+	 */
+	duk_push_string(ctx, "foo1");
+	hptr1 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo2");
+	hptr2 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo3");
+	hptr3 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo4");
+	hptr4 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo5");
+	hptr5 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo6");
+	hptr6 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo7");
+	hptr7 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo8");
+	hptr8 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo9");
+	hptr9 = duk_get_heapptr(ctx, -1);
+	duk_push_string(ctx, "foo10");
+	hptr10 = duk_get_heapptr(ctx, -1);
+
+	for (i = 0; i < 10000000; i++) {
+		switch (mode) {
+		case 0:
+			duk_push_string(ctx, "foo1");
+			duk_push_string(ctx, "foo2");
+			duk_push_string(ctx, "foo3");
+			duk_push_string(ctx, "foo4");
+			duk_push_string(ctx, "foo5");
+			duk_push_string(ctx, "foo6");
+			duk_push_string(ctx, "foo7");
+			duk_push_string(ctx, "foo8");
+			duk_push_string(ctx, "foo9");
+			duk_push_string(ctx, "foo10");
+			break;
+		case 1:
+			duk_push_lstring(ctx, "foo1", 4);
+			duk_push_lstring(ctx, "foo2", 4);
+			duk_push_lstring(ctx, "foo3", 4);
+			duk_push_lstring(ctx, "foo4", 4);
+			duk_push_lstring(ctx, "foo5", 4);
+			duk_push_lstring(ctx, "foo6", 4);
+			duk_push_lstring(ctx, "foo7", 4);
+			duk_push_lstring(ctx, "foo8", 4);
+			duk_push_lstring(ctx, "foo9", 4);
+			duk_push_lstring(ctx, "foo10", 5);
+			break;
+		case 2:
+			duk_push_literal(ctx, "foo1");
+			duk_push_literal(ctx, "foo2");
+			duk_push_literal(ctx, "foo3");
+			duk_push_literal(ctx, "foo4");
+			duk_push_literal(ctx, "foo5");
+			duk_push_literal(ctx, "foo6");
+			duk_push_literal(ctx, "foo7");
+			duk_push_literal(ctx, "foo8");
+			duk_push_literal(ctx, "foo9");
+			duk_push_literal(ctx, "foo10");
+			break;
+		case 3:
+			duk_push_heapptr(ctx, hptr1);
+			duk_push_heapptr(ctx, hptr2);
+			duk_push_heapptr(ctx, hptr3);
+			duk_push_heapptr(ctx, hptr4);
+			duk_push_heapptr(ctx, hptr5);
+			duk_push_heapptr(ctx, hptr6);
+			duk_push_heapptr(ctx, hptr7);
+			duk_push_heapptr(ctx, hptr8);
+			duk_push_heapptr(ctx, hptr9);
+			duk_push_heapptr(ctx, hptr10);
+			break;
+		case 10:
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo1");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo2");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo3");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo4");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo5");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo6");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo7");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo8");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo9");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_string(ctx, 0, "foo10");
+			duk_push_uint(ctx, 123);
+			duk_get_prop_string(ctx, 0, "foo1");
+			duk_get_prop_string(ctx, 0, "foo2");
+			duk_get_prop_string(ctx, 0, "foo3");
+			duk_get_prop_string(ctx, 0, "foo4");
+			duk_get_prop_string(ctx, 0, "foo5");
+			duk_get_prop_string(ctx, 0, "foo6");
+			duk_get_prop_string(ctx, 0, "foo7");
+			duk_get_prop_string(ctx, 0, "foo8");
+			duk_get_prop_string(ctx, 0, "foo9");
+			duk_get_prop_string(ctx, 0, "foo10");
+			break;
+		case 11:
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo1", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo2", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo3", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo4", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo5", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo6", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo7", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo8", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo9", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_lstring(ctx, 0, "foo10", 5);
+			duk_push_uint(ctx, 123);
+			duk_get_prop_lstring(ctx, 0, "foo1", 4);
+			duk_get_prop_lstring(ctx, 0, "foo2", 4);
+			duk_get_prop_lstring(ctx, 0, "foo3", 4);
+			duk_get_prop_lstring(ctx, 0, "foo4", 4);
+			duk_get_prop_lstring(ctx, 0, "foo5", 4);
+			duk_get_prop_lstring(ctx, 0, "foo6", 4);
+			duk_get_prop_lstring(ctx, 0, "foo7", 4);
+			duk_get_prop_lstring(ctx, 0, "foo8", 4);
+			duk_get_prop_lstring(ctx, 0, "foo9", 4);
+			duk_get_prop_lstring(ctx, 0, "foo10", 5);
+			break;
+		case 12:
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo1");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo2");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo3");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo4");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo5");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo6");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo7");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo8");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo9");
+			duk_push_uint(ctx, 123);
+			duk_put_prop_literal(ctx, 0, "foo10");
+			duk_push_uint(ctx, 123);
+			duk_get_prop_literal(ctx, 0, "foo1");
+			duk_get_prop_literal(ctx, 0, "foo2");
+			duk_get_prop_literal(ctx, 0, "foo3");
+			duk_get_prop_literal(ctx, 0, "foo4");
+			duk_get_prop_literal(ctx, 0, "foo5");
+			duk_get_prop_literal(ctx, 0, "foo6");
+			duk_get_prop_literal(ctx, 0, "foo7");
+			duk_get_prop_literal(ctx, 0, "foo8");
+			duk_get_prop_literal(ctx, 0, "foo9");
+			duk_get_prop_literal(ctx, 0, "foo10");
+			break;
+		case 13:
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr1);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr2);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr3);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr4);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr5);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr6);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr7);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr8);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr9);
+			duk_push_uint(ctx, 123);
+			duk_put_prop_heapptr(ctx, 0, hptr10);
+			duk_push_uint(ctx, 123);
+			duk_get_prop_heapptr(ctx, 0, hptr1);
+			duk_get_prop_heapptr(ctx, 0, hptr2);
+			duk_get_prop_heapptr(ctx, 0, hptr3);
+			duk_get_prop_heapptr(ctx, 0, hptr4);
+			duk_get_prop_heapptr(ctx, 0, hptr5);
+			duk_get_prop_heapptr(ctx, 0, hptr6);
+			duk_get_prop_heapptr(ctx, 0, hptr7);
+			duk_get_prop_heapptr(ctx, 0, hptr8);
+			duk_get_prop_heapptr(ctx, 0, hptr9);
+			duk_get_prop_heapptr(ctx, 0, hptr10);
+			break;
+		case 20:
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo1");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo2");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo3");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo4");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo5");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo6");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo7");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo8");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo9");
+			duk_push_uint(ctx, 123);
+			duk_put_global_string(ctx, "foo10");
+			duk_push_uint(ctx, 123);
+			duk_get_global_string(ctx, "foo1");
+			duk_get_global_string(ctx, "foo2");
+			duk_get_global_string(ctx, "foo3");
+			duk_get_global_string(ctx, "foo4");
+			duk_get_global_string(ctx, "foo5");
+			duk_get_global_string(ctx, "foo6");
+			duk_get_global_string(ctx, "foo7");
+			duk_get_global_string(ctx, "foo8");
+			duk_get_global_string(ctx, "foo9");
+			duk_get_global_string(ctx, "foo10");
+			break;
+		case 21:
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo1", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo2", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo3", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo4", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo5", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo6", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo7", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo8", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo9", 4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_lstring(ctx, "foo10", 5);
+			duk_push_uint(ctx, 123);
+			duk_get_global_lstring(ctx, "foo1", 4);
+			duk_get_global_lstring(ctx, "foo2", 4);
+			duk_get_global_lstring(ctx, "foo3", 4);
+			duk_get_global_lstring(ctx, "foo4", 4);
+			duk_get_global_lstring(ctx, "foo5", 4);
+			duk_get_global_lstring(ctx, "foo6", 4);
+			duk_get_global_lstring(ctx, "foo7", 4);
+			duk_get_global_lstring(ctx, "foo8", 4);
+			duk_get_global_lstring(ctx, "foo9", 4);
+			duk_get_global_lstring(ctx, "foo10", 5);
+			break;
+		case 22:
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo1");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo2");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo3");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo4");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo5");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo6");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo7");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo8");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo9");
+			duk_push_uint(ctx, 123);
+			duk_put_global_literal(ctx, "foo10");
+			duk_push_uint(ctx, 123);
+			duk_get_global_literal(ctx, "foo1");
+			duk_get_global_literal(ctx, "foo2");
+			duk_get_global_literal(ctx, "foo3");
+			duk_get_global_literal(ctx, "foo4");
+			duk_get_global_literal(ctx, "foo5");
+			duk_get_global_literal(ctx, "foo6");
+			duk_get_global_literal(ctx, "foo7");
+			duk_get_global_literal(ctx, "foo8");
+			duk_get_global_literal(ctx, "foo9");
+			duk_get_global_literal(ctx, "foo10");
+			break;
+		case 23:
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr1);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr2);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr3);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr4);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr5);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr6);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr7);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr8);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr9);
+			duk_push_uint(ctx, 123);
+			duk_put_global_heapptr(ctx, hptr10);
+			duk_push_uint(ctx, 123);
+			duk_get_global_heapptr(ctx, hptr1);
+			duk_get_global_heapptr(ctx, hptr2);
+			duk_get_global_heapptr(ctx, hptr3);
+			duk_get_global_heapptr(ctx, hptr4);
+			duk_get_global_heapptr(ctx, hptr5);
+			duk_get_global_heapptr(ctx, hptr6);
+			duk_get_global_heapptr(ctx, hptr7);
+			duk_get_global_heapptr(ctx, hptr8);
+			duk_get_global_heapptr(ctx, hptr9);
+			duk_get_global_heapptr(ctx, hptr10);
+			break;
+		default:
+			return 1;
+		}
+
+		/* Keep strings and test object. */
+		duk_set_top(ctx, 11);
+	}
+
+	duk_destroy_heap(ctx);
+	return 0;
+}

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -82,12 +82,12 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 		goto finish;
 	}
 	duk_push_pointer(thr, (void *) h);
-	duk_put_prop_string(thr, -2, "hptr");
+	duk_put_prop_literal(thr, -2, "hptr");
 
 #if 0
 	/* Covers a lot of information, e.g. buffer and string variants. */
 	duk_push_uint(thr, (duk_uint_t) DUK_HEAPHDR_GET_FLAGS(h));
-	duk_put_prop_string(thr, -2, "hflags");
+	duk_put_prop_literal(thr, -2, "hflags");
 #endif
 
 #if defined(DUK_USE_REFERENCE_COUNTING)

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -239,7 +239,7 @@ DUK_LOCAL duk_ret_t duk__decode_helper(duk_hthread *thr, duk__decode_context *de
 	                                      DUK_TYPE_MASK_LIGHTFUNC |
 	                                      DUK_TYPE_MASK_BUFFER |
 		                              DUK_TYPE_MASK_OBJECT);
-		if (duk_get_prop_string(thr, 1, "stream")) {
+		if (duk_get_prop_literal(thr, 1, "stream")) {
 			stream = duk_to_boolean(thr, -1);
 		}
 	}
@@ -449,10 +449,10 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_hthread *thr) {
 		duk_to_string(thr, 0);
 	}
 	if (!duk_is_null_or_undefined(thr, 1)) {
-		if (duk_get_prop_string(thr, 1, "fatal")) {
+		if (duk_get_prop_literal(thr, 1, "fatal")) {
 			fatal = duk_to_boolean(thr, -1);
 		}
-		if (duk_get_prop_string(thr, 1, "ignoreBOM")) {
+		if (duk_get_prop_literal(thr, 1, "ignoreBOM")) {
 			ignore_bom = duk_to_boolean(thr, -1);
 		}
 	}
@@ -467,7 +467,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_hthread *thr) {
 	dec_ctx->ignore_bom = (duk_uint8_t) ignore_bom;
 	duk__utf8_decode_init(dec_ctx);  /* Initializes remaining fields. */
 
-	duk_put_prop_string(thr, -2, DUK_INTERNAL_SYMBOL("Context"));
+	duk_put_prop_literal(thr, -2, DUK_INTERNAL_SYMBOL("Context"));
 	return 0;
 }
 
@@ -475,7 +475,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_hthread *thr) {
 DUK_LOCAL duk__decode_context *duk__get_textdecoder_context(duk_hthread *thr) {
 	duk__decode_context *dec_ctx;
 	duk_push_this(thr);
-	duk_get_prop_string(thr, -1, DUK_INTERNAL_SYMBOL("Context"));
+	duk_get_prop_literal(thr, -1, DUK_INTERNAL_SYMBOL("Context"));
 	dec_ctx = (duk__decode_context *) duk_require_buffer(thr, -1, NULL);
 	DUK_ASSERT(dec_ctx != NULL);
 	return dec_ctx;

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1069,9 +1069,9 @@ DUK_INTERNAL void duk_debug_send_status(duk_hthread *thr) {
 		duk_debug_write_int(thr, 0);
 	} else {
 		duk_push_tval(thr, &act->tv_func);
-		duk_get_prop_string(thr, -1, "fileName");
+		duk_get_prop_literal(thr, -1, "fileName");
 		duk__debug_write_hstring_safe_top(thr);
-		duk_get_prop_string(thr, -2, "name");
+		duk_get_prop_literal(thr, -2, "name");
 		duk__debug_write_hstring_safe_top(thr);
 		duk_pop_3(thr);
 		/* Report next pc/line to be executed. */
@@ -1116,7 +1116,7 @@ DUK_INTERNAL void duk_debug_send_throw(duk_hthread *thr, duk_bool_t fatal) {
 		act = thr->callstack_curr;
 		if (act != NULL) {
 			duk_push_tval(thr, &act->tv_func);
-			duk_get_prop_string(thr, -1, "fileName");
+			duk_get_prop_literal(thr, -1, "fileName");
 			duk__debug_write_hstring_safe_top(thr);
 			pc = (duk_uint32_t) duk_hthread_get_act_prev_pc(thr, act);
 			duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_pc2line_query(thr, -2, pc));

--- a/src-input/duk_forwdecl.h
+++ b/src-input/duk_forwdecl.h
@@ -44,8 +44,9 @@ struct duk_breakpoint;
 
 struct duk_activation;
 struct duk_catcher;
-struct duk_strcache;
 struct duk_ljstate;
+struct duk_strcache_entry;
+struct duk_litcache_entry;
 struct duk_strtab_entry;
 
 #if defined(DUK_USE_DEBUG)
@@ -104,8 +105,9 @@ typedef struct duk_breakpoint duk_breakpoint;
 
 typedef struct duk_activation duk_activation;
 typedef struct duk_catcher duk_catcher;
-typedef struct duk_strcache duk_strcache;
 typedef struct duk_ljstate duk_ljstate;
+typedef struct duk_strcache_entry duk_strcache_entry;
+typedef struct duk_litcache_entry duk_litcache_entry;
 typedef struct duk_strtab_entry duk_strtab_entry;
 
 #if defined(DUK_USE_DEBUG)

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -20,7 +20,7 @@
 DUK_INTERNAL void duk_heap_strcache_string_remove(duk_heap *heap, duk_hstring *h) {
 	duk_small_int_t i;
 	for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-		duk_strcache *c = heap->strcache + i;
+		duk_strcache_entry *c = heap->strcache + i;
 		if (c->h == h) {
 			DUK_DD(DUK_DDPRINT("deleting weak strcache reference to hstring %p from heap %p",
 			                   (void *) h, (void *) heap));
@@ -92,7 +92,7 @@ DUK_LOCAL const duk_uint8_t *duk__scan_backwards(const duk_uint8_t *p, const duk
 
 DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *thr, duk_hstring *h, duk_uint_fast32_t char_offset) {
 	duk_heap *heap;
-	duk_strcache *sce;
+	duk_strcache_entry *sce;
 	duk_uint_fast32_t byte_offset;
 	duk_small_int_t i;
 	duk_bool_t use_cache;
@@ -145,14 +145,14 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache before char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 			DUK_DDD(DUK_DDDPRINT("  [%ld] -> h=%p, cidx=%ld, bidx=%ld",
 			                     (long) i, (void *) c->h, (long) c->cidx, (long) c->bidx));
 		}
 #endif
 
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 
 			if (c->h == h) {
 				sce = c;
@@ -281,7 +281,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 			 *   C <- sce    ==>    B
 			 *   D                  D
 			 */
-			duk_strcache tmp;
+			duk_strcache_entry tmp;
 
 			tmp = *sce;
 			duk_memmove((void *) (&heap->strcache[1]),
@@ -294,7 +294,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 #if defined(DUK_USE_DEBUG_LEVEL) && (DUK_USE_DEBUG_LEVEL >= 2)
 		DUK_DDD(DUK_DDDPRINT("stringcache after char2byte (using cache):"));
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
-			duk_strcache *c = heap->strcache + i;
+			duk_strcache_entry *c = heap->strcache + i;
 			DUK_DDD(DUK_DDDPRINT("  [%ld] -> h=%p, cidx=%ld, bidx=%ld",
 			                     (long) i, (void *) c->h, (long) c->cidx, (long) c->bidx));
 		}

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -38,6 +38,9 @@
  * needed right now.
  */
 
+/* With lowmem builds the high 16 bits of duk_heaphdr are used for other
+ * purposes, so this leaves 7 duk_heaphdr flags and 9 duk_hstring flags.
+ */
 #define DUK_HSTRING_FLAG_ASCII                      DUK_HEAPHDR_USER_FLAG(0)  /* string is ASCII, clen == blen */
 #define DUK_HSTRING_FLAG_ARRIDX                     DUK_HEAPHDR_USER_FLAG(1)  /* string is a valid array index */
 #define DUK_HSTRING_FLAG_SYMBOL                     DUK_HEAPHDR_USER_FLAG(2)  /* string is a symbol (invalid utf-8) */
@@ -46,6 +49,7 @@
 #define DUK_HSTRING_FLAG_STRICT_RESERVED_WORD       DUK_HEAPHDR_USER_FLAG(5)  /* string is a reserved word (strict) */
 #define DUK_HSTRING_FLAG_EVAL_OR_ARGUMENTS          DUK_HEAPHDR_USER_FLAG(6)  /* string is 'eval' or 'arguments' */
 #define DUK_HSTRING_FLAG_EXTDATA                    DUK_HEAPHDR_USER_FLAG(7)  /* string data is external (duk_hstring_external) */
+#define DUK_HSTRING_FLAG_PINNED_LITERAL             DUK_HEAPHDR_USER_FLAG(8)  /* string is a literal, and pinned */
 
 #define DUK_HSTRING_HAS_ASCII(x)                    DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ASCII)
 #define DUK_HSTRING_HAS_ARRIDX(x)                   DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ARRIDX)
@@ -55,6 +59,7 @@
 #define DUK_HSTRING_HAS_STRICT_RESERVED_WORD(x)     DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_STRICT_RESERVED_WORD)
 #define DUK_HSTRING_HAS_EVAL_OR_ARGUMENTS(x)        DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EVAL_OR_ARGUMENTS)
 #define DUK_HSTRING_HAS_EXTDATA(x)                  DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EXTDATA)
+#define DUK_HSTRING_HAS_PINNED_LITERAL(x)           DUK_HEAPHDR_CHECK_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_PINNED_LITERAL)
 
 #define DUK_HSTRING_SET_ASCII(x)                    DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ASCII)
 #define DUK_HSTRING_SET_ARRIDX(x)                   DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ARRIDX)
@@ -64,6 +69,7 @@
 #define DUK_HSTRING_SET_STRICT_RESERVED_WORD(x)     DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_STRICT_RESERVED_WORD)
 #define DUK_HSTRING_SET_EVAL_OR_ARGUMENTS(x)        DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EVAL_OR_ARGUMENTS)
 #define DUK_HSTRING_SET_EXTDATA(x)                  DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EXTDATA)
+#define DUK_HSTRING_SET_PINNED_LITERAL(x)           DUK_HEAPHDR_SET_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_PINNED_LITERAL)
 
 #define DUK_HSTRING_CLEAR_ASCII(x)                  DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ASCII)
 #define DUK_HSTRING_CLEAR_ARRIDX(x)                 DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_ARRIDX)
@@ -73,6 +79,7 @@
 #define DUK_HSTRING_CLEAR_STRICT_RESERVED_WORD(x)   DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_STRICT_RESERVED_WORD)
 #define DUK_HSTRING_CLEAR_EVAL_OR_ARGUMENTS(x)      DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EVAL_OR_ARGUMENTS)
 #define DUK_HSTRING_CLEAR_EXTDATA(x)                DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EXTDATA)
+#define DUK_HSTRING_CLEAR_PINNED_LITERAL(x)         DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_PINNED_LITERAL)
 
 #if 0  /* Slightly smaller code without explicit flag, but explicit flag
         * is very useful when 'clen' is dropped.

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -748,7 +748,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			"f"
 #endif
 			" "
-			/* Low memory options */
+			/* Low memory/performance options */
 #if defined(DUK_USE_STRTAB_PTRCOMP)
 			"s"
 #endif
@@ -788,6 +788,9 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 			 * are in ROM.
 			 */
 			"Z"
+#endif
+#if defined(DUK_USE_LITCACHE_SIZE)
+			"l"
 #endif
 	                " "
 			/* Object property allocation layout */

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -690,4 +690,21 @@ DUK_INTERNAL_DECL duk_int32_t duk_double_to_int32_t(duk_double_t x);
 DUK_INTERNAL_DECL duk_uint32_t duk_double_to_uint32_t(duk_double_t x);
 DUK_INTERNAL_DECL duk_float_t duk_double_to_float_t(duk_double_t x);
 
+/*
+ *  Miscellaneous
+ */
+
+/* Example: x     = 0x10 = 0b00010000
+ *          x - 1 = 0x0f = 0b00001111
+ *          x & (x - 1) == 0
+ *
+ *          x     = 0x07 = 0b00000111
+ *          x - 1 = 0x06 = 0b00000110
+ *          x & (x - 1) != 0
+ *
+ * However, incorrectly true for x == 0 so check for that explicitly.
+ */
+#define DUK_IS_POWER_OF_TWO(x) \
+	((x) != 0U && ((x) & ((x) - 1U)) == 0U)
+
 #endif  /* DUK_UTIL_H_INCLUDED */

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -901,7 +901,8 @@ DUK_EXTERNAL_DECL void duk_config_buffer(duk_context *ctx, duk_idx_t idx, void *
  *  The basic function assumes key is on stack.  The _(l)string variant takes
  *  a C string as a property name; the _literal variant takes a C literal.
  *  The _index variant takes an array index as a property name (e.g. 123 is
- *  equivalent to the key "123").
+ *  equivalent to the key "123").  The _heapptr variant takes a raw, borrowed
+ *  heap pointer.
  */
 
 DUK_EXTERNAL_DECL duk_bool_t duk_get_prop(duk_context *ctx, duk_idx_t obj_idx);

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -2325,7 +2325,10 @@ def rom_emit_strings_source(genc, meta):
     for lst in romstr_hash:
         for v in reversed(lst):
             tmp = 'DUK_INTERNAL const duk_romstr_%d %s = {' % (len(v), bi_str_map[v])
-            flags = [ 'DUK_HTYPE_STRING', 'DUK_HEAPHDR_FLAG_READONLY', 'DUK_HEAPHDR_FLAG_REACHABLE' ]
+            flags = [ 'DUK_HTYPE_STRING',
+                      'DUK_HEAPHDR_FLAG_READONLY',
+                      'DUK_HEAPHDR_FLAG_REACHABLE',
+                      'DUK_HSTRING_FLAG_PINNED_LITERAL' ]
             is_arridx = string_is_arridx(v)
 
             blen = len(v)

--- a/website/api/duk_base64_decode.yaml
+++ b/website/api/duk_base64_decode.yaml
@@ -22,6 +22,7 @@ example: |
 
 tags:
   - codec
+  - base64
 
 seealso:
   - duk_base64_encode

--- a/website/api/duk_base64_encode.yaml
+++ b/website/api/duk_base64_encode.yaml
@@ -27,6 +27,7 @@ example: |
 
 tags:
   - codec
+  - base64
 
 seealso:
   - duk_base64_decode

--- a/website/api/duk_compile_lstring.yaml
+++ b/website/api/duk_compile_lstring.yaml
@@ -22,5 +22,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_compile_lstring_filename.yaml
+++ b/website/api/duk_compile_lstring_filename.yaml
@@ -22,5 +22,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_compile_string.yaml
+++ b/website/api/duk_compile_string.yaml
@@ -19,5 +19,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_compile_string_filename.yaml
+++ b/website/api/duk_compile_string_filename.yaml
@@ -19,5 +19,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_del_prop_heapptr.yaml
+++ b/website/api/duk_del_prop_heapptr.yaml
@@ -25,6 +25,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_del_prop

--- a/website/api/duk_del_prop_literal.yaml
+++ b/website/api/duk_del_prop_literal.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_del_prop_lstring.yaml
+++ b/website/api/duk_del_prop_lstring.yaml
@@ -18,6 +18,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_del_prop

--- a/website/api/duk_del_prop_string.yaml
+++ b/website/api/duk_del_prop_string.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_del_prop

--- a/website/api/duk_eval_lstring.yaml
+++ b/website/api/duk_eval_lstring.yaml
@@ -24,6 +24,7 @@ example: |
 
 tags:
   - compile
+  - string
 
 seealso:
   - duk_eval_lstring_noresult

--- a/website/api/duk_eval_lstring_noresult.yaml
+++ b/website/api/duk_eval_lstring_noresult.yaml
@@ -21,5 +21,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_eval_string.yaml
+++ b/website/api/duk_eval_string.yaml
@@ -21,6 +21,7 @@ example: |
 
 tags:
   - compile
+  - string
 
 seealso:
   - duk_eval_string_noresult

--- a/website/api/duk_eval_string_noresult.yaml
+++ b/website/api/duk_eval_string_noresult.yaml
@@ -18,5 +18,6 @@ example: |
 
 tags:
   - compile
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_get_global_heapptr.yaml
+++ b/website/api/duk_get_global_heapptr.yaml
@@ -18,6 +18,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_get_global_string

--- a/website/api/duk_get_global_literal.yaml
+++ b/website/api/duk_get_global_literal.yaml
@@ -21,6 +21,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_get_global_lstring.yaml
+++ b/website/api/duk_get_global_lstring.yaml
@@ -16,6 +16,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_get_global_string

--- a/website/api/duk_get_global_string.yaml
+++ b/website/api/duk_get_global_string.yaml
@@ -29,6 +29,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_get_global_lstring

--- a/website/api/duk_get_heapptr.yaml
+++ b/website/api/duk_get_heapptr.yaml
@@ -43,6 +43,7 @@ example: |
 tags:
   - stack
   - borrowed
+  - heapptr
 
 seealso:
   - duk_require_heapptr

--- a/website/api/duk_get_heapptr_default.yaml
+++ b/website/api/duk_get_heapptr_default.yaml
@@ -21,6 +21,7 @@ example: |
 tags:
   - stack
   - borrowed
+  - heapptr
 
 seealso:
   - duk_get_heapptr

--- a/website/api/duk_get_lstring.yaml
+++ b/website/api/duk_get_lstring.yaml
@@ -29,13 +29,13 @@ example: |
       printf("value is a string, %lu bytes\n", (unsigned long) len);
   }
 
+tags:
+  - stack
+  - string
+
 seealso:
   - duk_get_string
   - duk_get_lstring_default
   - duk_get_string_default
-
-tags:
-  - stack
-  - string
 
 introduced: 1.0.0

--- a/website/api/duk_get_lstring_default.yaml
+++ b/website/api/duk_get_lstring_default.yaml
@@ -19,11 +19,11 @@ example: |
 
   str = duk_get_lstring_default(ctx, -3, &len, "foo" "\x00" "bar", 7);
 
-seealso:
-  - duk_get_string_default
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_get_string_default
 
 introduced: 2.1.0

--- a/website/api/duk_get_prop_heapptr.yaml
+++ b/website/api/duk_get_prop_heapptr.yaml
@@ -26,6 +26,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_get_prop

--- a/website/api/duk_get_prop_literal.yaml
+++ b/website/api/duk_get_prop_literal.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_get_prop_lstring.yaml
+++ b/website/api/duk_get_prop_lstring.yaml
@@ -13,11 +13,12 @@ summary: |
 
 example: |
   (void) duk_get_prop_lstring(ctx, -3, "internal" "\x00" "nul", 12);
-  printf("obj.interanl[00]nul = %s\n", duk_to_string(ctx, -1));
+  printf("obj.internal[00]nul = %s\n", duk_to_string(ctx, -1));
   duk_pop(ctx);
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_get_prop

--- a/website/api/duk_get_prop_string.yaml
+++ b/website/api/duk_get_prop_string.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_get_prop

--- a/website/api/duk_get_string.yaml
+++ b/website/api/duk_get_string.yaml
@@ -28,13 +28,13 @@ example: |
       printf("value is a string: %s\n", str);
   }
 
+tags:
+  - stack
+  - string
+
 seealso:
   - duk_get_lstring
   - duk_get_string_default
   - duk_get_lstring_default
-
-tags:
-  - stack
-  - string
 
 introduced: 1.0.0

--- a/website/api/duk_get_string_default.yaml
+++ b/website/api/duk_get_string_default.yaml
@@ -16,11 +16,11 @@ summary: |
 example: |
   const char *host = duk_get_string_default(ctx, 3, "localhost");
 
-seealso:
-  - duk_get_lstring_default
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_get_lstring_default
 
 introduced: 2.1.0

--- a/website/api/duk_has_prop_heapptr.yaml
+++ b/website/api/duk_has_prop_heapptr.yaml
@@ -27,6 +27,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_has_prop

--- a/website/api/duk_has_prop_literal.yaml
+++ b/website/api/duk_has_prop_literal.yaml
@@ -20,6 +20,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_has_prop_lstring.yaml
+++ b/website/api/duk_has_prop_lstring.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_has_prop

--- a/website/api/duk_has_prop_string.yaml
+++ b/website/api/duk_has_prop_string.yaml
@@ -20,6 +20,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_has_prop

--- a/website/api/duk_hex_decode.yaml
+++ b/website/api/duk_hex_decode.yaml
@@ -22,6 +22,7 @@ example: |
 
 tags:
   - codec
+  - hex
 
 seealso:
   - duk_hex_encode

--- a/website/api/duk_hex_encode.yaml
+++ b/website/api/duk_hex_encode.yaml
@@ -27,6 +27,7 @@ example: |
 
 tags:
   - codec
+  - hex
 
 seealso:
   - duk_hex_decode

--- a/website/api/duk_is_string.yaml
+++ b/website/api/duk_is_string.yaml
@@ -12,13 +12,13 @@ summary: |
 
   <div include="symbols-are-strings.html" />
 
+tags:
+  - stack
+  - string
+
 example: |
   if (duk_is_string(ctx, -3)) {
       /* ... */
   }
-
-tags:
-  - stack
-  - string
 
 introduced: 1.0.0

--- a/website/api/duk_opt_heapptr.yaml
+++ b/website/api/duk_opt_heapptr.yaml
@@ -23,5 +23,6 @@ example: |
 tags:
   - stack
   - borrowed
+  - heapptr
 
 introduced: 2.1.0

--- a/website/api/duk_opt_lstring.yaml
+++ b/website/api/duk_opt_lstring.yaml
@@ -27,11 +27,11 @@ example: |
 
   str = duk_opt_lstring(ctx, -3, &len, "foo" "\x00" "bar", 7);
 
-seealso:
-  - duk_opt_string
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_opt_string
 
 introduced: 2.1.0

--- a/website/api/duk_opt_string.yaml
+++ b/website/api/duk_opt_string.yaml
@@ -27,11 +27,11 @@ summary: |
 example: |
   const char *host = duk_opt_string(ctx, 3, "localhost");
 
-seealso:
-  - duk_opt_lstring
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_opt_lstring
 
 introduced: 2.1.0

--- a/website/api/duk_pcompile_lstring.yaml
+++ b/website/api/duk_pcompile_lstring.yaml
@@ -30,5 +30,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_pcompile_lstring_filename.yaml
+++ b/website/api/duk_pcompile_lstring_filename.yaml
@@ -30,5 +30,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_pcompile_string.yaml
+++ b/website/api/duk_pcompile_string.yaml
@@ -27,5 +27,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_pcompile_string_filename.yaml
+++ b/website/api/duk_pcompile_string_filename.yaml
@@ -27,5 +27,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_peval_lstring.yaml
+++ b/website/api/duk_peval_lstring.yaml
@@ -29,6 +29,7 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 seealso:
   - duk_peval_lstring_noresult

--- a/website/api/duk_peval_lstring_noresult.yaml
+++ b/website/api/duk_peval_lstring_noresult.yaml
@@ -26,5 +26,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_peval_string.yaml
+++ b/website/api/duk_peval_string.yaml
@@ -26,6 +26,7 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 seealso:
   - duk_peval_string_noresult

--- a/website/api/duk_peval_string_noresult.yaml
+++ b/website/api/duk_peval_string_noresult.yaml
@@ -23,5 +23,6 @@ example: |
 tags:
   - compile
   - protected
+  - string
 
 introduced: 1.0.0

--- a/website/api/duk_push_heapptr.yaml
+++ b/website/api/duk_push_heapptr.yaml
@@ -57,6 +57,7 @@ tags:
   - stack
   - object
   - borrowed
+  - heapptr
 
 seealso:
   - duk_get_heapptr

--- a/website/api/duk_push_literal.yaml
+++ b/website/api/duk_push_literal.yaml
@@ -1,7 +1,7 @@
 name: duk_push_literal
 
 proto: |
-  const char *duk_push_literal(duk_context *ctx, const char *literal_str);
+  const char *duk_push_literal(duk_context *ctx, const char *str_literal);
 
 stack: |
   [ ... ] -> [ ... str! ]
@@ -9,26 +9,37 @@ stack: |
 summary: |
   <p>Push a C literal into the stack and return a pointer to the interned
   string data area (which may or may not be the same as the argument literal).
-  The argument <code>str_literal</code> must be a non-NULL C literal that can be
-  operated on using e.g. <code>sizeof(str)</code>.  The data contents of the
-  literal must be immutable, and the string must not contain NUL characters.
-  The <code>str_literal</code> argument may be evaluated multiple times by the
-  API macro.  Finally, no runtime NULL pointer check is made for the
+  The argument <code>str_literal</code>:</p>
+  <ul>
+  <li>must be a non-NULL C literal like <code>"foo"</code> which can be operated
+      on using e.g. <code>sizeof(str)</code>, where sizeof() yields string
+      length, including the automatic NUL terminator (for example, sizeof("foo")
+      is 4);</li>
+  <li>must have immutable data contents, i.e. read-only memory, or writable
+      memory but guaranteed not to be changed; and</li>
+  <li>must not contain internal NUL characters, and must have a terminating
+      NUL as usual for C strings.</li>
+  </ul>
+
+  <p>The <code>str_literal</code> argument may be evaluated multiple times by
+  the API macro.  No runtime NULL pointer check is made for the
   <code>str_literal</code> argument so passing in a NULL causes memory unsafe
   behavior.</p>
 
-  <p>This call is conceptually equivalent to duk_push_string(), and
-  only needs to be used if the minor differences in footprint or speed
-  matter.  The properties of immutable literals allows minor optimizations
+  <p>This call is conceptually equivalent to duk_push_string().  Calling code
+  only needs to use it if the minor differences in footprint or speed
+  matter.  The properties of immutable C literals allows minor optimizations
   in Duktape internals:</p>
   <ul>
   <li>The length of the string can be computed at compile time using
       <code>sizeof(str_literal) - 1</code> at the call site.</li>
-  <li>Because the string address is fixed at runtime, it could be used
-      for speeding up a string table lookup for the literal.  While common,
-      there's no assumption that strings are deduplicated, so there may be
-      multiple addresses with the same literal.  (This optimization is not
-      done as of Duktape 2.3.)</li>
+  <li>By default heap strings accessed via C literals (duk_push_literal()
+      or any of the literal convenience calls like duk_get_prop_literal())
+      are automatically pinned until heap destruction, and there's a lookup
+      cache for mapping a C literal address to the pinned internal heap string.
+      This optimization doesn't assume string deduplication (which is not
+      guaranteed), i.e. there may be multiple addresses with the same literal
+      data.</li>
   <li>Because the string data is assumed to be immutable, the internal
       string representation could just point to the data instead of
       making a copy.  (This optimization is not done as of Duktape 2.3.)</li>
@@ -51,7 +62,7 @@ example: |
 
 tags:
   - stack
-  - string
+  - literal
   - experimental
 
 introduced: 2.3.0

--- a/website/api/duk_put_global_heapptr.yaml
+++ b/website/api/duk_put_global_heapptr.yaml
@@ -18,6 +18,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_put_global_string

--- a/website/api/duk_put_global_literal.yaml
+++ b/website/api/duk_put_global_literal.yaml
@@ -17,6 +17,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_put_global_lstring.yaml
+++ b/website/api/duk_put_global_lstring.yaml
@@ -16,6 +16,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_put_global_string

--- a/website/api/duk_put_global_string.yaml
+++ b/website/api/duk_put_global_string.yaml
@@ -27,6 +27,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_put_global_lstring

--- a/website/api/duk_put_prop_heapptr.yaml
+++ b/website/api/duk_put_prop_heapptr.yaml
@@ -26,6 +26,8 @@ example: |
 
 tags:
   - property
+  - borrowed
+  - heapptr
 
 seealso:
   - duk_put_prop

--- a/website/api/duk_put_prop_literal.yaml
+++ b/website/api/duk_put_prop_literal.yaml
@@ -20,6 +20,7 @@ example: |
 
 tags:
   - property
+  - literal
   - experimental
 
 seealso:

--- a/website/api/duk_put_prop_lstring.yaml
+++ b/website/api/duk_put_prop_lstring.yaml
@@ -19,6 +19,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_put_prop

--- a/website/api/duk_put_prop_string.yaml
+++ b/website/api/duk_put_prop_string.yaml
@@ -20,6 +20,7 @@ example: |
 
 tags:
   - property
+  - string
 
 seealso:
   - duk_put_prop

--- a/website/api/duk_require_heapptr.yaml
+++ b/website/api/duk_require_heapptr.yaml
@@ -19,6 +19,7 @@ example: |
 tags:
   - stack
   - borrowed
+  - heapptr
 
 seealso:
   - duk_get_heapptr

--- a/website/api/duk_require_lstring.yaml
+++ b/website/api/duk_require_lstring.yaml
@@ -20,11 +20,11 @@ example: |
   buf = duk_require_lstring(ctx, -3, &len);
   printf("value is a string, %lu bytes\n", (unsigned long) len);
 
-seealso:
-  - duk_require_string
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_require_string
 
 introduced: 1.0.0

--- a/website/api/duk_require_string.yaml
+++ b/website/api/duk_require_string.yaml
@@ -21,11 +21,11 @@ example: |
   buf = duk_require_string(ctx, -3);
   printf("value is a string: %s\n", buf);
 
-seealso:
-  - duk_require_lstring
-
 tags:
   - stack
   - string
+
+seealso:
+  - duk_require_lstring
 
 introduced: 1.0.0


### PR DESCRIPTION
- [x] Automatically pin the `duk_hstring`s looked up using C API literals when they're encountered.
- [x] Add a C literal address -> `duk_hstring` cache ("litcache") to look up the `duk_hstring` matching a certain literal address quickly. Because the target `duk_hstring` is pinned until heap destruction, the cache doesn't need an invalidation mechanism.
- [x] Some more internal call site conversion to use duk_xxx_literal() variants.
- [x] Portability / warnings for litcache key computation.
- [x] Make pinning+litcache configurable.
- [x] ROM string handling.
- [x] API documentation updates.
- [x] 2.3 migration note updates.
- [x] Releases entry.

Overall the pinning+litcache makes e.g. `duk_get_prop_literal()` about as fast as `duk_get_prop_heapptr()` in most cases.