### PR TITLE
Use 'ECMAScript' spelling in website/

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3326,6 +3326,10 @@ Planned
 
 * Add Makefile.jsoncbor to the distributable (GH-1885)
 
+* Change spelling from Ecmascript to ECMAScript throughout the internal source
+  code; as far as external behavior is concerned this only affects a few
+  debug prints (GH-1894)
+
 * Fix potential dangling pointer use in Duktape thread termination handling;
   the dangling pointer could cause unsafe memory behavior (GH-1845, GH-1868)
 

--- a/src-input/builtins.yaml
+++ b/src-input/builtins.yaml
@@ -57,10 +57,10 @@
 #
 # Property value format:
 #
-#    - Ecmascript undefined:
+#    - ECMAScript undefined:
 #      - type: undefined
 #    - Plain YAML/JSON null (parses as Python None)
-#      - treated as Ecmascript null
+#      - treated as ECMAScript null
 #    - Plain string:
 #      - treated as plain string, string data as with keys
 #    - Plain symbol:

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -400,7 +400,7 @@ DUK_EXTERNAL duk_bool_t duk_is_strict_call(duk_hthread *thr) {
 	 * because all Duktape/C functions are considered strict,
 	 * and strict is also the default when nothing is running.
 	 * However, Duktape may call this function internally when
-	 * the current activation is an Ecmascript function, so
+	 * the current activation is an ECMAScript function, so
 	 * this cannot be replaced by a 'return 1' without fixing
 	 * the internal call sites.
 	 */

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -8,7 +8,7 @@
  *  Property handling
  *
  *  The API exposes only the most common property handling functions.
- *  The caller can invoke Ecmascript built-ins for full control (e.g.
+ *  The caller can invoke ECMAScript built-ins for full control (e.g.
  *  defineProperty, getOwnPropertyDescriptor).
  */
 
@@ -566,7 +566,7 @@ DUK_EXTERNAL void duk_def_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_uint_t f
 /*
  *  Object related
  *
- *  Note: seal() and freeze() are accessible through Ecmascript bindings,
+ *  Note: seal() and freeze() are accessible through ECMAScript bindings,
  *  and are not exposed through the API.
  */
 

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -5438,7 +5438,7 @@ DUK_EXTERNAL duk_idx_t duk_push_error_object_va_raw(duk_hthread *thr, duk_errcod
 		duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_MESSAGE, DUK_PROPDESC_FLAGS_WC);
 	} else {
 		/* If no explicit message given, put error code into message field
-		 * (as a number).  This is not fully in keeping with the Ecmascript
+		 * (as a number).  This is not fully in keeping with the ECMAScript
 		 * error model because messages are supposed to be strings (Error
 		 * constructors use ToString() on their argument).  However, it's
 		 * probably more useful than having a separate 'code' property.

--- a/src-input/duk_api_time.c
+++ b/src-input/duk_api_time.c
@@ -5,7 +5,7 @@
 #include "duk_internal.h"
 
 DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr) {
-	/* Ecmascript time, with millisecond fractions.  Exposed via
+	/* ECMAScript time, with millisecond fractions.  Exposed via
 	 * duk_get_now() for example.
 	 */
 	DUK_UNREF(thr);
@@ -13,7 +13,7 @@ DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time(duk_hthread *thr) {
 }
 
 DUK_INTERNAL duk_double_t duk_time_get_ecmascript_time_nofrac(duk_hthread *thr) {
-	/* Ecmascript time without millisecond fractions.  Exposed via
+	/* ECMAScript time without millisecond fractions.  Exposed via
 	 * the Date built-in which doesn't allow fractions.
 	 */
 	DUK_UNREF(thr);
@@ -56,7 +56,7 @@ DUK_EXTERNAL void duk_time_to_components(duk_hthread *thr, duk_double_t timeval,
 	DUK_UNREF(thr);
 
 	/* Convert as one-based, but change month to zero-based to match the
-	 * Ecmascript Date built-in behavior 1:1.
+	 * ECMAScript Date built-in behavior 1:1.
 	 */
 	flags = DUK_DATE_FLAG_ONEBASED | DUK_DATE_FLAG_NAN_TO_ZERO;
 

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -1,9 +1,9 @@
 /*
  *  Array built-ins
  *
- *  Most Array built-ins are intentionally generic in Ecmascript, and are
+ *  Most Array built-ins are intentionally generic in ECMAScript, and are
  *  intended to work even when the 'this' binding is not an Array instance.
- *  This Ecmascript feature is also used by much real world code.  For this
+ *  This ECMAScript feature is also used by much real world code.  For this
  *  reason the implementations here don't assume exotic Array behavior or
  *  e.g. presence of a .length property.  However, some algorithms have a
  *  fast path for duk_harray backed actual Array instances, enabled when

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -427,13 +427,13 @@ DUK_LOCAL duk_uint8_t duk__days_in_month[12] = {
 };
 
 /* Maximum iteration count for computing UTC-to-local time offset when
- * creating an Ecmascript time value from local parts.
+ * creating an ECMAScript time value from local parts.
  */
 #define DUK__LOCAL_TZOFFSET_MAXITER   4
 
 /* Because 'day since epoch' can be negative and is used to compute weekday
  * using a modulo operation, add this multiple of 7 to avoid negative values
- * when year is below 1970 epoch.  Ecmascript time values are restricted to
+ * when year is below 1970 epoch.  ECMAScript time values are restricted to
  * +/- 100 million days from epoch, so this adder fits nicely into 32 bits.
  * Round to a multiple of 7 (= floor(100000000 / 7) * 7) and add margin.
  */
@@ -624,10 +624,10 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 	d = DUK_FLOOR(d);  /* remove fractions if present */
 	DUK_ASSERT(DUK_FLOOR(d) == d);
 
-	/* The timevalue must be in valid Ecmascript range, but since a local
+	/* The timevalue must be in valid ECMAScript range, but since a local
 	 * time offset can be applied, we need to allow a +/- 24h leeway to
 	 * the value.  In other words, although the UTC time is within the
-	 * Ecmascript range, the local part values can be just outside of it.
+	 * ECMAScript range, the local part values can be just outside of it.
 	 */
 	DUK_UNREF(duk_bi_date_timeval_in_leeway_range);
 	DUK_ASSERT(duk_bi_date_timeval_in_leeway_range(d));
@@ -670,7 +670,7 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 	                     (long) parts[DUK_DATE_IDX_MILLISECOND]));
 
 	/* This assert depends on the input parts representing time inside
-	 * the Ecmascript range.
+	 * the ECMAScript range.
 	 */
 	DUK_ASSERT(t2 + DUK__WEEKDAY_MOD_ADDER >= 0);
 	parts[DUK_DATE_IDX_WEEKDAY] = (t2 + 4 + DUK__WEEKDAY_MOD_ADDER) % 7;  /* E5.1 Section 15.9.1.6 */
@@ -790,7 +790,7 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_timeval_from_dparts(duk_double_t *dpar
 	 * computation happens with intermediate results coerced to
 	 * double values (instead of using something more accurate).
 	 * E.g. E5.1 Section 15.9.1.11 requires use of IEEE 754
-	 * rules (= Ecmascript '+' and '*' operators).
+	 * rules (= ECMAScript '+' and '*' operators).
 	 *
 	 * Without 'volatile' even this approach fails on some platform
 	 * and compiler combinations.  For instance, gcc 4.8.1 on Ubuntu
@@ -1527,7 +1527,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor_now(duk_hthread *thr) {
  *  Notes:
  *
  *    - Date.prototype.toGMTString() and Date.prototype.toUTCString() are
- *      required to be the same Ecmascript function object (!), so it is
+ *      required to be the same ECMAScript function object (!), so it is
  *      omitted from here.
  *
  *    - Date.prototype.toUTCString(): E5.1 specification does not require a

--- a/src-input/duk_bi_date_unix.c
+++ b/src-input/duk_bi_date_unix.c
@@ -15,7 +15,7 @@
 #define DUK__STRFTIME_BUF_SIZE  64
 
 #if defined(DUK_USE_DATE_NOW_GETTIMEOFDAY)
-/* Get current Ecmascript time (= UNIX/Posix time, but in milliseconds). */
+/* Get current ECMAScript time (= UNIX/Posix time, but in milliseconds). */
 DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(void) {
 	struct timeval tv;
 	duk_double_t d;
@@ -63,7 +63,7 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 		return 0;
 	}
 
-	/* If not within Ecmascript range, some integer time calculations
+	/* If not within ECMAScript range, some integer time calculations
 	 * won't work correctly (and some asserts will fail), so bail out
 	 * if so.  This fixes test-bug-date-insane-setyear.js.  There is
 	 * a +/- 24h leeway in this range check to avoid a test262 corner
@@ -114,10 +114,10 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_gmtime(duk_double_t d) {
 	 *  Since we rely on the platform APIs for conversions between local
 	 *  time and UTC, we can't guarantee the above.  Rather, if the platform
 	 *  has historical DST rules they will be applied.  This seems to be the
-	 *  general preferred direction in Ecmascript standardization (or at least
+	 *  general preferred direction in ECMAScript standardization (or at least
 	 *  implementations) anyway, and even the equivalent year mapping should
 	 *  be disabled if the platform is known to handle DST properly for the
-	 *  full Ecmascript range.
+	 *  full ECMAScript range.
 	 *
 	 *  The following has useful discussion and links:
 	 *
@@ -267,16 +267,16 @@ DUK_INTERNAL duk_bool_t duk_bi_date_format_parts_strftime(duk_hthread *thr, duk_
 
 	DUK_UNREF(tzoffset);
 
-	/* If the platform doesn't support the entire Ecmascript range, we need
+	/* If the platform doesn't support the entire ECMAScript range, we need
 	 * to return 0 so that the caller can fall back to the default formatter.
 	 *
-	 * For now, assume that if time_t is 8 bytes or more, the whole Ecmascript
+	 * For now, assume that if time_t is 8 bytes or more, the whole ECMAScript
 	 * range is supported.  For smaller time_t values (4 bytes in practice),
 	 * assumes that the signed 32-bit range is supported.
 	 *
 	 * XXX: detect this more correctly per platform.  The size of time_t is
 	 * probably not an accurate guarantee of strftime() supporting or not
-	 * supporting a large time range (the full Ecmascript range).
+	 * supporting a large time range (the full ECMAScript range).
 	 */
 	if (sizeof(time_t) < 8 &&
 	    (parts[DUK_DATE_IDX_YEAR] < 1970 || parts[DUK_DATE_IDX_YEAR] > 2037)) {

--- a/src-input/duk_bi_date_windows.c
+++ b/src-input/duk_bi_date_windows.c
@@ -99,7 +99,7 @@ DUK_INTERNAL duk_int_t duk_bi_date_get_local_tzoffset_windows(duk_double_t d) {
 
 	/* XXX: handling of timestamps outside Windows supported range.
 	 * How does Windows deal with dates before 1600?  Does windows
-	 * support all Ecmascript years (like -200000 and +200000)?
+	 * support all ECMAScript years (like -200000 and +200000)?
 	 * Should equivalent year mapping be used here too?  If so, use
 	 * a shared helper (currently integrated into timeval-to-parts).
 	 */

--- a/src-input/duk_bi_duktape.c
+++ b/src-input/duk_bi_duktape.c
@@ -3,7 +3,7 @@
  *
  *  Size optimization note: it might seem that vararg multipurpose functions
  *  like fin(), enc(), and dec() are not very size optimal, but using a single
- *  user-visible Ecmascript function saves a lot of run-time footprint; each
+ *  user-visible ECMAScript function saves a lot of run-time footprint; each
  *  Function instance takes >100 bytes.  Using a shared native helper and a
  *  'magic' value won't save much if there are multiple Function instances
  *  anyway.

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -392,14 +392,14 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 		DUK_ASSERT(duk_is_string(thr, 0));  /* True if len > 0. */
 
 		/* XXX: duk_decode_string() is used to process the input
-		 * string.  For standard Ecmascript strings, represented
+		 * string.  For standard ECMAScript strings, represented
 		 * internally as CESU-8, this is fine.  However, behavior
 		 * beyond CESU-8 is not very strict: codepoints using an
 		 * extended form of UTF-8 are also accepted, and invalid
 		 * codepoint sequences (which are allowed in Duktape strings)
 		 * are not handled as well as they could (e.g. invalid
 		 * continuation bytes may mask following codepoints).
-		 * This is how Ecmascript code would also see such strings.
+		 * This is how ECMAScript code would also see such strings.
 		 * Maybe replace duk_decode_string() with an explicit strict
 		 * CESU-8 decoder here?
 		 */
@@ -427,7 +427,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 
 	/* Standard WHATWG output is a Uint8Array.  Here the Uint8Array will
 	 * be backed by a dynamic buffer which differs from e.g. Uint8Arrays
-	 * created as 'new Uint8Array(N)'.  Ecmascript code won't see the
+	 * created as 'new Uint8Array(N)'.  ECMAScript code won't see the
 	 * difference but C code will.  When bufferobjects are not supported,
 	 * returns a plain dynamic buffer.
 	 */

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -159,7 +159,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 
 			if (t == DUK_TYPE_OBJECT || t == DUK_TYPE_LIGHTFUNC) {
 				/*
-				 *  Ecmascript/native function call or lightfunc call
+				 *  ECMAScript/native function call or lightfunc call
 				 */
 
 				count_func++;

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -413,7 +413,7 @@ DUK_LOCAL void duk__transform_callback_unescape(duk__transform_context *tfm_ctx,
  *  Eval needs to handle both a "direct eval" and an "indirect eval".
  *  Direct eval handling needs access to the caller's activation so that its
  *  lexical environment can be accessed.  A direct eval is only possible from
- *  Ecmascript code; an indirect eval call is possible also from C code.
+ *  ECMAScript code; an indirect eval call is possible also from C code.
  *  When an indirect eval call is made from C code, there may not be a
  *  calling activation at all which needs careful handling.
  */
@@ -452,7 +452,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_hthread *thr) {
 
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
 	/* NOTE: level is used only by the debugger and should never be present
-	 * for an Ecmascript eval().
+	 * for an ECMAScript eval().
 	 */
 	DUK_ASSERT(level == -2);  /* by default, use caller's environment */
 	if (duk_get_top(thr) >= 2 && duk_is_number(thr, 1)) {

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -1298,9 +1298,9 @@ DUK_LOCAL void duk__enc_quote_string(duk_json_enc_ctx *js_ctx, duk_hstring *h_st
 				/* If XUTF-8 decoding fails, treat the offending byte as a codepoint directly
 				 * and go forward one byte.  This is of course very lossy, but allows some kind
 				 * of output to be produced even for internal strings which don't conform to
-				 * XUTF-8.  All standard Ecmascript strings are always CESU-8, so this behavior
-				 * does not violate the Ecmascript specification.  The behavior is applied to
-				 * all modes, including Ecmascript standard JSON.  Because the current XUTF-8
+				 * XUTF-8.  All standard ECMAScript strings are always CESU-8, so this behavior
+				 * does not violate the ECMAScript specification.  The behavior is applied to
+				 * all modes, including ECMAScript standard JSON.  Because the current XUTF-8
 				 * decoding is not very strict, this behavior only really affects initial bytes
 				 * and truncated codepoints.
 				 *

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -51,7 +51,7 @@ DUK_LOCAL duk_ret_t duk__math_minmax(duk_hthread *thr, duk_double_t initial, duk
 
 DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 	/* fmin() with args -0 and +0 is not guaranteed to return
-	 * -0 as Ecmascript requires.
+	 * -0 as ECMAScript requires.
 	 */
 	if (x == 0 && y == 0) {
 		duk_double_union du1, du2;
@@ -78,7 +78,7 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 
 DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 	/* fmax() with args -0 and +0 is not guaranteed to return
-	 * +0 as Ecmascript requires.
+	 * +0 as ECMAScript requires.
 	 */
 	if (x == 0 && y == 0) {
 		if (DUK_SIGNBIT(x) == 0 || DUK_SIGNBIT(y) == 0) {

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -514,7 +514,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_property(duk_hthread *th
 	DUK_ASSERT(duk_get_hobject(thr, 2) != NULL);
 
 	/*
-	 *  Validate and convert argument property descriptor (an Ecmascript
+	 *  Validate and convert argument property descriptor (an ECMAScript
 	 *  object) into a set of defprop_flags and possibly property value,
 	 *  getter, and/or setter values on the value stack.
 	 *

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -75,7 +75,7 @@ DUK_LOCAL duk_int_t duk__str_search_shared(duk_hthread *thr, duk_hstring *h_this
 	while (p <= p_end && p >= p_start) {
 		t = *p;
 
-		/* For Ecmascript strings, this check can only match for
+		/* For ECMAScript strings, this check can only match for
 		 * initial UTF-8 bytes (not continuation bytes).  For other
 		 * strings all bets are off.
 		 */

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -40,7 +40,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_constructor(duk_hthread *thr) {
  *
  *  The thread must be in resumable state, either (a) new thread which hasn't
  *  yet started, or (b) a thread which has previously yielded.  This method
- *  must be called from an Ecmascript function.
+ *  must be called from an ECMAScript function.
  *
  *  Args:
  *    - thread
@@ -88,7 +88,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 
 	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
-		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be Ecmascript code"));
+		DUK_DD(DUK_DDPRINT("resume state invalid: caller must be ECMAScript code"));
 		goto state_error;
 	}
 
@@ -116,7 +116,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 
 		DUK_ASSERT(thr_resume->state == DUK_HTHREAD_STATE_INACTIVE);
 
-		/* The initial function must be an Ecmascript function (but
+		/* The initial function must be an ECMAScript function (but
 		 * can be bound).  We must make sure of that before we longjmp
 		 * because an error in the RESUME handler call processing will
 		 * not be handled very cleanly.
@@ -195,7 +195,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
  *  The thread must be in yieldable state: it must have a resumer, and there
  *  must not be any yield-preventing calls (native calls and constructor calls,
  *  currently) in the thread's call stack (otherwise a resume would not be
- *  possible later).  This method must be called from an Ecmascript function.
+ *  possible later).  This method must be called from an ECMAScript function.
  *
  *  Args:
  *    - value
@@ -244,7 +244,7 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_yield(duk_hthread *thr) {
 
 	caller_func = DUK_ACT_GET_FUNC(thr->callstack_curr->parent);
 	if (!DUK_HOBJECT_IS_COMPFUNC(caller_func)) {
-		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be Ecmascript code"));
+		DUK_DD(DUK_DDPRINT("yield state invalid: caller must be ECMAScript code"));
 		goto state_error;
 	}
 

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -35,7 +35,7 @@
  *      (excluding the null terminator).  If retval == buffer size,
  *      output was truncated (except for corner cases).
  *
- *    * Output format is intentionally different from Ecmascript
+ *    * Output format is intentionally different from ECMAScript
  *      formatting requirements, as formatting here serves debugging
  *      of internals.
  *

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1593,7 +1593,7 @@ DUK_LOCAL void duk__debug_handle_eval(duk_hthread *thr, duk_heap *heap) {
 			fun = DUK_ACT_GET_FUNC(act);
 			if (fun != NULL && DUK_HOBJECT_IS_COMPFUNC(fun)) {
 				/* Direct eval requires that there's a current
-				 * activation and it is an Ecmascript function.
+				 * activation and it is an ECMAScript function.
 				 * When Eval is executed from e.g. cooperate API
 				 * call we'll need to do an indirect eval instead.
 				 */
@@ -2736,7 +2736,7 @@ DUK_INTERNAL void duk_debug_halt_execution(duk_hthread *thr, duk_bool_t use_prev
 		fun = (duk_hcompfunc *) DUK_ACT_GET_FUNC(act);
 
 		/* Short circuit if is safe: if act->curr_pc != NULL, 'fun' is
-		 * guaranteed to be a non-NULL Ecmascript function.
+		 * guaranteed to be a non-NULL ECMAScript function.
 		 */
 		DUK_ASSERT(act->curr_pc == NULL ||
 		           (fun != NULL && DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) fun)));

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -20,8 +20,8 @@
  *  Error codes: defined in duktape.h
  *
  *  Error codes are used as a shorthand to throw exceptions from inside
- *  the implementation.  The appropriate Ecmascript object is constructed
- *  based on the code.  Ecmascript code throws objects directly.  The error
+ *  the implementation.  The appropriate ECMAScript object is constructed
+ *  based on the code.  ECMAScript code throws objects directly.  The error
  *  codes are defined in the public API header because they are also used
  *  by calling code.
  */

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -14,7 +14,7 @@
  *
  *  Error augmentation may throw an internal error (e.g. alloc error).
  *
- *  Ecmascript allows throwing any values, so all values cannot be
+ *  ECMAScript allows throwing any values, so all values cannot be
  *  augmented.  Currently, the built-in augmentation at error creation
  *  only augments error values which are Error instances (= have the
  *  built-in Error.prototype in their prototype chain) and are also

--- a/src-input/duk_error_throw.c
+++ b/src-input/duk_error_throw.c
@@ -1,8 +1,8 @@
 /*
- *  Create and throw an Ecmascript error object based on a code and a message.
+ *  Create and throw an ECMAScript error object based on a code and a message.
  *
- *  Used when we throw errors internally.  Ecmascript generated error objects
- *  are created by Ecmascript code, and the throwing is handled by the bytecode
+ *  Used when we throw errors internally.  ECMAScript generated error objects
+ *  are created by ECMAScript code, and the throwing is handled by the bytecode
  *  executor.
  */
 

--- a/src-input/duk_hcompfunc.h
+++ b/src-input/duk_hcompfunc.h
@@ -1,7 +1,7 @@
 /*
- *  Heap compiled function (Ecmascript function) representation.
+ *  Heap compiled function (ECMAScript function) representation.
  *
- *  There is a single data buffer containing the Ecmascript function's
+ *  There is a single data buffer containing the ECMAScript function's
  *  bytecode, constants, and inner functions.
  */
 

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -1,12 +1,12 @@
 /*
  *  Heap object representation.
  *
- *  Heap objects are used for Ecmascript objects, arrays, and functions,
+ *  Heap objects are used for ECMAScript objects, arrays, and functions,
  *  but also for internal control like declarative and object environment
  *  records.  Compiled functions, native functions, and threads are also
  *  objects but with an extended C struct.
  *
- *  Objects provide the required Ecmascript semantics and exotic behaviors
+ *  Objects provide the required ECMAScript semantics and exotic behaviors
  *  especially for property access.
  *
  *  Properties are stored in three conceptual parts:
@@ -635,7 +635,7 @@
 #define DUK_HOBJECT_PROTOTYPE_CHAIN_SANITY      10000L
 
 /*
- *  Ecmascript [[Class]]
+ *  ECMAScript [[Class]]
  */
 
 /* range check not necessary because all 4-bit values are mapped */

--- a/src-input/duk_hobject_class.c
+++ b/src-input/duk_hobject_class.c
@@ -1,5 +1,5 @@
 /*
- *  Hobject Ecmascript [[Class]].
+ *  Hobject ECMAScript [[Class]].
  */
 
 #include "duk_internal.h"

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -643,7 +643,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_hthread *thr, duk_bool_t
 }
 
 /*
- *  Get enumerated keys in an Ecmascript array.  Matches Object.keys() behavior
+ *  Get enumerated keys in an ECMAScript array.  Matches Object.keys() behavior
  *  described in E5 Section 15.2.3.14.
  */
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -53,7 +53,7 @@
 #define DUK__HASH_DELETED               DUK_HOBJECT_HASHIDX_DELETED
 
 /* Valstack space that suffices for all local calls, excluding any recursion
- * into Ecmascript or Duktape/C calls (Proxy, getters, etc).
+ * into ECMAScript or Duktape/C calls (Proxy, getters, etc).
  */
 #define DUK__VALSTACK_SPACE             10
 
@@ -1615,7 +1615,7 @@ DUK_LOCAL void duk__check_arguments_map_for_delete(duk_hthread *thr, duk_hobject
 }
 
 /*
- *  Ecmascript compliant [[GetOwnProperty]](P), for internal use only.
+ *  ECMAScript compliant [[GetOwnProperty]](P), for internal use only.
  *
  *  If property is found:
  *    - Fills descriptor fields to 'out_desc'
@@ -1990,7 +1990,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_get_own_propdesc(duk_hthread *thr, duk_hobje
 }
 
 /*
- *  Ecmascript compliant [[GetProperty]](P), for internal use only.
+ *  ECMAScript compliant [[GetProperty]](P), for internal use only.
  *
  *  If property is found:
  *    - Fills descriptor fields to 'out_desc'
@@ -2329,7 +2329,7 @@ DUK_LOCAL duk_bool_t duk__putprop_fastpath_bufobj_tval(duk_hthread *thr, duk_hob
 #endif  /* DUK_USE_BUFFEROBJECT_SUPPORT */
 
 /*
- *  GETPROP: Ecmascript property read.
+ *  GETPROP: ECMAScript property read.
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key) {
@@ -2816,7 +2816,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 }
 
 /*
- *  HASPROP: Ecmascript property existence check ("in" operator).
+ *  HASPROP: ECMAScript property existence check ("in" operator).
  *
  *  Interestingly, the 'in' operator does not do any coercion of
  *  the target object.
@@ -3301,9 +3301,9 @@ DUK_LOCAL duk_bool_t duk__handle_put_array_length(duk_hthread *thr, duk_hobject 
 }
 
 /*
- *  PUTPROP: Ecmascript property write.
+ *  PUTPROP: ECMAScript property write.
  *
- *  Unlike Ecmascript primitive which returns nothing, returns 1 to indicate
+ *  Unlike ECMAScript primitive which returns nothing, returns 1 to indicate
  *  success and 0 to indicate failure (assuming throw is not set).
  *
  *  This is an extremely tricky function.  Some examples:
@@ -4254,7 +4254,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, 
 }
 
 /*
- *  Ecmascript compliant [[Delete]](P, Throw).
+ *  ECMAScript compliant [[Delete]](P, Throw).
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_small_uint_t flags) {
@@ -4414,7 +4414,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 }
 
 /*
- *  DELPROP: Ecmascript property deletion.
+ *  DELPROP: ECMAScript property deletion.
  */
 
 DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_bool_t throw_flag) {
@@ -4813,7 +4813,7 @@ DUK_INTERNAL duk_size_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *ob
 	val = duk_to_number_m1(thr);
 	duk_pop_3_unsafe(thr);
 
-	/* This isn't part of Ecmascript semantics; return a value within
+	/* This isn't part of ECMAScript semantics; return a value within
 	 * duk_size_t range, or 0 otherwise.
 	 */
 	if (val >= 0.0 && val <= (duk_double_t) DUK_SIZE_MAX) {
@@ -4924,7 +4924,7 @@ DUK_INTERNAL void duk_hobject_object_get_own_property_descriptor(duk_hthread *th
  *  NormalizePropertyDescriptor() related helper.
  *
  *  Internal helper which validates and normalizes a property descriptor
- *  represented as an Ecmascript object (e.g. argument to defineProperty()).
+ *  represented as an ECMAScript object (e.g. argument to defineProperty()).
  *  The output of this conversion is a set of defprop_flags and possibly
  *  some values pushed on the value stack to (1) ensure borrowed pointers
  *  remain valid, and (2) avoid unnecessary pops for footprint reasons.
@@ -5064,7 +5064,7 @@ void duk_hobject_prepare_property_descriptor(duk_hthread *thr,
  *
  *  Inlines all [[DefineOwnProperty]] exotic behaviors.
  *
- *  Note: Ecmascript compliant [[DefineOwnProperty]](P, Desc, Throw) is not
+ *  Note: ECMAScript compliant [[DefineOwnProperty]](P, Desc, Throw) is not
  *  implemented directly, but Object.defineProperty() serves its purpose.
  *  We don't need the [[DefineOwnProperty]] internally and we don't have a
  *  property descriptor with 'missing values' so it's easier to avoid it

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -8,7 +8,7 @@
  *  strings used as internal property names and raw buffers converted to
  *  strings.  In such cases the 'clen' field contains an inaccurate value.
  *
- *  Ecmascript requires support for 32-bit long strings.  However, since each
+ *  ECMAScript requires support for 32-bit long strings.  However, since each
  *  16-bit codepoint can take 3 bytes in CESU-8, this representation can only
  *  support about 1.4G codepoint long strings in extreme cases.  This is not
  *  really a practical issue.
@@ -32,7 +32,7 @@
 #define DUK_HSTRING_MAX_BYTELEN                     (0x7fffffffUL)
 #endif
 
-/* XXX: could add flags for "is valid CESU-8" (Ecmascript compatible strings),
+/* XXX: could add flags for "is valid CESU-8" (ECMAScript compatible strings),
  * "is valid UTF-8", "is valid extended UTF-8" (internal strings are not,
  * regexp bytecode is), and "contains non-BMP characters".  These are not
  * needed right now.

--- a/src-input/duk_hstring_misc.c
+++ b/src-input/duk_hstring_misc.c
@@ -33,7 +33,7 @@ DUK_INTERNAL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr, duk
 	                     (const void *) p_start, (const void *) p_end,
 	                     (const void *) p));
 
-	/* For invalid UTF-8 (never happens for standard Ecmascript strings)
+	/* For invalid UTF-8 (never happens for standard ECMAScript strings)
 	 * return U+FFFD replacement character.
 	 */
 	if (duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp1)) {

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -222,14 +222,14 @@ struct duk_activation {
 	duk_instr_t *curr_pc;   /* next instruction to execute (points to 'func' bytecode, stable pointer), NULL for native calls */
 
 	/* bottom_byteoff and retval_byteoff are only used for book-keeping
-	 * of Ecmascript-initiated calls, to allow returning to an Ecmascript
+	 * of ECMAScript-initiated calls, to allow returning to an ECMAScript
 	 * function properly.
 	 */
 
 	/* Bottom of valstack for this activation, used to reset
 	 * valstack_bottom on return; offset is absolute.  There's
 	 * no need to track 'top' because native call handling deals
-	 * with that using locals, and for Ecmascript returns 'nregs'
+	 * with that using locals, and for ECMAScript returns 'nregs'
 	 * indicates the necessary top.
 	 */
 	duk_size_t bottom_byteoff;

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript execution, support primitives.
+ *  ECMAScript execution, support primitives.
  */
 
 #if !defined(DUK_JS_H_INCLUDED)

--- a/src-input/duk_js_arith.c
+++ b/src-input/duk_js_arith.c
@@ -4,7 +4,7 @@
 
 #include "duk_internal.h"
 
-/* Ecmascript modulus ('%') does not match IEEE 754 "remainder" operation
+/* ECMAScript modulus ('%') does not match IEEE 754 "remainder" operation
  * (implemented by remainder() in C99) but does seem to match ANSI C fmod().
  * Compare E5 Section 11.5.3 and "man fmod".
  */
@@ -58,9 +58,9 @@ DUK_INTERNAL double duk_js_arith_mod(double d1, double d2) {
 
 /* Shared helper for Math.pow() and exponentiation operator. */
 DUK_INTERNAL double duk_js_arith_pow(double x, double y) {
-	/* The ANSI C pow() semantics differ from Ecmascript.
+	/* The ANSI C pow() semantics differ from ECMAScript.
 	 *
-	 * E.g. when x==1 and y is +/- infinite, the Ecmascript required
+	 * E.g. when x==1 and y is +/- infinite, the ECMAScript required
 	 * result is NaN, while at least Linux pow() returns 1.
 	 */
 

--- a/src-input/duk_js_bytecode.h
+++ b/src-input/duk_js_bytecode.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript bytecode
+ *  ECMAScript bytecode
  */
 
 #if !defined(DUK_JS_BYTECODE_H_INCLUDED)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -3,7 +3,7 @@
  *
  *  duk_handle_call_unprotected():
  *
- *    - Unprotected call to Ecmascript or Duktape/C function, from native
+ *    - Unprotected call to ECMAScript or Duktape/C function, from native
  *      code or bytecode executor.
  *
  *    - Also handles Ecma-to-Ecma calls which reuses a currently running
@@ -1682,10 +1682,10 @@ DUK_LOCAL void duk__call_setup_act_not_tailcall(duk_hthread *thr,
 		 *  Update return value stack index of current activation (if any).
 		 *
 		 *  Although it might seem this is not necessary (bytecode executor
-		 *  does this for Ecmascript-to-Ecmascript calls; other calls are
+		 *  does this for ECMAScript-to-ECMAScript calls; other calls are
 		 *  handled here), this turns out to be necessary for handling yield
-		 *  and resume.  For them, an Ecmascript-to-native call happens, and
-		 *  the Ecmascript call's retval_byteoff must be set for things to work.
+		 *  and resume.  For them, an ECMAScript-to-native call happens, and
+		 *  the ECMAScript call's retval_byteoff must be set for things to work.
 		 */
 
 		act->retval_byteoff = entry_valstack_bottom_byteoff + (duk_size_t) idx_func * sizeof(duk_tval);
@@ -1898,10 +1898,10 @@ DUK_LOCAL void duk__call_thread_state_update(duk_hthread *thr) {
 /*
  *  Main unprotected call handler, handles:
  *
- *    - All combinations of native/Ecmascript caller and native/Ecmascript
+ *    - All combinations of native/ECMAScript caller and native/ECMAScript
  *      target.
  *
- *    - Optimized Ecmascript-to-Ecmascript call where call handling only
+ *    - Optimized ECMAScript-to-ECMAScript call where call handling only
  *      sets up a new duk_activation but reuses an existing bytecode executor
  *      (the caller) without native recursion.
  *
@@ -1950,7 +1950,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	DUK_STATS_INC(thr->heap, stats_call_all);
 
 	/* If a tail call:
-	 *   - an Ecmascript activation must be on top of the callstack
+	 *   - an ECMAScript activation must be on top of the callstack
 	 *   - there cannot be any catch stack entries that would catch
 	 *     a return
 	 */
@@ -2102,7 +2102,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	 *  compiler; the compiled function's parent env will contain
 	 *  the (immutable) binding already.
 	 *
-	 *  This handling is now identical for C and Ecmascript functions.
+	 *  This handling is now identical for C and ECMAScript functions.
 	 *  C functions always have the 'NEWENV' flag set, so their
 	 *  environment record initialization is delayed (which is good).
 	 *
@@ -2149,7 +2149,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 
 	if (func != NULL && DUK_HOBJECT_IS_COMPFUNC(func)) {
 		/*
-		 *  Ecmascript call.
+		 *  ECMAScript call.
 		 */
 
 		DUK_ASSERT(func != NULL);
@@ -2334,7 +2334,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	 * calls caused by side effects (e.g. when doing a DUK_OP_GETPROP), see
 	 * GH-303.  Only needed for success path, error path always causes a
 	 * breakpoint recheck in the executor.  It would be enough to set this
-	 * only when returning to an Ecmascript activation, but setting the flag
+	 * only when returning to an ECMAScript activation, but setting the flag
 	 * on every return should have no ill effect.
 	 */
 #if defined(DUK_USE_DEBUGGER_SUPPORT)
@@ -2817,7 +2817,7 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 /*
  *  Property-based call (foo.noSuch()) error setup: replace target function
  *  on stack top with a specially tagged (hidden Symbol) error which gets
- *  thrown in call handling at the proper spot to follow Ecmascript semantics.
+ *  thrown in call handling at the proper spot to follow ECMAScript semantics.
  */
 
 #if defined(DUK_USE_VERBOSE_ERRORS)

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript compiler.
+ *  ECMAScript compiler.
  *
  *  Parses an input string and generates a function template result.
  *  Compilation may happen in multiple contexts (global code, eval
@@ -2317,7 +2317,7 @@ DUK_LOCAL void duk__ivalue_toplain_raw(duk_compiler_ctx *comp_ctx, duk_ivalue *x
 				}
 			} else if (x->op == DUK_OP_ADD && DUK_TVAL_IS_STRING(tv1) && DUK_TVAL_IS_STRING(tv2)) {
 				/* Inline string concatenation.  No need to check for
-				 * symbols, as all inputs are valid Ecmascript strings.
+				 * symbols, as all inputs are valid ECMAScript strings.
 				 */
 				duk_dup(thr, x->x1.valstack_idx);
 				duk_dup(thr, x->x2.valstack_idx);
@@ -7829,7 +7829,7 @@ DUK_LOCAL duk_int_t duk__parse_func_like_fnum(duk_compiler_ctx *comp_ctx, duk_sm
  *  Compile input string into an executable function template without
  *  arguments.
  *
- *  The string is parsed as the "Program" production of Ecmascript E5.
+ *  The string is parsed as the "Program" production of ECMAScript E5.
  *  Compilation context can be either global code or eval code (see E5
  *  Sections 14 and 15.1.2.1).
  *

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript compiler.
+ *  ECMAScript compiler.
  */
 
 #if !defined(DUK_JS_COMPILER_H_INCLUDED)

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript bytecode executor.
+ *  ECMAScript bytecode executor.
  */
 
 #include "duk_internal.h"
@@ -774,7 +774,7 @@ DUK_LOCAL DUK__INLINE_PERF void duk__prepost_incdec_var_helper(duk_hthread *thr,
  * top are combined into one pass.
  */
 
-/* Reconfigure value stack for return to an Ecmascript function at
+/* Reconfigure value stack for return to an ECMAScript function at
  * callstack top (caller unwinds).
  */
 DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
@@ -790,7 +790,7 @@ DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
 
 	/* Clamp so that values at 'clamp_top' and above are wiped and won't
 	 * retain reachable garbage.  Then extend to 'nregs' because we're
-	 * returning to an Ecmascript function.
+	 * returning to an ECMAScript function.
 	 */
 
 	h_func = (duk_hcompfunc *) DUK_ACT_GET_FUNC(act);
@@ -806,7 +806,7 @@ DUK_LOCAL void duk__reconfig_valstack_ecma_return(duk_hthread *thr) {
 	/* XXX: a best effort shrink check would be OK here */
 }
 
-/* Reconfigure value stack for an Ecmascript catcher.  Use topmost catcher
+/* Reconfigure value stack for an ECMAScript catcher.  Use topmost catcher
  * in 'act'.
  */
 DUK_LOCAL void duk__reconfig_valstack_ecma_catcher(duk_hthread *thr, duk_activation *act) {
@@ -1098,7 +1098,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		/* duk_bi_duk_object_yield() and duk_bi_duk_object_resume() ensure all of these are met */
 
 		DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);                                                         /* unchanged by Duktape.Thread.resume() */
-		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(thr->callstack_curr != NULL);
 		DUK_ASSERT(thr->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL &&
@@ -1116,7 +1116,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		DUK_ASSERT(resumee->state == DUK_HTHREAD_STATE_INACTIVE ||
 		           resumee->state == DUK_HTHREAD_STATE_YIELDED);                                                     /* checked by Duktape.Thread.resume() */
 		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_YIELDED ||
-		           resumee->callstack_top >= 2);                                                                     /* YIELDED: Ecmascript activation + Duktape.Thread.yield() activation */
+		           resumee->callstack_top >= 2);                                                                     /* YIELDED: ECMAScript activation + Duktape.Thread.yield() activation */
 		DUK_ASSERT(resumee->state != DUK_HTHREAD_STATE_YIELDED ||
 		           (DUK_ACT_GET_FUNC(resumee->callstack_curr) != NULL &&
 		            DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(resumee->callstack_curr)) &&
@@ -1154,8 +1154,8 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 			goto check_longjmp;
 		} else if (resumee->state == DUK_HTHREAD_STATE_YIELDED) {
 			/* Unwind previous Duktape.Thread.yield() call.  The
-			 * activation remaining must always be an Ecmascript
-			 * call now (yield() accepts calls from Ecmascript
+			 * activation remaining must always be an ECMAScript
+			 * call now (yield() accepts calls from ECMAScript
 			 * only).
 			 */
 			duk_activation *act_resumee;
@@ -1163,7 +1163,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 			DUK_ASSERT(resumee->callstack_top >= 2);
 			act_resumee = resumee->callstack_curr;  /* Duktape.Thread.yield() */
 			DUK_ASSERT(act_resumee != NULL);
-			act_resumee = act_resumee->parent;      /* Ecmascript call site for yield() */
+			act_resumee = act_resumee->parent;      /* ECMAScript call site for yield() */
 			DUK_ASSERT(act_resumee != NULL);
 
 			tv = (duk_tval *) (void *) ((duk_uint8_t *) resumee->valstack + act_resumee->retval_byteoff);  /* return value from Duktape.Thread.yield() */
@@ -1234,7 +1234,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 	case DUK_LJ_TYPE_YIELD: {
 		/*
 		 *  Currently only allowed only if yielding thread has only
-		 *  Ecmascript activations (except for the Duktape.Thread.yield()
+		 *  ECMAScript activations (except for the Duktape.Thread.yield()
 		 *  call at the callstack top) and none of them constructor
 		 *  calls.
 		 *
@@ -1250,27 +1250,27 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		DUK_ASSERT(thr != entry_thread);                                                                             /* Duktape.Thread.yield() should prevent */
 #endif
 		DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);                                                         /* unchanged from Duktape.Thread.yield() */
-		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* Ecmascript activation + Duktape.Thread.yield() activation */
+		DUK_ASSERT(thr->callstack_top >= 2);                                                                         /* ECMAScript activation + Duktape.Thread.yield() activation */
 		DUK_ASSERT(thr->callstack_curr != NULL);
 		DUK_ASSERT(thr->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr) != NULL &&
 		           DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr)) &&
 		           ((duk_hnatfunc *) DUK_ACT_GET_FUNC(thr->callstack_curr))->func == duk_bi_thread_yield);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));                              /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));                              /* an ECMAScript function */
 
 		resumer = thr->resumer;
 
 		DUK_ASSERT(resumer != NULL);
 		DUK_ASSERT(resumer->state == DUK_HTHREAD_STATE_RESUMED);                                                     /* written by a previous RESUME handling */
-		DUK_ASSERT(resumer->callstack_top >= 2);                                                                     /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(resumer->callstack_top >= 2);                                                                     /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(resumer->callstack_curr != NULL);
 		DUK_ASSERT(resumer->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(resumer->callstack_curr) != NULL &&
 		           DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr)) &&
 		           ((duk_hnatfunc *) DUK_ACT_GET_FUNC(resumer->callstack_curr))->func == duk_bi_thread_resume);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent)));                            /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(resumer->callstack_curr->parent)));                            /* an ECMAScript function */
 
 		if (thr->heap->lj.iserror) {
 			thr->state = DUK_HTHREAD_STATE_YIELDED;
@@ -1324,7 +1324,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		 *      resumer in this case.)
 		 *
 		 *  Note: until we hit the entry level, there can only be
-		 *  Ecmascript activations.
+		 *  ECMAScript activations.
 		 */
 
 		duk_activation *act;
@@ -1391,11 +1391,11 @@ DUK_LOCAL duk_small_uint_t duk__handle_longjmp(duk_hthread *thr, duk_activation 
 		 */
 
 		DUK_ASSERT(thr->resumer != NULL);
-		DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* Ecmascript activation + Duktape.Thread.resume() activation */
+		DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* ECMAScript activation + Duktape.Thread.resume() activation */
 		DUK_ASSERT(thr->resumer->callstack_curr != NULL);
 		DUK_ASSERT(thr->resumer->callstack_curr->parent != NULL);
 		DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent) != NULL &&
-		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an Ecmascript function */
+		           DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an ECMAScript function */
 
 		resumer = thr->resumer;
 
@@ -1547,7 +1547,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	 *    2. The return happens at the entry level of the bytecode
 	 *       executor, so return from the executor (in C stack).
 	 *
-	 *    3. There is a calling (Ecmascript) activation in the call
+	 *    3. There is a calling (ECMAScript) activation in the call
 	 *       stack => return to it, in the same executor instance.
 	 *
 	 *    4. There is no calling activation, and the thread is
@@ -1592,10 +1592,10 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	}
 
 	if (thr->callstack_top >= 2) {
-		/* There is a caller; it MUST be an Ecmascript caller (otherwise it would
+		/* There is a caller; it MUST be an ECMAScript caller (otherwise it would
 		 * match entry_act check).
 		 */
-		DUK_DDD(DUK_DDDPRINT("return to Ecmascript caller, retval_byteoff=%ld, lj_value1=%!T",
+		DUK_DDD(DUK_DDDPRINT("return to ECMAScript caller, retval_byteoff=%ld, lj_value1=%!T",
 		                     (long) (thr->callstack_curr->parent->retval_byteoff),
 		                     (duk_tval *) &thr->heap->lj.value1));
 
@@ -1631,14 +1631,14 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 	DUK_DD(DUK_DDPRINT("no calling activation, thread finishes (similar to yield)"));
 
 	DUK_ASSERT(thr->resumer != NULL);
-	DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* Ecmascript activation + Duktape.Thread.resume() activation */
+	DUK_ASSERT(thr->resumer->callstack_top >= 2);  /* ECMAScript activation + Duktape.Thread.resume() activation */
 	DUK_ASSERT(thr->resumer->callstack_curr != NULL);
 	DUK_ASSERT(thr->resumer->callstack_curr->parent != NULL);
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr) != NULL &&
 			DUK_HOBJECT_IS_NATFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr)) &&
 			((duk_hnatfunc *) DUK_ACT_GET_FUNC(thr->resumer->callstack_curr))->func == duk_bi_thread_resume);  /* Duktape.Thread.resume() */
 	DUK_ASSERT(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent) != NULL &&
-			DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an Ecmascript function */
+			DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->resumer->callstack_curr->parent)));  /* an ECMAScript function */
 	DUK_ASSERT(thr->state == DUK_HTHREAD_STATE_RUNNING);
 	DUK_ASSERT(thr->resumer->state == DUK_HTHREAD_STATE_RESUMED);
 
@@ -1835,7 +1835,7 @@ DUK_LOCAL void duk__interrupt_handle_debugger(duk_hthread *thr, duk_bool_t *out_
 		if (diff_last < 0.0 || diff_last >= (duk_double_t) DUK_HEAP_DBG_RATELIMIT_MILLISECS) {
 			/* Monotonic time should not experience time jumps,
 			 * but the provider may be missing and we're actually
-			 * using Ecmascript time.  So, tolerate negative values
+			 * using ECMAScript time.  So, tolerate negative values
 			 * so that a time jump works reasonably.
 			 *
 			 * Same interval is now used for status sending and
@@ -2670,7 +2670,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
 }
 
 /*
- *  Ecmascript bytecode executor.
+ *  ECMAScript bytecode executor.
  *
  *  Resume execution for the current thread from its current activation.
  *  Returns when execution would return from the entry level activation,
@@ -2679,7 +2679,7 @@ DUK_LOCAL duk_bool_t duk__executor_handle_call(duk_hthread *thr, duk_idx_t idx, 
  *  a longjmp() with type DUK_LJ_TYPE_THROW is called on the entry level
  *  setjmp() jmpbuf.
  *
- *  Ecmascript function calls and coroutine resumptions are handled
+ *  ECMAScript function calls and coroutine resumptions are handled
  *  internally (by the outer executor function) without recursive C calls.
  *  Other function calls are handled using duk_handle_call(), increasing
  *  C recursion depth.

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -1,7 +1,7 @@
 /*
- *  Ecmascript specification algorithm and conversion helpers.
+ *  ECMAScript specification algorithm and conversion helpers.
  *
- *  These helpers encapsulate the primitive Ecmascript operation semantics,
+ *  These helpers encapsulate the primitive ECMAScript operation semantics,
  *  and are used by the bytecode executor and the API (among other places).
  *  Some primitives are only implemented as part of the API and have no
  *  "internal" helper.  This is the case when an internal helper would not
@@ -433,7 +433,7 @@ DUK_LOCAL duk_bool_t duk__js_equals_number(duk_double_t x, duk_double_t y) {
 	return 0;
 #else  /* DUK_USE_PARANOID_MATH */
 	/* Better equivalent algorithm.  If the compiler is compliant, C and
-	 * Ecmascript semantics are identical for this particular comparison.
+	 * ECMAScript semantics are identical for this particular comparison.
 	 * In particular, NaNs must never compare equal and zeroes must compare
 	 * equal regardless of sign.  Could also use a macro, but this inlines
 	 * already nicely (no difference on gcc, for instance).
@@ -1061,7 +1061,7 @@ DUK_LOCAL duk_bool_t duk__js_instanceof_helper(duk_hthread *thr, duk_tval *tv_x,
 
 	if (!DUK_HOBJECT_IS_CALLABLE(func)) {
 		/*
-		 *  Note: of native Ecmascript objects, only Function instances
+		 *  Note: of native ECMAScript objects, only Function instances
 		 *  have a [[HasInstance]] internal property.  Custom objects might
 		 *  also have it, but not in current implementation.
 		 *

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -6,7 +6,7 @@
  *  be used for most identifier accesses.  Consequently, these slow path
  *  primitives should be optimized for maximum compactness.
  *
- *  Ecmascript environment records (declarative and object) are represented
+ *  ECMAScript environment records (declarative and object) are represented
  *  as internal objects with control keys.  Environment records have a
  *  parent record ("outer environment reference") which is represented by
  *  the implicit prototype for technical reasons (in other words, it is a
@@ -48,7 +48,7 @@ typedef struct {
  *  Create a new function object based on a "template function" which contains
  *  compiled bytecode, constants, etc, but lacks a lexical environment.
  *
- *  Ecmascript requires that each created closure is a separate object, with
+ *  ECMAScript requires that each created closure is a separate object, with
  *  its own set of editable properties.  However, structured property values
  *  (such as the formal arguments list and the variable map) are shared.
  *  Also the bytecode, constants, and inner functions are shared.

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -2,7 +2,7 @@
  *  Lexer for source files, ToNumber() string conversions, RegExp expressions,
  *  and JSON.
  *
- *  Provides a stream of Ecmascript tokens from an UTF-8/CESU-8 buffer.  The
+ *  Provides a stream of ECMAScript tokens from an UTF-8/CESU-8 buffer.  The
  *  caller can also rewind the token stream into a certain position which is
  *  needed by the compiler part for multi-pass scanning.  Tokens are
  *  represented as duk_token structures, and contain line number information.
@@ -25,14 +25,14 @@
  *
  *  Token parsing supports the full range of Unicode characters as described
  *  in the E5 specification.  Parsing has been optimized for ASCII characters
- *  because ordinary Ecmascript code consists almost entirely of ASCII
+ *  because ordinary ECMAScript code consists almost entirely of ASCII
  *  characters.  Matching of complex Unicode codepoint sets (such as in the
  *  IdentifierStart and IdentifierPart productions) is optimized for size,
  *  and is done using a linear scan of a bit-packed list of ranges.  This is
  *  very slow, but should never be entered unless the source code actually
  *  contains Unicode characters.
  *
- *  Ecmascript tokenization is partially context sensitive.  First,
+ *  ECMAScript tokenization is partially context sensitive.  First,
  *  additional future reserved words are recognized in strict mode (see E5
  *  Section 7.6.1.2).  Second, a forward slash character ('/') can be
  *  recognized either as starting a RegExp literal or as a division operator,
@@ -129,7 +129,7 @@
  *
  *    * In particular, surrogate pairs are allowed and not combined, which
  *      allows source files to represent all SourceCharacters with CESU-8.
- *      Broken surrogate pairs are allowed, as Ecmascript does not mandate
+ *      Broken surrogate pairs are allowed, as ECMAScript does not mandate
  *      their validation.
  *
  *    * Allow non-shortest UTF-8 encodings.
@@ -137,20 +137,20 @@
  *  Leniency here causes few security concerns because all character data is
  *  decoded into Unicode codepoints before lexer processing, and is then
  *  re-encoded into CESU-8.  The source can be parsed as strict UTF-8 with
- *  a compiler option.  However, Ecmascript source characters include -all-
+ *  a compiler option.  However, ECMAScript source characters include -all-
  *  16-bit unsigned integer codepoints, so leniency seems to be appropriate.
  *
  *  Note that codepoints above the BMP are not strictly SourceCharacters,
  *  but the lexer still accepts them as such.  Before ending up in a string
  *  or an identifier name, codepoints above BMP are converted into surrogate
  *  pairs and then CESU-8 encoded, resulting in 16-bit Unicode data as
- *  expected by Ecmascript.
+ *  expected by ECMAScript.
  *
  *  An alternative approach to dealing with invalid or partial sequences
  *  would be to skip them and replace them with e.g. the Unicode replacement
  *  character U+FFFD.  This has limited utility because a replacement character
  *  will most likely cause a parse error, unless it occurs inside a string.
- *  Further, Ecmascript source is typically pure ASCII.
+ *  Further, ECMAScript source is typically pure ASCII.
  *
  *  See:
  *
@@ -959,7 +959,7 @@ DUK_LOCAL void duk__lexer_skip_to_endofline(duk_lexer_ctx *lex_ctx) {
 }
 
 /*
- *  Parse Ecmascript source InputElementDiv or InputElementRegExp
+ *  Parse ECMAScript source InputElementDiv or InputElementRegExp
  *  (E5 Section 7), skipping whitespace, comments, and line terminators.
  *
  *  Possible results are:
@@ -986,13 +986,13 @@ DUK_LOCAL void duk__lexer_skip_to_endofline(duk_lexer_ctx *lex_ctx) {
  *  lookup window to quickly determine which production is the -longest-
  *  matching one, and then parse that.  The top-level if-else clauses
  *  match the first character, and the code blocks for each clause
- *  handle -all- alternatives for that first character.  Ecmascript
+ *  handle -all- alternatives for that first character.  ECMAScript
  *  specification uses the "longest match wins" semantics, so the order
  *  of the if-clauses matters.
  *
  *  Misc notes:
  *
- *    * Ecmascript numeric literals do not accept a sign character.
+ *    * ECMAScript numeric literals do not accept a sign character.
  *      Consequently e.g. "-1.0" is parsed as two tokens: a negative
  *      sign and a positive numeric literal.  The compiler performs
  *      the negation during compilation, so this has no adverse impact.
@@ -1502,7 +1502,7 @@ void duk_lexer_parse_js_input_element(duk_lexer_ctx *lex_ctx,
 		 *  (the tokens DUK_TOK_GET and DUK_TOK_SET are actually not
 		 *  used now).  The compiler needs to work around this.
 		 *
-		 *  Strictly speaking, following Ecmascript longest match
+		 *  Strictly speaking, following ECMAScript longest match
 		 *  specification, an invalid escape for the first character
 		 *  should cause a syntax error.  However, an invalid escape
 		 *  for IdentifierParts should just terminate the identifier

--- a/src-input/duk_lexer.h
+++ b/src-input/duk_lexer.h
@@ -388,7 +388,7 @@ struct duk_lexer_codepoint {
 	duk_int_t line;
 };
 
-/* Lexer context.  Same context is used for Ecmascript and Regexp parsing. */
+/* Lexer context.  Same context is used for ECMAScript and Regexp parsing. */
 struct duk_lexer_ctx {
 #if defined(DUK_USE_LEXER_SLIDING_WINDOW)
 	duk_lexer_codepoint *window; /* unicode code points, window[0] is always next, points to 'buffer' */

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -1209,7 +1209,7 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	duk_uint8_t *buf;
 
 	/*
-	 *  The string conversion here incorporates all the necessary Ecmascript
+	 *  The string conversion here incorporates all the necessary ECMAScript
 	 *  semantics without attempting to be generic.  nc_ctx->digits contains
 	 *  nc_ctx->count digits (>= 1), with the topmost digit's 'position'
 	 *  indicated by nc_ctx->k as follows:
@@ -1220,11 +1220,11 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	 *    digits="123" count=3 k=-1  -->   0.0123
 	 *
 	 *  Note that the identifier names used for format selection are different
-	 *  in Burger-Dybvig paper and Ecmascript specification (quite confusingly
+	 *  in Burger-Dybvig paper and ECMAScript specification (quite confusingly
 	 *  so, because e.g. 'k' has a totally different meaning in each).  See
 	 *  documentation for discussion.
 	 *
-	 *  Ecmascript doesn't specify any specific behavior for format selection
+	 *  ECMAScript doesn't specify any specific behavior for format selection
 	 *  (e.g. when to use exponent notation) for non-base-10 numbers.
 	 *
 	 *  The bigint space in the context is reused for string output, as there
@@ -1308,7 +1308,7 @@ DUK_LOCAL void duk__dragon4_convert_and_push(duk__numconv_stringify_ctx *nc_ctx,
 	/* Exponent */
 	if (expt != DUK__NO_EXP) {
 		/*
-		 *  Exponent notation for non-base-10 numbers isn't specified in Ecmascript
+		 *  Exponent notation for non-base-10 numbers isn't specified in ECMAScript
 		 *  specification, as it never explicitly turns up: non-decimal numbers can
 		 *  only be formatted with Number.prototype.toString([radix]) and for that,
 		 *  behavior is not explicitly specified.
@@ -1882,7 +1882,7 @@ DUK_INTERNAL void duk_numconv_parse(duk_hthread *thr, duk_small_int_t radix, duk
 	 *  accuracy, so that Dragon4 will generate enough binary output digits.
 	 *  For decimal numbers, this means generating a 20-digit significand,
 	 *  which should yield enough practical accuracy to parse IEEE doubles.
-	 *  In fact, the Ecmascript specification explicitly allows an
+	 *  In fact, the ECMAScript specification explicitly allows an
 	 *  implementation to treat digits beyond 20 as zeroes (and even
 	 *  to round the 20th digit upwards).  For non-decimal numbers, the
 	 *  appropriate number of digits has been precomputed for comparable

--- a/src-input/duk_numconv.h
+++ b/src-input/duk_numconv.h
@@ -1,6 +1,6 @@
 /*
  *  Number-to-string conversion.  The semantics of these is very tightly
- *  bound with the Ecmascript semantics required for call sites.
+ *  bound with the ECMAScript semantics required for call sites.
  */
 
 #if !defined(DUK_NUMCONV_H_INCLUDED)

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -1,7 +1,7 @@
 /*
  *  Regexp executor.
  *
- *  Safety: the Ecmascript executor should prevent user from reading and
+ *  Safety: the ECMAScript executor should prevent user from reading and
  *  replacing regexp bytecode.  Even so, the executor must validate all
  *  memory accesses etc.  When an invalid access is detected (e.g. a 'save'
  *  opcode to invalid, unallocated index) it should fail with an internal
@@ -855,7 +855,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		 *      internal/limit error occurs (which causes a longjmp())
 		 *
 		 *    - If we supported anchored matches, we would break out here
-		 *      unconditionally; however, Ecmascript regexps don't have anchored
+		 *      unconditionally; however, ECMAScript regexps don't have anchored
 		 *      matches.  It might make sense to implement a fast bail-out if
 		 *      the regexp begins with '^' and sp is not 0: currently we'll just
 		 *      run through the entire input string, trivially failing the match

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -141,7 +141,7 @@ DUK_INTERNAL duk_small_int_t duk_unicode_encode_cesu8(duk_ucodepoint_t cp, duk_u
 		/*
 		 *  Unicode codepoints above U+FFFF are encoded as surrogate
 		 *  pairs here.  This ensures that all CESU-8 codepoints are
-		 *  16-bit values as expected in Ecmascript.  The surrogate
+		 *  16-bit values as expected in ECMAScript.  The surrogate
 		 *  pairs always get a 3-byte encoding (each) in CESU-8.
 		 *  See: http://en.wikipedia.org/wiki/Surrogate_pair
 		 *

--- a/src-input/duk_unicode_tables.c
+++ b/src-input/duk_unicode_tables.c
@@ -9,7 +9,7 @@
  *  packed format.  These tables are used to match non-ASCII
  *  characters of complex productions by resorting to a linear
  *  range-by-range comparison.  This is very slow, but is expected
- *  to be very rare in practical Ecmascript source code, and thus
+ *  to be very rare in practical ECMAScript source code, and thus
  *  compactness is most important.
  *
  *  The tables are matched using uni_range_match() and the format

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -34,7 +34,7 @@
 
 /* Duktape version, (major * 10000) + (minor * 100) + patch.  Allows C code
  * to #if (DUK_VERSION >= NNN) against Duktape API version.  The same value
- * is also available to Ecmascript code in Duktape.version.  Unofficial
+ * is also available to ECMAScript code in Duktape.version.  Unofficial
  * development snapshots have 99 for patch level (e.g. 0.10.99 would be a
  * development version after 0.10.0 but before the next official release).
  */
@@ -42,7 +42,7 @@
 
 /* Git commit, describe, and branch for Duktape build.  Useful for
  * non-official snapshot builds so that application code can easily log
- * which Duktape snapshot was used.  Not available in the Ecmascript
+ * which Duktape snapshot was used.  Not available in the ECMAScript
  * environment.
  */
 #define DUK_GIT_COMMIT                    @GIT_COMMIT_CSTRING@
@@ -142,7 +142,7 @@ struct duk_number_list_entry {
 };
 
 struct duk_time_components {
-	duk_double_t year;          /* year, e.g. 2016, Ecmascript year range */
+	duk_double_t year;          /* year, e.g. 2016, ECMAScript year range */
 	duk_double_t month;         /* month: 1-12 */
 	duk_double_t day;           /* day: 1-31 */
 	duk_double_t hours;         /* hour: 0-59 */
@@ -178,12 +178,12 @@ struct duk_time_components {
 /* Value types, used by e.g. duk_get_type() */
 #define DUK_TYPE_MIN                      0U
 #define DUK_TYPE_NONE                     0U    /* no value, e.g. invalid index */
-#define DUK_TYPE_UNDEFINED                1U    /* Ecmascript undefined */
-#define DUK_TYPE_NULL                     2U    /* Ecmascript null */
-#define DUK_TYPE_BOOLEAN                  3U    /* Ecmascript boolean: 0 or 1 */
-#define DUK_TYPE_NUMBER                   4U    /* Ecmascript number: double */
-#define DUK_TYPE_STRING                   5U    /* Ecmascript string: CESU-8 / extended UTF-8 encoded */
-#define DUK_TYPE_OBJECT                   6U    /* Ecmascript object: includes objects, arrays, functions, threads */
+#define DUK_TYPE_UNDEFINED                1U    /* ECMAScript undefined */
+#define DUK_TYPE_NULL                     2U    /* ECMAScript null */
+#define DUK_TYPE_BOOLEAN                  3U    /* ECMAScript boolean: 0 or 1 */
+#define DUK_TYPE_NUMBER                   4U    /* ECMAScript number: double */
+#define DUK_TYPE_STRING                   5U    /* ECMAScript string: CESU-8 / extended UTF-8 encoded */
+#define DUK_TYPE_OBJECT                   6U    /* ECMAScript object: includes objects, arrays, functions, threads */
 #define DUK_TYPE_BUFFER                   7U    /* fixed or dynamic, garbage collected byte buffer */
 #define DUK_TYPE_POINTER                  8U    /* raw void pointer */
 #define DUK_TYPE_LIGHTFUNC                9U    /* lightweight function pointer */
@@ -1037,7 +1037,7 @@ DUK_EXTERNAL_DECL void duk_trim(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_codepoint_t duk_char_code_at(duk_context *ctx, duk_idx_t idx, duk_size_t char_offset);
 
 /*
- *  Ecmascript operators
+ *  ECMAScript operators
  */
 
 DUK_EXTERNAL_DECL duk_bool_t duk_equals(duk_context *ctx, duk_idx_t idx1, duk_idx_t idx2);
@@ -1201,7 +1201,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MSEC_HOUR            (60L * 60L * 1000L)
 #define DUK_DATE_MSEC_DAY             (24L * 60L * 60L * 1000L)
 
-/* Ecmascript date range is 100 million days from Epoch:
+/* ECMAScript date range is 100 million days from Epoch:
  * > 100e6 * 24 * 60 * 60 * 1000  // 100M days in millisecs
  * 8640000000000000
  * (= 8.64e15)
@@ -1209,7 +1209,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MSEC_100M_DAYS         (8.64e15)
 #define DUK_DATE_MSEC_100M_DAYS_LEEWAY  (8.64e15 + 24 * 3600e3)
 
-/* Ecmascript year range:
+/* ECMAScript year range:
  * > new Date(100e6 * 24 * 3600e3).toISOString()
  * '+275760-09-13T00:00:00.000Z'
  * > new Date(-100e6 * 24 * 3600e3).toISOString()
@@ -1219,7 +1219,7 @@ DUK_EXTERNAL_DECL duk_double_t duk_components_to_time(duk_context *ctx, duk_time
 #define DUK_DATE_MAX_ECMA_YEAR     275760L
 
 /* Part indices for internal breakdowns.  Part order from DUK_DATE_IDX_YEAR
- * to DUK_DATE_IDX_MILLISECOND matches argument ordering of Ecmascript API
+ * to DUK_DATE_IDX_MILLISECOND matches argument ordering of ECMAScript API
  * calls (like Date constructor call).  Some functions in duk_bi_date.c
  * depend on the specific ordering, so change with care.  16 bits are not
  * enough for all parts (year, specifically).

--- a/website/README.rst
+++ b/website/README.rst
@@ -37,7 +37,7 @@ A custom templating model is used to generate the HTML files, see
 * The resulting HTML document is parsed with BeautifulSoup into a parse tree.
 
 * Transformation passes are applied to the parse tree.  For instance, C and
-  Ecmascript code is colorized with ``source-highlight``.
+  ECMAScript code is colorized with ``source-highlight``.
 
 * Finally, the parse tree is converted into an ASCII HTML document with
   BeautifulSoup.

--- a/website/api/concepts.html
+++ b/website/api/concepts.html
@@ -13,7 +13,7 @@ contexts.</p>
 <h2>Call stack (of a context)</h2>
 
 <p>Book-keeping of the active function call chain of a context.
-Includes both Ecmascript and Duktape/C function calls.</p>
+Includes both ECMAScript and Duktape/C function calls.</p>
 
 <h2>Value stack (of a context)</h2>
 
@@ -110,7 +110,7 @@ if (duk_check_type_mask(ctx, -3, DUK_TYPE_MASK_NUMBER |
 
 <h2>Array index</h2>
 
-<p>Ecmascript object and array keys can only be strings; this includes
+<p>ECMAScript object and array keys can only be strings; this includes
 array indices (0, 1, 2, ...) which are expressed as canonical string
 representations ("0", "1", "2", ...) of the respective numbers for all
 integers in the range [0, 2**32-1].  Conceptually any key used in a
@@ -119,13 +119,13 @@ is really just a shorthand for <code>obj["123"]</code>.</p>
 
 <p>Duktape tries to avoid explicit number-to-string conversions for array
 accesses whenever possible, so it is preferable to use numeric array
-indices in both Ecmascript code and C code using the Duktape API.</p>
+indices in both ECMAScript code and C code using the Duktape API.</p>
 
 <h2>Duktape/C function</h2>
 
 <p>A C function with a Duktape/C API signature can be associated with an
-Ecmascript function object or a lightfunc value, and gets called when
-the associated value is called from Ecmascript code.  Example:</p>
+ECMAScript function object or a lightfunc value, and gets called when
+the associated value is called from ECMAScript code.  Example:</p>
 <pre class="c-code">
 int my_func(duk_context *ctx) {
     duk_push_int(ctx, 123);
@@ -134,7 +134,7 @@ int my_func(duk_context *ctx) {
 </pre>
 
 <p>Argument count given in value stack is specified when the corresponding
-Ecmascript function object is created: either a fixed number of arguments
+ECMAScript function object is created: either a fixed number of arguments
 of <code>DUK_VARARGS</code> for getting arguments "as is".  Extra arguments
 are dropped and missing arguments padded with <code>undefined</code> as necessary.
 Use <code><a href="#duk_get_top">duk_get_top()</a></code> to determine number of
@@ -164,8 +164,8 @@ int my_func(duk_context *ctx) {
 <h2>Stashes</h2>
 
 <p>A stash is an object reachable from C code using the Duktape/C API, but
-which is unreachable from Ecmascript code.  Stashes allow C code to store
-internal state which can be safely isolated from Ecmascript code.  There are
+which is unreachable from ECMAScript code.  Stashes allow C code to store
+internal state which can be safely isolated from ECMAScript code.  There are
 three stashes:</p>
 <ul>
 <li>Heap stash: shared by all threads in the same heap.</li>

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -9,7 +9,7 @@ the define names.  When in doubt, consult the header directly.</p>
 
 <p>Duktape version is available through the <code>DUK_VERSION</code> define,
 with the numeric value <code>(major * 10000 + minor * 100 + patch)</code>.
-The same value is available to Ecmascript code through <code>Duktape.version</code>.
+The same value is available to ECMAScript code through <code>Duktape.version</code>.
 For example, version 1.2.3 would have <code>DUK_VERSION</code> and
 <code>Duktape.version</code> set to 10203.  For pre-releases <code>DUK_VERSION</code>
 is one less than the actual release, e.g. 1199 for a 0.12.0 pre-release and 10299
@@ -38,7 +38,7 @@ identify prototypes built from a development branch.</td>
 </tr>
 </table>
 
-<p>There are no equivalent defines in the Ecmascript environment.</p>
+<p>There are no equivalent defines in the ECMAScript environment.</p>
 
 <h2>Debug protocol version</h2>
 

--- a/website/api/duk_compile.yaml
+++ b/website/api/duk_compile.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... source! filename! ] -> [ ... function! ]
 
 summary: |
-  <p>Compile Ecmascript source code and replace it with a compiled function
+  <p>Compile ECMAScript source code and replace it with a compiled function
   object (the code is not executed).  The <code>filename</code> argument is stored
   as the <code>fileName</code> property of the resulting function, and is the name
   used in e.g. tracebacks to identify the function.  May throw a <code>SyntaxError</code>
@@ -18,11 +18,11 @@ summary: |
   <table>
   <tr>
   <td>DUK_COMPILE_EVAL</td>
-  <td>Compile the input as eval code instead of as an Ecmascript program</td>
+  <td>Compile the input as eval code instead of as an ECMAScript program</td>
   </tr>
   <tr>
   <td>DUK_COMPILE_FUNCTION</td>
-  <td>Compile the input as a function instead of as an Ecmascript program</td>
+  <td>Compile the input as a function instead of as an ECMAScript program</td>
   </tr>
   <tr>
   <td>DUK_COMPILE_STRICT</td>
@@ -39,15 +39,15 @@ summary: |
 
   <ul>
   <li>Global code: compiles into a function with zero arguments, which
-      executes like a top level Ecmascript program (default)</li>
+      executes like a top level ECMAScript program (default)</li>
   <li>Eval code: compiles into a function with zero arguments, which
-      executes like an Ecmascript <code>eval</code> call
+      executes like an ECMAScript <code>eval</code> call
       (flag <code>DUK_COMPILE_EVAL</code>)</li>
   <li>Function code: compiles into a function with zero or more arguments
       (flag <code>DUK_COMPILE_FUNCTION</code>)</li>
   </ul>
 
-  <p>All of these have slightly different semantics in Ecmascript.  See
+  <p>All of these have slightly different semantics in ECMAScript.  See
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-10.4">Establishing an Execution Context</a>
   for a detailed discussion.
   One major difference is that global and eval contexts have an implicit
@@ -64,7 +64,7 @@ summary: |
   123;  // implicit return value
   </pre>
 
-  <p>Function code follows the Ecmascript <code>function</code> syntax
+  <p>Function code follows the ECMAScript <code>function</code> syntax
   (the function name is optional):</p>
   <pre class="ecmascript-code">
   function adder(x,y) {
@@ -90,7 +90,7 @@ summary: |
   thus preferable to have as much code inside functions as possible.</p>
 
   <p>When compiling eval and global expressions, be careful to avoid the
-  usual Ecmascript gotchas, such as:</p>
+  usual ECMAScript gotchas, such as:</p>
   <pre class="ecmascript-code">
   /* Function at top level is a function declaration which registers a global
    * function, and is different from a function expression.  Use parentheses

--- a/website/api/duk_components_to_time.yaml
+++ b/website/api/duk_components_to_time.yaml
@@ -8,7 +8,7 @@ summary: |
   time value.  The <code>comp-&gt;weekday</code> argument is ignored in the
   conversion.  If the component values are invalid, an error is thrown.</p>
 
-  <p>There are some differences to the Ecmascript <code>Date.UTC()</code>
+  <p>There are some differences to the ECMAScript <code>Date.UTC()</code>
   built-in:</p>
   <ul>
   <li>There's no special handling of two-digit years.  For example,
@@ -18,7 +18,7 @@ summary: |
       resolution) so that the resulting time value may have fractions.</li>
   </ul>
 
-  <p>Like the Ecmascript primitives, the components can exceed their natural
+  <p>Like the ECMAScript primitives, the components can exceed their natural
   range and are normalized.  For example, specifying <code>comp-&gt;minutes</code>
   as 120 is interpreted as adding 2 hours to the time value.  The components are
   expressed as IEEE doubles to allow large and negative values to be used.</p>

--- a/website/api/duk_debugger_pause.yaml
+++ b/website/api/duk_debugger_pause.yaml
@@ -5,18 +5,18 @@ proto: |
 
 summary: |
   <p>Request a debugger pause as soon as possible and return without blocking.
-  The pause will be triggered the next time Ecmascript bytecode is executed,
+  The pause will be triggered the next time ECMAScript bytecode is executed,
   which is usually almost immediate.  However, if a native call such as a
-  Duktape/C function is in progress or no Ecmascript code is currently
+  Duktape/C function is in progress or no ECMAScript code is currently
   executing, it may take longer for the pause to take effect.</p>
 
   <p>The call is a no-op if (1) debugger support has not been compiled in, (2)
   the debugger is not attached, or (3) Duktape is already paused.  This mimics
-  the semantics of the Ecmascript <code>debugger</code> statement.</p>
+  the semantics of the ECMAScript <code>debugger</code> statement.</p>
 
   <div class="note">
   Like all Duktape API calls, this call is not thread safe.  It may be tempting
-  to trigger a pause from a thread different than one running Ecmascript code
+  to trigger a pause from a thread different than one running ECMAScript code
   for the context, but this is unsafe and not currently supported.
   </div>
 

--- a/website/api/duk_def_prop.yaml
+++ b/website/api/duk_def_prop.yaml
@@ -24,7 +24,7 @@ summary: |
   and enumerable attributes are given in the flags field, while property value,
   getter, and setter are given as value stack arguments.  When creating a new
   property, missing attribute values cause
-  <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.1">Ecmascript defaults</a>
+  <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.1">ECMAScript defaults</a>
   to be used (false for all boolean attributes, undefined for value, getter, setter);
   when modifying an existing property missing attribute values mean that existing
   attribute values are not touched.</p>
@@ -46,7 +46,7 @@ summary: |
 
   <p>With the <code>DUK_DEFPROP_FORCE</code> flag property changes can be forced
   even when an operation would normally fail due to a non-extensible target object
-  or a non-configurable property.  This cannot be done from Ecmascript code with
+  or a non-configurable property.  This cannot be done from ECMAScript code with
   <code>Object.defineProperty()</code> and is useful for e.g. sandboxing setup.
   In some cases even a forced change is not possible and will cause an error to be
   thrown.  For instance, properties implemented internally as virtual properties
@@ -263,7 +263,7 @@ example: |
   duk_def_prop(ctx, obj_idx, DUK_DEFPROP_CLEAR_CONFIGURABLE);
 
   /* Create an accessor property which is non-configurable and non-enumerable.
-   * Attribute flags are not given so they default to Ecmascript defaults
+   * Attribute flags are not given so they default to ECMAScript defaults
    * (false) automatically.  Equivalent to:
    *
    *   object.defineproperty(obj, 'my_accessor_1', {
@@ -281,7 +281,7 @@ example: |
 
   /* Create an accessor property which is non-configurable but enumerable.
    * Attribute flags are given explicitly which is easier to read without
-   * knowing about Ecmascript attribute default values.  Equivalent to:
+   * knowing about ECMAScript attribute default values.  Equivalent to:
    *
    *   Object.defineProperty(obj, 'my_accessor_2', {
    *      get: my_getter, set: my_setter, enumerable: true, configurable: false
@@ -311,7 +311,7 @@ example: |
                DUK_DEFPROP_HAVE_SET_ENUMERABLE);
 
   /* Change the value of a non-configurable property by force.
-   * No Ecmascript equivalent.
+   * No ECMAScript equivalent.
    */
 
   duk_push_string(ctx, "my_nonconfigurable_prop");

--- a/website/api/duk_del_prop.yaml
+++ b/website/api/duk_del_prop.yaml
@@ -22,12 +22,12 @@ summary: |
   <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
-  <p>The property deletion is equivalent to the Ecmascript expression
+  <p>The property deletion is equivalent to the ECMAScript expression
   <code>res = delete obj[key]</code>.  For precise semantics, see
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.1">Property Accessors</a>,
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.4.1">The delete operator</a>
   and <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.7">[[Delete]] (P, Throw)</a>.
-  The return value and error throwing behavior mirrors the Ecmascript
+  The return value and error throwing behavior mirrors the ECMAScript
   <code>delete</code> operator behavior.
   Both the target value and the <code>key</code> are coerced:</p>
   <ul>
@@ -44,7 +44,7 @@ summary: |
 
   <div class="note">
   This API call returns <code>1</code> when the target property does not exist.
-  This is not very intuitive, but follows Ecmascript semantics:
+  This is not very intuitive, but follows ECMAScript semantics:
   <code>delete obj.nonexistent</code> also evaluates to <code>true</code>.
   </div>
 

--- a/website/api/duk_dump_function.yaml
+++ b/website/api/duk_dump_function.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... function! ] -> [ ... bytecode! ]
 
 summary: |
-  <p>Dump an Ecmascript function at stack top into
+  <p>Dump an ECMAScript function at stack top into
   <a href="https://github.com/svaarala/duktape/blob/master/doc/bytecode.rst">bytecode</a>,
   replacing the function with a buffer containing the bytecode data.
   The bytecode can be loaded back using

--- a/website/api/duk_enum.yaml
+++ b/website/api/duk_enum.yaml
@@ -60,7 +60,7 @@ summary: |
   <p>Without any flags the enumeration behaves like <code>for-in</code>:
   own and inherited enumerable properties are included, and enumeration
   order follows the
-  <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">Ecmascript ES2015 [[OwnPropertyKeys]]</a>
+  <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">ECMAScript ES2015 [[OwnPropertyKeys]]</a>
   enumeration order, applied for each inheritance level.</p>
 
   <p>Once the enumerator has been created, use

--- a/website/api/duk_equals.yaml
+++ b/website/api/duk_equals.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Compare values at <code>idx1</code> and <code>idx2</code> for equality.
-  Returns 1 if values are considered equal using Ecmascript
+  Returns 1 if values are considered equal using ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.1">Equals</a>
   operator (<code>==</code>) semantics, otherwise returns 0.  Also returns 0 if either
   index is invalid.</p>

--- a/website/api/duk_eval.yaml
+++ b/website/api/duk_eval.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... source! ] -> [ ... result! ]
 
 summary: |
-  <p>Evaluate the Ecmascript source code at the top of the stack, and leave a single
+  <p>Evaluate the ECMAScript source code at the top of the stack, and leave a single
   return value on top of the stack.  May throw an error, errors are not caught
   automatically.  The filename associated with the temporary eval function is
   <code>"eval"</code>.</p>
@@ -30,7 +30,7 @@ summary: |
   <code><a href="#duk_eval_string">duk_eval_string()</a></code>.</p>
 
 example: |
-  /* Eval result in Ecmascript is the last non-empty statement; here, the
+  /* Eval result in ECMAScript is the last non-empty statement; here, the
    * result of the eval is the number 123.
    */
 

--- a/website/api/duk_get_boolean.yaml
+++ b/website/api/duk_get_boolean.yaml
@@ -11,7 +11,7 @@ summary: |
   the value.  Returns 1 if the value is <code>true</code>, 0 if the value is
   <code>false</code>, not a boolean, or the index is invalid.</p>
 
-  <p>Note that the value is not coerced, so even a "truthy" Ecmascript value
+  <p>Note that the value is not coerced, so even a "truthy" ECMAScript value
   (like a non-empty string) will be treated as false.  If you want to coerce
   the value, use <code><a href="#duk_to_boolean">duk_to_boolean()</a></code>.</p>
 

--- a/website/api/duk_get_buffer_data.yaml
+++ b/website/api/duk_get_buffer_data.yaml
@@ -39,7 +39,7 @@ summary: |
   lifetime of the buffer.  For dynamic and external buffers the pointer may
   change as the buffer is resized or reconfigured; the caller is responsible for
   ensuring pointer values returned from this API call are not used after the
-  buffer is resized/reconfigured.  Buffers created from Ecmascript code directly
+  buffer is resized/reconfigured.  Buffers created from ECMAScript code directly
   e.g. as <code>new Buffer(8)</code> are backed by an automatic fixed buffer, so
   their pointers are always stable.</p>
 

--- a/website/api/duk_get_c_function.yaml
+++ b/website/api/duk_get_c_function.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Get the Duktape/C function pointer (a <code>duk_c_function</code>) from an
-  Ecmascript function object associated with a Duktape/C function.  If the
+  ECMAScript function object associated with a Duktape/C function.  If the
   value is not such a function or <code>idx</code> is invalid, returns <code>NULL</code>.</p>
 
   <p>If you prefer an error to be thrown for an invalid value or index, use

--- a/website/api/duk_get_int.yaml
+++ b/website/api/duk_get_int.yaml
@@ -29,7 +29,7 @@ summary: |
   <div class="note">
   The coercion is different from a basic C cast from <code>double</code> to
   integer, which may have counterintuitive (and non-portable) behavior like coercing
-  NaN to <code>DUK_INT_MIN</code>.  The coercion is also different from Ecmascript
+  NaN to <code>DUK_INT_MIN</code>.  The coercion is also different from ECMAScript
   <code>ToInt32()</code> coercion because the full range of the native
   <code>duk_int_t</code> is allowed (which may be more than 32 bits).
   </div>

--- a/website/api/duk_get_now.yaml
+++ b/website/api/duk_get_now.yaml
@@ -4,7 +4,7 @@ proto: |
   duk_double_t duk_get_now(duk_context *ctx);
 
 summary: |
-  Get current time in POSIX milliseconds, as seen by the Ecmascript
+  Get current time in POSIX milliseconds, as seen by the ECMAScript
   environment.  The return value matches Date.now() with the reservation
   that sub-millisecond resolution may be available.
 

--- a/website/api/duk_get_prop.yaml
+++ b/website/api/duk_get_prop.yaml
@@ -23,7 +23,7 @@ summary: |
   <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
-  <p>The property read is equivalent to the Ecmascript expression
+  <p>The property read is equivalent to the ECMAScript expression
   <code>res = obj[key]</code> with the exception that the presence or absence of the
   property is indicated by the call return value.  For precise semantics, see
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.1">Property Accessors</a>,

--- a/website/api/duk_get_uint.yaml
+++ b/website/api/duk_get_uint.yaml
@@ -29,7 +29,7 @@ summary: |
   <div class="note">
   The coercion is different from a basic C cast from <code>double</code> to
   unsigned integer, which may have counterintuitive (and non-portable) behavior
-  for e.g. NaN values.  The coercion is also different from Ecmascript
+  for e.g. NaN values.  The coercion is also different from ECMAScript
   <code>ToUint32()</code> coercion because the full range of the native
   <code>duk_uint_t</code> is allowed (which may be more than 32 bits).
   </div>

--- a/website/api/duk_has_prop.yaml
+++ b/website/api/duk_has_prop.yaml
@@ -17,7 +17,7 @@ summary: |
   <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
-  <p>The property existence check is equivalent to the Ecmascript expression
+  <p>The property existence check is equivalent to the ECMAScript expression
   <code>res = key in obj</code>.  For semantics, see
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.1">Property Accessors</a>,
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.8.7">The in operator</a>,
@@ -40,7 +40,7 @@ summary: |
   Instead of accepting any
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">object coercible</a>
   value (like most property related API calls) this call accepts only an object
-  as its target value.  This is intentional as it follows Ecmascript operator semantics.
+  as its target value.  This is intentional as it follows ECMAScript operator semantics.
   </div>
 
   <p>If the key is a fixed string you can avoid one API call and use the

--- a/website/api/duk_inspect_callstack_entry.yaml
+++ b/website/api/duk_inspect_callstack_entry.yaml
@@ -31,12 +31,12 @@ summary: |
   </tr>
   <tr>
   <td class="propname">pc</td>
-  <td>Program counter for Ecmascript functions.  Zero if executing a native
+  <td>Program counter for ECMAScript functions.  Zero if executing a native
       function.</td>
   </tr>
   <tr>
   <td class="propname">lineNumber</td>
-  <td>Line number for Ecmascript functions.  Zero if executing a native
+  <td>Line number for ECMAScript functions.  Zero if executing a native
       function or if pc-to-line translation data is not available.</td>
   </tr>
   </tbody>

--- a/website/api/duk_inspect_value.yaml
+++ b/website/api/duk_inspect_value.yaml
@@ -61,7 +61,7 @@ summary: |
   </tr>
   <tr>
   <td class="propname">bcbytes</td>
-  <td>Byte size of Ecmascript function bytecode (instructions, constants).
+  <td>Byte size of ECMAScript function bytecode (instructions, constants).
       Shared between all instances (closures) of a certain function template.</td>
   </tr>
   <tr>

--- a/website/api/duk_instanceof.yaml
+++ b/website/api/duk_instanceof.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Compare values at <code>idx1</code> and <code>idx2</code> using the
-  Ecmascript <a href="https://www.ecma-international.org/ecma-262/6.0/#sec-instanceofoperator">instanceof</a>
+  ECMAScript <a href="https://www.ecma-international.org/ecma-262/6.0/#sec-instanceofoperator">instanceof</a>
   operator.  Returns 1 if <code>val1 instanceof val2</code>, 0 if not.  Throws an error
   if either index is invalid; <code>instanceof</code> itself also throws errors for
   invalid argument types.</p>

--- a/website/api/duk_is_array.yaml
+++ b/website/api/duk_is_array.yaml
@@ -7,11 +7,11 @@ stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>idx</code> is an object and is an Ecmascript array
+  <p>Returns 1 if value at <code>idx</code> is an object and is an ECMAScript array
   (has the internal class <code>Array</code>), otherwise returns 0.  If <code>idx</code>
   is invalid, also returns 0.</p>
 
-  <p>This function returns 1 when the following Ecmascript expression is true:</p>
+  <p>This function returns 1 when the following ECMAScript expression is true:</p>
   <pre class="ecmascript-code">
   Object.prototype.toString.call(val) === '[object Array]'
   </pre>

--- a/website/api/duk_is_bound_function.yaml
+++ b/website/api/duk_is_bound_function.yaml
@@ -8,10 +8,10 @@ stack: |
 
 summary: |
   <p>Returns 1 if value at <code>idx</code> is a Function object which has
-  been created with Ecmascript <code>Function.prototype.bind()</code>,
+  been created with ECMAScript <code>Function.prototype.bind()</code>,
   otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
-  <p>Bound functions are an Ecmascript concept: they point to a target
+  <p>Bound functions are an ECMAScript concept: they point to a target
   function and supply a <code>this</code> binding and zero or more argument
   bindings.  See
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4.5">Function.prototype.bind (thisArg [, arg1 [, arg2, ...]])</a>.

--- a/website/api/duk_is_ecmascript_function.yaml
+++ b/website/api/duk_is_ecmascript_function.yaml
@@ -8,11 +8,11 @@ stack: |
 
 summary: |
   <p>Returns 1 if value at <code>idx</code> is a Function object which has
-  been compiled from Ecmascript source code, otherwise returns 0.
+  been compiled from ECMAScript source code, otherwise returns 0.
   If <code>idx</code> is invalid, also returns 0.</p>
 
-  <p>Internally Ecmascript functions are compiled into bytecode and executed
-  with the Ecmascript bytecode interpreter.</p>
+  <p>Internally ECMAScript functions are compiled into bytecode and executed
+  with the ECMAScript bytecode interpreter.</p>
 
 example: |
   if (duk_is_ecmascript_function(ctx, -3)) {

--- a/website/api/duk_is_function.yaml
+++ b/website/api/duk_is_function.yaml
@@ -11,7 +11,7 @@ summary: |
   internal class <code>Function</code>), otherwise returns 0.  If <code>idx</code> is
   invalid, also returns 0.</p>
 
-  <p>This function returns 1 when the following Ecmascript expression is true:</p>
+  <p>This function returns 1 when the following ECMAScript expression is true:</p>
   <pre class="ecmascript-code">
   Object.prototype.toString.call(val) === '[object Function]'
   </pre>

--- a/website/api/duk_is_null_or_undefined.yaml
+++ b/website/api/duk_is_null_or_undefined.yaml
@@ -10,7 +10,7 @@ summary: |
   <p>Returns 1 if value at <code>idx</code> is either <code>null</code> or <code>undefined</code>,
   otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
-  <p>This API call is similar to a <code>(x == null)</code> comparison in Ecmascript, which
+  <p>This API call is similar to a <code>(x == null)</code> comparison in ECMAScript, which
   is true for both <code>null</code> and <code>undefined</code>.</p>
 
 example: |

--- a/website/api/duk_is_object.yaml
+++ b/website/api/duk_is_object.yaml
@@ -13,9 +13,9 @@ summary: |
   <p>Note that many values are considered to be an object, e.g.:</p>
 
   <ul>
-  <li>Ecmascript object</li>
-  <li>Ecmascript array</li>
-  <li>Ecmascript function</li>
+  <li>ECMAScript object</li>
+  <li>ECMAScript array</li>
+  <li>ECMAScript function</li>
   <li>Duktape thread (coroutine)</li>
   <li>Duktape internal objects</li>
   </ul>

--- a/website/api/duk_is_object_coercible.yaml
+++ b/website/api/duk_is_object_coercible.yaml
@@ -11,7 +11,7 @@ summary: |
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.10">CheckObjectCoercible</a>,
   otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
 
-  <p>All Ecmascript types are object coercible except <code>undefined</code> and
+  <p>All ECMAScript types are object coercible except <code>undefined</code> and
   <code>null</code>.  The custom buffer and pointer types are object coercible.</p>
 
 example: |

--- a/website/api/duk_load_function.yaml
+++ b/website/api/duk_load_function.yaml
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Load a buffer containing
   <a href="https://github.com/svaarala/duktape/blob/master/doc/bytecode.rst">bytecode</a>,
-  recreating the original Ecmascript function (with some limitations).  You <b>must</b>
+  recreating the original ECMAScript function (with some limitations).  You <b>must</b>
   ensure that the bytecode has been dumped with a compatible Duktape version and that the
   bytecode has not been modified since.  <b>Loading bytecode from an untrusted source is
   memory unsafe and may load to exploitable vulnerabilities.</b></p>

--- a/website/api/duk_new.yaml
+++ b/website/api/duk_new.yaml
@@ -26,7 +26,7 @@ summary: |
 
 example: |
   /* Assume target function is already on stack at func_idx.
-   * Equivalent to Ecmascript 'new func("foo", 123)'.
+   * Equivalent to ECMAScript 'new func("foo", 123)'.
    */
   duk_idx_t func_idx = /* ... */;
 

--- a/website/api/duk_opt_c_function.yaml
+++ b/website/api/duk_opt_c_function.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Get the Duktape/C function pointer (a <code>duk_c_function</code>) from an
-  Ecmascript function object associated with a Duktape/C function.  If the
+  ECMAScript function object associated with a Duktape/C function.  If the
   value is <code>undefined</code> or the index is invalid, <code>def_value</code>
   default value is returned.  In other cases (<code>null</code> or non-matching
   type) throws an error.</p>

--- a/website/api/duk_push_array.yaml
+++ b/website/api/duk_push_array.yaml
@@ -20,7 +20,7 @@ example: |
   duk_put_prop_index(ctx, arr_idx, 1);
 
   /* array is now: [ "foo", "bar" ], and array.length is 2 (automatically
-   * updated for Ecmascript arrays).
+   * updated for ECMAScript arrays).
    */
 
   duk_pop(ctx);  /* pop array */

--- a/website/api/duk_push_c_function.yaml
+++ b/website/api/duk_push_c_function.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Push a new function object, associated with a C function, to the stack.
-  The function object is an Ecmascript function object; when called, <code>func</code>
+  The function object is an ECMAScript function object; when called, <code>func</code>
   will be called using the Duktape/C function interface.  Returns non-negative index
   (relative to stack bottom) of the pushed function.</p>
 
@@ -29,7 +29,7 @@ summary: |
   and as a constructor (<code>new func()</code>).  You can differentiate between the two
   call styles using <code><a href="#duk_is_constructor_call">duk_is_constructor_call()</a></code>.
   Although the function can be used as a constructor, it doesn't have an automatic
-  <code>prototype</code> property like Ecmascript functions.</p>
+  <code>prototype</code> property like ECMAScript functions.</p>
 
   <div class="note">
   If you intend to use the pushed function as a constructor, you should usually

--- a/website/api/duk_push_current_function.yaml
+++ b/website/api/duk_push_current_function.yaml
@@ -9,7 +9,7 @@ stack: |
 
 summary: |
   <p>Push the currently running function to the stack.  The value pushed is
-  an Ecmascript Function object.  If there is no current function,
+  an ECMAScript Function object.  If there is no current function,
   <code>undefined</code> is pushed instead.</p>
 
   <p>If the current function was called via one or more bound functions or a

--- a/website/api/duk_push_current_thread.yaml
+++ b/website/api/duk_push_current_thread.yaml
@@ -9,7 +9,7 @@ stack: |
 
 summary: |
   <p>Push the currently running Duktape thread to the stack.  The value pushed
-  is a thread object which is also an Ecmascript object.  If there is no current
+  is a thread object which is also an ECMAScript object.  If there is no current
   thread, <code>undefined</code> is pushed instead.</p>
 
   <p>The current thread is (almost always) the thread represented by the

--- a/website/api/duk_push_external_buffer.yaml
+++ b/website/api/duk_push_external_buffer.yaml
@@ -14,7 +14,7 @@ summary: |
   <code><a href="#duk_config_buffer">duk_config_buffer()</a></code>
   to update the external buffer pointer and size.</p>
 
-  <p>External buffers are useful to allow Ecmascript code access externally
+  <p>External buffers are useful to allow ECMAScript code access externally
   allocated data structures.  You can use it to e.g. write bytes to an
   externally allocated frame buffer.  The external buffer has no alignment
   requirements (Duktape makes no alignment assumptions when accessing it).</p>
@@ -33,12 +33,12 @@ example: |
   duk_push_external_buffer(ctx);
   duk_config_buffer(ctx, -1, p, len);
 
-  /* Ecmascript code with access to the buffer object could now do
+  /* ECMAScript code with access to the buffer object could now do
    * something like:
    *
    *    buf[100] = 123;
    *
-   * Calling code must make sure Ecmascript never reads/writes an
+   * Calling code must make sure ECMAScript never reads/writes an
    * external buffer whose backing buffer is no longer valid.
    */
 

--- a/website/api/duk_push_global_stash.yaml
+++ b/website/api/duk_push_global_stash.yaml
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Push the global stash object to the stack.  The global stash is an internal
   object which can be used to store key/value pairs from C code so that they are
-  reachable for garbage collection, but are not accessible from Ecmascript code.
+  reachable for garbage collection, but are not accessible from ECMAScript code.
   The stash is only accessible from C code with a <code>ctx</code> argument
   associated with the same global object.</p>
 

--- a/website/api/duk_push_heap_stash.yaml
+++ b/website/api/duk_push_heap_stash.yaml
@@ -9,7 +9,7 @@ stack: |
 summary: |
   <p>Push the heap stash object to the stack.  The heap stash is an internal
   object which can be used to store key/value pairs from C code so that they are
-  reachable for garbage collection, but are not accessible from Ecmascript code.
+  reachable for garbage collection, but are not accessible from ECMAScript code.
   The stash is only accessible from C code; the same stash object is used by all
   code sharing the same Duktape heap (even if they don't share the same global
   object).</p>

--- a/website/api/duk_push_string.yaml
+++ b/website/api/duk_push_string.yaml
@@ -13,7 +13,7 @@ summary: |
   A pointer to the interned string data is returned.  If the operation fails,
   throws an error.</p>
 
-  <p>If <code>str</code> is <code>NULL</code>, an Ecmascript <code>null</code> is pushed
+  <p>If <code>str</code> is <code>NULL</code>, an ECMAScript <code>null</code> is pushed
   to the stack and <code>NULL</code> is returned.  This behavior differs from
   <code><a href="#duk_push_lstring">duk_push_lstring</a></code> on purpose.</p>
 
@@ -22,7 +22,7 @@ summary: |
   Some invalid CESU-8/UTF-8 byte sequences are reserved for special
   uses such as representing Symbol values.  When you push such an invalid
   byte sequence, the value on the value stack will behave like a string for
-  C code but will appear as a <code>Symbol</code> for Ecmascript code.
+  C code but will appear as a <code>Symbol</code> for ECMAScript code.
   See <a href="guide.html#symbols">Symbols</a> for more discussion.
   </div>
 

--- a/website/api/duk_push_thread_stash.yaml
+++ b/website/api/duk_push_thread_stash.yaml
@@ -11,7 +11,7 @@ summary: |
   <code>ctx</code> and <code>target_ctx</code> arguments may refer to the same
   thread).  The thread stash is an internal object which can be used to store
   key/value pairs from C code so that they are reachable for garbage collection,
-  but are not accessible from Ecmascript code.  The stash is only accessible
+  but are not accessible from ECMAScript code.  The stash is only accessible
   from C code with a matching <code>target_ctx</code> argument.</p>
 
   <p>If <code>target_ctx</code> is <code>NULL</code>, throws an error.</p>

--- a/website/api/duk_put_prop.yaml
+++ b/website/api/duk_put_prop.yaml
@@ -20,9 +20,9 @@ summary: |
   <li>If <code>obj_idx</code> is invalid, throws an error.</li>
   </ul>
 
-  <p>The property write is equivalent to the Ecmascript expression
+  <p>The property write is equivalent to the ECMAScript expression
   <code>obj[key] = val</code>.  The exact rules of when a property write
-  succeeds or fails are the same as for Ecmascript code making the
+  succeeds or fails are the same as for ECMAScript code making the
   equivalent assignment.  For precise semantics, see
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.1">Property Accessors</a>,
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.7.2">PutValue (V, W)</a>,
@@ -31,7 +31,7 @@ summary: |
   <ul>
   <li>The target value is automatically coerced to an object.  However, the object
       is transitory so writing its properties is not very useful.  Moreover,
-      Ecmascript semantics prevent new properties from being created for such
+      ECMAScript semantics prevent new properties from being created for such
       transitory objects (see
       <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.7.2">PutValue (V, W)</a>,
       step 7 of the special [[Put]] variant).</li>
@@ -45,10 +45,10 @@ summary: |
   the trap is invoked and the API call return value matches the trap return value.</p>
 
   <div class="note">
-  In Ecmascript an assignment expression has the value of the right-hand-side
+  In ECMAScript an assignment expression has the value of the right-hand-side
   expression, regardless of whether or not the assignment succeeds.  The return
-  value for this API call is not specified by Ecmascript or available to
-  Ecmascript code: the API call returns <code>0</code> or <code>1</code>
+  value for this API call is not specified by ECMAScript or available to
+  ECMAScript code: the API call returns <code>0</code> or <code>1</code>
   depending on whether the assignment succeeded or not (with the <code>0</code>
   return value promoted to an error in strict code).
   </div>

--- a/website/api/duk_require_c_function.yaml
+++ b/website/api/duk_require_c_function.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Like <code><a href="#duk_get_c_function">duk_get_c_function()</a></code>, but
-  throws an error if the value at <code>idx</code> is not an Ecmascript function
+  throws an error if the value at <code>idx</code> is not an ECMAScript function
   associated with a Duktape/C function or if the index is invalid.</p>
 
 example: |

--- a/website/api/duk_samevalue.yaml
+++ b/website/api/duk_samevalue.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Compare values at <code>idx1</code> and <code>idx2</code> for equality.
-  Returns 1 if values are considered equal using Ecmascript
+  Returns 1 if values are considered equal using ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.12">SameValue</a>
   algorithm (<code>Object.is()</code> in ES2015) semantics, otherwise returns 0.
   Also returns 0 if either index is invalid.</p>

--- a/website/api/duk_set_length.yaml
+++ b/website/api/duk_set_length.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Set "length" for value at <code>idx</code>.  Equivalent to the Ecmascript
+  <p>Set "length" for value at <code>idx</code>.  Equivalent to the ECMAScript
   statement <code>obj.length = len;</code>.</p>
 
 example: |

--- a/website/api/duk_set_prototype.yaml
+++ b/website/api/duk_set_prototype.yaml
@@ -13,7 +13,7 @@ summary: |
   <code>undefined</code>, an error is thrown.</p>
 
   <div class="note">
-  Unlike Ecmascript prototype manipulation primitives, this API call allows
+  Unlike ECMAScript prototype manipulation primitives, this API call allows
   creation of a prototype loop.  Calling code should always avoid creating a
   prototype loop: although Duktape detects long or looped prototype chains
   and throws an error when it encounters one, such behavior is only intended

--- a/website/api/duk_strict_equals.yaml
+++ b/website/api/duk_strict_equals.yaml
@@ -8,7 +8,7 @@ stack: |
 
 summary: |
   <p>Compare values at <code>idx1</code> and <code>idx2</code> for equality.
-  Returns 1 if values are considered equal using Ecmascript
+  Returns 1 if values are considered equal using ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.4">Strict Equals</a>
   operator (<code>===</code>) semantics, otherwise returns 0.  Also returns 0 if either index
   is invalid.</p>

--- a/website/api/duk_throw.yaml
+++ b/website/api/duk_throw.yaml
@@ -19,7 +19,7 @@ summary: |
   </pre>
 
 example: |
-  /* Throw a string value; equivalent to the Ecmascript code:
+  /* Throw a string value; equivalent to the ECMAScript code:
    *
    *   throw "this string is thrown";
    */

--- a/website/api/duk_time_to_components.yaml
+++ b/website/api/duk_time_to_components.yaml
@@ -5,10 +5,10 @@ proto: |
 
 summary: |
   <p>Convert a time value to components (year, month, day, etc) interpreted
-  in UTC.  If the time value is invalid, e.g. beyond the valid Ecmascript
+  in UTC.  If the time value is invalid, e.g. beyond the valid ECMAScript
   time range, an error is thrown.</p>
 
-  <p>There are some differences to the Ecmascript <code>Date</code> UTC
+  <p>There are some differences to the ECMAScript <code>Date</code> UTC
   accessors like <code>Date.prototype.getUTCMinutes()</code>:</p>
   <ul>
   <li>The time value is allowed to have fractions (sub-millisecond
@@ -24,9 +24,9 @@ example: |
     "Thursday", "Friday", "Saturday"
   };
 
-  /* Note that month is zero-based to match the Ecmascript API, so for
+  /* Note that month is zero-based to match the ECMAScript API, so for
    * human readable printing add 1 to the month.  Time components are
-   * IEEE doubles to match Ecmascript Date behavior.
+   * IEEE doubles to match ECMAScript Date behavior.
    */
   duk_time_to_components(ctx, time, &comp);
   printf("Datetime: %04d-%02d-%02d %02d:%02d:%02d.%03dZ\n",

--- a/website/api/duk_to_boolean.yaml
+++ b/website/api/duk_to_boolean.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToBoolean(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.2">ToBoolean()</a>
   coerced value.  Returns 1 if the result of the coercion <code>true</code>, 0 otherwise.
   If <code>idx</code> is invalid, throws an error.</p>

--- a/website/api/duk_to_buffer.yaml
+++ b/website/api/duk_to_buffer.yaml
@@ -16,7 +16,7 @@ summary: |
   <ul>
   <li>Buffer: no change, dynamic/fixed/external nature not changed</li>
   <li>String: coerces into a fixed size buffer, byte-for-byte</li>
-  <li>Other types: first apply Ecmascript
+  <li>Other types: first apply ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.8">ToString()</a>,
   then coerce into a fixed size buffer, byte-for-byte</li>
   </ul>

--- a/website/api/duk_to_int.yaml
+++ b/website/api/duk_to_int.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToNumber(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>index</code> with an Ecmascript
+  <p>Replace the value at <code>index</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.4">ToInteger()</a>
   coerced value.  Returns an <code>duk_int_t</code> further coerced from the <code>ToInteger()</code>
   result using the algorithm described in

--- a/website/api/duk_to_int32.yaml
+++ b/website/api/duk_to_int32.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToInt32(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.5">ToInt32()</a>
   coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>

--- a/website/api/duk_to_lstring.yaml
+++ b/website/api/duk_to_lstring.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.8">ToString()</a>
   coerced value.  Returns a non-<code>NULL</code> pointer to the read-only,
   NUL-terminated string data, and writes the string byte length to <code>*out_len</code>

--- a/website/api/duk_to_number.yaml
+++ b/website/api/duk_to_number.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToNumber(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.3">ToNumber()</a>
   coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>

--- a/website/api/duk_to_object.yaml
+++ b/website/api/duk_to_object.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToObject(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.9">ToObject()</a>
   coerced value.  There is no return value.  Throws an error if value at
   <code>idx</code> is not

--- a/website/api/duk_to_primitive.yaml
+++ b/website/api/duk_to_primitive.yaml
@@ -7,14 +7,14 @@ stack: |
   [ ... val! ... ] -> [ ... ToPrimitive(val)! ]
 
 summary: |
-  <p>Replace the object at <code>idx</code> with an Ecmascript
+  <p>Replace the object at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.1">ToPrimitive()</a>
   coerced value.  The <code>hint</code> argument affects coercion of an object into a
   primitive type, and indicates preference for a string (<code>DUK_HINT_STRING</code>),
   a number (<code>DUK_HINT_NUMBER</code>), or neither (<code>DUK_HINT_NONE</code>).
   <code>DUK_HINT_NONE</code> causes a preference to a number, unless the input value
   is a <code>Date</code> instance, in which case a string is preferred (the exact
-  coercion behavior is described in the Ecmascript specification).  If <code>idx</code>
+  coercion behavior is described in the ECMAScript specification).  If <code>idx</code>
   is invalid, throws an error.</p>
 
   <p>Custom type coercion:</p>

--- a/website/api/duk_to_string.yaml
+++ b/website/api/duk_to_string.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToString(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.8">ToString()</a>
   coerced value.  Returns a non-<code>NULL</code> pointer to the read-only,
   NUL-terminated string data.  If <code>idx</code> is invalid, throws an error.</p>

--- a/website/api/duk_to_uint16.yaml
+++ b/website/api/duk_to_uint16.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToUint16(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.7">ToUint16()</a>
   coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>

--- a/website/api/duk_to_uint32.yaml
+++ b/website/api/duk_to_uint32.yaml
@@ -7,7 +7,7 @@ stack: |
   [ ... val! ... ] -> [ ... ToUint32(val)! ... ]
 
 summary: |
-  <p>Replace the value at <code>idx</code> with an Ecmascript
+  <p>Replace the value at <code>idx</code> with an ECMAScript
   <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9.6">ToUint32()</a>
   coerced value.  Returns the coerced value.  If <code>idx</code> is invalid, throws
   an error.</p>

--- a/website/api/intro.html
+++ b/website/api/intro.html
@@ -5,7 +5,7 @@
 <h2>Document scope</h2>
 
 <p>The Duktape API (defined in <code>duktape.h</code>) is a set of constants
-and API calls which allows C/C++ programs to interface with Ecmascript
+and API calls which allows C/C++ programs to interface with ECMAScript
 code and shields them from internal details like value representation.
 </p>
 

--- a/website/guide/bufferobjects.html
+++ b/website/guide/bufferobjects.html
@@ -113,10 +113,10 @@ However, they have more overhead than plain buffers.</p>
 
 <h2>Working with buffers</h2>
 
-<p>Buffer values work in both C and Ecmascript code:</p>
+<p>Buffer values work in both C and ECMAScript code:</p>
 
 <ul>
-<li>For Ecmascript code most of the behavior is defined in the relevant API
+<li>For ECMAScript code most of the behavior is defined in the relevant API
     standards, with exceptions for Duktape-specific features like mixing
     different buffer types.</li>
 <li>For C code there are API calls to work with

--- a/website/guide/bytecodedumpload.html
+++ b/website/guide/bytecodedumpload.html
@@ -3,7 +3,7 @@
 <p>The API calls
 <code><a href="api.html#duk_dump_function">duk_dump_function()</a></code> and
 <code><a href="api.html#duk_load_function">duk_load_function()</a></code> allow
-calling C code to (1) serialize an Ecmascript function into a portable
+calling C code to (1) serialize an ECMAScript function into a portable
 bytecode and then (2) load the bytecode to reconstitute the function.</p>
 
 <p>The bytecode format is Duktape version specific and it's unsafe to

--- a/website/guide/compatibility.html
+++ b/website/guide/compatibility.html
@@ -1,29 +1,29 @@
 <h1 id="compatibility">Compatibility</h1>
 
-<p>This section discussed Duktape compatibility with Ecmascript dialects,
+<p>This section discussed Duktape compatibility with ECMAScript dialects,
 extensions, frameworks, and test suites.</p>
 
-<h2 id="compatibility-e5">Ecmascript E5 / E5.1</h2>
+<h2 id="compatibility-e5">ECMAScript E5 / E5.1</h2>
 
-<p>The main compatibility goal of Duktape is to be Ecmascript E5/E5.1
+<p>The main compatibility goal of Duktape is to be ECMAScript E5/E5.1
 compatible.  However, ES5 feature semantics are updated to ES2015 (or
 later) where incompatible changes have been made in newer specification
 versions.  Current level of compatibility should be quite high.</p>
 
-<h2 id="compatibility-e6">Ecmascript 2015 (E6)</h2>
+<h2 id="compatibility-e6">ECMAScript 2015 (E6)</h2>
 
-<p>Duktape implements some features from Ecmascript 2015 (E6), but generally there
+<p>Duktape implements some features from ECMAScript 2015 (E6), but generally there
 is no compatibility with E6 yet.</p>
 
-<h2 id="compatibility-e7">Ecmascript 2016 (E7)</h2>
+<h2 id="compatibility-e7">ECMAScript 2016 (E7)</h2>
 
-<p>Duktape implements some features from Ecmascript 2016 (E7), but generally there
+<p>Duktape implements some features from ECMAScript 2016 (E7), but generally there
 is no compatibility with E7 yet.</p>
 
-<h2 id="compatibility-e3">Ecmascript E3</h2>
+<h2 id="compatibility-e3">ECMAScript E3</h2>
 
 <p>There is no effort to maintain
-<a href="http://www.mozilla.org/js/language/E262-3.pdf">Ecmascript E3</a>
+<a href="http://www.mozilla.org/js/language/E262-3.pdf">ECMAScript E3</a>
 compatibility, other than required by the E5/E5.1 specification.</p>
 
 <h2 id="compatibility-coffeescript">CoffeeScript</h2>
@@ -72,7 +72,7 @@ running the resulting Javascript using Duktape.  It's also possible to
 <h2 id="compatibility-underscorejs">Underscore.js</h2>
 
 <p><a href="http://underscorejs.org/">Underscore.js</a> provides a lot of
-useful utilities to plain Ecmascript.  Duktape passes almost all of Underscore's
+useful utilities to plain ECMAScript.  Duktape passes almost all of Underscore's
 test cases, see
 <a href="https://github.com/svaarala/duktape/blob/master/doc/underscore-status.rst">underscore-status.rst</a>
 for current compatibility status.</p>
@@ -93,7 +93,7 @@ target language for compilers".  As a subset of JavaScript, functions using
 asm.js type annotations should be fully compatible with Duktape.  However,
 Duktape has no specific support for asm.js and won't optimize asm.js code.
 In fact, asm.js code will generate unnecessary bytecode and execute slower
-than normal Ecmascript code.  The <code>"use asm"</code> directive specified
+than normal ECMAScript code.  The <code>"use asm"</code> directive specified
 by asm.js is ignored by Duktape.  Also, because there is not typed array
 support yet, no "heap object" can be provided.</p>
 

--- a/website/guide/compiling.html
+++ b/website/guide/compiling.html
@@ -59,14 +59,14 @@ a few variants:</p>
 <p>These preconfigured sources provide automatic platform, compiler, and
 architecture detection and use the Duktape default configuration:</p>
 <ul>
-<li>Full Ecmascript E5/E5.1 compliance
+<li>Full ECMAScript E5/E5.1 compliance
     (including the optional
     <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-B">Annex B</a>
     features), except for intentional real world compatibility deviations
     (see <a href="#custombehavior">Custom behavior</a>)</li>
 <li>ES2015 typed array and Node.js Buffer support</li>
-<li>Some features from <a href="#es6features">Ecmascript 2015 (E6)</a> and
-    <a href="#es7features">Ecmascript 2016 (E7)</a></li>
+<li>Some features from <a href="#es6features">ECMAScript 2015 (E6)</a> and
+    <a href="#es7features">ECMAScript 2016 (E7)</a></li>
 <li>Packed value representation (8 bytes per value) when available,
     unpacked value representation (usually 16 bytes per value) when not</li>
 <li>Reference counting and mark-and-sweep garbage collection</li>
@@ -85,7 +85,7 @@ Run <code>configure.py</code> with the <code>--dll</code> option to do that.
 <p>The <code>configure.py</code> utility prepares Duktape source and header
 files for a specific configuration described using command line options.
 For example, to prepare Duktape sources for a DLL build with fastint
-support enabled and Ecmascript 6 <code>Proxy</code> object support disabled:</p>
+support enabled and ECMAScript 6 <code>Proxy</code> object support disabled:</p>
 <pre>
 # Default output format is single source file (--separate-sources for separate
 # sources) and no #line directives (--line-directives to enable them).
@@ -197,7 +197,7 @@ for more practical details.</p>
 </ul>
 
 <p>Reference counting relies on mark-and-sweep to handle reference cycles.
-For example, every Ecmascript function instance is required to be in a
+For example, every ECMAScript function instance is required to be in a
 reference loop with an automatic prototype object created for the function.
 You can break this loop manually if you wish.  For internal technical reasons,
 named function expressions are also in a reference loop; this loop cannot be

--- a/website/guide/coroutines.html
+++ b/website/guide/coroutines.html
@@ -34,7 +34,7 @@ finished can no longer be resumed; attempt to do so will cause a TypeError.</p>
 
 <p>There are currently strict limitations on when a yield is possible.
 In short, a coroutine can only yield if its entire active call stack consists
-of plain Ecmascript-to-Ecmascript calls.  The following prevent a yield if
+of plain ECMAScript-to-ECMAScript calls.  The following prevent a yield if
 they are present anywhere in the yielding coroutine's call stack:</p>
 <ul>
 <li>a Duktape/C function call</li>

--- a/website/guide/custombehavior.html
+++ b/website/guide/custombehavior.html
@@ -13,7 +13,7 @@ types are custom.</p>
 
 <p>Objects may have properties with <a href="#symbols">hidden Symbol</a> keys.
 These are similar to ES2015 Symbols but won't be enumerated or returned from even
-<code>Object.getOwnPropertySymbols()</code>.  Ordinary Ecmascript code cannot
+<code>Object.getOwnPropertySymbols()</code>.  Ordinary ECMAScript code cannot
 refer to such properties because the keys intentionally use an invalid (extended)
 UTF-8 representation.</p>
 
@@ -25,7 +25,7 @@ It prevents a function from being tail called.</p>
 <h2>"const" treated mostly like "var"</h2>
 
 <p>The <code>const</code> keyword is supported with minimal non-standard
-semantics (officially defined in Ecmascript 6).  See
+semantics (officially defined in ECMAScript 6).  See
 <a href="#es6-const">Const variables</a> for more detail.</p>
 
 <h2>Additional Error and Function object properties</h2>
@@ -90,10 +90,10 @@ binding in any of the points A, B, or C.</p>
 
 <h2>RegExp leniency</h2>
 
-<p>Most Ecmascript engines support more syntax than guaranteed by the
-<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1">Ecmascript
+<p>Most ECMAScript engines support more syntax than guaranteed by the
+<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1">ECMAScript
 E5.1 specification (Section 15.10.1 Patterns)</a>.  As a result there's quite
-a lot of code that won't work with strict Ecmascript E5.1 regexp syntax.  Much
+a lot of code that won't work with strict ECMAScript E5.1 regexp syntax.  Much
 of the additional syntax expected of web browser engines is documented in
 <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regular-expressions-patterns">ES2015 Annex B.1.4 Regular Expression Patterns</a>.
 However, note that features in
@@ -135,7 +135,7 @@ be enabled by disabling the config option <code>DUK_USE_NONSTD_ARRAY_SPLICE_DELC
 
 <h2>Setter/getter key argument</h2>
 
-<p>Ecmascript standard behavior is that setters and getters are not given
+<p>ECMAScript standard behavior is that setters and getters are not given
 the name of the property being accessed.  This prevents reusing a single
 setter or a getter for multiple properties; separate functions are needed
 for each property which is sometimes inconvenient and wastes memory.</p>
@@ -194,7 +194,7 @@ to be fixed, e.g. small differences in argument coercion e.g. for offset
 and length values.</p>
 
 <p>The plain buffer custom type behaves mostly like an Uint8Array object
-for Ecmascript code, but has a separate type in the Duktape C API.</p>
+for ECMAScript code, but has a separate type in the Duktape C API.</p>
 
 <h2 id="nodejsbuffer-custombehavior">Node.js Buffer binding</h2>
 

--- a/website/guide/customdirectives.html
+++ b/website/guide/customdirectives.html
@@ -1,6 +1,6 @@
 <h1 id="customdirectives">Custom directives</h1>
 
-<p>Ecmascript E5/E5.1 employs a
+<p>ECMAScript E5/E5.1 employs a
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-14.1">directive prologue</a>
 to allow version or implementation specific features be activated.
 The standard only provides one such directive, <code>"use strict"</code>, while

--- a/website/guide/customjson.html
+++ b/website/guide/customjson.html
@@ -1,9 +1,9 @@
 <h1 id="customjson">Custom JSON formats</h1>
 
-<h2>Ecmascript JSON shortcomings</h2>
+<h2>ECMAScript JSON shortcomings</h2>
 
 <p>The standard JSON format has a number of shortcomings when used with
-Ecmascript:</p>
+ECMAScript:</p>
 <ul>
 <li><code>undefined</code> and function values are not supported</li>
 <li>NaN and infinity values are not supported</li>
@@ -13,7 +13,7 @@ Ecmascript:</p>
 <li>The output is not printable ASCII which is often inconvenient</li>
 </ul>
 
-<p>These limitations are part of the Ecmascript specification which
+<p>These limitations are part of the ECMAScript specification which
 explicitly prohibits more lenient behavior.  Duktape provides two more
 programmer friendly custom JSON format variants: <b>JX</b> and <b>JC</b>,
 described below.</p>
@@ -67,12 +67,12 @@ instead.</p>
 
 <h2>Codepoints above U+FFFF and invalid UTF-8 data</h2>
 
-<p>All standard Ecmascript strings are valid CESU-8 data internally, so
+<p>All standard ECMAScript strings are valid CESU-8 data internally, so
 behavior for codepoints above U+FFFF never poses compliance issues.  However,
 Duktape strings may contain <a href="#extended-utf8">extended UTF-8</a>
 codepoints and may even contain invalid UTF-8 data.</p>
 
-<p>The Duktape JSON implementation, including the standard Ecmascript JSON API,
+<p>The Duktape JSON implementation, including the standard ECMAScript JSON API,
 use replacement characters to deal with invalid UTF-8 data.  The resulting
 string may look a bit odd, but this behavior is preferable to throwing an
 error.</p>
@@ -191,7 +191,7 @@ encoding:</p>
 <td><code>"U+1234abcd"</code></td>
 <td><code>"\U1234abcd"</code></td>
 <td><code>"U+1234abcd"</code></td>
-<td>Non-BMP characters are not standard Ecmascript, JX format borrowed from Python</td>
+<td>Non-BMP characters are not standard ECMAScript, JX format borrowed from Python</td>
 </tr>
 <tr>
 <td>object</td>

--- a/website/guide/datetime.html
+++ b/website/guide/datetime.html
@@ -11,14 +11,14 @@ for more exotic environments.  An external Date provider can also be used e.g.
 when a time offset needs to be applied to the platform time, or when using
 time virtualization.</p>
 
-<p>Ecmascript code interacts with date/time through the standard
+<p>ECMAScript code interacts with date/time through the standard
 <code>Date</code> built-in which is, by specification, limited to millisecond
-resolution.  There are currently no Duktape specific Ecmascript date/time APIs.
+resolution.  There are currently no Duktape specific ECMAScript date/time APIs.
 (A custom API may be added later to deal with sub-millisecond resolution.)</p>
 
 <p>C code can of course use platform date/time APIs directly, but the Duktape
 C API also provides date/time API calls.  These calls see the same time values
-as Ecmascript code which may matter when e.g. time virtualization is used.
+as ECMAScript code which may matter when e.g. time virtualization is used.
 Using these calls makes your code platform neutral and thus more portable.
 The Duktape C API allows sub-millisecond resolution for time values.  See
 <a href="http://wiki.duktape.org/HowtoTimeValues.html">How to work with time values</a>

--- a/website/guide/duktapebuiltins.html
+++ b/website/guide/duktapebuiltins.html
@@ -1,6 +1,6 @@
 <h1 id="duktapebuiltins">Duktape built-ins</h1>
 
-<p>This section summarizes Duktape-specific and non-Ecmascript built-in
+<p>This section summarizes Duktape-specific and non-ECMAScript built-in
 objects, methods, and values.</p>
 
 <h2>Additional global object properties</h2>
@@ -308,7 +308,7 @@ integer flags field, see <code>duktape.h</code> for constants.</p>
 <h3 id="builtin-duktape-compact">compact()</h3>
 
 <p>Minimize the memory allocated for a target object.  Same as the C API call
-<code>duk_compact()</code> but accessible from Ecmascript code.  If called with
+<code>duk_compact()</code> but accessible from ECMAScript code.  If called with
 a non-object argument, this call is a no-op.  The argument value is returned by
 the function, which allows code such as:</p>
 <pre class="ecmascript-code">
@@ -400,7 +400,7 @@ ordinary function and as a constructor.  The behavior is the same in both
 cases:</p>
 <ul>
 <li>The first argument is checked to be a function (if not, a <code>TypeError</code>
-    is thrown).  The function must be an Ecmascript function (bound or non-bound).
+    is thrown).  The function must be an ECMAScript function (bound or non-bound).
     The return value is a new thread whose initial function is recorded to be the
     argument function (this function will start executing when the new thread is
     first resumed).  The internal prototype of the newly created Thread will be the

--- a/website/guide/errorobjects.html
+++ b/website/guide/errorobjects.html
@@ -2,8 +2,8 @@
 
 <h2>Property summary</h2>
 
-<p>Ecmascript Error objects have very few standard properties, so many
-Ecmascript implementations have added quite a few custom properties.
+<p>ECMAScript Error objects have very few standard properties, so many
+ECMAScript implementations have added quite a few custom properties.
 Duktape uses standard Error properties but also borrows the most useful
 properties used by other implementations.  The number of "own" properties
 of error objects is minimized to keep error objects as small as possible.</p>
@@ -40,7 +40,7 @@ somewhat complicated.  The related issues and current behavior are described in:
     match other engines.</li>
 <li>The raw traceback data needed by the accessor properties is stored in an internal
     property (<code>\x82Tracedata</code>) which is not normally accessible from
-    Ecmascript code.</li>
+    ECMAScript code.</li>
 </ul>
 
 <p>If Duktape is compiled without traceback support:</p>
@@ -175,7 +175,7 @@ delete Duktape.errCreate;
 
 <p>Similarly, if <code>Duktape.errThrow</code> has been set, it is called
 right before an error is thrown, and can process or replace the error value.
-Because Ecmascript allows any value type to be thrown, the error handler
+Because ECMAScript allows any value type to be thrown, the error handler
 may get called with arbitrary input values (not just <code>Error</code>
 instances).  It may also be called more than once for the same value because
 an error can be re-thrown multiple times.</p>
@@ -211,7 +211,7 @@ delete Duktape.errThrow;
 
 <ul>
 <li>There is no cause chain support.  Cause chains would be useful but there
-    are no cause chains in Ecmascript, nor does there seem to be a de facto
+    are no cause chains in ECMAScript, nor does there seem to be a de facto
     standard for them.</li>
 <li>These is currently no way to access traceback elements programmatically in
     a version compatible manner.  However, you can access the <code>_Tracedata</code>

--- a/website/guide/finalization.html
+++ b/website/guide/finalization.html
@@ -5,8 +5,8 @@
 <p>Duktape supports object finalization as a custom feature.  A finalizer
 is called when an object is about to be freed, so that application code
 can e.g. free native resources associated with the object.  The finalizer
-can be either an Ecmascript function or a Duktape/C function.  However,
-Ecmascript finalizers may interact badly with script timeouts, see below.</p>
+can be either an ECMAScript function or a Duktape/C function.  However,
+ECMAScript finalizers may interact badly with script timeouts, see below.</p>
 
 <p>See <a href="http://wiki.duktape.org/HowtoFinalization.html">How to use finalization</a>
 for examples.</p>
@@ -18,10 +18,10 @@ prototype chain (or in the object itself) is subject to finalization before
 being freed.  The internal property should not be accessed directly, but can
 be read/written using the following:</p>
 <ul>
-<li><code>Duktape.fin(obj)</code> (Ecmascript) or
+<li><code>Duktape.fin(obj)</code> (ECMAScript) or
     <code>duk_get_finalizer()</code> (C)
     gets the current finalizer.</li>
-<li><code>Duktape.fin(obj, fn)</code> (Ecmascript) or
+<li><code>Duktape.fin(obj, fn)</code> (ECMAScript) or
     <code>duk_set_finalizer()</code> (C)
     sets the current finalizer.</li>
 </ul>
@@ -84,7 +84,7 @@ see below for more discussion:</p>
 <li>Heap destruction finalizer sanity limit may cause a finalizer not to
     be executed.</li>
 <li>When a script timeout is being propagated out of the current callstack,
-    Ecmascript finalizers will immediately rethrow the script timeout error.
+    ECMAScript finalizers will immediately rethrow the script timeout error.
     Duktape/C finalizers will execute normally.</li>
 <li>If Duktape runs out of memory (despite emergency GC) when trying to call a
     finalizer, the call error is silently ignored and the finalizer will be
@@ -119,7 +119,7 @@ finalizer behavior:</p>
 <ul>
 <li>When script execution timeout
 (<code>DUK_USE_EXEC_TIMEOUT_CHECK</code>)
-is used and a timeout occurs, it's possible for an Ecmascript finalizer to start
+is used and a timeout occurs, it's possible for an ECMAScript finalizer to start
 running but immediately fail due to a script timeout.  If this is a concrete
 concern, use a Duktape/C native finalizer instead which will run normally even
 when propagating a timeout.</li>

--- a/website/guide/functionobjects.html
+++ b/website/guide/functionobjects.html
@@ -1,8 +1,8 @@
 <h1 id="functionobjects">Function objects</h1>
 
-<h2 id="ecmascript-function-properties">Ecmascript functions</h2>
+<h2 id="ecmascript-function-properties">ECMAScript functions</h2>
 
-<p>Duktape Function objects add a few properties to standard Ecmascript
+<p>Duktape Function objects add a few properties to standard ECMAScript
 properties.  The table below summarizes properties assigned to newly
 created function instances (properties can of course be added or removed
 afterwards):</p>
@@ -41,7 +41,7 @@ var bar = function () {
 </pre>
 
 <div class="note">
-Several Ecmascript built-in functions have properties different from user
+Several ECMAScript built-in functions have properties different from user
 created Functions.
 </div>
 
@@ -72,7 +72,7 @@ is useful because it affects how a function appears in tracebacks.</p>
 <h2 id="duktapec-lightfunc-properties">Lightweight Duktape/C functions</h2>
 
 <p>Lightweight Duktape/C functions (lightfuncs) are a very memory efficient way
-of representing a native function in the Ecmascript environment.  Lightfuncs
+of representing a native function in the ECMAScript environment.  Lightfuncs
 don't have a property table so they can't hold properties.  However, they inherit
 from <code>Function.prototype</code> and have the following virtual properties
 (which are non-configurable and non-writable):</p>

--- a/website/guide/gettingstarted.html
+++ b/website/guide/gettingstarted.html
@@ -50,7 +50,7 @@ by editing the Makefile:
 </ul>
 </div>
 
-<p>You can now run Ecmascript code interactively:</p>
+<p>You can now run ECMAScript code interactively:</p>
 <pre>
 $ ./duk
 ((o) Duktape 2.2.0 (v2.2.0)
@@ -59,7 +59,7 @@ Hello world!
 = undefined
 </pre>
 
-<p>You can also run Ecmascript code from a file which is useful for playing with
+<p>You can also run ECMAScript code from a file which is useful for playing with
 features and algorithms.  As an example, create <code>fib.js</code>:</p>
 <pre class="ecmascript-code" include="fib.js"></pre>
 
@@ -101,13 +101,13 @@ $ gcc -std=c99 -o hello -Isrc src/duktape.c examples/hello/hello.c -lm
 <p>To customize Duktape configuration use <code>configure.py</code>:</p>
 <pre>
 $ cd /tmp/duktape-&lt;version&gt;/
-# Here we disable Ecmascript 6 Proxy object support
+# Here we disable ECMAScript 6 Proxy object support
 $ python2 tools/configure.py --output-directory duktape-src -UDUK_USE_ES6_PROXY
 $ gcc -std=c99 -o hello -Iduktape-src duktape-src/duktape.c examples/hello/hello.c -lm
 </pre>
 
 <p>The test program creates a Duktape context and uses it to run some
-Ecmascript code:</p>
+ECMAScript code:</p>
 <pre>
 $ ./hello
 Hello world!
@@ -137,11 +137,11 @@ with native code; for example:</p>
 <ul>
 <li>Run the main application in C/C++ code but call into Duktape for
     extending base functionality (e.g. plugins or configuration).</li>
-<li>Run the main application in Ecmascript code, and call into simple
+<li>Run the main application in ECMAScript code, and call into simple
     C/C++ native bindings for I/O, performance intensive operations, etc.
     The native bindings are often kept stateless so that state logic
     remains in view of script code.</li>
-<li>Run the main application in Ecmascript code, but use more complex,
+<li>Run the main application in ECMAScript code, but use more complex,
     stateful C/C++ native bindings for performance intensive operations.
     For example, a graphics engine can be implemented as a native object.</li>
 </ul>

--- a/website/guide/intro.html
+++ b/website/guide/intro.html
@@ -17,10 +17,10 @@ if you wish to tinker with them.</p>
 
 <h2>What is Duktape?</h2>
 
-<p>Duktape is an embeddable Ecmascript engine with a focus on portability
+<p>Duktape is an embeddable ECMAScript engine with a focus on portability
 and compact footprint.  By integrating Duktape into your C/C++ program you
 can easily extend its functionality through scripting.  You can also build
-the main control flow of your program in Ecmascript and use fast C code
+the main control flow of your program in ECMAScript and use fast C code
 functions to do heavy lifting.</p>
 
 <p>Embeddability means that Duktape makes minimal assumptions about the
@@ -31,12 +31,12 @@ text to the console or to interact with the file system.  Duktape
 distributable package includes example providers which you can easily
 integrate if they suit your needs.</p>
 
-<p>The terms Ecmascript and Javascript are often considered more or less
+<p>The terms ECMAScript and Javascript are often considered more or less
 equivalent, although Javascript and its variants are technically just one
-environment where the Ecmascript language is used.  The line between the
-two is not very clear in practice: even non-browser Ecmascript environments
+environment where the ECMAScript language is used.  The line between the
+two is not very clear in practice: even non-browser ECMAScript environments
 often provide some browser-specific built-ins.  Even so, we use the term
-Ecmascript throughout to refer to the language implemented by Duktape.</p>
+ECMAScript throughout to refer to the language implemented by Duktape.</p>
 
 <h2>Conformance</h2>
 
@@ -47,7 +47,7 @@ later where appropriate:</p>
 <li><a href="http://www.ecma-international.org/ecma-262/5.1/">ECMAScript&#x00ae; Language Specification 5.1 Edition</a></li>
 </ul>
 
-<p>Duktape tracks the latest Ecmascript specification for semantics and
+<p>Duktape tracks the latest ECMAScript specification for semantics and
 built-ins (however support for ES2015 and later is still incomplete), see:</p>
 <ul>
 <li><a href="http://www.ecma-international.org/ecma-262/6.0/">ECMAScript&#x00ae; 2015 Language Specification</a></li>
@@ -83,22 +83,22 @@ was based on Khronos TypedArray specification:</p>
 
 <h2>Features</h2>
 
-<p>Besides standard Ecmascript features, Duktape has the following additional
+<p>Besides standard ECMAScript features, Duktape has the following additional
 features (some are visible to applications, while others are internal):</p>
 <ul>
 <li>ES2015 <a href="https://www.khronos.org/registry/typedarray/specs/latest/">TypedArray</a>
     and <a href="https://nodejs.org/docs/v6.9.1/api/buffer.html">Node.js Buffer</a> bindings,
     plain buffer type (lightweight Uint8Array)</li>
-<li>From Ecmascript 2015 (ES6): <code>setPrototypeOf</code>/<code>__proto__</code>,
+<li>From ECMAScript 2015 (ES6): <code>setPrototypeOf</code>/<code>__proto__</code>,
     a subset of <code>Proxy</code> objects, <code>Reflect</code>, computed property names,
     and minimal <code>const</code> support</li>
-<li>From Ecmascript 2016 (ES7): exponentiation operator (<code>**</code>, <code>**=</code>)</li>
+<li>From ECMAScript 2016 (ES7): exponentiation operator (<code>**</code>, <code>**=</code>)</li>
 <li><a href="https://encoding.spec.whatwg.org/#api">Encoding API</a> bindings based on the WHATWG Encoding Living Standard</li>
 <li>Duktape specific built-ins: provided by the <code>Duktape</code> global object</li>
 <li>Extended types: custom "buffer" and "pointer" types, extended string type
     which supports arbitary binary strings and
     non-<a href="http://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane">BMP</a>
-    strings (standard Ecmascript only supports 16-bit codepoints)</li>
+    strings (standard ECMAScript only supports 16-bit codepoints)</li>
 <li>Combined reference counting and mark-and-sweep garbage collection,
     with finalizers and emergency garbage collection (you can also build
     with just mark-and-sweep)</li>
@@ -114,9 +114,9 @@ features (some are visible to applications, while others are internal):</p>
 
 <h2>Goals</h2>
 
-<p><b>Compliance</b>.  Ecmascript E5/E5.1 and real world compliance.
-Ecmascript compliance requires regular expression and Unicode support.
-When possible, implement features from latest or draft Ecmascript
+<p><b>Compliance</b>.  ECMAScript E5/E5.1 and real world compliance.
+ECMAScript compliance requires regular expression and Unicode support.
+When possible, implement features from latest or draft ECMAScript
 specifications to minimize Duktape custom features.</p>
 
 <p><b>Portability</b>.  Minimal system dependencies are nice when porting,
@@ -168,7 +168,7 @@ discuss core Duktape concepts such as <i>heap</i>, <i>context</i>, <i>value stac
 <i>Duktape API</i>, and <i>Duktape/C functions</i>.  Duktape stack types and C type
 wrappers are discussed in detail.</p>
 
-<p>Duktape specific Ecmascript features are discussed in multiple sections:
+<p>Duktape specific ECMAScript features are discussed in multiple sections:
 <a href="#typealgorithms">Type algorithms</a> (for custom types),
 <a href="#duktapebuiltins">Duktape built-ins</a> (additional built-ins), 
 <a href="#postes5features">Post-ES5 features</a> (features implemented from ES2016 and beyond),
@@ -200,7 +200,7 @@ as part of your application.
 <a href="#portability">Portability</a> covers platform and compiler specific
 issues and other portability issues.
 <a href="#compatibility">Compatibility</a> discusses Duktape's compatibility
-with Ecmascript dialects, extensions, and frameworks.
+with ECMAScript dialects, extensions, and frameworks.
 <a href="#versioning">Versioning</a> describes Duktape versioning and what version
 compatibility to expect.
 <a href="#limitations">Limitations</a> summarizes currently known limitations

--- a/website/guide/limitations.html
+++ b/website/guide/limitations.html
@@ -105,7 +105,7 @@ purpose:</p>
 
 <h2>Function temporaries may be live for garbage collection longer than expected</h2>
 
-<p>Ecmascript functions are compiled into bytecode with a fixed set of
+<p>ECMAScript functions are compiled into bytecode with a fixed set of
 registers.  Some registers are reserved for arguments and variable
 bindings while others are used as temporaries.  All registers are
 considered live from a garbage collection perspective, even temporary
@@ -134,7 +134,7 @@ function foreverLoop() {
 
 <h2>Function instances are garbage collected only by mark-and-sweep</h2>
 
-<p>Every Ecmascript function instance is, by default, in a reference loop with
+<p>Every ECMAScript function instance is, by default, in a reference loop with
 an automatic prototype object created for the function.  The function instance's
 <code>prototype</code> property points to the prototype object, and the prototype's
 <code>constructor</code> property points back to the function instance.  Only

--- a/website/guide/luacomparison.html
+++ b/website/guide/luacomparison.html
@@ -18,7 +18,7 @@ In Lua, slices are indicated with inclusive indices (i.e. [start,end]).</p>
 <h2>Object type represents functions and threads</h2>
 
 <p>In Lua functions and threads are a separate type from objects.
-In Duktape the object type is used for plain objects, Ecmascript and
+In Duktape the object type is used for plain objects, ECMAScript and
 native functions, and threads (coroutines).  As a result, all of these
 have a mutable and extensible set of properties.</p>
 
@@ -75,8 +75,8 @@ similar to Lua <code>lua_dump()</code>. See
 
 <h2>Metatables</h2>
 
-<p>There is no equivalent of Lua metatables in Ecmascript E5/E5.1, but
-<a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-objects">Ecmascript ES2015 Proxy objects</a>
+<p>There is no equivalent of Lua metatables in ECMAScript E5/E5.1, but
+<a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-objects">ECMAScript ES2015 Proxy objects</a>
 provide similar functionality.  To allow property virtualization better than available in
 E5/E5.1, Duktape implements an <a href="#es6-proxy">ES2015 Proxy subset</a>.</p>
 
@@ -89,7 +89,7 @@ key and/or value.</p>
 <h2>Raw accessors</h2>
 
 <p>There is no equivalent to Lua raw table access functions like
-<code>lua_rawget</code>.  One can use the following Ecmascript built-ins
+<code>lua_rawget</code>.  One can use the following ECMAScript built-ins
 for a similar effect (though not with respect to performance):
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.3">Object.getOwnPropertyDescriptor ( O, P )</a>,
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.6">Object.defineProperty ( O, P, Attributes )</a>.</p>
@@ -104,8 +104,8 @@ coroutines cannot yield from inside constructor calls or getter/setter calls.</p
 
 <h2>Multiple return values</h2>
 
-<p>Lua supports multiple return values, Duktape (or Ecmascript) currently
-doesn't.  This may change with Ecmascript ES2015, which has a syntax for
+<p>Lua supports multiple return values, Duktape (or ECMAScript) currently
+doesn't.  This may change with ECMAScript ES2015, which has a syntax for
 multiple value returns.  The Duktape/C API reserves return values above 1
 so that they may be later used for multiple return values.</p>
 
@@ -116,7 +116,7 @@ so that they may be later used for multiple return values.</p>
 <h2>Unicode</h2>
 
 <p>Lua has no built-in Unicode support (strings are byte strings), while
-Duktape has support for 16-bit Unicode as part of Ecmascript compliance.</p>
+Duktape has support for 16-bit Unicode as part of ECMAScript compliance.</p>
 
 <h2>Streaming compilation</h2>
 

--- a/website/guide/memoryusage.html
+++ b/website/guide/memoryusage.html
@@ -2,7 +2,7 @@
 
 <p>Duktape allocates memory on demand and doesn't require a pre-allocated heap.
 When you create a heap on a 32-bit system, Duktape needs about 70kB for the
-built-in Ecmascript objects.  With specific
+built-in ECMAScript objects.  With specific
 <a href="#memory-constrained-options">low memory options</a> initial memory
 usage is about 27kB.  This can be further reduced to about 3kB when moving
 built-in objects and strings to ROM (read-only data section).  It's also
@@ -16,7 +16,7 @@ participate in reference loops; these are collected eventually by mark-and-sweep
 <p>The memory allocations needed by Duktape fall into two basic categories.
 First, there are a lot of small allocations between roughly 16 to 128 bytes
 which are needed for strings, buffers, objects, object property tables, etc.
-Second, there are much fewer larger allocations needed for e.g. Ecmascript
+Second, there are much fewer larger allocations needed for e.g. ECMAScript
 function bytecode, large strings and buffers, value stacks, the global string
 table, and the Duktape heap object.</p>
 

--- a/website/guide/programming.html
+++ b/website/guide/programming.html
@@ -9,14 +9,14 @@
     to your build.</li>
 <li>Create a Duktape <b>heap</b> (a garbage collection region) and an initial
     <b>context</b> (essentially a thread handle) in your program.</li>
-<li>Load the necessary Ecmascript script files, and register your Duktape/C
+<li>Load the necessary ECMAScript script files, and register your Duktape/C
     functions.  Duktape/C functions are C functions you can call from
-    Ecmascript code for better performance, bindings to native libraries, etc.</li>
-<li>Use the Duktape API to call Ecmascript functions whenever appropriate.
+    ECMAScript code for better performance, bindings to native libraries, etc.</li>
+<li>Use the Duktape API to call ECMAScript functions whenever appropriate.
     Duktape API is used to pass values to and from functions.  Values are
     converted between their C representation and the Duktape internal
-    (Ecmascript compatible) representation.</li>
-<li>Duktape API is also used by Duktape/C functions (called from Ecmascript)
+    (ECMAScript compatible) representation.</li>
+<li>Duktape API is also used by Duktape/C functions (called from ECMAScript)
     to access call arguments and to provide return values.</li>
 </ul>
 
@@ -25,17 +25,17 @@
 <h2>Heap and context</h2>
 
 <p>A Duktape <b>heap</b> is a single region for garbage collection.  A heap
-is used to allocate storage for strings, Ecmascript objects, and other
+is used to allocate storage for strings, ECMAScript objects, and other
 variable size, garbage collected data.  Objects in the heap have an internal
 heap header which provides the necessary information for reference counting,
 mark-and-sweep garbage collection, object finalization, etc.
 Heap objects can reference each other, creating a reachability graph from
-a garbage collection perspective.  For instance, the properties of an Ecmascript
+a garbage collection perspective.  For instance, the properties of an ECMAScript
 object reference both the keys and values of the object's property set.  You can
 have multiple heaps, but objects in different heaps cannot reference each other
 directly; you need to use serialization to pass values between heaps.</p>
 
-<p>A Duktape <b>context</b> is an Ecmascript "thread of execution" which lives
+<p>A Duktape <b>context</b> is an ECMAScript "thread of execution" which lives
 in a certain Duktape heap.  A context is represented by a <code>duk_context *</code>
 in the Duktape API, and is associated with an internal Duktape coroutine (a form
 of a co-operative thread).  Each context is also associated with an environment
@@ -46,8 +46,8 @@ the Duktape coroutine: values can be inserted and queries, functions can be call
 and so on.</p>
 
 <p>Each coroutine has a <b>call stack</b> which controls execution, keeping
-track of function calls, native or Ecmascript, within the Ecmascript engine.
-Each coroutine also has a <b>value stack</b> which stores all the Ecmascript
+track of function calls, native or ECMAScript, within the ECMAScript engine.
+Each coroutine also has a <b>value stack</b> which stores all the ECMAScript
 values of the coroutine's active call stack.  The value stack always has an
 active <b>stack frame</b> for the most recent function call (when no function
 calls have been made, the active stack frame is the value stack as is).
@@ -124,7 +124,7 @@ the heap destruction call returns.</p>
 <h2>Call stack and catch stack (of a context)</h2>
 
 <p>The call stack of a context is not directly visible to the caller.
-It keeps track of the chain of function calls, either C or Ecmascript,
+It keeps track of the chain of function calls, either C or ECMAScript,
 currently executing in a context.  The main purpose of this book-keeping is
 to facilitate the passing of arguments and results between function callers
 and callees, and to keep track of how the value stack is divided between
@@ -273,14 +273,14 @@ the internal number of value stack elements available beyond the caller
 specified extra varies considerably.  The caller does not need to take this
 into account and should never rely on any additional elements being available.</p>
 
-<h2>Ecmascript array index</h2>
+<h2>ECMAScript array index</h2>
 
-<p>Ecmascript object and array keys can only be strings.  Array indices
+<p>ECMAScript object and array keys can only be strings.  Array indices
 (e.g. 0, 1, 2) are represented as canonical string representations of the
 respective numbers.  More technically, all canonical string representations
 of the integers in the range [0, 2**32-1] are valid array indices.</p>
 
-<p>To illustrate the Ecmascript array index handling, consider the following
+<p>To illustrate the ECMAScript array index handling, consider the following
 example:</p>
 
 <pre class="ecmascript-code">
@@ -293,16 +293,16 @@ print(arr[1.0]);   // refers to 'bar', canonical encoding is "1"
 print(arr["1.0"]); // undefined, not an array index
 </pre>
 
-<p>Some API calls operating on Ecmascript arrays accept numeric array index
+<p>Some API calls operating on ECMAScript arrays accept numeric array index
 arguments.  This is really just a short hand for denoting a string conversion
 of that number.  For instance, if the API is given the integer 123, this
 really refers to the property name "123".</p>
 
 <p>Internally, Duktape tries to avoid converting numeric indices to actual
 strings whenever possible, so it is preferable to use array index API calls
-when they are relevant.  Similarly, when writing Ecmascript code it is
+when they are relevant.  Similarly, when writing ECMAScript code it is
 preferable to use numeric rather than string indices, as the same fast path
-applies for Ecmascript code.</p>
+applies for ECMAScript code.</p>
 
 <h2 id="duktape-api">Duktape API</h2>
 
@@ -335,7 +335,7 @@ the following guarantees for macros:</p>
 <h2>Duktape/C function</h2>
 
 <p>A C function with a Duktape/C API signature can be associated with an
-Ecmascript function object, and gets called when the Ecmascript function
+ECMAScript function object, and gets called when the ECMAScript function
 object is called.  A Duktape/C API function looks as follows:</p>
 <pre class="c-code">
 duk_ret_t my_func(duk_context *ctx) {
@@ -344,14 +344,14 @@ duk_ret_t my_func(duk_context *ctx) {
 }
 </pre>
 
-<p>The function gets Ecmascript call argument in the value stack of
+<p>The function gets ECMAScript call argument in the value stack of
 <code>ctx</code>, with
 <code><a href="api.html#duk_get_top">duk_get_top()</a></code>
 indicating the number of
 arguments present on the value stack.  The <code>this</code> binding is not
 automatically pushed to the value stack; use
 <code><a href="api.html#duk_push_this">duk_push_this()</a></code>
-to access it.  When creating an Ecmascript function object associated with a
+to access it.  When creating an ECMAScript function object associated with a
 Duktape/C function, one can select the desired number of arguments.  Extra
 arguments are dropped and missing arguments are replaced with
 <code>undefined</code>.  A function can also be registered as a vararg
@@ -368,9 +368,9 @@ which case call arguments are not modified prior to C function entry.</p>
     thrown.  Error codes named <code>DUK_RET_xxx</code> map to specific kinds
     of errors (do not confuse these with <code>DUK_ERR_xxx</code> which are
     positive values).</li>
-<li>A return value higher than 1 is currently undefined, as Ecmascript
+<li>A return value higher than 1 is currently undefined, as ECMAScript
     doesn't support multiple return values in Edition 5.1.  (Values higher
-    than 1 may be taken into to support multiple return values in Ecmascript
+    than 1 may be taken into to support multiple return values in ECMAScript
     Edition 6.)</li>
 </ul>
 
@@ -390,12 +390,12 @@ duk_ret_t my_func(duk_context *ctx) {
 </pre>
 
 <p>All Duktape/C functions are considered <b>strict</b> in the
-<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.2.2">Ecmascript sense</a>.
-Duktape API calls always obey Ecmascript strict mode semantics, even when the API calls
+<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.2.2">ECMAScript sense</a>.
+Duktape API calls always obey ECMAScript strict mode semantics, even when the API calls
 are made outside of any Duktape/C function, i.e. with an empty call stack.
 For instance, attempt to delete a non-configurable property using
 <code><a href="api.html#duk_del_prop">duk_del_prop()</a></code>
-will cause an error to be thrown.  This is the case with a strict Ecmascript function too:</p>
+will cause an error to be thrown.  This is the case with a strict ECMAScript function too:</p>
 
 <pre class="ecmascript-code">
 function f() {
@@ -410,7 +410,7 @@ print(f());  // this throws an error because f() is strict
 <p>Another consequence of Duktape/C function strictness is that the <code>this</code>
 binding given to Duktape/C functions is not
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-10.4.3">coerced</a>.
-This is also the case for strict Ecmascript code:</p>
+This is also the case for strict ECMAScript code:</p>
 <pre class="ecmascript-code">
 function strictFunc() { 'use strict'; print(typeof this); }
 function nonStrictFunc() { print(typeof this); }
@@ -437,7 +437,7 @@ property by default, so the default object instance (given to the constructor
 as <code>this</code>) inherits from <code>Object.prototype</code>.  To use a
 custom prototype you can define <code>prototype</code> for the Duktape/C
 function explicitly.  Another approach is to ignore the default object instance
-and construct one manually within the Duktape/C call: as with Ecmascript
+and construct one manually within the Duktape/C call: as with ECMAScript
 functions, if a constructor returns an object value, that value replaces the
 default object instance and becomes the value of the <code>new</code>
 expression.</p>
@@ -459,14 +459,14 @@ There are several ways to achieve this.</p>
 
 <p>First, a Duktape/C function can use its Function object to store state
 or parameters.  A certain Duktape/C function (the actual C function)
-is always represented by an Ecmascript Function object which is
+is always represented by an ECMAScript Function object which is
 internally associated with the underlying C function.   The Function
 object can be used to store properties related to that particular
 instance of the function.  Note that a certain Duktape/C function can
 be associated with multiple independent Function objects and thus
 independent states.</p>
 
-<p>Accessing the Ecmascript Function object related to a Duktape/C function
+<p>Accessing the ECMAScript Function object related to a Duktape/C function
 is easy:</p>
 <pre class="c-code">
 duk_push_current_function(ctx);
@@ -495,9 +495,9 @@ duk_get_prop_string(ctx, -1, "my_state_variable");
 
 <h3 id="hidden-symbol-properties">Hidden Symbol properties</h3>
 
-<p>If data needs to be associated with an object, but hidden from Ecmascript
+<p>If data needs to be associated with an object, but hidden from ECMAScript
 code, hidden <a href="#symbols">Symbols</a> can be used as a property key. The
-key is only accessible via the C API, unless passed to Ecmascript code from the
+key is only accessible via the C API, unless passed to ECMAScript code from the
 C API. A common use case is to associated backing pointers/data to C memory.
 Symbols are created as a string, but are differentiated with macros that mark
 them as Symbols.</p>
@@ -552,7 +552,7 @@ more stable alternative.
 
 <p>The heap stash is an object visible only from C code.  It is associated
 with the Duktape heap, and allows Duktape/C code to store "under the hood"
-state data which is not exposed to Ecmascript code.  It is accessed with the
+state data which is not exposed to ECMAScript code.  It is accessed with the
 <code><a href="api.html#duk_push_heap_stash">duk_push_heap_stash()</a></code>
 API call.</p>
 
@@ -575,7 +575,7 @@ API call.</p>
 
 <p>The Duktape version is available through the <code>DUK_VERSION</code> define,
 with the numeric value <code>(major * 10000) + (minor * 100) + patch</code>.
-The same value is available to Ecmascript code through <code>Duktape.version</code>.
+The same value is available to ECMAScript code through <code>Duktape.version</code>.
 Calling code can use this define for Duktape version specific code.</p>
 
 <p>For C code:</p>
@@ -589,7 +589,7 @@ Calling code can use this define for Duktape version specific code.</p>
 #endif
 </pre>
 
-<p>For Ecmascript code (also see <a href="#duktapebuiltins">Duktape built-ins</a>):</p>
+<p>For ECMAScript code (also see <a href="#duktapebuiltins">Duktape built-ins</a>):</p>
 <pre class="ecmascript-code">
 if (typeof Duktape !== 'object') {
     print('not Duktape');
@@ -616,7 +616,7 @@ shorthand to automatically throw an error.</p>
 
 <h2 id="error-handling">Error handling</h2>
 
-<p>Error handling in the Duktape API is similar to how Ecmascript handles
+<p>Error handling in the Duktape API is similar to how ECMAScript handles
 errors: errors are thrown either explicitly or implicitly, then caught and
 handled.  However, instead of a try-catch statement application code uses
 <code><a href="api.html#taglist-protected">protected</a></code>
@@ -718,7 +718,7 @@ e.g. write fatal error information to <code>stderr</code> before process exit.</
 <p>An <b>ordinary error</b> is caused by a <code>throw</code> statement, a
 <code><a href="api.html#duk_throw">duk_throw()</a></code>
 API call (or similar), or by an internal, recoverable Duktape error.
-Ordinary errors can be caught with a <code>try-catch</code> in Ecmascript
+Ordinary errors can be caught with a <code>try-catch</code> in ECMAScript
 code or e.g. <code><a href="api.html#duk_pcall">duk_pcall()</a></code>
 (see API calls tagged
 <code><a href="api.html#taglist-protected">protected</a></code>)

--- a/website/guide/sandboxing.html
+++ b/website/guide/sandboxing.html
@@ -9,7 +9,7 @@ goals in mind:</p>
     consuming all available memory or entering an infinite loop.</li>
 </ul>
 
-<p>Duktape provides mechanisms to achieve these goals for untrusted Ecmascript
+<p>Duktape provides mechanisms to achieve these goals for untrusted ECMAScript
 code.  All C code is expected to be trusted.
 See
 <a href="https://github.com/svaarala/duktape/blob/master/doc/sandboxing.rst">sandboxing.rst</a>

--- a/website/guide/stacktypes.html
+++ b/website/guide/stacktypes.html
@@ -119,7 +119,7 @@ indicate that a value does not exist, a stack index is invalid, etc.</p>
 
 <h2 id="type-undefined">Undefined</h2>
 
-<p>The <b>undefined</b> type maps to Ecmascript <code>undefined</code>, which is
+<p>The <b>undefined</b> type maps to ECMAScript <code>undefined</code>, which is
 distinguished from a <code>null</code>.</p>
 
 <p>Values read from outside the active value stack range read back as
@@ -127,7 +127,7 @@ distinguished from a <code>null</code>.</p>
 
 <h2 id="type-null">Null</h2>
 
-<p>The <b>null</b> type maps to Ecmascript <code>null</code>.</p>
+<p>The <b>null</b> type maps to ECMAScript <code>null</code>.</p>
 
 <h2 id="type-boolean">Boolean</h2>
 
@@ -190,11 +190,11 @@ for efficiency: only a single copy of a certain string ever exists at a time.
 Strings are immutable and must NEVER be changed by calling C code.  Doing so will
 lead to very mysterious issues which are hard to diagnose.</p>
 
-<p>Calling code most often deals with Ecmascript strings, which may contain
+<p>Calling code most often deals with ECMAScript strings, which may contain
 arbitrary 16-bit codepoints in the range U+0000 to U+FFFF but cannot represent
 non-<a href="http://en.wikipedia.org/wiki/Basic_Multilingual_Plane#Basic_Multilingual_Plane">BMP</a>
-codepoints.  This is how strings are defined in the Ecmascript standard.
-In Duktape, Ecmascript strings are encoded with
+codepoints.  This is how strings are defined in the ECMAScript standard.
+In Duktape, ECMAScript strings are encoded with
 <a href="http://en.wikipedia.org/wiki/CESU-8">CESU-8</a> encoding.  CESU-8
 matches <a href="http://en.wikipedia.org/wiki/UTF-8">UTF-8</a> except that it
 allows codepoints in the surrogate pair range (U+D800 to U+DFFF) to be encoded
@@ -238,16 +238,16 @@ marker encoding.  This is not a practical concern in Duktape's internal use.</p>
 
 <p>Finally, invalid extended UTF-8 byte sequences are used for special purposes
 such as representing Symbol values.  Invalid extened UTF-8/CESU-8 byte sequences
-never conflict with standard Ecmascript strings (which are CESU-8) and will remain
+never conflict with standard ECMAScript strings (which are CESU-8) and will remain
 cleanly separated within object property tables.  For more information see
 <a href="#symbols">Symbols</a> and
 <a href="https://github.com/svaarala/duktape/blob/master/doc/symbols.rst">symbols.rst</a>.</p>
 
 <p>Strings with invalid extended UTF-8 sequences can be pushed on the value stack
-from C code and also passed to Ecmascript functions, with two caveats:</p>
+from C code and also passed to ECMAScript functions, with two caveats:</p>
 <ul>
 <li>If the invalid byte sequence matches the internal format used to represent
-    Symbols, the value will appear as a Symbol rather than a string for Ecmascript
+    Symbols, the value will appear as a Symbol rather than a string for ECMAScript
     code.  For example, <code>typeof val</code> will be <code>symbol</code>.</li>
 <li>Behavior of string operations on invalid byte sequences if not well defined
     and results may vary, and change even in minor Duktape version updates.</li>
@@ -255,7 +255,7 @@ from C code and also passed to Ecmascript functions, with two caveats:</p>
 
 <h2 id="type-object">Object</h2>
 
-<p>The <b>object</b> type includes Ecmascript objects and arrays, functions,
+<p>The <b>object</b> type includes ECMAScript objects and arrays, functions,
 threads (coroutines), and buffer objects.  In other words, anything with
 properties is an object.  Properties are key-value pairs with a string key
 and an arbitrary value (including <b>undefined</b>).</p>
@@ -362,7 +362,7 @@ varargs), (2) virtual <code>length</code> property value (0 to 15), and
 (3) a magic value (-128 to 127).</p>
 
 <p>Lightfuncs are a separate tagged type in the Duktape C API, but behave mostly
-like Function objects for Ecmascript code.  They have significant limitations
+like Function objects for ECMAScript code.  They have significant limitations
 compared to ordinary Function objects, the most important being:</p>
 
 <ul>

--- a/website/guide/symbols.html
+++ b/website/guide/symbols.html
@@ -4,7 +4,7 @@
 <p>Duktape supports ES2015 Symbols and also provides a Duktape specific
 <b>hidden Symbol</b> variant similar to internal strings in Duktape 1.x.
 Hidden Symbols differ from ES2015 Symbols in that they're hidden from
-ordinary Ecmascript code: they can't be created from Ecmascript code,
+ordinary ECMAScript code: they can't be created from ECMAScript code,
 won't be enumerated or JSON-serialized, and won't be returned from
 <code>Object.getOwnPropertyNames()</code> or even
 <code>Object.getOwnPropertySymbols()</code>.  Properties with hidden Symbol
@@ -28,17 +28,17 @@ access Duktape's hidden Symbol keyed properties: the set of such properties can
 change arbitrarily between versions.</p>
 
 <div class="note">
-Note that the internal UTF-8 byte sequences cannot be created from Ecmascript
-code as a valid Ecmascript string.  For example, a hidden Symbol might be
+Note that the internal UTF-8 byte sequences cannot be created from ECMAScript
+code as a valid ECMAScript string.  For example, a hidden Symbol might be
 represented using <code>\xFFxyz</code>, i.e. the byte sequence
-<code>ff 78 79 7a</code>, while the Ecmascript string <code>"\u00ffxyz"</code>
+<code>ff 78 79 7a</code>, while the ECMAScript string <code>"\u00ffxyz"</code>
 would be represented as the CESU-8 bytes <code>c3 bf 78 79 7a</code> in memory.
 </div>
 
 <p>Creating a Symbol is straightforward from C code:</p>
 <pre class="c-code">
 /* Create a hidden Symbol which can then be used to read/write properties.
- * The Symbol can be passed on to Ecmascript code like any other string or
+ * The Symbol can be passed on to ECMAScript code like any other string or
  * Symbol.
  */
 duk_push_string(ctx, DUK_HIDDEN_SYMBOL("mySymbol"));
@@ -55,7 +55,7 @@ used directly:</p>
 duk_push_string(ctx, "\xff" "mySymbol");
 </pre>
 
-<p>Hidden Symbols cannot be created from Ecmascript code using the default
+<p>Hidden Symbols cannot be created from ECMAScript code using the default
 built-ins alone.  Standard ES2015 Symbols can be created using the
 <code>Symbol</code> built-in, e.g. as <code>Symbol.for('foo')</code>.
 When sandboxing, ensure that application C bindings don't accidentally provide
@@ -65,5 +65,5 @@ to a string without applying an encoding.</p>
 <p>There's currently no special access control for properties with hidden
 Symbol keys: if user code has access to the Symbol, it can read/write the
 property value.  This will most likely change in future major versions so
-that Ecmascript code cannot access a property with a hidden Symbol key,
+that ECMAScript code cannot access a property with a hidden Symbol key,
 even when holding a reference to the hidden Symbol value.</p>

--- a/website/guide/typealgorithms.html
+++ b/website/guide/typealgorithms.html
@@ -1,6 +1,6 @@
 <h1 id="typealgorithms">Type algorithms</h1>
 
-<p>This section describes how type-related Ecmascript algorithms
+<p>This section describes how type-related ECMAScript algorithms
 like comparisons and coercions are extended to Duktape custom types.
 Duktape specific type algorithms (<code>ToBuffer()</code> and <code>ToPointer()</code>)
 are also discussed.</p>
@@ -139,7 +139,7 @@ for standard types.  Custom type behavior is as follows:</p>
 
 <h2 id="type-conversion-and-testing">Type conversion and testing</h2>
 
-<p>The custom types behave as follows for Ecmascript coercions described
+<p>The custom types behave as follows for ECMAScript coercions described
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-9">Type Conversion and Testing</a>
 (except SameValue which was already covered above):</p>
 
@@ -236,7 +236,7 @@ using the Duktape C API.
 
 <h2>Addition</h2>
 
-<p>The Ecmascript addition operator is specified in
+<p>The ECMAScript addition operator is specified in
 <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.6.1">The Addition operator (+)</a>.
 Addition behaves specially if either argument is a string: the other argument
 is coerced to a string and the strings are then concatenated.  This behavior

--- a/website/guide/versioning.html
+++ b/website/guide/versioning.html
@@ -14,9 +14,9 @@ official releases:</p>
 <ul>
 <li>The Duktape API calls documented on duktape.org; except those tagged
     <code>experimental</code>.</li>
-<li>The global environment visible to Ecmascript code, including the <code>Duktape</code>
-    object and other Ecmascript extensions, as documented on duktape.org;
-    except changes needed to align with latest Ecmascript specifications.</li>
+<li>The global environment visible to ECMAScript code, including the <code>Duktape</code>
+    object and other ECMAScript extensions, as documented on duktape.org;
+    except changes needed to align with latest ECMAScript specifications.</li>
 </ul>
 
 <p>The following are not part of the "public API" versioning guarantees:</p>
@@ -27,8 +27,8 @@ official releases:</p>
     even if their symbol visibility is public.</li>
 <li>Changing an API call from a function call to a macro (or vice versa).
     These are considered compatible changes (but are not done in patch releases).</li>
-<li>Aligning with latest Ecmascript specifications.  Duktape tracks the latest
-    Ecmascript specification (currently ES2016).  Backwards incompatible changes
+<li>Aligning with latest ECMAScript specifications.  Duktape tracks the latest
+    ECMAScript specification (currently ES2016).  Backwards incompatible changes
     required to align with the latest specifications may be done in minor
     versions too (but not in patch versions unless necessary to fix a bug).
     Typically such changes are relatively minor, for example argument coercion
@@ -54,7 +54,7 @@ official releases:</p>
     typing doesn't change, API call function/macro status doesn't change.</li>
 <li>Bytecode dump/load format doesn't change so that you can load bytecode
     dumped from an older version which only differs in patch version.</li>
-<li>Ecmascript semantics fixes are not included unless necessary to fix
+<li>ECMAScript semantics fixes are not included unless necessary to fix
     a bug.</li>
 <li>Config options won't change in an incompatible manner.</li>
 </ul>

--- a/website/index/index.html
+++ b/website/index/index.html
@@ -7,7 +7,7 @@ with a focus on <b>portability</b> and compact <b>footprint</b>.</p>
 
 <p>Duktape is easy to integrate into a C/C++ project: add <code>duktape.c</code>,
 <code>duktape.h</code>, and <code>duk_config.h</code> to your build, and use the
-Duktape API to call Ecmascript functions from C code and vice versa.</p>
+Duktape API to call ECMAScript functions from C code and vice versa.</p>
 
 <script>
 // <![CDATA[
@@ -38,11 +38,11 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
 <ul>
 <li>Embeddable, portable, compact:
     can run on platforms with 160kB flash and 64kB system RAM</li>
-<li><a href="http://www.ecma-international.org/ecma-262/5.1/">Ecmascript E5/E5.1</a>,
+<li><a href="http://www.ecma-international.org/ecma-262/5.1/">ECMAScript E5/E5.1</a>,
     with some semantics updated from ES2015+</li>
 <li>Partial support for
-    <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">Ecmascript 2015 (E6)</a> and
-    <a href="http://www.ecma-international.org/ecma-262/7.0/index.html">Ecmascript 2016 (E7)</a>, see
+    <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">ECMAScript 2015 (E6)</a> and
+    <a href="http://www.ecma-international.org/ecma-262/7.0/index.html">ECMAScript 2016 (E7)</a>, see
     <a href="http://wiki.duktape.org/PostEs5Features.html">Post-ES5 feature status</a> and
     <a href="https://kangax.github.io/compat-table">kangax/compat-table</a>
 </li>
@@ -57,7 +57,7 @@ Duktape API to call Ecmascript functions from C code and vice versa.</p>
 <li>Combined reference counting and mark-and-sweep garbage collection
     with finalization</li>
 <li>Coroutines</li>
-<li>Property virtualization using a subset of Ecmascript ES2015 Proxy object</li>
+<li>Property virtualization using a subset of ECMAScript ES2015 Proxy object</li>
 <li>Bytecode dump/load for caching compiled functions</li>
 <li>Distributable includes an optional logging framework, CommonJS-based module
     loading implementations, etc</li>
@@ -138,7 +138,7 @@ $ ./test
 </pre>
 
 <p>To <a href="http://wiki.duktape.org/Configuring.html">customize Duktape configuration</a>,
-here to disable Ecmascript 6 <code>Proxy</code> object support:</p>
+here to disable ECMAScript 6 <code>Proxy</code> object support:</p>
 
 <pre>
 $ python2 duktape-2.2.0/tools/configure.py --output-directory src-duktape \
@@ -171,7 +171,7 @@ int main(int argc, char *argv[]) {
 
 <h1><span class="step">3</span> Add C function bindings</h1>
 
-<p>To call a C function from Ecmascript code, first declare your
+<p>To call a C function from ECMAScript code, first declare your
 C functions:</p>
 
 <pre class="c-code">
@@ -208,7 +208,7 @@ duk_push_c_function(ctx, native_adder, DUK_VARARGS);
 duk_put_global_string(ctx, "adder");
 </pre>
 
-<p>You can then call your function from Ecmascript code:</p>
+<p>You can then call your function from ECMAScript code:</p>
 
 <pre class="c-code">
 duk_eval_string_noresult(ctx, "print('2+3=' + adder(2, 3));");


### PR DESCRIPTION
Use 'ECMAScript' spelling in website documentation, see #1892.