### PR TITLE
Allow pinned literals to be collected in mark-and-sweep

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3209,14 +3209,16 @@ Planned
   (GH-1805)
 
 * Automatically pin strings accessed using the C literal API call variants
-  such as duk_get_prop_literal(ctx, "propname") so that the strings are only
-  freed on heap destruction; this behavior can be disabled by disabling
-  DUK_USE_LITCACHE_SIZE in configure.py (GH-1813)
+  such as duk_get_prop_literal(ctx, "propname") between mark-and-sweep rounds
+  to facilitate literal caching and to reduce string table traffic; this
+  behavior can be disabled by disabling DUK_USE_LITCACHE_SIZE in configure.py
+  (GH-1813)
 
 * Add a lookup cache for C literals to speed up string table lookups when
   using API call variants such as duk_get_prop_literal(ctx, "propname");
-  the cache relies on literals being pinned, and can be disabled by disabling
-  DUK_USE_LITCACHE_SIZE in configure.py (GH-1813)
+  the cache relies on literals being pinned between mark-and-sweep rounds,
+  and can be disabled by disabling DUK_USE_LITCACHE_SIZE in configure.py
+  (GH-1813)
 
 * ES2015 Number constructor properties: EPSILON, MIN_SAFE_INTEGER,
   MAX_SAFE_INTEGER, isFinite(), isInteger(), isNaN(), isSafeInteger(),

--- a/config/config-options/DUK_USE_LITCACHE_SIZE.yaml
+++ b/config/config-options/DUK_USE_LITCACHE_SIZE.yaml
@@ -14,12 +14,14 @@ description: >
   pointers with duk_xxx_heapptr().
 
   When this option is defined, duk_hstrings related to literals encountered
-  in duk_xxx_literal() API calls are automatically pinned for the lifetime of
-  the heap.  This accomplishes two things.  First, it avoids the need for
-  any form of cache invalidation for the literal cache.  Second, it avoids
-  string table traffic (i.e. freeing and reallocating) for literals which are
-  likely to occur again and again.  However, the downside is that some strings
-  that may occur only temporarily will remain pinned.  You can avoid this by
-  simply using e.g. duk_xxx_string() when dealing with such strings.
+  in duk_xxx_literal() API calls are automatically pinned between
+  mark-and-sweep rounds.  This accomplishes two things.  First, it avoids the
+  need for cache invalidation for the literal cache in normal operation between
+  mark-and-sweep rounds.  Second, it reduces string table traffic (i.e. freeing
+  and reallocating) for literals which are likely to occur again and again.
+  However, the downside is that some strings that may occur only temporarily
+  will remain pinned until the next mark-and-sweep round.  If this matter, you
+  can avoid it by simply using e.g. duk_xxx_string() when dealing with such
+  strings.
 
   The literal cache size must be a power of two (2^N).

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -18,9 +18,9 @@ Main changes in this release (see RELEASES.rst for full details):
   conceptually similar to the duk_xxx_string() variants, but can take advantage
   of the fact that e.g. string length for a C literal can be determined at
   compile time using sizeof("myProperty") - 1 (the -1 is for NUL termination).
-  Literal strings used by application code are also automatically pinned for
-  the duration of the heap, and a small lookup cache makes mapping a C literal
-  to a heap string object quite fast (almost as fast as using a heapptr).
+  Literal strings used by application code are also automatically pinned
+  between mark-and-sweep rounds, and a small lookup cache makes mapping a C
+  literal to a heap string object quite fast (almost as fast as using a heapptr).
   For now the calls are experimental.
 
 Upgrading from Duktape 2.2

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -540,7 +540,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	DUK_ASSERT((count_const == 0 && count_funcs == 0) || tv1 != NULL);
 
 	q = fun_data;
