### PR TITLE
Fix unlinkSync call in runtests.js

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Jakub Nowakowski (https://github.com/jimvonmoon)
 * Tommy Nguyen (https://github.com/tn0502)
 * Fabrice Fontaine (https://github.com/ffontaine)
+* Christopher Hiller (https://github.com/boneskull)
 
 Other contributions
 ===================

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -44,7 +44,7 @@ function mkTempName(ext) {
 function safeUnlinkSync(filePath) {
     try {
         if (filePath) {
-            fs.unlink(filePath);
+            fs.unlinkSync(filePath);
         }
     } catch (e) {
         console.log('Failed to unlink ' + filePath + ' (ignoring): ' + e);


### PR DESCRIPTION
I noticed that the call to `unlink` on L47 was actually asynchronous--you want `unlinkSync`.   I noticed this because with newer versions of Node.js (8 or newer), calling an async function in a core module without the callback results in a deprecation notice.  Well, more than one...

```
Executing 1122 testcase(s) with 1 engine(s) using 4 thread(s), total 1085 task(s)
(node:2027) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:2027) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:2027) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:2027) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
... etc ...
```

This PR eliminates the torrent of warnings.  

