### PR TITLE
Add ES2015 @@toStringTag support

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3194,6 +3194,9 @@ Planned
   operator and duk_instanceof() API call; also add Symbol.hasInstance and
   Function.prototype[@@hasInstance] (GH-1821)
 
+* Add support for Symbol.toStringTag (@@toStringTag) in
+  Object.prototype.toString() (GH-1822)
+
 * Add duk_random() to allow C code access to the same random number source
   as Ecmascript code (GH-1815)
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -2838,6 +2838,7 @@ objects:
         value: "Math"
         attributes: "c"
         es6: true
+        present_if: DUK_USE_SYMBOL_BUILTIN
 
   - id: bi_json
     class: JSON
@@ -2868,6 +2869,7 @@ objects:
       #    string: "Symbol.toStringTag"
       #  value: XXX
       #  es6: true
+      #  present_if: DUK_USE_SYMBOL_BUILTIN
 
   # E5 Section 13.2.3
   - id: bi_type_error_thrower
@@ -3451,7 +3453,7 @@ objects:
           type: symbol
           variant: wellknown
           string: "Symbol.toStringTag"
-        value: "symbol"
+        value: "Symbol"
         attributes: "c"
         es6: true
         present_if: DUK_USE_SYMBOL_BUILTIN

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -147,7 +147,7 @@ DUK_INTERNAL_DECL duk_bool_t duk_to_boolean_top_pop(duk_hthread *thr);
 #if defined(DUK_USE_DEBUGGER_SUPPORT)  /* only needed by debugger for now */
 DUK_INTERNAL_DECL duk_hstring *duk_safe_to_hstring(duk_hthread *thr, duk_idx_t idx);
 #endif
-DUK_INTERNAL_DECL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv);
+DUK_INTERNAL_DECL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv, duk_bool_t avoid_side_effects);
 
 DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped_raw(duk_hthread *thr, duk_idx_t idx, duk_int_t minval, duk_int_t maxval, duk_bool_t *out_clamped);  /* out_clamped=NULL, RangeError if outside range */
 DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped(duk_hthread *thr, duk_idx_t idx, duk_int_t minval, duk_int_t maxval);

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -7,12 +7,9 @@
 /* Needed even when Object built-in disabled. */
 DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_string(duk_hthread *thr) {
 	duk_tval *tv;
+
 	tv = DUK_HTHREAD_THIS_PTR(thr);
-	/* XXX: This is not entirely correct anymore; in ES2015 the
-	 * default lookup should use @@toStringTag to come up with
-	 * e.g. [object Symbol].
-	 */
-	duk_push_class_string_tval(thr, tv);
+	duk_push_class_string_tval(thr, tv, 0 /*avoid_side_effects*/);
 	return 1;
 }
 

--- a/src-input/strings.yaml
+++ b/src-input/strings.yaml
@@ -486,6 +486,10 @@ strings:
       type: symbol
       variant: wellknown
       string: "Symbol.hasInstance"
+  - str:
+      type: symbol
+      variant: wellknown
+      string: "Symbol.toStringTag"
 
   # Misc
   - str: "setPrototypeOf"

