### PR TITLE
Fix broken link in README

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,6 +87,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * https://github.com/chris-y
 * Laurent Zubiaur (https://github.com/lzubiaur)
 * Neil Kolban (https://github.com/nkolban)
+* Wilhelm Wanecek (https://github.com/wanecek)
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Main features:
 * Ecmascript E5/E5.1 compliant, with some semantics updated from ES2015+
 * Partial support for Ecmascript 2015 (E6) and Ecmascript 2016 (E7),
   [Post-ES5 feature status](http://wiki.duktape.org/PostEs5Features.html),
-  [kangax/compat-table](https://kangax.github.io/compat-table">kangax/compat-table)
+  [kangax/compat-table](https://kangax.github.io/compat-table)
 * ES2015 TypedArray and Node.js Buffer bindings
 * WHATWG Encoding API living standard
 * Built-in debugger


### PR DESCRIPTION
Fix a broken link to [kangax/compat-table](https://kangax.github.io/compat-table) in the README.md