### PR TITLE
Use 'ECMAScript' spelling in src-input/

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3326,6 +3326,10 @@ Planned
 
 * Add Makefile.jsoncbor to the distributable (GH-1885)
 
+* Change spelling from Ecmascript to ECMAScript throughout the internal source
+  code; as far as external behavior is concerned this only affects a few
+  debug prints (GH-1894)
+
 * Fix potential dangling pointer use in Duktape thread termination handling;
   the dangling pointer could cause unsafe memory behavior (GH-1845, GH-1868)
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -57,10 +57,10 @@
 #
 # Property value format:
 #
-#    - Ecmascript undefined:
+#    - ECMAScript undefined:
 #      - type: undefined
 #    - Plain YAML/JSON null (parses as Python None)
-#      - treated as Ecmascript null
+#      - treated as ECMAScript null
 #    - Plain string:
 #      - treated as plain string, string data as with keys
 #    - Plain symbol:

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -400,7 +400,7 @@ DUK_EXTERNAL duk_bool_t duk_is_strict_call(duk_hthread *thr) {
 	 * because all Duktape/C functions are considered strict,
 	 * and strict is also the default when nothing is running.
 	 * However, Duktape may call this function internally when
-	 * the current activation is an Ecmascript function, so
+	 * the current activation is an ECMAScript function, so
 	 * this cannot be replaced by a 'return 1' without fixing
 	 * the internal call sites.
 	 */

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -8,7 +8,7 @@
  *  Property handling
  *
  *  The API exposes only the most common property handling functions.
- *  The caller can invoke Ecmascript built-ins for full control (e.g.
+ *  The caller can invoke ECMAScript built-ins for full control (e.g.
  *  defineProperty, getOwnPropertyDescriptor).
  */
 
@@ -566,7 +566,7 @@ DUK_EXTERNAL void duk_def_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_uint_t f
 /*
  *  Object related
  *
- *  Note: seal() and freeze() are accessible through Ecmascript bindings,
+ *  Note: seal() and freeze() are accessible through ECMAScript bindings,
  *  and are not exposed through the API.
  */
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -5438,7 +5438,7 @@ DUK_EXTERNAL duk_idx_t duk_push_error_object_va_raw(duk_hthread *thr, duk_errcod
 		duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	} else {
 		/* If no explicit message given, put error code into message field
-		 * (as a number).  This is not fully in keeping with the Ecmascript
+		 * (as a number).  This is not fully in keeping with the ECMAScript
 		 * error model because messages are supposed to be strings (Error
 		 * constructors use ToString() on their argument).  However, it's
 		 * probably more useful than having a separate 'code' property.

--- a/src-input/duk_api_time.c
+++ b/src-input/duk_api_time.c
@@ -5,7 +5,7 @@
 #include "duk_internal.h"
 
 DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr) {
-	/* Ecmascript time, with millisecond fractions.  Exposed via
+	/* ECMAScript time, with millisecond fractions.  Exposed via
 	 * duk_get_now() for example.
 	 */
 	DUK_UNREF(thr);
@@ -13,7 +13,7 @@ DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr) {
 }
 
 DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time_nofrac(duk_hthread *thr) {
-	/* Ecmascript time without millisecond fractions.  Exposed via
+	/* ECMAScript time without millisecond fractions.  Exposed via
 	 * the Date built-in which doesn't allow fractions.
 	 */
 	DUK_UNREF(thr);
@@ -56,7 +56,7 @@ DUK_EXTERNAL void duk_time_to_components(duk_hthread *thr, duk_double_t timeval,
 	DUK_UNREF(thr);
 
 	/* Convert as one-based, but change month to zero-based to match the
-	 * Ecmascript Date built-in behavior 1:1.
+	 * ECMAScript Date built-in behavior 1:1.
 	 */
 	flags = DUK_DATE_FLAG_ONEBASED | DUK_DATE_FLAG_NAN_TO_ZERO;
 

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -1,9 +1,9 @@
 /*
  *  Array built-ins
  *
- *  Most Array built-ins are intentionally generic in Ecmascript, and are
+ *  Most Array built-ins are intentionally generic in ECMAScript, and are
  *  intended to work even when the 'this' binding is not an Array instance.
- *  This Ecmascript feature is also used by much real world code.  For this
+ *  This ECMAScript feature is also used by much real world code.  For this
  *  reason the implementations here don't assume exotic Array behavior or
  *  e.g. presence of a .length property.  However, some algorithms have a
  *  fast path for duk_harray backed actual Array instances, enabled when

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -427,13 +427,13 @@ DUK_LOCAL duk_uint8_t duk__days_in_month[12] = {
 };
 
 /* Maximum iteration count for computing UTC-to-local time offset when
- * creating an Ecmascript time value from local parts.
+ * creating an ECMAScript time value from local parts.
  */
 #define DUK__LOCAL_TZOFFSET_MAXITER   4
 
 /* Because 'day since epoch' can be negative and is used to compute weekday
  * using a modulo operation, add this multiple of 7 to avoid negative values
- * when year is below 1970 epoch.  Ecmascript time values are restricted to
+ * when year is below 1970 epoch.  ECMAScript time values are restricted to
  * +/- 100 million days from epoch, so this adder fits nicely into 32 bits.
  * Round to a multiple of 7 (= floor(100000000 / 7) * 7) and add margin.
  */
@@ -624,10 +624,10 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 	d = DUK_FLOOR(d);  /* remove fractions if present */
 	DUK_ASSERT(DUK_FLOOR(d) == d);
 
-	/* The timevalue must be in valid Ecmascript range, but since a local
+	/* The timevalue must be in valid ECMAScript range, but since a local
 	 * time offset can be applied, we need to allow a +/- 24h leeway to
 	 * the value.  In other words, although the UTC time is within the
-	 * Ecmascript range, the local part values can be just outside of it.
+	 * ECMAScript range, the local part values can be just outside of it.
 	 */
 	DUK_UNREF(duk_bi_date_timeval_in_leeway_range);
 	DUK_ASSERT(duk_bi_date_timeval_in_leeway_range(d));
@@ -670,7 +670,7 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 	                     (long) parts[DUK_DATE_IDX_MILLISECOND]));
 
 	/* This assert depends on the input parts representing time inside
-	 * the Ecmascript range.
+	 * the ECMAScript range.
 	 */
 	DUK_ASSERT(t2 + DUK__WEEKDAY_MOD_ADDER >= 0);
 	parts[DUK_DATE_IDX_WEEKDAY] = (t2 + 4 + DUK__WEEKDAY_MOD_ADDER) % 7;  /* E5.1 Section 15.9.1.6 */
@@ -790,7 +790,7 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_timeval_from_dparts(duk_double_t *dpar
 	 * computation happens with intermediate results coerced to
 	 * double values (instead of using something more accurate).
 	 * E.g. E5.1 Section 15.9.1.11 requires use of IEEE 754
-	 * rules (= Ecmascript '+' and '*' operators).
+	 * rules (= ECMAScript '+' and '*' operators).
 	 *
 	 * Without 'volatile' even this approach fails on some platform
 	 * and compiler combinations.  For instance, gcc 4.8.1 on Ubuntu
@@ -1527,7 +1527,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor_now(duk_hthread *thr) {
  *  Notes:
  *
  *    - Date.prototype.toGMTString() and Date.prototype.toUTCString() are
- *      required to be the same Ecmascript function object (!), so it is
+ *      required to be the same ECMAScript function object (!), so it is
  *      omitted from here.
  *
  *    - Date.prototype.toUTCString(): E5.1 specification does not require a

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -15,7 +15,7 @@
 #define DUK__STRFTIME_BUF_SIZE  64
 
 #if defined(DUK_USE_DATE_NOW_GETTIMEOFDAY)
-/* Get current Ecmascript time (= UNIX/Posix time, but in milliseconds). */
+/* Get current ECMAScript time (= UNIX/Posix time, but in milliseconds). */
 DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(void) {
 	struct timeval tv;
 	duk_double_t d;
@@ -63,7 +63,7 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 		return 0;
 	}
 
-	/* If not within Ecmascript range, some integer time calculations
+	/* If not within ECMAScript range, some integer time calculations
 	 * won't work correctly (and some asserts will fail), so bail out
 	 * if so.  This fixes test-bug-date-insane-setyear.js.  There is
 	 * a +/- 24h leeway in this range check to avoid a test262 corner
@@ -114,10 +114,10 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 	 *  Since we rely on the platform APIs for conversions between local
 	 *  time and UTC, we can't guarantee the above.  Rather, if the platform
 	 *  has historical DST rules they will be applied.  This seems to be the
-	 *  general preferred direction in Ecmascript standardization (or at least
+	 *  general preferred direction in ECMAScript standardization (or at least
 	 *  implementations) anyway, and even the equivalent year mapping should
 	 *  be disabled if the platform is known to handle DST properly for the
-	 *  full Ecmascript range.
+	 *  full ECMAScript range.
 	 *
 	 *  The following has useful discussion and links:
 	 *
@@ -267,16 +267,16 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_
 
 	DUK_UNREF(tzoffset);
 
-	/* If the platform doesn't support the entire Ecmascript range, we need
+	/* If the platform doesn't support the entire ECMAScript range, we need
 	 * to return 0 so that the caller can fall back to the default formatter.
 	 *
-	 * For now, assume that if time_t is 8 bytes or more, the whole Ecmascript
+	 * For now, assume that if time_t is 8 bytes or more, the whole ECMAScript
 	 * range is supported.  For smaller time_t values (4 bytes in practice),
 	 * assumes that the signed 32-bit range is supported.
 	 *
 	 * XXX: detect this more correctly per platform.  The size of time_t is
 	 * probably not an accurate guarantee of strftime() supporting or not
-	 * supporting a large time range (the full Ecmascript range).
+	 * supporting a large time range (the full ECMAScript range).
 	 */
 	if (sizeof(time_t) < 8 &&
 	    (parts[DUK_DATE_IDX_YEAR] < 1970 || parts[DUK_DATE_IDX_YEAR] > 2037)) {

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -99,7 +99,7 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t d) {
 
 	/* XXX: handling of timestamps outside Windows supported range.
 	 * How does Windows deal with dates before 1600?  Does windows
-	 * support all Ecmascript years (like -200000 and +200000)?
+	 * support all ECMAScript years (like -200000 and +200000)?
 	 * Should equivalent year mapping be used here too?  If so, use
 	 * a shared helper (currently integrated into timeval-to-parts).
 	 */

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -3,7 +3,7 @@
  *
  *  Size optimization note: it might seem that vararg multipurpose functions
  *  like fin(), enc(), and dec() are not very size optimal, but using a single
- *  user-visible Ecmascript function saves a lot of run-time footprint; each
+ *  user-visible ECMAScript function saves a lot of run-time footprint; each
  *  Function instance takes >100 bytes.  Using a shared native helper and a
  *  'magic' value won't save much if there are multiple Function instances
  *  anyway.

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -392,14 +392,14 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 		DUK_ASSERT(duk_is_string(thr, 0));  /* True if len > 0. */
 
 		/* XXX: duk_decode_string() is used to process the input
-		 * string.  For standard Ecmascript strings, represented
+		 * string.  For standard ECMAScript strings, represented
 		 * internally as CESU-8, this is fine.  However, behavior
 		 * beyond CESU-8 is not very strict: codepoints using an
 		 * extended form of UTF-8 are also accepted, and invalid
 		 * codepoint sequences (which are allowed in Duktape strings)
 		 * are not handled as well as they could (e.g. invalid
 		 * continuation bytes may mask following codepoints).
-		 * This is how Ecmascript code would also see such strings.
+		 * This is how ECMAScript code would also see such strings.
 		 * Maybe replace duk_decode_string() with an explicit strict
 		 * CESU-8 decoder here?
 		 */
@@ -427,7 +427,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 
 	/* Standard WHATWG output is a Uint8Array.  Here the Uint8Array will
 	 * be backed by a dynamic buffer which differs from e.g. Uint8Arrays
-	 * created as 'new Uint8Array(N)'.  Ecmascript code won't see the
+	 * created as 'new Uint8Array(N)'.  ECMAScript code won't see the
 	 * difference but C code will.  When bufferobjects are not supported,
 	 * returns a plain dynamic buffer.
 	 */

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -159,7 +159,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 
 			if (t == DUK_TYPE_OBJECT || t == DUK_TYPE_LIGHTFUNC) {
 				/*
-				 *  Ecmascript/native function call or lightfunc call
+				 *  ECMAScript/native function call or lightfunc call
 				 */
 
 				count_func++;

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -413,7 +413,7 @@ DUK_LOCAL void duk__transform_callback_unescape(duk__transform_context *tfm_ctx,
  *  Eval needs to handle both a "direct eval" and an "indirect eval".
  *  Direct eval handling needs access to the caller's activation so that its
  *  lexical environment can be accessed.  A direct eval is only possible from
- *  Ecmascript code; an indirect eval call is possible also from C code.
+ *  ECMAScript code; an indirect eval call is possible also from C code.
  *  When an indirect eval call is made from C code, there may not be a
  *  calling activation at all which needs careful handling.
  */
@@ -452,7 +452,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_hthread *thr) {
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	/* NOTE: level is used only by the debugger and should never be present
-	 * for an Ecmascript eval().
+	 * for an ECMAScript eval().
 	 */
 	DUK_ASSERT(level == -2);  /* by default, use caller's environment */
 	if (duk_get_top(thr) >= 2 && duk_is_number(thr, 1)) {

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1298,9 +1298,9 @@ DUK_LOCAL void duk__enc_quote_string(duk_json_enc_ctx *js_ctx, duk_hstring *h_st
 				/* If XUTF-8 decoding fails, treat the offending byte as a codepoint directly
 				 * and go forward one byte.  This is of course very lossy, but allows some kind
 				 * of output to be produced even for internal strings which don't conform to
-				 * XUTF-8.  All standard Ecmascript strings are always CESU-8, so this behavior
-				 * does not violate the Ecmascript specification.  The behavior is applied to
-				 * all modes, including Ecmascript standard JSON.  Because the current XUTF-8
+				 * XUTF-8.  All standard ECMAScript strings are always CESU-8, so this behavior
+				 * does not violate the ECMAScript specification.  The behavior is applied to
+				 * all modes, including ECMAScript standard JSON.  Because the current XUTF-8
 				 * decoding is not very strict, this behavior only really affects initial bytes
 				 * and truncated codepoints.
 				 *

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -51,7 +51,7 @@ DUK_LOCAL duk_ret_t duk__math_minmax(duk_hthread *thr, duk_double_t initial, duk
 
 DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 	/* fmin() with args -0 and +0 is not guaranteed to return
-	 * -0 as Ecmascript requires.
+	 * -0 as ECMAScript requires.
 	 */
 	if (x == 0 && y == 0) {
 		duk_double_union du1, du2;
@@ -78,7 +78,7 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 
 DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 	/* fmax() with args -0 and +0 is not guaranteed to return
-	 * +0 as Ecmascript requires.
+	 * +0 as ECMAScript requires.
 	 */
 	if (x == 0 && y == 0) {
 		if (DUK_SIGNBIT(x) == 0 || DUK_SIGNBIT(y) == 0) {

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -514,7 +514,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 	DUK_ASSERT(duk_get_hobject(thr, 2) != NULL);
 
 	/*
-	 *  Validate and convert argument property descriptor (an Ecmascript
+	 *  Validate and convert argument property descriptor (an ECMAScript
 	 *  object) into a set of defprop_flags and possibly property value,
 	 *  getter, and/or setter values on the value stack.
 	 *

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -75,7 +75,7 @@ DUK_LOCAL duk_int_t duk__str_search_shared(duk_hthread *thr, duk_hstring *h_this
 	while (p <= p_end && p >= p_start) {
 		t = *p;
 
-		/* For Ecmascript strings, this check can only match for
+		/* For ECMAScript strings, this check can only match for
 		 * initial UTF-8 bytes (not continuation bytes).  For other
 		 * strings all bets are off.
 		 */

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -40,7 +40,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_hthread *thr) {
  *
  *  The thread must be in resumable state, either (a) new thread which hasn't
  *  yet started, or (b) a thread which has previously yielded.  This method
- *  must be called from an Ecmascript function.
+ *  must be called from an ECMAScript function.
  *
  *  Args:
  *    - thread
@@ -88,7 +88,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 
 	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
-		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be Ecmascript code"));
+		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be ECMAScript code"));
 		goto state_error;
 	}
 
@@ -116,7 +116,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 
 		DUK_ASSERT(thr_resume->state == DUK_HTHREAD_STATE_INACTIVE);
 
-		/* The initial function must be an Ecmascript function (but
+		/* The initial function must be an ECMAScript function (but
 		 * can be bound).  We must make sure of that before we longjmp
 		 * because an error in the RESUME handler call processing will
 		 * not be handled very cleanly.
@@ -195,7 +195,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
  *  The thread must be in yieldable state: it must have a resumer, and there
  *  must not be any yield-preventing calls (native calls and constructor calls,
  *  currently) in the thread's call stack (otherwise a resume would not be
- *  possible later).  This method must be called from an Ecmascript function.
+ *  possible later).  This method must be called from an ECMAScript function.
  *
  *  Args:
  *    - value
@@ -244,7 +244,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_hthread *thr) {
 
 	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
-		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be Ecmascript code"));
+		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be ECMAScript code"));
 		goto state_error;
 	}
 

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -35,7 +35,7 @@
  *      (excluding the null terminator).  If retval == buffer size,
  *      output was truncated (except for corner cases).
  *
- *    * Output format is intentionally different from Ecmascript
+ *    * Output format is intentionally different from ECMAScript
  *      formatting requirements, as formatting here serves debugging
  *      of internals.
  *

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1593,7 +1593,7 @@ DUK_LOCAL void duk__debug_handle_eval(duk_hthread *thr, duk_heap *heap) {
 			fun = DUK_ACT_GET_FUNC(act);
 			if (fun != NULL && DUK_HOBJECT_IS_COMPFUNC(fun)) {
 				/* Direct eval requires that there's a current
-				 * activation and it is an Ecmascript function.
+				 * activation and it is an ECMAScript function.
 				 * When Eval is executed from e.g. cooperate API
 				 * call we'll need to do an indirect eval instead.
 				 */
@@ -2736,7 +2736,7 @@ DUK_INTERNAL void duk_debug_halt_execution(duk_hthread *thr, duk_bool_t use_prev
 		fun = (duk_hcompfunc *) DUK_ACT_GET_FUNC(act);
 
 		/* Short circuit if is safe: if act->curr_pc != NULL, 'fun' is
-		 * guaranteed to be a non-NULL Ecmascript function.
+		 * guaranteed to be a non-NULL ECMAScript function.
 		 */
 		DUK_ASSERT(act->curr_pc == NULL ||
 		           (fun != NULL && DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) fun)));

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -20,8 +20,8 @@
  *  Error codes: defined in duktape.h
  *
  *  Error codes are used as a shorthand to throw exceptions from inside
- *  the implementation.  The appropriate Ecmascript object is constructed
- *  based on the code.  Ecmascript code throws objects directly.  The error
+ *  the implementation.  The appropriate ECMAScript object is constructed
+ *  based on the code.  ECMAScript code throws objects directly.  The error
  *  codes are defined in the public API header because they are also used
  *  by calling code.
  */

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -14,7 +14,7 @@
  *
  *  Error augmentation may throw an internal error (e.g. alloc error).
  *
- *  Ecmascript allows throwing any values, so all values cannot be
+ *  ECMAScript allows throwing any values, so all values cannot be
  *  augmented.  Currently, the built-in augmentation at error creation
  *  only augments error values which are Error instances (= have the
  *  built-in Error.prototype in their prototype chain) and are also

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -1,8 +1,8 @@
 /*
- *  Create and throw an Ecmascript error object based on a code and a message.
+ *  Create and throw an ECMAScript error object based on a code and a message.
  *
- *  Used when we throw errors internally.  Ecmascript generated error objects
- *  are created by Ecmascript code, and the throwing is handled by the bytecode
+ *  Used when we throw errors internally.  ECMAScript generated error objects
+ *  are created by ECMAScript code, and the throwing is handled by the bytecode
  *  executor.
  */
 

--- a/src-input/duk_hcompfunc.h
+++ b/src-input/duk_hcompfunc.h
@@ -1,7 +1,7 @@
 /*
- *  Heap compiled function (Ecmascript function) representation.
+ *  Heap compiled function (ECMAScript function) representation.
  *
- *  There is a single data buffer containing the Ecmascript function's
+ *  There is a single data buffer containing the ECMAScript function's
  *  bytecode, constants, and inner functions.
  */
 

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -1,12 +1,12 @@
 /*
  *  Heap object representation.
  *
- *  Heap objects are used for Ecmascript objects, arrays, and functions,
+ *  Heap objects are used for ECMAScript objects, arrays, and functions,
  *  but also for internal control like declarative and object environment
  *  records.  Compiled functions, native functions, and threads are also
  *  objects but with an extended C struct.
  *
- *  Objects provide the required Ecmascript semantics and exotic behaviors
+ *  Objects provide the required ECMAScript semantics and exotic behaviors
  *  especially for property access.
  *
  *  Properties are stored in three conceptual parts:
@@ -635,7 +635,7 @@
 #define DUK_HOBJECT_PROTOTYPE_CHAIN_SANITY      10000L
 
 /*
- *  Ecmascript [[Class]]
+ *  ECMAScript [[Class]]
  */
 
 /* range check not necessary because all 4-bit values are mapped */

--- a/src-input/duk_hobject_class.c
+++ b/src-input/duk_hobject_class.c
@@ -1,5 +1,5 @@
 /*
- *  Hobject Ecmascript [[Class]].
+ *  Hobject ECMAScript [[Class]].
  */
 
 #include "duk_internal.h"

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -643,7 +643,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_hthread *thr, duk_bool_t
 }
 
 /*
- *  Get enumerated keys in an Ecmascript array.  Matches Object.keys() behavior
+ *  Get enumerated keys in an ECMAScript array.  Matches Object.keys() behavior
  *  described in E5 Section 15.2.3.14.
  */
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -53,7 +53,7 @@
 #define DUK__HASH_DELETED               DUK_HOBJECT_HASHIDX_DELETED
 
 /* Valstack space that suffices for all local calls, excluding any recursion
- * into Ecmascript or Duktape/C calls (Proxy, getters, etc).
+ * into ECMAScript or Duktape/C calls (Proxy, getters, etc).
  */
 #define DUK__VALSTACK_SPACE             10
 
@@ -1615,7 +1615,7 @@ DUK_LOCAL void duk__check_arguments_map_for_delete(duk_hthread *thr, duk_hobject
 }
 
 /*
- *  Ecmascript compliant [[GetOwnProperty]](P), for internal use only.
+ *  ECMAScript compliant [[GetOwnProperty]](P), for internal use only.
  *
  *  If property is found:
  *    - Fills descriptor fields to 'out_desc'
@@ -1990,7 +1990,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_get_own_propdesc(duk_hthread *thr, duk_hobje
 }
 
 /*
- *  Ecmascript compliant [[GetProperty]](P), for internal use only.
+ *  ECMAScript compliant [[GetProperty]](P), for internal use only.
  *
  *  If property is found:
  *    - Fills descriptor fields to 'out_desc'
@@ -2329,7 +2329,7 @@ DUK_LOCAL duk_bool_t duk__putprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
- *  GETPROP: Ecmascript property read.
+ *  GETPROP: ECMAScript property read.
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key) {
@@ -2816,7 +2816,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 }
 
 /*
- *  HASPROP: Ecmascript property existence check ("in" operator).
+ *  HASPROP: ECMAScript property existence check ("in" operator).
  *
  *  Interestingly, the 'in' operator does not do any coercion of
  *  the target object.
@@ -3301,9 +3301,9 @@ DUK_LOCAL duk_bool_t duk__handle_put_array_length(duk_hthread *thr, duk_hobject 
 }
 
 /*
- *  PUTPROP: Ecmascript property write.
+ *  PUTPROP: ECMAScript property write.
  *
- *  Unlike Ecmascript primitive which returns nothing, returns 1 to indicate
+ *  Unlike ECMAScript primitive which returns nothing, returns 1 to indicate
  *  success and 0 to indicate failure (assuming throw is not set).
  *
  *  This is an extremely tricky function.  Some examples:
@@ -4254,7 +4254,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 }
 
 /*
- *  Ecmascript compliant [[Delete]](P, Throw).
+ *  ECMAScript compliant [[Delete]](P, Throw).
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_small_uint_t flags) {
@@ -4414,7 +4414,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 }
 
 /*
- *  DELPROP: Ecmascript property deletion.
+ *  DELPROP: ECMAScript property deletion.
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_bool_t throw_flag) {
@@ -4813,7 +4813,7 @@ DUK_INTERNAL duk_size_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *ob
 	val = duk_to_number_m1(thr);
 	duk_pop_3_unsafe(thr);
 
-	/* This isn't part of Ecmascript semantics; return a value within
+	/* This isn't part of ECMAScript semantics; return a value within
 	 * duk_size_t range, or 0 otherwise.
 	 */
 	if (val >= 0.0 && val <= (duk_double_t) DUK_SIZE_MAX) {
@@ -4924,7 +4924,7 @@ DUK_INTERNAL void duk_hobject_object_get_own_property_descriptor(duk_hthread *th
  *  NormalizePropertyDescriptor() related helper.
  *
  *  Internal helper which validates and normalizes a property descriptor
- *  represented as an Ecmascript object (e.g. argument to defineProperty()).
+ *  represented as an ECMAScript object (e.g. argument to defineProperty()).
  *  The output of this conversion is a set of defprop_flags and possibly
  *  some values pushed on the value stack to (1) ensure borrowed pointers
  *  remain valid, and (2) avoid unnecessary pops for footprint reasons.
@@ -5064,7 +5064,7 @@ void duk_hobject_prepare_property_descriptor(duk_hthread *thr,
  *
  *  Inlines all [[DefineOwnProperty]] exotic behaviors.
  *
- *  Note: Ecmascript compliant [[DefineOwnProperty]](P, Desc, Throw) is not
+ *  Note: ECMAScript compliant [[DefineOwnProperty]](P, Desc, Throw) is not
  *  implemented directly, but Object.defineProperty() serves its purpose.
  *  We don't need the [[DefineOwnProperty]] internally and we don't have a
  *  property descriptor with 'missing values' so it's easier to avoid it

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -8,7 +8,7 @@
  *  strings used as internal property names and raw buffers converted to
  *  strings.  In such cases the 'clen' field contains an inaccurate value.
  *
- *  Ecmascript requires support for 32-bit long strings.  However, since each
+ *  ECMAScript requires support for 32-bit long strings.  However, since each
  *  16-bit codepoint can take 3 bytes in CESU-8, this representation can only
  *  support about 1.4G codepoint long strings in extreme cases.  This is not
  *  really a practical issue.
@@ -32,7 +32,7 @@
 #define DUK_HSTRING_MAX_BYTELEN                     (0x7fffffffUL)
 #endif
 
-/* XXX: could add flags for "is valid CESU-8" (Ecmascript compatible strings),
+/* XXX: could add flags for "is valid CESU-8" (ECMAScript compatible strings),
  * "is valid UTF-8", "is valid extended UTF-8" (internal strings are not,
  * regexp bytecode is), and "contains non-BMP characters".  These are not
  * needed right now.

--- a/src-input/duk_hstring_misc.c
+++ b/src-input/duk_hstring_misc.c
@@ -33,7 +33,7 @@ DUK_INTERNAL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr, duk
 	                     (const void *) p_start, (const void *) p_end,
 	                     (const void *) p));
 
-	/* For invalid UTF-8 (never happens for standard Ecmascript strings)
+	/* For invalid UTF-8 (never happens for standard ECMAScript strings)
 	 * return U+FFFD replacement character.
 	 */
 	if (duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp1)) {

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -222,14 +222,14 @@ struct duk_activation {
 	duk_instr_t *curr_pc;   /* next instruction to execute (points to 'func' bytecode, stable pointer), NULL for native calls */
 
 	/* bottom_byteoff and retval_byteoff are only used for book-keeping
-	 * of Ecmascript-initiated calls, to allow returning to an Ecmascript
+	 * of ECMAScript-initiated calls, to allow returning to an ECMAScript
 	 * function properly.
 	 */
 
 	/* Bottom of valstack for this activation, used to reset
 	 * valstack_bottom on return; offset is absolute.  There's
 	 * no need to track 'top' because native call handling deals
-	 * with that using locals, and for Ecmascript returns 'nregs'
+	 * with that using locals, and for ECMAScript returns 'nregs'
 	 * indicates the necessary top.
 	 */
 	duk_size_t bottom_byteoff;

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript execution, support primitives.
+ *  ECMAScript execution, support primitives.
  */
 
 #if !defined(DUK_JS_H_INCLUDED)

--- a/src-input/duk_js_arith.c
+++ b/src-input/duk_js_arith.c
@@ -4,7 +4,7 @@
 
 #include "duk_internal.h"
 
-/* Ecmascript modulus ('%') does not match IEEE 754 "remainder" operation
+/* ECMAScript modulus ('%') does not match IEEE 754 "remainder" operation
  * (implemented by remainder() in C99) but does seem to match ANSI C fmod().
  * Compare E5 Section 11.5.3 and "man fmod".
  */
@@ -58,9 +58,9 @@ DUK_INTERNAL double duk_js_arith_mod(double d1, double d2) {
 
 /* Shared helper for Math.pow() and exponentiation operator. */
 DUK_INTERNAL double duk_js_arith_pow(double x, double y) {
-	/* The ANSI C pow() semantics differ from Ecmascript.
+	/* The ANSI C pow() semantics differ from ECMAScript.
 	 *
-	 * E.g. when x==1 and y is +/- infinite, the Ecmascript required
+	 * E.g. when x==1 and y is +/- infinite, the ECMAScript required
 	 * result is NaN, while at least Linux pow() returns 1.
 	 */
 

--- a/src-input/duk_js_bytecode.h
+++ b/src-input/duk_js_bytecode.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript bytecode
+ *  ECMAScript bytecode
  */
 
 #if !defined(DUK_JS_BYTECODE_H_INCLUDED)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -3,7 +3,7 @@
  *
  *  duk_handle_call_unprotected():
  *
- *    - Unprotected call to Ecmascript or Duktape/C function, from native
+ *    - Unprotected call to ECMAScript or Duktape/C function, from native
  *      code or bytecode executor.
  *
  *    - Also handles Ecma-to-Ecma calls which reuses a currently running
@@ -1682,10 +1682,10 @@ DUK_LOCAL void duk__call_setup_act_not_tailcall(duk_hthread *thr,
 		 *  Update return value stack index of current activation (if any).
 		 *
 		 *  Although it might seem this is not necessary (bytecode executor
-		 *  does this for Ecmascript-to-Ecmascript calls; other calls are
+		 *  does this for ECMAScript-to-ECMAScript calls; other calls are
 		 *  handled here), this turns out to be necessary for handling yield
-		 *  and resume.  For them, an Ecmascript-to-native call happens, and
-		 *  the Ecmascript call's retval_byteoff must be set for things to work.
+		 *  and resume.  For them, an ECMAScript-to-native call happens, and
+		 *  the ECMAScript call's retval_byteoff must be set for things to work.
 		 */
 
 		act->retval_byteoff = entry_valstack_bottom_byteoff + (duk_size_t) idx_func * sizeof(duk_tval);
@@ -1898,10 +1898,10 @@ DUK_LOCAL void duk__call_thread_state_update(duk_hthread *thr) {
 /*
  *  Main unprotected call handler, handles:
  *
- *    - All combinations of native/Ecmascript caller and native/Ecmascript
+ *    - All combinations of native/ECMAScript caller and native/ECMAScript
  *      target.
  *
- *    - Optimized Ecmascript-to-Ecmascript call where call handling only
+ *    - Optimized ECMAScript-to-ECMAScript call where call handling only
  *      sets up a new duk_activation but reuses an existing bytecode executor
  *      (the caller) without native recursion.
  *
@@ -1950,7 +1950,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	DUK_STATS_INC(thr->heap, stats_call_all);
 
 	/* If a tail call:
-	 *   - an Ecmascript activation must be on top of the callstack
+	 *   - an ECMAScript activation must be on top of the callstack
 	 *   - there cannot be any catch stack entries that would catch
 	 *     a return
 	 */
@@ -2102,7 +2102,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	 *  compiler; the compiled function's parent env will contain
 	 *  the (immutable) binding already.
 	 *
-	 *  This handling is now identical for C and Ecmascript functions.
+	 *  This handling is now identical for C and ECMAScript functions.
 	 *  C functions always have the 'NEWENV' flag set, so their
 	 *  environment record initialization is delayed (which is good).
 	 *
@@ -2149,7 +2149,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 
 	if (func != NULL && DUK_HOBJECT_IS_COMPFUNC(func)) {
 		/*
-		 *  Ecmascript call.
+		 *  ECMAScript call.
 		 */
 
 		DUK_ASSERT(func != NULL);
@@ -2334,7 +2334,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	 * calls caused by side effects (e.g. when doing a DUK_OP_GETPROP), see
 	 * GH-303.  Only needed for success path, error path always causes a
 	 * breakpoint recheck in the executor.  It would be enough to set this
-	 * only when returning to an Ecmascript activation, but setting the flag
+	 * only when returning to an ECMAScript activation, but setting the flag
 	 * on every return should have no ill effect.
 	 */
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
@@ -2817,7 +2817,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 /*
  *  Property-based call (foo.noSuch()) error setup: replace target function
  *  on stack top with a specially tagged (hidden Symbol) error which gets
- *  thrown in call handling at the proper spot to follow Ecmascript semantics.
+ *  thrown in call handling at the proper spot to follow ECMAScript semantics.
  */
 
 #if defined(DUK_USE_VERBOSE_ERRORS)

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript compiler.
+ *  ECMAScript compiler.
  *
  *  Parses an input string and generates a function template result.
  *  Compilation may happen in multiple contexts (global code, eval
@@ -2317,7 +2317,7 @@ DUK_LOCAL void duk__ivalue_toplain_raw(duk_compiler_ctx *comp_ctx, duk_ivalue *x
 				}
 			} else if (x->op == DUK_OP_ADD && DUK_TVAL_IS_STRING(tv1) && DUK_TVAL_IS_STRING(tv2)) {
 				/* Inline string concatenation.  No need to check for
-				 * symbols, as all inputs are valid Ecmascript strings.
+				 * symbols, as all inputs are valid ECMAScript strings.
 				 */
 				duk_dup(thr, x->x1.valstack_idx);
 				duk_dup(thr, x->x2.valstack_idx);
@@ -7829,7 +7829,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
  *  Compile input string into an executable function template without
  *  arguments.
  *
- *  The string is parsed as the "Program" production of Ecmascript E5.
+ *  The string is parsed as the "Program" production of ECMAScript E5.
  *  Compilation context can be either global code or eval code (see E5
  *  Sections 14 and 15.1.2.1).
  *

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript compiler.
+ *  ECMAScript compiler.
  */
 
 #if !defined(DUK_JS_COMPILER_H_INCLUDED)

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript bytecode executor.
+ *  ECMAScript bytecode executor.
  */
 
 #include "duk_internal.h"
@@ -774,7 +774,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr,
  * top are combined into one pass.
  */
 
-/* Reconfigure value stack for return to an Ecmascript function at
+/* Reconfigure value stack for return to an ECMAScript function at
  * callstack top (caller unwinds).
  */
 DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
@@ -790,7 +790,7 @@ DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
 
 	/* Clamp so that values at 'clamp_top' and above are wiped and won't
 	 * retain reachable garbage.  Then extend to 'nregs' because we're
-	 * returning to an Ecmascript function.
+	 * returning to an ECMAScript function.
 	 */
 
 	h_func = (duk_hcompfunc *) DUK_ACT_GET_FUNC(act);
@@ -806,7 +806,7 @@ DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
 	/* XXX: a best effort shrink check would be OK here */
 }
 
-/* Reconfigure value stack for an Ecmascript catcher.  Use topmost catcher
+/* Reconfigure value stack for an ECMAScript catcher.  Use topmost catcher
  * in 'act'.
  */
 DUK_LOCAL void duk__reconfig_valstack_ecma_catcher(duk_hthread *thr, duk_activation *act) {
@@ -1098,7 +1098,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		/* duk_bi_duk_object_yield() and duk_bi_duk_object_resume() ensure all of these are met */
 
 		DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);                                                         /* unchanged by Duktape.Thread.resume() */
-		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(thr->callstack_curr != NULL);
 		DUK_ASSERT(thr->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL &&
@@ -1116,7 +1116,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		DUK_ASSERT(resumee->state == DUK_HTHREAD_STATE_INACTIVE ||
 		           resumee->state == DUK_HTHREAD_STATE_YIELDED);                                                     /* checked by Duktape.Thread.resume() */
 		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_YIELDED ||
-		           resumee->callstack_top >= 2);                                                                     /* YIELDED: Ecmascript activation + Duktape.Thread.yield() activation */
+		           resumee->callstack_top >= 2);                                                                     /* YIELDED: ECMAScript activation + Duktape.Thread.yield() activation */
 		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_YIELDED ||
 		           (DUK_ACT_GET_FUNC(resumee->callstack_curr) != NULL &&
 		            DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(resumee->callstack_curr)) &&
@@ -1154,8 +1154,8 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 			goto check_longjmp;
 		} else if (resumee->state == DUK_HTHREAD_STATE_YIELDED) {
 			/* Unwind previous Duktape.Thread.yield() call.  The
-			 * activation remaining must always be an Ecmascript
-			 * call now (yield() accepts calls from Ecmascript
+			 * activation remaining must always be an ECMAScript
+			 * call now (yield() accepts calls from ECMAScript
 			 * only).
 			 */
 			duk_activation *act_resumee;
@@ -1163,7 +1163,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 			DUK_ASSERT(resumee->callstack_top >= 2);
 			act_resumee = resumee->callstack_curr;  /* Duktape.Thread.yield() */
 			DUK_ASSERT(act_resumee != NULL);
-			act_resumee = act_resumee->parent;      /* Ecmascript call site for yield() */
+			act_resumee = act_resumee->parent;      /* ECMAScript call site for yield() */
 			DUK_ASSERT(act_resumee != NULL);
 
 			tv = (duk_tval *) (void *) ((duk_uint8_t *) resumee->valstack + act_resumee->retval_byteoff);  /* return value from Duktape.Thread.yield() */
@@ -1234,7 +1234,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 	case DUK_LJ_TYPE_YIELD: {
 		/*
 		 *  Currently only allowed only if yielding thread has only
-		 *  Ecmascript activations (except for the Duktape.Thread.yield()
+		 *  ECMAScript activations (except for the Duktape.Thread.yield()
 		 *  call at the callstack top) and none of them constructor
 		 *  calls.
 		 *
@@ -1250,27 +1250,27 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		DUK_ASSERT(thr != entry_thread);                                                                             /* Duktape.Thread.yield() should prevent */
 #endif
 		DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);                                                         /* unchanged from Duktape.Thread.yield() */
-		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* Ecmascript activation + Duktape.Thread.yield() activation */
+		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* ECMAScript activation + Duktape.Thread.yield() activation */
 		DUK_ASSERT(thr->callstack_curr != NULL);
 		DUK_ASSERT(thr->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL &&
 		           DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)) &&
 		           ((duk_hnatfunc *) DUK_ACT_GET_FUNC(thr->callstack_curr))->func == duk_bi_thread_yield);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));                              /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));                              /* an ECMAScript function */
 
 		resumer = thr->resumer;
 
 		DUK_ASSERT(resumer != NULL);
 		DUK_ASSERT(resumer->state == DUK_HTHREAD_STATE_RESUMED);                                                     /* written by a previous RESUME handling */
-		DUK_ASSERT(resumer->callstack_top >= 2);                                                                     /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(resumer->callstack_top >= 2);                                                                     /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(resumer->callstack_curr != NULL);
 		DUK_ASSERT(resumer->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(resumer->callstack_curr) != NULL &&
 		           DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr)) &&
 		           ((duk_hnatfunc *) DUK_ACT_GET_FUNC(resumer->callstack_curr))->func == duk_bi_thread_resume);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent)));                            /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent)));                            /* an ECMAScript function */
 
 		if (thr->heap->lj.iserror) {
 			thr->state = DUK_HTHREAD_STATE_YIELDED;
@@ -1324,7 +1324,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		 *      resumer in this case.)
 		 *
 		 *  Note: until we hit the entry level, there can only be
-		 *  Ecmascript activations.
+		 *  ECMAScript activations.
 		 */
 
 		duk_activation *act;
@@ -1391,11 +1391,11 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		 */
 
 		DUK_ASSERT(thr->resumer != NULL);
-		DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(thr->resumer->callstack_curr != NULL);
 		DUK_ASSERT(thr->resumer->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an ECMAScript function */
 
 		resumer = thr->resumer;
 
@@ -1547,7 +1547,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	 *    2. The return happens at the entry level of the bytecode
 	 *       executor, so return from the executor (in C stack).
 	 *
-	 *    3. There is a calling (Ecmascript) activation in the call
+	 *    3. There is a calling (ECMAScript) activation in the call
 	 *       stack => return to it, in the same executor instance.
 	 *
 	 *    4. There is no calling activation, and the thread is
@@ -1592,10 +1592,10 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	}
 
 	if (thr->callstack_top >= 2) {
-		/* There is a caller; it MUST be an Ecmascript caller (otherwise it would
+		/* There is a caller; it MUST be an ECMAScript caller (otherwise it would
 		 * match entry_act check).
 		 */
-		DUK_DDD(DUK_DDDPRINT("return to Ecmascript caller, retval_byteoff=%ld, lj_value1=%!T",
+		DUK_DDD(DUK_DDDPRINT("return to ECMAScript caller, retval_byteoff=%ld, lj_value1=%!T",
 		                     (long) (thr->callstack_curr->parent->retval_byteoff),
 		                     (duk_tval *) &thr->heap->lj.value1));
 
@@ -1631,14 +1631,14 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	DUK_DD(DUK_DDPRINT("no calling activation, thread finishes (similar to yield)"));
 
 	DUK_ASSERT(thr->resumer != NULL);
-	DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* Ecmascript activation + Duktape.Thread.resume() activation */
+	DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* ECMAScript activation + Duktape.Thread.resume() activation */
 	DUK_ASSERT(thr->resumer->callstack_curr != NULL);
 	DUK_ASSERT(thr->resumer->callstack_curr->parent != NULL);
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr) != NULL &&
 			DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr)) &&
 			((duk_hnatfunc *) DUK_ACT_GET_FUNC(thr->resumer->callstack_curr))->func == duk_bi_thread_resume);  /* Duktape.Thread.resume() */
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent) != NULL &&
-			DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an Ecmascript function */
+			DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an ECMAScript function */
 	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
 	DUK_ASSERT(thr->resumer->state == DUK_HTHREAD_STATE_RESUMED);
 
@@ -1835,7 +1835,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 		if (diff_last < 0.0 || diff_last >= (duk_double_t) DUK_HEAP_DBG_RATELIMIT_MILLISECS) {
 			/* Monotonic time should not experience time jumps,
 			 * but the provider may be missing and we're actually
-			 * using Ecmascript time.  So, tolerate negative values
+			 * using ECMAScript time.  So, tolerate negative values
 			 * so that a time jump works reasonably.
 			 *
 			 * Same interval is now used for status sending and
@@ -2670,7 +2670,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
 }
 
 /*
- *  Ecmascript bytecode executor.
+ *  ECMAScript bytecode executor.
  *
  *  Resume execution for the current thread from its current activation.
  *  Returns when execution would return from the entry level activation,
@@ -2679,7 +2679,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
  *  a longjmp() with type DUK_LJ_TYPE_THROW is called on the entry level
  *  setjmp() jmpbuf.
  *
- *  Ecmascript function calls and coroutine resumptions are handled
+ *  ECMAScript function calls and coroutine resumptions are handled
  *  internally (by the outer executor function) without recursive C calls.
  *  Other function calls are handled using duk_handle_call(), increasing
  *  C recursion depth.

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1,7 +1,7 @@
 /*
- *  Ecmascript specification algorithm and conversion helpers.
+ *  ECMAScript specification algorithm and conversion helpers.
  *
- *  These helpers encapsulate the primitive Ecmascript operation semantics,
+ *  These helpers encapsulate the primitive ECMAScript operation semantics,
  *  and are used by the bytecode executor and the API (among other places).
  *  Some primitives are only implemented as part of the API and have no
  *  "internal" helper.  This is the case when an internal helper would not
@@ -433,7 +433,7 @@ DUK_LOCAL duk_bool_t duk__js_equals_number(duk_double_t x, duk_double_t y) {
 	return 0;
 #else  /* DUK_USE_PARANOID_MATH */
 	/* Better equivalent algorithm.  If the compiler is compliant, C and
-	 * Ecmascript semantics are identical for this particular comparison.
+	 * ECMAScript semantics are identical for this particular comparison.
 	 * In particular, NaNs must never compare equal and zeroes must compare
 	 * equal regardless of sign.  Could also use a macro, but this inlines
 	 * already nicely (no difference on gcc, for instance).
@@ -1061,7 +1061,7 @@ DUK_LOCAL duk_bool_t duk__js_instanceof_helper(duk_hthread *thr, duk_tval *tv_x,
 
 	if (!DUK_HOBJECT_IS_CALLABLE(func)) {
 		/*
-		 *  Note: of native Ecmascript objects, only Function instances
+		 *  Note: of native ECMAScript objects, only Function instances
 		 *  have a [[HasInstance]] internal property.  Custom objects might
 		 *  also have it, but not in current implementation.
 		 *

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -6,7 +6,7 @@
  *  be used for most identifier accesses.  Consequently, these slow path
  *  primitives should be optimized for maximum compactness.
  *
- *  Ecmascript environment records (declarative and object) are represented
+ *  ECMAScript environment records (declarative and object) are represented
  *  as internal objects with control keys.  Environment records have a
  *  parent record ("outer environment reference") which is represented by
  *  the implicit prototype for technical reasons (in other words, it is a
@@ -48,7 +48,7 @@ typedef struct {
  *  Create a new function object based on a "template function" which contains
  *  compiled bytecode, constants, etc, but lacks a lexical environment.
  *
- *  Ecmascript requires that each created closure is a separate object, with
+ *  ECMAScript requires that each created closure is a separate object, with
  *  its own set of editable properties.  However, structured property values
  *  (such as the formal arguments list and the variable map) are shared.
  *  Also the bytecode, constants, and inner functions are shared.

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -2,7 +2,7 @@
  *  Lexer for source files, ToNumber() string conversions, RegExp expressions,
  *  and JSON.
  *
- *  Provides a stream of Ecmascript tokens from an UTF-8/CESU-8 buffer.  The
+ *  Provides a stream of ECMAScript tokens from an UTF-8/CESU-8 buffer.  The
  *  caller can also rewind the token stream into a certain position which is
  *  needed by the compiler part for multi-pass scanning.  Tokens are
  *  represented as duk_token structures, and contain line number information.
@@ -25,14 +25,14 @@
  *
  *  Token parsing supports the full range of Unicode characters as described
  *  in the E5 specification.  Parsing has been optimized for ASCII characters
- *  because ordinary Ecmascript code consists almost entirely of ASCII
+ *  because ordinary ECMAScript code consists almost entirely of ASCII
  *  characters.  Matching of complex Unicode codepoint sets (such as in the
  *  IdentifierStart and IdentifierPart productions) is optimized for size,
  *  and is done using a linear scan of a bit-packed list of ranges.  This is
  *  very slow, but should never be entered unless the source code actually
  *  contains Unicode characters.
  *
- *  Ecmascript tokenization is partially context sensitive.  First,
+ *  ECMAScript tokenization is partially context sensitive.  First,
  *  additional future reserved words are recognized in strict mode (see E5
  *  Section 7.6.1.2).  Second, a forward slash character ('/') can be
  *  recognized either as starting a RegExp literal or as a division operator,
@@ -129,7 +129,7 @@
  *
  *    * In particular, surrogate pairs are allowed and not combined, which
  *      allows source files to represent all SourceCharacters with CESU-8.
- *      Broken surrogate pairs are allowed, as Ecmascript does not mandate
+ *      Broken surrogate pairs are allowed, as ECMAScript does not mandate
  *      their validation.
  *
  *    * Allow non-shortest UTF-8 encodings.
@@ -137,20 +137,20 @@
  *  Leniency here causes few security concerns because all character data is
  *  decoded into Unicode codepoints before lexer processing, and is then
  *  re-encoded into CESU-8.  The source can be parsed as strict UTF-8 with
- *  a compiler option.  However, Ecmascript source characters include -all-
+ *  a compiler option.  However, ECMAScript source characters include -all-
  *  16-bit unsigned integer codepoints, so leniency seems to be appropriate.
  *
  *  Note that codepoints above the BMP are not strictly SourceCharacters,
  *  but the lexer still accepts them as such.  Before ending up in a string
  *  or an identifier name, codepoints above BMP are converted into surrogate
  *  pairs and then CESU-8 encoded, resulting in 16-bit Unicode data as
- *  expected by Ecmascript.
+ *  expected by ECMAScript.
  *
  *  An alternative approach to dealing with invalid or partial sequences
  *  would be to skip them and replace them with e.g. the Unicode replacement
  *  character U+FFFD.  This has limited utility because a replacement character
  *  will most likely cause a parse error, unless it occurs inside a string.
- *  Further, Ecmascript source is typically pure ASCII.
+ *  Further, ECMAScript source is typically pure ASCII.
  *
  *  See:
  *
@@ -959,7 +959,7 @@ DUK_LOCAL void duk__lexer_skip_to_endofline(duk_lexer_ctx *lex_ctx) {
 }
 
 /*
- *  Parse Ecmascript source InputElementDiv or InputElementRegExp
+ *  Parse ECMAScript source InputElementDiv or InputElementRegExp
  *  (E5 Section 7), skipping whitespace, comments, and line terminators.
  *
  *  Possible results are:
@@ -986,13 +986,13 @@ DUK_LOCAL void duk__lexer_skip_to_endofline(duk_lexer_ctx *lex_ctx) {
  *  lookup window to quickly determine which production is the -longest-
  *  matching one, and then parse that.  The top-level if-else clauses
  *  match the first character, and the code blocks for each clause
- *  handle -all- alternatives for that first character.  Ecmascript
+ *  handle -all- alternatives for that first character.  ECMAScript
  *  specification uses the "longest match wins" semantics, so the order
  *  of the if-clauses matters.
  *
  *  Misc notes:
  *
- *    * Ecmascript numeric literals do not accept a sign character.
+ *    * ECMAScript numeric literals do not accept a sign character.
  *      Consequently e.g. "-1.0" is parsed as two tokens: a negative
  *      sign and a positive numeric literal.  The compiler performs
  *      the negation during compilation, so this has no adverse impact.
@@ -1502,7 +1502,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		 *  (the tokens DUK_TOK_GET and DUK_TOK_SET are actually not
 		 *  used now).  The compiler needs to work around this.
 		 *
-		 *  Strictly speaking, following Ecmascript longest match
+		 *  Strictly speaking, following ECMAScript longest match
 		 *  specification, an invalid escape for the first character
 		 *  should cause a syntax error.  However, an invalid escape
 		 *  for IdentifierParts should just terminate the identifier

--- a/src-input/duk_lexer.h
+++ b/src-input/duk_lexer.h
@@ -388,7 +388,7 @@ struct duk_lexer_codepoint {
 	duk_int_t line;
 };
 
-/* Lexer context.  Same context is used for Ecmascript and Regexp parsing. */
+/* Lexer context.  Same context is used for ECMAScript and Regexp parsing. */
 struct duk_lexer_ctx {
 #if defined(DUK_USE_LEXER_SLIDING_WINDOW)
 	duk_lexer_codepoint *window; /* unicode code points, window[0] is always next, points to 'buffer' */

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -1209,7 +1209,7 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	duk_uint8_t *buf;
 
 	/*
-	 *  The string conversion here incorporates all the necessary Ecmascript
+	 *  The string conversion here incorporates all the necessary ECMAScript
 	 *  semantics without attempting to be generic.  nc_ctx->digits contains
 	 *  nc_ctx->count digits (>= 1), with the topmost digit's 'position'
 	 *  indicated by nc_ctx->k as follows:
@@ -1220,11 +1220,11 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	 *    digits="123" count=3 k=-1  -->   0.0123
 	 *
 	 *  Note that the identifier names used for format selection are different
-	 *  in Burger-Dybvig paper and Ecmascript specification (quite confusingly
+	 *  in Burger-Dybvig paper and ECMAScript specification (quite confusingly
 	 *  so, because e.g. 'k' has a totally different meaning in each).  See
 	 *  documentation for discussion.
 	 *
-	 *  Ecmascript doesn't specify any specific behavior for format selection
+	 *  ECMAScript doesn't specify any specific behavior for format selection
 	 *  (e.g. when to use exponent notation) for non-base-10 numbers.
 	 *
 	 *  The bigint space in the context is reused for string output, as there
@@ -1308,7 +1308,7 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	/* Exponent */
 	if (expt != DUK__NO_EXP) {
 		/*
-		 *  Exponent notation for non-base-10 numbers isn't specified in Ecmascript
+		 *  Exponent notation for non-base-10 numbers isn't specified in ECMAScript
 		 *  specification, as it never explicitly turns up: non-decimal numbers can
 		 *  only be formatted with Number.prototype.toString([radix]) and for that,
 		 *  behavior is not explicitly specified.
@@ -1882,7 +1882,7 @@ DUK_INTERNAL void duk_numconv_parse(duk_hthread *thr, duk_small_int_t radix, duk
 	 *  accuracy, so that Dragon4 will generate enough binary output digits.
 	 *  For decimal numbers, this means generating a 20-digit significand,
 	 *  which should yield enough practical accuracy to parse IEEE doubles.
-	 *  In fact, the Ecmascript specification explicitly allows an
+	 *  In fact, the ECMAScript specification explicitly allows an
 	 *  implementation to treat digits beyond 20 as zeroes (and even
 	 *  to round the 20th digit upwards).  For non-decimal numbers, the
 	 *  appropriate number of digits has been precomputed for comparable

--- a/src-input/duk_numconv.h
+++ b/src-input/duk_numconv.h
@@ -1,6 +1,6 @@
 /*
  *  Number-to-string conversion.  The semantics of these is very tightly
- *  bound with the Ecmascript semantics required for call sites.
+ *  bound with the ECMAScript semantics required for call sites.
  */
 
 #if !defined(DUK_NUMCONV_H_INCLUDED)

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -1,7 +1,7 @@
 /*
  *  Regexp executor.
  *
- *  Safety: the Ecmascript executor should prevent user from reading and
+ *  Safety: the ECMAScript executor should prevent user from reading and
  *  replacing regexp bytecode.  Even so, the executor must validate all
  *  memory accesses etc.  When an invalid access is detected (e.g. a 'save'
  *  opcode to invalid, unallocated index) it should fail with an internal
@@ -855,7 +855,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		 *      internal/limit error occurs (which causes a longjmp())
 		 *
 		 *    - If we supported anchored matches, we would break out here
-		 *      unconditionally; however, Ecmascript regexps don't have anchored
+		 *      unconditionally; however, ECMAScript regexps don't have anchored
 		 *      matches.  It might make sense to implement a fast bail-out if
 		 *      the regexp begins with '^' and sp is not 0: currently we'll just
 		 *      run through the entire input string, trivially failing the match

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -141,7 +141,7 @@ DUK_INTERNAL duk_small_int_t duk_unicode_encode_cesu8(duk_ucodepoint_t cp, duk_u
 		/*
 		 *  Unicode codepoints above U+FFFF are encoded as surrogate
 		 *  pairs here.  This ensures that all CESU-8 codepoints are
-		 *  16-bit values as expected in Ecmascript.  The surrogate
+		 *  16-bit values as expected in ECMAScript.  The surrogate
 		 *  pairs always get a 3-byte encoding (each) in CESU-8.
 		 *  See: http://en.wikipedia.org/wiki/Surrogate_pair
 		 *

--- a/src-input/duk_unicode_tables.c
+++ b/src-input/duk_unicode_tables.c
@@ -9,7 +9,7 @@
  *  packed format.  These tables are used to match non-ASCII
  *  characters of complex productions by resorting to a linear
  *  range-by-range comparison.  This is very slow, but is expected
- *  to be very rare in practical Ecmascript source code, and thus
+ *  to be very rare in practical ECMAScript source code, and thus
  *  compactness is most important.
  *
  *  The tables are matched using uni_range_match() and the format

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -34,7 +34,7 @@
 
 /* Duktape version, (major * 10000) + (minor * 100) + patch.  Allows C code
  * to #if (DUK_VERSION >= NNN) against Duktape API version.  The same value
- * is also available to Ecmascript code in Duktape.version.  Unofficial
+ * is also available to ECMAScript code in Duktape.version.  Unofficial
  * development snapshots have 99 for patch level (e.g. 0.10.99 would be a
  * development version after 0.10.0 but before the next official release).
  */
@@ -42,7 +42,7 @@
 
 /* Git commit, describe, and branch for Duktape build.  Useful for
  * non-official snapshot builds so that application code can easily log
- * which Duktape snapshot was used.  Not available in the Ecmascript
+ * which Duktape snapshot was used.  Not available in the ECMAScript
  * environment.
  */
 #define DUK_GIT_COMMIT                    @GIT_COMMIT_CSTRING@
@@ -142,7 +142,7 @@ struct duk_number_list_entry {
 };
 
 struct duk_time_components {
-	duk_double_t year;          /* year, e.g. 2016, Ecmascript year range */
+	duk_double_t year;          /* year, e.g. 2016, ECMAScript year range */
 	duk_double_t month;         /* month: 1-12 */
 	duk_double_t day;           /* day: 1-31 */
 	duk_double_t hours;         /* hour: 0-59 */
@@ -178,12 +178,12 @@ struct duk_time_components {
 /* Value types, used by e.g. duk_get_type() */
 #define DUK_TYPE_MIN                      0U
 #define DUK_TYPE_NONE                     0U    /* no value, e.g. invalid index */
-#define DUK_TYPE_UNDEFINED                1U    /* Ecmascript undefined */
-#define DUK_TYPE_NULL                     2U    /* Ecmascript null */
-#define DUK_TYPE_BOOLEAN                  3U    /* Ecmascript boolean: 0 or 1 */
-#define DUK_TYPE_NUMBER                   4U    /* Ecmascript number: double */
-#define DUK_TYPE_STRING                   5U    /* Ecmascript string: CESU-8 / extended UTF-8 encoded */
-#define DUK_TYPE_OBJECT                   6U    /* Ecmascript object: includes objects, arrays, functions, threads */
+#define DUK_TYPE_UNDEFINED                1U    /* ECMAScript undefined */
+#define DUK_TYPE_NULL                     2U    /* ECMAScript null */
+#define DUK_TYPE_BOOLEAN                  3U    /* ECMAScript boolean: 0 or 1 */
+#define DUK_TYPE_NUMBER                   4U    /* ECMAScript number: double */
+#define DUK_TYPE_STRING                   5U    /* ECMAScript string: CESU-8 / extended UTF-8 encoded */
+#define DUK_TYPE_OBJECT                   6U    /* ECMAScript object: includes objects, arrays, functions, threads */
 #define DUK_TYPE_BUFFER                   7U    /* fixed or dynamic, garbage collected byte buffer */
 #define DUK_TYPE_POINTER                  8U    /* raw void pointer */
 #define DUK_TYPE_LIGHTFUNC                9U    /* lightweight function pointer */
@@ -1037,7 +1037,7 @@ DUK_EXTERNAL_DECL void duk_trim(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t idx, duk_size_t char_offset);
 
 /*
- *  Ecmascript operators
+ *  ECMAScript operators
  */
 
 DUK_EXTERNAL_DECL duk_bool_t duk_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
@@ -1201,7 +1201,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MSEC_HOUR            (60L * 60L * 1000L)
 #define DUK_DATE_MSEC_DAY             (24L * 60L * 60L * 1000L)
 
-/* Ecmascript date range is 100 million days from Epoch:
+/* ECMAScript date range is 100 million days from Epoch:
  * > 100e6 * 24 * 60 * 60 * 1000  // 100M days in millisecs
  * 8640000000000000
  * (= 8.64e15)
@@ -1209,7 +1209,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MSEC_100M_DAYS         (8.64e15)
 #define DUK_DATE_MSEC_100M_DAYS_LEEWAY  (8.64e15 + 24 * 3600e3)
 
-/* Ecmascript year range:
+/* ECMAScript year range:
  * > new Date(100e6 * 24 * 3600e3).toISOString()
  * '+275760-09-13T00:00:00.000Z'
  * > new Date(-100e6 * 24 * 3600e3).toISOString()
@@ -1219,7 +1219,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MAX_ECMA_YEAR     275760L
 
 /* Part indices for internal breakdowns.  Part order from DUK_DATE_IDX_YEAR
- * to DUK_DATE_IDX_MILLISECOND matches argument ordering of Ecmascript API
+ * to DUK_DATE_IDX_MILLISECOND matches argument ordering of ECMAScript API
  * calls (like Date constructor call).  Some functions in duk_bi_date.c
  * depend on the specific ordering, so change with care.  16 bits are not
  * enough for all parts (year, specifically).


### PR DESCRIPTION
Use 'ECMAScript' spelling in src-input, see #1892.