--- a/tests/ecmascript/test-bi-object-proto-tostring-tostringtag.js
+++ b/tests/ecmascript/test-bi-object-proto-tostring-tostringtag.js
@@ -1,0 +1,158 @@
+/*===
+[object Object]
+[object MyObject]
+[object Object]
+[object Object]
+[object Object]
+[object OverrideDate]
+[object Symbol]
+[object OverrideSymbol]
+[object Symbol]
+===*/
+
+function basicTest() {
+    var o = {};
+    print(o.toString());
+    o[Symbol.toStringTag] = 'MyObject';
+    print(o.toString());
+
+    // If @@toStringTag exists but isn't a string, it is ignored.
+    // Check a Symbol value specifically because it's internally very
+    // string like; it too must be ignored.
+    var o = {};
+    o[Symbol.toStringTag] = Symbol('foo');
+    print(o.toString());
+    var o = {};
+    o[Symbol.toStringTag] = 123;
+    print(o.toString());
+    var o = {};
+    o[Symbol.toStringTag] = { test: 1 };
+    print(o.toString());
+
+    // Override @toStringTag for a built-in object which has a legacy
+    // fallback.
+    var o = new Date();
+    o[Symbol.toStringTag] = 'OverrideDate';
+    print(Object.prototype.toString.call(o));
+
+    // If a Symbol object has a non-string @@toStringTag, the legacy algorithm
+    // should be used.  Based on https://www.ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring
+    // (which is unchanged in later versions for this case) the result should
+    // be "[object Object]":
+    //  - Step 3: the value is already an object, so no-op.
+    //  - Steps 6-14: no match.
+    //  - Step 15 sets builtinTag to "Object".
+    //  - Steps 16-18: Type(tag) is not a string, so set tag to builtinTag, i.e. "Object".
+    //  - Step 19: return "[object Object]".
+    //
+    // However, both V8 and Firefox return "[object Symbol]" so we also do that
+    // here for now.  This may change in later versions.
+    var o = Object(Symbol('foo'));
+    print(Object.prototype.toString.call(o));
+    var o = Object(Symbol('foo'));
+    Object.defineProperty(o, Symbol.toStringTag, { value: 'OverrideSymbol', configurable: true });
+    print(Object.prototype.toString.call(o));
+    var o = Object(Symbol('foo'));
+    Object.defineProperty(o, Symbol.toStringTag, { value: 123, configurable: true });
+    print(Object.prototype.toString.call(o));
+}
+
+try {
+    basicTest();
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+[object OverrideNumber]
+[object OverrideNumber]
+false
+true
+false
+false
+false
+true
+Number.prototype[@@toStringTag] read
+object false true false
+OverrideString
+Number.prototype[@@toStringTag] read
+object false true false
+[object OverrideString]
+Number.prototype[@@toStringTag] read
+number false true false
+OverrideString
+Number.prototype[@@toStringTag] read
+object false false false
+[object OverrideString]
+===*/
+
+function primTypeTest() {
+    var o;
+
+    // When Object.prototype.toString() is applied to a primitive type,
+    // the value is (at least conceptually) converted to an object and
+    // a @@toStringTag lookup is done on the object.  As a result, setting
+    // e.g. Number.prototype[@@toStringTag] should affect .toString()
+    // conversion of a primitive value too.
+    Object.defineProperty(Number.prototype, Symbol.toStringTag, {
+        value: 'OverrideNumber',
+        configurable: true
+    });
+    o = new Number(123);
+    print(Object.prototype.toString.call(o));
+    o = 123;
+    print(Object.prototype.toString.call(o));
+
+    // For summaries a @@toStringTag lookup is not yet done because it might
+    // invoke Proxy or getter side effects.  So for now only the default legacy
+    // class name is available.  Ideally summary string creation would do a
+    // safe lookup (skipping Proxy and getter side effects) and then sanitize
+    // the @@toStringTag string.  This would work fine in 99+% of cases.  Also
+    // note that summary strings retain the primitive vs. object type difference
+    // because it matters for diagnostics.
+    o = new Number(123);
+    try {
+        o();
+        print('never here');
+    } catch (e) {
+        print(e.message.indexOf('[object OverrideNumber]') >= 0);
+        print(e.message.indexOf('[object Number]') >= 0);
+        print(e.message.indexOf('123') >= 0);
+    }
+    o = 123;
+    try {
+        o();
+        print('never here');
+    } catch (e) {
+        print(e.message.indexOf('[object OverrideNumber]') >= 0);
+        print(e.message.indexOf('[object Number]') >= 0);
+        print(e.message.indexOf('123') >= 0);
+    }
+
+    // If @@toStringTag is a getter, the getter 'this' binding must be a
+    // ToObject() coercion of the primitive value.  Normally the 'this'
+    // binding would be the primitive value as is for a strict getter,
+    // but the Object.prototype.toString() algorithm does an explicit
+    // object coercion.
+    Object.defineProperty(Number.prototype, Symbol.toStringTag, {
+        get: function () {
+            'use strict';
+            print('Number.prototype[@@toStringTag] read');
+            print(typeof this, this === 'foo', this === o, this === Number.prototype);
+            return 'OverrideString';
+        },
+        configurable: true
+    });
+    o = new Number(123);
+    print(o[Symbol.toStringTag]);
+    print(Object.prototype.toString.call(o));
+    o = 123;
+    print(o[Symbol.toStringTag]);
+    print(Object.prototype.toString.call(o));
+}
+
+try {
+    primTypeTest();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
Add support for `@@toStringTag` in `Object.prototype.toString()`. Doesn't yet add string tags to all objects, so string coercion still relies on legacy behavior for built-ins. User code can now do something like the following, assuming symbol support is enabled:
```
duk> o = {}; o[Symbol.toStringTag] = 'ButtonWidget';
= "ButtonWidget"
duk> o.toString()
= "[object ButtonWidget]"
```

Safe summaries don't yet incorporate this change because a naive `@@toStringTag` lookup could invoke a getter or a Proxy which is unsafe. A reasonable change would be to look up `@@toStringTag` (skipping Proxy behavior to avoid side effects), and use the value in the summary in a sanitized form only if it's a data value with a string type; a getter would not be invoked at all.