-	duk_memcpy((void *) q, (const void *) tv1, sizeof(duk_tval) * count_const);
+	duk_memcpy_unsafe((void *) q, (const void *) tv1, sizeof(duk_tval) * count_const);
 	for (n = count_const; n > 0; n--) {
 		DUK_TVAL_INCREF_FAST(thr, (duk_tval *) (void *) q);  /* no side effects */
 		q += sizeof(duk_tval);

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -1035,7 +1035,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 #else
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	{
-		duk_small_uint_t i;
+		duk_uint32_t i;
 	        for (i = 0; i < st_initsize; i++) {
 			res->strtable[i] = NULL;
 	        }
@@ -1051,7 +1051,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	{
-		duk_small_uint_t i;
+		duk_uint_t i;
 		for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
 			res->strcache[i].h = NULL;
 		}
@@ -1066,7 +1066,7 @@ duk_heap *duk_heap_alloc(duk_alloc_function alloc_func,
 	DUK_ASSERT(DUK_IS_POWER_OF_TWO((duk_uint_t) DUK_USE_LITCACHE_SIZE));
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
 	{
-		duk_small_uint_t i;
+		duk_uint_t i;
 		for (i = 0; i < DUK_USE_LITCACHE_SIZE; i++) {
 			res->litcache[i].addr = NULL;
 			res->litcache[i].h = NULL;

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -18,7 +18,7 @@
  */
 
 DUK_INTERNAL void duk_heap_strcache_string_remove(duk_heap *heap, duk_hstring *h) {
-	duk_small_int_t i;
+	duk_uint_t i;
 	for (i = 0; i < DUK_HEAP_STRCACHE_SIZE; i++) {
 		duk_strcache_entry *c = heap->strcache + i;
 		if (c->h == h) {
@@ -94,7 +94,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	duk_heap *heap;
 	duk_strcache_entry *sce;
 	duk_uint_fast32_t byte_offset;
-	duk_small_int_t i;
+	duk_uint_t i;
 	duk_bool_t use_cache;
 	duk_uint_fast32_t dist_start, dist_end, dist_sce;
 	duk_uint_fast32_t char_length;

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -831,8 +831,8 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern_literal_checked(duk_hthread *
 	key = duk__strtable_litcache_key(str, blen);
 	ent = thr->heap->litcache + key;
 	if (ent->addr == str) {
-		DUK_D(DUK_DPRINT("intern check for cached, pinned literal: str=%p, blen=%ld -> duk_hstring %!O",
-		                 (const void *) str, (long) blen, (duk_heaphdr *) ent->h));
+		DUK_DD(DUK_DDPRINT("intern check for cached, pinned literal: str=%p, blen=%ld -> duk_hstring %!O",
+		                   (const void *) str, (long) blen, (duk_heaphdr *) ent->h));
 		DUK_ASSERT(ent->h != NULL);
 		DUK_ASSERT(DUK_HSTRING_HAS_PINNED_LITERAL(ent->h));
 		DUK_STATS_INC(thr->heap, stats_strtab_litcache_hit);
@@ -845,14 +845,15 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern_literal_checked(duk_hthread *
 	ent->h = h;
 	DUK_STATS_INC(thr->heap, stats_strtab_litcache_miss);
 
-	/* Pin the duk_hstring for the duration of the heap.  This means
-	 * litcache entries don't need to be invalidated as their target
-	 * duk_hstring is not freed until heap destruction.  The pin remains
-	 * even if the literal cache entry is overwritten, and is still useful
-	 * to avoid string table traffic.
+	/* Pin the duk_hstring until the next mark-and-sweep.  This means
+	 * litcache entries don't need to be invalidated until the next
+	 * mark-and-sweep as their target duk_hstring is not freed before
+	 * the mark-and-sweep happens.  The pin remains even if the literal
+	 * cache entry is overwritten, and is still useful to avoid string
+	 * table traffic.
 	 */
 	if (!DUK_HSTRING_HAS_PINNED_LITERAL(h)) {
-		DUK_D(DUK_DPRINT("pin duk_hstring because it is a literal: %!O", (duk_heaphdr *) h));
+		DUK_DD(DUK_DDPRINT("pin duk_hstring because it is a literal: %!O", (duk_heaphdr *) h));
 		DUK_ASSERT(!DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h));
 		DUK_HSTRING_INCREF(thr, h);
 		DUK_HSTRING_SET_PINNED_LITERAL(h);

--- a/tests/api/test-push-literal.c
+++ b/tests/api/test-push-literal.c
@@ -77,6 +77,23 @@ static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	printf("len: %ld\n", (long) len);
 	duk_pop(ctx);
 
+	/* Push a literal (which pins it temporarily), force mark-and-sweep to
+	 * free it, repush, etc.  This exercises freeing of temporarily pinned
+	 * literals, and is useful for assertion testing.
+	 */
+	(void) duk_push_literal(ctx, "canBeCollected");
+	duk_pop(ctx);
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+	(void) duk_push_literal(ctx, "canBeCollected");
+	duk_pop(ctx);
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+	(void) duk_push_literal(ctx, "canBeCollected");
+	duk_pop(ctx);
+	duk_gc(ctx, 0);
+	duk_gc(ctx, 0);
+
 	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }

--- a/website/api/duk_push_literal.yaml
+++ b/website/api/duk_push_literal.yaml
@@ -35,11 +35,11 @@ summary: |
       <code>sizeof(str_literal) - 1</code> at the call site.</li>
   <li>By default heap strings accessed via C literals (duk_push_literal()
       or any of the literal convenience calls like duk_get_prop_literal())
-      are automatically pinned until heap destruction, and there's a lookup
-      cache for mapping a C literal address to the pinned internal heap string.
-      This optimization doesn't assume string deduplication (which is not
-      guaranteed), i.e. there may be multiple addresses with the same literal
-      data.</li>
+      are automatically pinned until the next mark-and-sweep round, and
+      there's a lookup cache for mapping a C literal address to the pinned
+      internal heap string.  This optimization doesn't assume string
+      deduplication (which is common but not guaranteed), i.e. there may be
+      multiple addresses with the same literal data.</li>
   <li>Because the string data is assumed to be immutable, the internal
       string representation could just point to the data instead of
       making a copy.  (This optimization is not done as of Duktape 2.3.)</li>


### PR DESCRIPTION
Refine the literal cache mechanism so that pinned strings are pinned only until the next mark-and-sweep round rather than until heap destruction. This keeps the literal cache simple and avoids the need for an invalidation mechanism in normal operation (= between mark-and-sweep rounds). However, mark-and-sweep is able to free pinned literals if they stop occurring.

Tasks:
- [x] Litcache change
- [x] Migration note update
- [x] API doc update
- [x] Releases update