### PR TITLE
Use 'ECMAScript' spelling in testcases/

### DIFF
--- a/tests/api/test-bufferobject-example-1.c
+++ b/tests/api/test-bufferobject-example-1.c
@@ -3,7 +3,7 @@
  */
 
 /*
- *  Example 1: Buffer objects are created by Ecmascript code and then handed
+ *  Example 1: Buffer objects are created by ECMAScript code and then handed
  *  over to a Duktape/C function which accesses the raw bytes from C code.
  */
 
@@ -40,7 +40,7 @@ static duk_ret_t draw_pixels(duk_context *ctx) {
 	 *
 	 * The returned pointer is stable if the underlying buffer is a
 	 * fixed buffer (this is always the case when a buffer object is
-	 * created from Ecmascript code e.g. as "new ArrayBuffer()").
+	 * created from ECMAScript code e.g. as "new ArrayBuffer()").
 	 * For dynamic and external buffers the pointer is stable unless
 	 * the buffer is resized or reconfigured.  Caller is responsible
 	 * for avoiding the use of stale pointers in such cases.  When in
@@ -49,7 +49,7 @@ static duk_ret_t draw_pixels(duk_context *ctx) {
 	 * The duk_{get,require}_buffer_data() calls take into account
 	 * "slices" so that the returned ptr/size is always to the active
 	 * slice as one would expect compared to how buffers behave in
-	 * Ecmascript code.
+	 * ECMAScript code.
 	 */
 	ptr = duk_require_buffer_data(ctx, 0, &sz);
 
@@ -139,7 +139,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 
 /*
  *  Example 2: buffer object is created from C code and used in
- *  Ecmascript code.
+ *  ECMAScript code.
  */
 
 /*===

--- a/tests/api/test-bug-bufferobject-arraybuffer-offset-length.c
+++ b/tests/api/test-bug-bufferobject-arraybuffer-offset-length.c
@@ -51,7 +51,7 @@ static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	duk_pop(ctx);  /* eval result */
 	duk_pop_2(ctx);  /* fixed buffer, buffer object */
 
-	/* Ecmascript equivalent. */
+	/* ECMAScript equivalent. */
 
 	duk_eval_string_noresult(ctx,
 		"(function (buf) {\n"

--- a/tests/api/test-bug-set-cfunc-name.c
+++ b/tests/api/test-bug-set-cfunc-name.c
@@ -11,7 +11,7 @@
  *  Fixed in Duktape 1.1 so that Function.prototype.name is writable.
  *  The best fix would actually be to have the property non-writable
  *  while simultaneously allowing a Function instance's 'name' property
- *  to be set - but Ecmascript cannot express such an access control
+ *  to be set - but ECMAScript cannot express such an access control
  *  policy.
  *
  *  Duktape 2.x follows ES2015 where .name is again non-writable, but is

--- a/tests/api/test-bug-tailcall-preventyield-assert.c
+++ b/tests/api/test-bug-tailcall-preventyield-assert.c
@@ -6,15 +6,15 @@
  *
  *  This happened when:
  *
- *    - A C function called an Ecmascript function
- *    - That Ecmascript function tailcalled another Ecmascript function
+ *    - A C function called an ECMAScript function
+ *    - That ECMAScript function tailcalled another ECMAScript function
  *
  *  What happens under the hood:
  *
- *   - The first C-to-Ecmascript call establishes an activation which has
+ *   - The first C-to-ECMAScript call establishes an activation which has
  *     DUK_ACT_FLAG_PREVENT_YIELD set.
  *
- *   - The Ecmascript-to-Ecmascript call is in principle an allowed tail
+ *   - The ECMAScript-to-ECMAScript call is in principle an allowed tail
  *     call.  However, the current call handling code assumes that the
  *     reused activation cannot have DUK_ACT_FLAG_PREVENT_YIELD set.
  *
@@ -27,7 +27,7 @@
  *
  *  A simple fix is to convert the tailcall to a normal call if the
  *  current activation has incompatible flags.  This would then prevent
- *  a tailcall even in an Ecmascript-to-Ecmascript case if the current
+ *  a tailcall even in an ECMAScript-to-ECMAScript case if the current
  *  frame was called from C.
  *
  *  NOTE: test_1() only fails with asserts enabled.

--- a/tests/api/test-dev-cmodule-guide.c
+++ b/tests/api/test-dev-cmodule-guide.c
@@ -120,7 +120,7 @@ static duk_ret_t my_modsearch(duk_context *ctx) {
 	/* [ id require exports module c_module ] */
 	duk_put_prop_string(ctx, 3 /*module*/, "exports");  /* module.exports = c_module; */
 
-	return 0;  /* return undefined, no Ecmascript source code */
+	return 0;  /* return undefined, no ECMAScript source code */
 }
 
 static duk_ret_t test_modsearch_module(duk_context *ignored_ctx, void *udata) {

--- a/tests/api/test-dev-func-tostring.c
+++ b/tests/api/test-dev-func-tostring.c
@@ -1,7 +1,7 @@
 /*
  *  Test the current Function .toString() format.
  *
- *  Cover a few cases which cannot be exercised using Ecmascript code alone.
+ *  Cover a few cases which cannot be exercised using ECMAScript code alone.
  */
 
 /*===

--- a/tests/api/test-dev-lightfunc.c
+++ b/tests/api/test-dev-lightfunc.c
@@ -964,7 +964,7 @@ static duk_ret_t test_to_buffer(duk_context *ctx, void *udata) {
 		printf("%ld: ", (long) sz);
 #endif
 
-		/* Sanitize with Ecmascript because it's easier... */
+		/* Sanitize with ECMAScript because it's easier... */
 		duk_eval_string(ctx, "(function (x) { return String(x)"
 		                     ".replace(/\\/\\*/g, '(*').replace(/\\*\\//g, '*)')"
 		                     ".replace(/light_[0-9a-fA-F]+_/g, 'light_PTR_'); })");

--- a/tests/api/test-dev-return-types.c
+++ b/tests/api/test-dev-return-types.c
@@ -1,6 +1,6 @@
 /*
  *  Supporting testcase for test-dev-return-types.js: cover return types
- *  which can't be exercised from Ecmascript code.
+ *  which can't be exercised from ECMAScript code.
  */
 
 /*===
@@ -67,7 +67,7 @@ static duk_ret_t test_basic_explicit(duk_context *ctx, void *udata) {
 	return 0;
 }
 
-/* Ecmascript finally captures return and the return is propagated
+/* ECMAScript finally captures return and the return is propagated
  * onwards after finally finishes.
  */
 static duk_ret_t test_endfin_return(duk_context *ctx, void *udata) {

--- a/tests/api/test-dev-valstack-checked-size-call.c
+++ b/tests/api/test-dev-valstack-checked-size-call.c
@@ -3,7 +3,7 @@
  *  stack to contain space for at least N elements, this reserve should
  *  not be reduced without warning.
  *
- *  In Duktape 0.11.0 function calls (Ecmascript or Duktape/C) would
+ *  In Duktape 0.11.0 function calls (ECMAScript or Duktape/C) would
  *  essentially reset the "checked" stack size.  This testcase demonstrates
  *  the issue and documents the desired behavior.
  */

--- a/tests/api/test-dev-write-duktapec-func-length.c
+++ b/tests/api/test-dev-write-duktapec-func-length.c
@@ -12,7 +12,7 @@ static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	/* User Duktape/C function .length is inherited from
 	 * %NativeFunctionPrototype% and is not writable so
 	 * a direct write fails.  This matches ES2015 .length
-	 * property of Ecmascript functions which is non-writable
+	 * property of ECMAScript functions which is non-writable
 	 * but configurable.
 	 */
 	duk_push_c_function(ctx, dummy_func, 3);

--- a/tests/api/test-dev-write-duktapec-func-name.c
+++ b/tests/api/test-dev-write-duktapec-func-name.c
@@ -12,7 +12,7 @@ static duk_ret_t test_basic(duk_context *ctx, void *udata) {
 	/* User Duktape/C function .name is inherited from
 	 * %NativeFunctionPrototype% and is not writable so
 	 * a direct write fails.  This matches ES2015 .name
-	 * property of Ecmascript functions which is non-writable
+	 * property of ECMAScript functions which is non-writable
 	 * but configurable.
 	 */
 	duk_push_c_function(ctx, dummy_func, 3);

--- a/tests/api/test-eval-this-binding.c
+++ b/tests/api/test-eval-this-binding.c
@@ -22,7 +22,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	/* For non-strict eval code the 'this' binding was effectively
 	 * the global object even before fixing GH-164: an undefined
 	 * 'this' binding gets promoted to the global object by the
-	 * usual Ecmascript call handling semantics.
+	 * usual ECMAScript call handling semantics.
 	 */
 	duk_eval_string(ctx,
 		"print('non-strict eval from C');\n"
@@ -34,7 +34,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 
 	/* For strict eval code the 'this' binding was undefined when
 	 * eval was being done from C code (but was the global object
-	 * when done from Ecmascript code).  With GH-164 fixed the
+	 * when done from ECMAScript code).  With GH-164 fixed the
 	 * 'this' binding is global object for strict eval code too.
 	 */
 

--- a/tests/api/test-get-set-finalizer.c
+++ b/tests/api/test-get-set-finalizer.c
@@ -94,7 +94,7 @@ static duk_ret_t test_recursive_finalizer(duk_context *ctx, void *udata) {
 	duk_push_int(ctx, 123);
 	duk_put_prop_string(ctx, -2, "foo");
 
-	/* Ecmascript finalizer */
+	/* ECMAScript finalizer */
 	duk_eval_string(ctx, "(function (obj) { print('finalizing obj, obj.foo:', obj.foo); })");
 	duk_push_int(ctx, 321);
 	duk_put_prop_string(ctx, -2, "bar");
@@ -102,7 +102,7 @@ static duk_ret_t test_recursive_finalizer(duk_context *ctx, void *udata) {
 	/* [ target finalizer ] */
 
 	/* Break the function <-> prototype reference loop so that the
-	 * Ecmascript finalizer is not in a reference loop and gets
+	 * ECMAScript finalizer is not in a reference loop and gets
 	 * collected by refcounting.
 	 *
 	 * (Note that 'prototype' is not configurable so we can't
@@ -111,7 +111,7 @@ static duk_ret_t test_recursive_finalizer(duk_context *ctx, void *udata) {
 	duk_push_string(ctx, "dummy");
 	duk_put_prop_string(ctx, -2, "prototype");
 
-	/* Add a Duktape/C finalizer for the Ecmascript finalizer to
+	/* Add a Duktape/C finalizer for the ECMAScript finalizer to
 	 * exercise both Duktape/C finalizers and recursive finalization
 	 */
 	duk_push_c_function(ctx, c_finalizer, 1);
@@ -121,7 +121,7 @@ static duk_ret_t test_recursive_finalizer(duk_context *ctx, void *udata) {
 
 	/* [ target(foo:123) finalizer(bar:321) ] */
 
-	/* Set Ecmascript finalizer to original object */
+	/* Set ECMAScript finalizer to original object */
 	duk_set_finalizer(ctx, -2);
 
 	/* [ target(foo:123) ] */

--- a/tests/api/test-get-set-magic.c
+++ b/tests/api/test-get-set-magic.c
@@ -2,7 +2,7 @@
  *  Test setting and getting the Duktape/C function magic value.
  *
  *  The magic value is useful in sharing a single native helper
- *  with multiple Ecmascript bindings, with the helper's behavior
+ *  with multiple ECMAScript bindings, with the helper's behavior
  *  being controlled by flags or other values in the magic value.
  *  The magic value is stored cheaply without needing a property
  *  slot.

--- a/tests/api/test-get-set-prototype.c
+++ b/tests/api/test-get-set-prototype.c
@@ -1,7 +1,7 @@
 /*
  *  Testcase for object prototype manipulation
  *
- *  Test also prototype loops.  The Ecmascript primitives like Object.create()
+ *  Test also prototype loops.  The ECMAScript primitives like Object.create()
  *  and Object.setPrototypeOf() guard against creating a prototype loop (as
  *  required by the specification) but no such safeguard is used for the C API.
  *  A prototype loop is expected to be terminated by a sanity limit inside

--- a/tests/api/test-hello-world.c
+++ b/tests/api/test-hello-world.c
@@ -1,10 +1,10 @@
 /*===
-Hello world from Ecmascript!
+Hello world from ECMAScript!
 Hello world from C!
 ===*/
 
 void test(duk_context *ctx) {
-	duk_push_string(ctx, "print('Hello world from Ecmascript!');");
+	duk_push_string(ctx, "print('Hello world from ECMAScript!');");
 	duk_eval(ctx);
 	printf("Hello world from C!\n");
 }

--- a/tests/api/test-instanceof.c
+++ b/tests/api/test-instanceof.c
@@ -46,7 +46,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	return 0;
 }
 
-/* duk_instanceof() inherits the Ecmascript type requirements for lval and rval.
+/* duk_instanceof() inherits the ECMAScript type requirements for lval and rval.
  * In particular, rval must be a -callable- object.  Here, for example, trying
  * to do the equivalent of: "new Error() instanceof new Error()" is a TypeError
  * because the rval is a non-callable object.

--- a/tests/api/test-json-fastpath.c
+++ b/tests/api/test-json-fastpath.c
@@ -1,5 +1,5 @@
 /*
- *  JSON fast path tests which cannot be covered from pure Ecmascript code.
+ *  JSON fast path tests which cannot be covered from pure ECMAScript code.
  */
 
 /*===

--- a/tests/api/test-push-array.c
+++ b/tests/api/test-push-array.c
@@ -16,7 +16,7 @@ void test(duk_context *ctx) {
 	duk_put_prop_index(ctx, arr_idx, 1);
 
 	/* array is now: [ "foo", "bar" ], and array.length is 2 (automatically
-	 * updated for Ecmascript arrays).
+	 * updated for ECMAScript arrays).
 	 */
 
 	printf("duk_is_array(%ld) = %d\n", (long) arr_idx, (int) duk_is_array(ctx, arr_idx));

--- a/tests/api/test-push-buffer-object.c
+++ b/tests/api/test-push-buffer-object.c
@@ -189,7 +189,7 @@ static duk_ret_t test_arraybuffer_base_for_u32array(duk_context *ctx, void *udat
 	 *  fields in duk_hbufobj; since there's only one, the external
 	 *  .byteOffset will currently return the internal offset.
 	 *
-	 *  If Ecmascript code calls new Uint32Array() for an ArrayBuffer
+	 *  If ECMAScript code calls new Uint32Array() for an ArrayBuffer
 	 *  with a non-zero offset (which can only be created from C code),
 	 *  the result is the same (see separate test below).
 	 *
@@ -241,11 +241,11 @@ static duk_ret_t test_arraybuffer_base_for_u32array_ecma(duk_context *ctx, void 
 	(void) udata;
 
 	/* Same as above, but replace the second duk_push_buffer_object()
-	 * with a new Uint32Array() call from Ecmascript.  As above, the
+	 * with a new Uint32Array() call from ECMAScript.  As above, the
 	 * view's .byteOffset will still be odd when the base ArrayBuffer
 	 * has a non-zero offset.  This test is just here to demonstrate
 	 * that given the same ArrayBuffer base object, the view constructed
-	 * over it via the C API or Ecmascript API behaves the same.
+	 * over it via the C API or ECMAScript API behaves the same.
 	 */
 
 	buf = duk_push_fixed_buffer(ctx, 32);

--- a/tests/api/test-put-prop-primbase.c
+++ b/tests/api/test-put-prop-primbase.c
@@ -8,7 +8,7 @@
 static duk_ret_t test_put(duk_context *ctx) {
 	duk_ret_t rc;
 
-	/* In Ecmascript, '(0).foo = "bar"' should work and evaluate to "bar"
+	/* In ECMAScript, '(0).foo = "bar"' should work and evaluate to "bar"
 	 * in non-strict mode, but cause an error to be thrown in strict mode
 	 * (E5.1, Section 8.7.2, exotic [[Put]] variant, step 7.
 	 */

--- a/tests/api/test-put-prop.c
+++ b/tests/api/test-put-prop.c
@@ -143,8 +143,8 @@ final top: 1
 
 /* Test property writing API call.
  *
- * Property write behavior is quite complex in Ecmascript and there
- * are many Ecmascript testcases to cover the behavior.  The purpose
+ * Property write behavior is quite complex in ECMAScript and there
+ * are many ECMAScript testcases to cover the behavior.  The purpose
  * of this testcase is to ensure the exposed API behavior is as
  * expected without covering every specification case.  In particular,
  * different throwing / return code combinations need to be covered.

--- a/tests/api/test-set-global-object.c
+++ b/tests/api/test-set-global-object.c
@@ -259,7 +259,7 @@ static duk_ret_t test_noeval(duk_context *ctx_root, void *udata) {
 
 	/*
 	 *  Build a global environment with no eval - check that we can't
-	 *  eval stuff anymore from Ecmascript code.  The C eval APIs still
+	 *  eval stuff anymore from ECMAScript code.  The C eval APIs still
 	 *  work.
 	 */
 
@@ -283,10 +283,10 @@ static duk_ret_t test_noeval(duk_context *ctx_root, void *udata) {
 	duk_pop(ctx);
 
 	/*
-	 *  Eval with Ecmascript.
+	 *  Eval with ECMAScript.
 	 */
 	(void) duk_peval_string(ctx,
-		"eval('print(\"hello from Ecmascript eval\")')\n"
+		"eval('print(\"hello from ECMAScript eval\")')\n"
 	);
 	printf("result: %s\n", duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);

--- a/tests/api/test-time-components.c
+++ b/tests/api/test-time-components.c
@@ -30,7 +30,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 
 	(void) udata;
 
-	/* Ecmascript time-to-components (UTC):
+	/* ECMAScript time-to-components (UTC):
 	 *
 	 *   - d.getUTCMonth() is zero-based.
 	 *   - d.getUTCDate() (day in month) is one-based.
@@ -83,7 +83,7 @@ static duk_ret_t test_2(duk_context *ctx, void *udata) {
 
 	(void) udata;
 
-	/* Ecmascript components-to-time (UTC):
+	/* ECMAScript components-to-time (UTC):
 	 *
 	 *   - Year argument has a hack for two-digit years (e.g. Date.UTC(99, ...)
 	 *     creates a time value for year 1999.

--- a/tests/api/test-to-primitive.c
+++ b/tests/api/test-to-primitive.c
@@ -28,7 +28,7 @@ index 18, ToString(result): '0xdeadbeef', type: 8 -> 8
 ===*/
 
 /* XXX: coverage is pretty poor, e.g. different hints are not tested.
- * They are indirectly covered by Ecmascript tests to some extent, though.
+ * They are indirectly covered by ECMAScript tests to some extent, though.
  */
 
 static duk_ret_t test_1(duk_context *ctx, void *udata) {

--- a/tests/ecmascript/test-bi-array-proto-filter.js
+++ b/tests/ecmascript/test-bi-array-proto-filter.js
@@ -338,7 +338,7 @@ function coercionTest() {
     test([], [ null ]);
 
     // return value of callback is ToBoolean() coerced; this has no
-    // side effects, but test each Ecmascript type
+    // side effects, but test each ECMAScript type
 
     var testvalues = [ undefined, null, true, false, 0, 123, '', 'foo', [1,2], { foo: 1, bar: 2 } ];
     test([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], [ function (val, key, obj) {

--- a/tests/ecmascript/test-bi-array-push-maxlen.js
+++ b/tests/ecmascript/test-bi-array-push-maxlen.js
@@ -2,7 +2,7 @@
  *  If array length is 0xffffffff, Array.prototype.push() appends all the
  *  requested items and then sets the final 'length'.
  *
- *  For Ecmascript arrays (objects with array special behavior), the item
+ *  For ECMAScript arrays (objects with array special behavior), the item
  *  writes will succeed, and the modified [[DefineOwnProperty]] algorithm
  *  in Section 15.4.5.1 triggers an automatic 'length' update for items
  *  whose index is in the range [0,0xfffffffe].  Outside this range the
@@ -11,7 +11,7 @@
  *  would be above 0xffffffff.  In error cases -all items- get written and
  *  length may be updated (up to 0xffffffff).
  *
- *  When the argument is not an Ecmascript array, the length is updated to
+ *  When the argument is not an ECMAScript array, the length is updated to
  *  0x100000000.
  */
 

--- a/tests/ecmascript/test-bi-date-local-parts-fi.js
+++ b/tests/ecmascript/test-bi-date-local-parts-fi.js
@@ -1,10 +1,10 @@
 /*
  *  When parsing a timestamp from local time parts (year, month, etc) the
  *  implementation needs to figure out the UTC time corresponding to the
- *  local parts and then convert the UTC time to an Ecmascript time value.
+ *  local parts and then convert the UTC time to an ECMAScript time value.
  *
  *  The concrete conversion algorithm tries to figure out the UTC-to-local
- *  offset so that it can be taken into account in the Ecmascript time value.
+ *  offset so that it can be taken into account in the ECMAScript time value.
  *  There's a practical problem in this conversion: DUK__GET_LOCAL_TZOFFSET()
  *  provides a UTC-to-local-time offset for an input time value which is
  *  essentially a *UTC* timestamp.  However, we don't know the UTC time yet

--- a/tests/ecmascript/test-bi-date-makeday.js
+++ b/tests/ecmascript/test-bi-date-makeday.js
@@ -53,12 +53,12 @@ try {
     print(MakeDay(-1970.9, -1.9, -2.9));
 
     // Components even outside valid ecmascript range are OK as long as
-    // the result will be within Ecmascript range.  Here day and month
+    // the result will be within ECMAScript range.  Here day and month
     // should cancel out, leaving year zero, day 55.
     print(MakeDay(100e10, -1200e10, 55));
     print(MakeDay(0, 0, 55));
 
-    // XXX: rounding errors?  MakeTime() is required to use Ecmascript
+    // XXX: rounding errors?  MakeTime() is required to use ECMAScript
     // (IEEE double) arithmetic.  These never occur unless extremely
     // unnormalized values are used.
 } catch (e) {

--- a/tests/ecmascript/test-bi-date-no-fracs.js
+++ b/tests/ecmascript/test-bi-date-no-fracs.js
@@ -8,7 +8,7 @@
 -123
 ===*/
 
-/* The internal time value of an Ecmascript Date has no fractions.
+/* The internal time value of an ECMAScript Date has no fractions.
  * For instance, TimeClip() applies ToInteger() for all finite
  * values.
  *

--- a/tests/ecmascript/test-bi-date-parse-iso8601.js
+++ b/tests/ecmascript/test-bi-date-parse-iso8601.js
@@ -109,7 +109,7 @@ function iso8601ParseTest() {
           Date.parse('+287396-10-12T08:59:00.992Z'));  // out of valid E5 range
 
     // Note that the first and last extended year examples are out of
-    // Ecmascript valid range:
+    // ECMAScript valid range:
     print(new Date(0 + 100e6*24*3600*1000).getUTCFullYear(),
           new Date(0 + 100e6*24*3600*1000 + 1).getUTCFullYear(),
           new Date(0 - 100e6*24*3600*1000).getUTCFullYear(),

--- a/tests/ecmascript/test-bi-date-tojson-generic.js
+++ b/tests/ecmascript/test-bi-date-tojson-generic.js
@@ -145,7 +145,7 @@ try {
     obj = {
         valueOf: function() {
             // Note: returning a finite number which is still outside
-            // Ecmascript range should NOT cause a 'null' return!
+            // ECMAScript range should NOT cause a 'null' return!
             print('valueOf()');
             return (100e6 * 86400e3) + 1e10;
         },

--- a/tests/ecmascript/test-bi-date-tzoffset.js
+++ b/tests/ecmascript/test-bi-date-tzoffset.js
@@ -9,7 +9,7 @@ no output expected
  * timestamp range (1970-2038).
  *
  * (Of course, some UNIX systems provide a 64-bit timestamp and have no
- * issues covering the Ecmascript date range.)
+ * issues covering the ECMAScript date range.)
  */
 
 function test(tv) {

--- a/tests/ecmascript/test-bi-duktape-errhandler.js
+++ b/tests/ecmascript/test-bi-duktape-errhandler.js
@@ -1,5 +1,5 @@
 /*
- *  Testcases for error handler behavior from Ecmascript code point of view.
+ *  Testcases for error handler behavior from ECMAScript code point of view.
  *  Checks both Duktape.errCreate and Duktape.errThrow.
  */
 
@@ -80,7 +80,7 @@ function errCreateTest() {
         }
     }
 
-    // Error created from Ecmascript
+    // Error created from ECMAScript
     function errTest2() {
         var e = new URIError('fake uri error');
         errPrint(e);
@@ -166,7 +166,7 @@ function errCreateTest() {
      *  There is some inconsistent behavior here now.  If the original error
      *  is thrown by Duktape itself (referencing 'aiee') the second error
      *  causes the error to be replaced with a DoubleError.  However, if the
-     *  original error is thrown by Ecmascript code (throw X) the error from
+     *  original error is thrown by ECMAScript code (throw X) the error from
      *  errCreate will replace the original error as is (here it will be
      *  a ReferenceError caused by referencing 'zork').
      */
@@ -359,7 +359,7 @@ function errThrowTest() {
         }
     }
 
-    // Error thrown from Ecmascript
+    // Error thrown from ECMAScript
     function errTest2() {
         try {
             throw new URIError('fake uri error');
@@ -441,7 +441,7 @@ function errThrowTest() {
      *  There is some inconsistent behavior here now.  If the original error
      *  is thrown by Duktape itself (referencing 'aiee') the second error
      *  causes the error to be replaced with a DoubleError.  However, if the
-     *  original error is thrown by Ecmascript code (throw X) the error from
+     *  original error is thrown by ECMAScript code (throw X) the error from
      *  errThrow will replace the original error as is (here it will be
      *  a ReferenceError caused by referencing 'zork').
      */
@@ -550,7 +550,7 @@ function errThrowTest() {
     }
 
     /*
-     *  In addition to Duktape internal errors and explicit Ecmascript
+     *  In addition to Duktape internal errors and explicit ECMAScript
      *  throws, coroutine yield() / resume() errors are processed with
      *  the errThrow.
      */

--- a/tests/ecmascript/test-bi-duktape-json-custom.js
+++ b/tests/ecmascript/test-bi-duktape-json-custom.js
@@ -741,8 +741,8 @@ jc "\u0000"
 ===*/
 
 /* Test invalid XUTF-8 handling in all modes, including standard JSON.  This
- * behavior is always outside the scope of Ecmascript because all valid
- * Ecmascript strings are valid CESU-8.
+ * behavior is always outside the scope of ECMAScript because all valid
+ * ECMAScript strings are valid CESU-8.
  *
  * Because the XUTF-8 decoding is now lenient (it does not, for instance,
  * check continuation bytes at all), this test is now focused on testing

--- a/tests/ecmascript/test-bi-error-instance-custom.js
+++ b/tests/ecmascript/test-bi-error-instance-custom.js
@@ -1,7 +1,7 @@
 /*
  *  Custom Error properties.
  *
- *  Ecmascript engines vary a lot in what Error properties exist and how they
+ *  ECMAScript engines vary a lot in what Error properties exist and how they
  *  are implemented (e.g. as own properties, inherited properties, accessors,
  *  enumerability).
  *
@@ -59,7 +59,7 @@ function test() {
 
     // Only 'message' is an own property.  Stack trace etc are accessors
     // and back into an internal _tracedata property which cannot normally
-    // be accessed from Ecmascript code.
+    // be accessed from ECMAScript code.
 
     print('own properties');
     Object.getOwnPropertyNames(err).forEach(function (k) {

--- a/tests/ecmascript/test-bi-function-nonstd-caller-prop.js
+++ b/tests/ecmascript/test-bi-function-nonstd-caller-prop.js
@@ -7,7 +7,7 @@
  *  This non-standard behavior is available in Duktape with a special
  *  feature option (not by default).  The behavior is modelled after
  *  V8 behavior.  Note: when testing with NodeJS, the program does not
- *  execute in a genuine Ecmascript global/program context, so some
+ *  execute in a genuine ECMAScript global/program context, so some
  *  V8/NodeJS behavior is not as expected.  This is an artifact of the
  *  NodeJS wrapper.
  */
@@ -86,7 +86,7 @@ function basicTest() {
     pd = Object.getOwnPropertyDescriptor(f1_nonstrict, 'caller');
     print(pd.value, pd.writable, pd.enumerable, pd.configurable, typeof pd.get, typeof pd.set);
 
-    // Strict function: obeys Ecmascript specification, and is an accessor
+    // Strict function: obeys ECMAScript specification, and is an accessor
     // with a thrower.
     pd = Object.getOwnPropertyDescriptor(f1_strict, 'caller');
     print(pd.value, pd.writable, pd.enumerable, pd.configurable, typeof pd.get, typeof pd.set);
@@ -151,20 +151,20 @@ TypeError
  */
 
 function callTypeTest() {
-    // Global-to-Ecmascript call (same as native-to-Ecmascript with slight
+    // Global-to-ECMAScript call (same as native-to-ECMAScript with slight
     // handling differences because 'caller' will be null).  NOTE: NodeJS
     // prints 'anon' here because the test case executes from a function, not
     // an actual global context.
     print('entry', summarizeCaller(callTypeTest));
 
-    // Ecmascript-to-Ecmascript call, no tail recursion
+    // ECMAScript-to-ECMAScript call, no tail recursion
     function ecmaNoTail() {
         print('in ecmaNoTail', summarizeCaller(ecmaNoTail));
     }
     ecmaNoTail();
     print('after ecmaNoTail', summarizeCaller(ecmaNoTail));
 
-    // Ecmascript-to-Ecmascript call, with tail recursion
+    // ECMAScript-to-ECMAScript call, with tail recursion
     function ecmaTail1(idx) {
         print(idx, 'in ecmaTail1, ecmaTail1', summarizeCaller(ecmaTail1));
         print(idx, 'in ecmaTail1, ecmaTail2', summarizeCaller(ecmaTail2));
@@ -181,7 +181,7 @@ function callTypeTest() {
     print('after ecmaNoTail, ecmaTail1', summarizeCaller(ecmaTail1));
     print('after ecmaNoTail, ecmaTail2', summarizeCaller(ecmaTail2));
 
-    // Native-to-Ecmascript call
+    // Native-to-ECMAScript call
     function nativeCall() {
         print('in nativeCall', summarizeCaller(nativeCall));
     }

--- a/tests/ecmascript/test-bi-global-uri.js
+++ b/tests/ecmascript/test-bi-global-uri.js
@@ -10,7 +10,7 @@
 // indirect eval -> this is bound to the global object, E5 Section 10.4.2, step 1.a.
 var g = (function () { var e = eval; return e('this'); } )();
 
-/* Pure Ecmascript helper to URI encode a codepoint into URI escaped form.
+/* Pure ECMAScript helper to URI encode a codepoint into URI escaped form.
  * Allows surrogate pairs to be encoded into invalid UTF-8 on purpose.
  */
 function encCodePoint(x, forced_len) {
@@ -194,7 +194,7 @@ decode non-bmp
 
 /* Decode non-BMP characters and check that surrogate pairs are decoded
  * correctly.  In other words, a single UTF-8 encoded codepoint becomes
- * two Ecmascript codepoints.
+ * two ECMAScript codepoints.
  *
  * Decoding of non-BMP characters above U+10FFFF is required to result
  * in URIError, and is tested separately below in invalid UTF-8 tests.
@@ -235,7 +235,7 @@ combine surrogate pairs in encode
 %F4%8F%BF%BF
 ===*/
 
-/* When encoding, surrogate pairs found in Ecmascript strings must be combined,
+/* When encoding, surrogate pairs found in ECMAScript strings must be combined,
  * and encoded into UTF-8 (as a single codepoint).
  */
 
@@ -337,7 +337,7 @@ invalid utf-8 decode
  *
  *   - Non-shortest UTF-8 encodings, e.g. URIError is required for C0 80.
  *
- *   - U+10FFFF decodes correctly to an Ecmascript string with a surrogate pair
+ *   - U+10FFFF decodes correctly to an ECMAScript string with a surrogate pair
  *
  *   - U+110000 causes an URIError
  *

--- a/tests/ecmascript/test-bi-json-dec-numbers.js
+++ b/tests/ecmascript/test-bi-json-dec-numbers.js
@@ -1,7 +1,7 @@
 /*
  *  Testcase for JSON parsing of numbers.
  *
- *  The number syntax for JSON differs a bit from Ecmascript syntax.
+ *  The number syntax for JSON differs a bit from ECMAScript syntax.
  */
 
 /*===

--- a/tests/ecmascript/test-bi-json-dec-reclimit.js
+++ b/tests/ecmascript/test-bi-json-dec-reclimit.js
@@ -21,7 +21,7 @@ RangeError
  *
  * Note: we don't check the parse result now; using JSON.stringify()
  * to print the result would hit stringify()'s recursion limit.  So
- * if printing is added, do it with Ecmascript and avoid Ecmascript
+ * if printing is added, do it with ECMAScript and avoid ECMAScript
  * recursion limit.
  *
  * To ensure recursion limit is reached for even a deep stack configuration,

--- a/tests/ecmascript/test-bi-json-dec-types.js
+++ b/tests/ecmascript/test-bi-json-dec-types.js
@@ -75,7 +75,7 @@ SyntaxError
 SyntaxError
 ===*/
 
-/* JSONNumber does not accept NaN, Infinity, -Infinity.  Ecmascript also
+/* JSONNumber does not accept NaN, Infinity, -Infinity.  ECMAScript also
  * does not but they parse as identifier references (and unary minus for
  * -Infinity) and usually evaluate to something useful.
  *
@@ -139,7 +139,7 @@ leading plus
 SyntaxError
 ===*/
 
-/* JSONNumber does not allow a plus sign.  Actually Ecmascript doesn't either,
+/* JSONNumber does not allow a plus sign.  Actually ECMAScript doesn't either,
  * a leading plus sign is an unary plus operator.
  */
 
@@ -198,7 +198,7 @@ SyntaxError
 ===*/
 
 /* JSONNumber does not allow additional leading zeroes.  This is probably a
- * good thing even if Ecmascript parsing allows octal literals.
+ * good thing even if ECMAScript parsing allows octal literals.
  */
 
 print('leading zeroes');
@@ -233,7 +233,7 @@ foo
 SyntaxError
 ===*/
 
-/* JSONString does not allow single quotes, Ecmascript does. */
+/* JSONString does not allow single quotes, ECMAScript does. */
 
 print('single quotes');
 
@@ -344,7 +344,7 @@ eval 1 31
 json SyntaxError
 ===*/
 
-/* JSONString does not accept codepoints U+0000 to U+001F (Ecmascript does). */
+/* JSONString does not accept codepoints U+0000 to U+001F (ECMAScript does). */
 
 print('string codepoints');
 
@@ -497,7 +497,7 @@ json SyntaxError
 ===*/
 
 /* JSONString does not allow "unknown" backslash escapes.  These are handled
- * by the Ecmascript grammar as "no-ops", e.g. "\d" === "d" but must be rejected
+ * by the ECMAScript grammar as "no-ops", e.g. "\d" === "d" but must be rejected
  * by JSON parsing.
  */
 
@@ -549,7 +549,7 @@ zero escape
 SyntaxError
 ===*/
 
-/* Ecmascript strings accept a zero escape, JSONString does not. */
+/* ECMAScript strings accept a zero escape, JSONString does not. */
 
 print('zero escape');
 
@@ -588,7 +588,7 @@ A
 SyntaxError
 ===*/
 
-/* JSONString does not accept hex escapes, Ecmascript strings do. */
+/* JSONString does not accept hex escapes, ECMAScript strings do. */
 
 print('hex escape');
 

--- a/tests/ecmascript/test-bi-json-enc-types.js
+++ b/tests/ecmascript/test-bi-json-enc-types.js
@@ -278,7 +278,7 @@ try {
 /* Functions (anything callable) serialize as 'null' */
 
 try {
-    // anonymous Ecmascript function
+    // anonymous ECMAScript function
     t = JSON.stringify([1,2,function(){},4]);
     print(t);
 

--- a/tests/ecmascript/test-bi-json-enc-u2028-u2029.js
+++ b/tests/ecmascript/test-bi-json-enc-u2028-u2029.js
@@ -1,7 +1,7 @@
 /*
- *  Ecmascript specification requires that U+2028 and U+2029 are not escaped
+ *  ECMAScript specification requires that U+2028 and U+2029 are not escaped
  *  by JSON.stringify().  Because these characters are considered line breaks
- *  by Ecmascript, the resulting JSON won't work when pasted e.g. into a web
+ *  by ECMAScript, the resulting JSON won't work when pasted e.g. into a web
  *  page.
  *
  *  Duktape escapes these codepoints to work better with e.g. web templating.

--- a/tests/ecmascript/test-bi-logger.js
+++ b/tests/ecmascript/test-bi-logger.js
@@ -189,7 +189,7 @@ function formattingTest() {
     logger = new Duktape.Logger('myLogger');
 
     // Formatting test, all standard types except function (function coerces
-    // a string with Ecmascript comments which interferes with the expect string)
+    // a string with ECMAScript comments which interferes with the expect string)
 
     print('types');
     logger.info('type:', undefined);

--- a/tests/ecmascript/test-bi-math-tonumber.js
+++ b/tests/ecmascript/test-bi-math-tonumber.js
@@ -1,7 +1,7 @@
 /*
  *  Math object ToNumber side effects (ES5 15.8.2)
  *
- *  Ecmascript 5.1 requires that all Math object methods coerce all arguments
+ *  ECMAScript 5.1 requires that all Math object methods coerce all arguments
  *  with ToNumber from left to right.  This ensures that all side effects
  *  caused by ToNumber coercion have a chance to be evaluated.
  */

--- a/tests/ecmascript/test-bi-proxy-in-constructor.js
+++ b/tests/ecmascript/test-bi-proxy-in-constructor.js
@@ -1,5 +1,5 @@
 /*
- *  If an Ecmascript constructor returns an object value, the value replaces
+ *  If an ECMAScript constructor returns an object value, the value replaces
  *  the default instance created (the 'this' value that a constructor gets).
  *  This can be used to wrap the 'this' value behind a Proxy.
  */

--- a/tests/ecmascript/test-bi-reflect-construct-tail.js
+++ b/tests/ecmascript/test-bi-reflect-construct-tail.js
@@ -1,6 +1,6 @@
 /*
  *  In Duktape 2.2 Reflect.construct() is handled inline in call handling and
- *  doesn't involve a native call.  Ecmascript-to-Ecmascript Reflect.construct()
+ *  doesn't involve a native call.  ECMAScript-to-ECMAScript Reflect.construct()
  *  calls are thus only limited by callstack limit (not recursion C limit).
  *
  *  Reflect.construct() can be used in tailcall position as long as the function

--- a/tests/ecmascript/test-bi-typedarray-nan-handling.js
+++ b/tests/ecmascript/test-bi-typedarray-nan-handling.js
@@ -68,7 +68,7 @@ function nanHandlingTest() {
     }
 
     /*
-     *  Then writing NaN explicitly, reading it into an Ecmascript value,
+     *  Then writing NaN explicitly, reading it into an ECMAScript value,
      *  writing it back, and checking through DataView.
      */
 

--- a/tests/ecmascript/test-bug-date-setyear-overflow.js
+++ b/tests/ecmascript/test-bug-date-setyear-overflow.js
@@ -1,5 +1,5 @@
 /*
- *  Duktape 0.11.0 had a bug where setting a year outside the Ecmascript
+ *  Duktape 0.11.0 had a bug where setting a year outside the ECMAScript
  *  range could overflow in integer arithmetic, resulting in an incorrect
  *  year being set.  The test would print:
  *

--- a/tests/ecmascript/test-bug-date-timeval-edges.js
+++ b/tests/ecmascript/test-bug-date-timeval-edges.js
@@ -1,7 +1,7 @@
 /*
  *  Date corner case bugs found through test262
  *
- *  Ecmascript E5.1 Section 15.9.1.1
+ *  ECMAScript E5.1 Section 15.9.1.1
  *
  *      The actual range of times supported by ECMAScript Date objects
  *      is slightly smaller: exactly -100,000,000 days to 100,000,000
@@ -34,7 +34,7 @@ test3
  *
  * This test used to fail because tzoffset computation was avoided (with
  * result replaced with zero) when a temporary timevalue was outside the
- * strict Ecmascript range.  This was fixed by adding a 24h leeway to that
+ * strict ECMAScript range.  This was fixed by adding a 24h leeway to that
  * range check in duk__get_local_tzoffset().
  */
 function test1() {
@@ -46,7 +46,7 @@ function test1() {
 
     d = new Date(1970,            // year
                  0,               // month (Jan)
-                 100000001,       // days: 100M + 1 (one day over Ecmascript maximum)
+                 100000001,       // days: 100M + 1 (one day over ECMAScript maximum)
                  0,               // hour
                  0 + tzMin - 60,  // minutes: one hour backwards from day 101M UTC
                  0,               // seconds
@@ -66,7 +66,7 @@ function test2() {
 
     d = new Date(1970,            // year
                  0,               // month (Jan)
-                 100000001,       // days: 100M + 1 (one day over Ecmascript maximum)
+                 100000001,       // days: 100M + 1 (one day over ECMAScript maximum)
                  0,               // hour
                  0 + tzMin - 60,  // minutes: one hour backwards from day 101M UTC
                  0,               // seconds
@@ -79,9 +79,9 @@ function test2() {
 function test3() {
     /* toString(), which coerces to local time, caused an assert failure for
      * similar reasons as with test1() and test2().  When converting an
-     * Ecmascript time value to local time, the implementation adds a local
+     * ECMAScript time value to local time, the implementation adds a local
      * time offset before generating the parts (year, month, etc).  This
-     * temporary time value can be just outside Ecmascript range even if the
+     * temporary time value can be just outside ECMAScript range even if the
      * original UTC time value is within the range.  A +/- 24h leeway was
      * added to the assert in duk__timeval_to_parts() to fix the assert error.
      */

--- a/tests/ecmascript/test-commonjs-module-search-function.js
+++ b/tests/ecmascript/test-commonjs-module-search-function.js
@@ -7,11 +7,11 @@
  *
  *    - Add symbols directly to the 'exports' table.
  *
- *    - Return a string which is interpreted as Ecmascript source
+ *    - Return a string which is interpreted as ECMAScript source
  *      of the module.
  *
  *    - Return a non-string which is interpreted to mean that the
- *      module has been found, but has no Ecmascript source.  In other
+ *      module has been found, but has no ECMAScript source.  In other
  *      words, the module is a "pure C" one, and all necessary symbols
  *      have been added to the exports table.
  */
@@ -137,7 +137,7 @@ function moduleSearchTest() {
 
     /*
      *  Mixed modules are also possible.  This test simulates the case where
-     *  a C module provides funcRaw() and Ecmascript module provides a safe
+     *  a C module provides funcRaw() and ECMAScript module provides a safe
      *  wrapper around it.
      */
 

--- a/tests/ecmascript/test-dev-bound-func-chain.js
+++ b/tests/ecmascript/test-dev-bound-func-chain.js
@@ -145,7 +145,7 @@ function test() {
     var func;
     var F, G, H, I;
 
-    // Final function is an Ecmascript function.
+    // Final function is an ECMAScript function.
 
     func = function foo(a, b, c, d) {
         print(typeof this, this);

--- a/tests/ecmascript/test-dev-buffer-copy-example.js
+++ b/tests/ecmascript/test-dev-buffer-copy-example.js
@@ -1,5 +1,5 @@
 /*
- *  Making a copy of a plain buffer with Ecmascript code.
+ *  Making a copy of a plain buffer with ECMAScript code.
  */
 
 /*@include util-buffer.js@*/

--- a/tests/ecmascript/test-dev-buffer-to-string.js
+++ b/tests/ecmascript/test-dev-buffer-to-string.js
@@ -67,7 +67,7 @@ function test() {
     print(s.length, Duktape.enc('jx', s));
     print(Duktape.enc('jx', stringToBuffer(s)));
 
-    // In Duktape 2.x there's no default Ecmascript built-in for doing a
+    // In Duktape 2.x there's no default ECMAScript built-in for doing a
     // 1:1 string conversion, but "duk" command fills in String.fromBufferRaw().
     // The active slice of any buffer or buffer object argumented is
     // interpreted as bytes (even for e.g. Uint32Array) and copied 1:1 into

--- a/tests/ecmascript/test-dev-builtin-constructability.js
+++ b/tests/ecmascript/test-dev-builtin-constructability.js
@@ -1,5 +1,5 @@
 /*
- *  Normal Ecmascript functions declared by user code (and all Duktape/C)
+ *  Normal ECMAScript functions declared by user code (and all Duktape/C)
  *  functions are constructable.  Also built-in top level functions like
  *  Number, String, etc. are constructable.  The rest of the built-in
  *  functions apparently must not be.  Test a few here (not comprehensive).

--- a/tests/ecmascript/test-dev-call-special-misc.js
+++ b/tests/ecmascript/test-dev-call-special-misc.js
@@ -26,7 +26,7 @@ function test() {
         print(e);
     }
 
-    // Same test, argArray is an Ecmascript function (this makes no sense,
+    // Same test, argArray is an ECMAScript function (this makes no sense,
     // but covers a development time bug).
     try {
         print(Reflect.construct(foo.call, foo));

--- a/tests/ecmascript/test-dev-compiler-reclimit2.js
+++ b/tests/ecmascript/test-dev-compiler-reclimit2.js
@@ -1,5 +1,5 @@
 /*
- *  Ecmascript compiler recursion limits.  These are quite arbitrary, so here
+ *  ECMAScript compiler recursion limits.  These are quite arbitrary, so here
  *  we test against the current limits, ensuring that reasonable expressions
  *  get parsed while "unreasonable" ones cause a recursion error.
  *

--- a/tests/ecmascript/test-dev-constructor-bound.js
+++ b/tests/ecmascript/test-dev-constructor-bound.js
@@ -28,7 +28,7 @@ function test() {
     print(t.test('fooFOO'));
     print(t.test('foobar'));
 
-    // Ecmascript constructor function, bound arguments.
+    // ECMAScript constructor function, bound arguments.
     bound = MyConstructor.bind({ foo: 123, ignored: true }, 'foo', 'bar', 'quux');
     t = new bound('baz', 'quuux');
     print(typeof t);

--- a/tests/ecmascript/test-dev-cont-callstack.js
+++ b/tests/ecmascript/test-dev-cont-callstack.js
@@ -14,7 +14,7 @@ still here
 ===*/
 
 function test() {
-    // Use an Ecmascript-to-Ecmascript call to hit the call stack limit
+    // Use an ECMAScript-to-ECMAScript call to hit the call stack limit
     // without hitting the native call limit.  Avoid tail recursion which
     // would cause an infinite loop.
 

--- a/tests/ecmascript/test-dev-cont-valstack.js
+++ b/tests/ecmascript/test-dev-cont-valstack.js
@@ -14,7 +14,7 @@ still here
 ===*/
 
 function test() {
-    // Use an Ecmascript-to-Ecmascript call to hit the value stack limit
+    // Use an ECMAScript-to-ECMAScript call to hit the value stack limit
     // without hitting the native call limit.  Use a function with a lot
     // of temporaries to ensure value stack limit is reached before call
     // stack limit (this depends on specific constants of course).  Avoid

--- a/tests/ecmascript/test-dev-eval-this-binding.js
+++ b/tests/ecmascript/test-dev-eval-this-binding.js
@@ -1,6 +1,6 @@
 /*
  *  Demonstrate 'this' binding behavior for "direct calls to eval" made
- *  from Ecmascript code.  The behavior for both strict and non-strict is
+ *  from ECMAScript code.  The behavior for both strict and non-strict is
  *  the same: the 'this' binding is inherited from the calling context,
  *  see E5.1 Section 10.4.2:
  *

--- a/tests/ecmascript/test-dev-fastint-basic.js
+++ b/tests/ecmascript/test-dev-fastint-basic.js
@@ -1711,7 +1711,7 @@ return value downgrade test
 ===*/
 
 function retvalDowngradeTest() {
-    // All function return values (both Ecmascript and C) are automatically
+    // All function return values (both ECMAScript and C) are automatically
     // double-to-fastint downgraded.
 
     function myfunc() {

--- a/tests/ecmascript/test-dev-include-test.js
+++ b/tests/ecmascript/test-dev-include-test.js
@@ -1,5 +1,5 @@
 /*
- *  Test the include mechanism - not an actual Ecmascript testcase.
+ *  Test the include mechanism - not an actual ECMAScript testcase.
  */
 
 /*===

--- a/tests/ecmascript/test-dev-jsfuck-hello-world.js
+++ b/tests/ecmascript/test-dev-jsfuck-hello-world.js
@@ -4,7 +4,7 @@
  *  Source: print('hello world!')
  */
 
-// Jsfuck uses String.prototype.italics() which is not part of standard Ecmascript
+// Jsfuck uses String.prototype.italics() which is not part of standard ECMAScript
 String.prototype.italics = function (x) {
     return '<i>' + x + '</i>';
 };

--- a/tests/ecmascript/test-dev-large-nregs.js
+++ b/tests/ecmascript/test-dev-large-nregs.js
@@ -66,7 +66,7 @@ function test() {
     var src, fn;
     var i;
 
-    // Max nregs/nargs for an Ecmascript function is now limited to 16 bits
+    // Max nregs/nargs for an ECMAScript function is now limited to 16 bits
     // i.e. 65535.  Take shuffle regs into account.
 
     for (i = 8; i <= 65536; i *= 2) {

--- a/tests/ecmascript/test-dev-lightfunc.js
+++ b/tests/ecmascript/test-dev-lightfunc.js
@@ -58,7 +58,7 @@ function getNormalFunc() {
 }
 
 function sanitizeLfunc(x) {
-    /* Escape Ecmascript comments which appear e.g. when coercing function
+    /* Escape ECMAScript comments which appear e.g. when coercing function
      * values to string.  Hide lightfunc pointer which is variable data.
      */
     x = String(x);
@@ -334,7 +334,7 @@ function instanceofTest() {
     /*
      *  The same happens for an ordinary function which doesn't have a
      *  'prototype' property.  To demonstrate this we need a function
-     *  without a 'prototype' property: normal Ecmascript functions
+     *  without a 'prototype' property: normal ECMAScript functions
      *  always have the property and it's not configurable so we can't
      *  delete it.  Luckily many non-constructor built-ins don't have
      *  the property so we can use one of them.
@@ -513,7 +513,7 @@ function toStringTest() {
     /* String coercion of functions is not strictly defined - so here the
      * coercion output can identify the function as a lightweight function.
      *
-     * Because the string coercion output includes Ecmascript comment chars
+     * Because the string coercion output includes ECMAScript comment chars
      * and a variable pointer, we need sanitization before printing.
      */
 
@@ -2931,7 +2931,7 @@ function duktapeThreadBuiltinTest() {
     var thr;
 
     // Lightfunc should be accepted as an initial function for a thread, but
-    // as of Duktape 1.0 only non-bound Ecmascript functions are allowed.
+    // as of Duktape 1.0 only non-bound ECMAScript functions are allowed.
     try {
         thr = new Duktape.Thread(lfunc);
         print(Duktape.Thread.resume(thr, 1.23));

--- a/tests/ecmascript/test-dev-string-charlen-correctness.js
+++ b/tests/ecmascript/test-dev-string-charlen-correctness.js
@@ -33,7 +33,7 @@ function testOne(blen) {
         if ((buf[i] & 0xc0) == 0x80) { buf[i] = 0xfe; }
     }
 
-    // Expected character length computed using Ecmascript:
+    // Expected character length computed using ECMAScript:
     // all bytes outside of [0x80,0xbf] (UTF-8 continuation
     // bytes) contribute +1 to character length.
     clen = 0;

--- a/tests/ecmascript/test-dev-totp.js
+++ b/tests/ecmascript/test-dev-totp.js
@@ -1,5 +1,5 @@
 /*
- *  Standalone TOTP implementation in Ecmascript.
+ *  Standalone TOTP implementation in ECMAScript.
  *
  *  http://tools.ietf.org/html/rfc6238
  *  http://tools.ietf.org/html/rfc4226

--- a/tests/ecmascript/test-err-callstack-headroom-1.js
+++ b/tests/ecmascript/test-err-callstack-headroom-1.js
@@ -1,7 +1,7 @@
 /*
  *  Error handling callstack headroom (GH-191)
  *
- *  When a RangeError is thrown due to the Ecmascript callstack limit being
+ *  When a RangeError is thrown due to the ECMAScript callstack limit being
  *  reached, there should be enough headroom for at least 10 further recursions.
  *  Prior to Duktape 1.3, this wasn't the case and a DoubleError would be
  *  generated if the callstack limit was reached and, e.g. Duktape.errCreate

--- a/tests/ecmascript/test-misc-array-fast-write.js
+++ b/tests/ecmascript/test-misc-array-fast-write.js
@@ -21,7 +21,7 @@
  *  non-writable or accessor Array.prototype["7"] would capture a write to
  *  "7").
  *
- *  For Ecmascript code is difficult to predict when the fast path is active
+ *  For ECMAScript code is difficult to predict when the fast path is active
  *  because some of the conditions are related to internal state.  However,
  *  there's no reason to do that: as long as there are no conflicting numeric
  *  properties in Array.prototype there is no outward difference in behavior

--- a/tests/ecmascript/test-misc-e51-corrections.js
+++ b/tests/ecmascript/test-misc-e51-corrections.js
@@ -214,7 +214,7 @@ try {
  * that cannot occur.
  *
  * (The URI syntax changes between RFC 2396 and RFC 3986 don't affect URI
- * decoding in Ecmascript, but e.g. reserved character set has changed.  See
+ * decoding in ECMAScript, but e.g. reserved character set has changed.  See
  * doc/uri.txt for discussion.)
  */
 

--- a/tests/ecmascript/test-regexp-nonstandard-brace.js
+++ b/tests/ecmascript/test-regexp-nonstandard-brace.js
@@ -1,6 +1,6 @@
 /*
- *  Ecmascript regexp pattern character production does not allow literal
- *  curly braces in any position, but many Ecmascript regexp engines allow
+ *  ECMAScript regexp pattern character production does not allow literal
+ *  curly braces in any position, but many ECMAScript regexp engines allow
  *  them when the meaning is unambiguous.  Since Duktape 1.5.0 Duktape also
  *  allows literal curly braces in regexps.
  */

--- a/tests/ecmascript/test-spec-bound-constructor.js
+++ b/tests/ecmascript/test-spec-bound-constructor.js
@@ -3,7 +3,7 @@
  *  ordinary bound function handling slightly.  The "this" binding value
  *  provided by the bound functions is essentially ignored when making a
  *  constructor call.  That is, the final function gets as its 'this'
- *  binding the fresh Ecmascript object as usual for constructors.
+ *  binding the fresh ECMAScript object as usual for constructors.
  */
 
 function func1(v1, v2, v3) {
@@ -44,7 +44,7 @@ res.value2 bar
 res.value3 quux
 ===*/
 
-// Constructor call causes the fresh Ecmascript object (created in E5.1
+// Constructor call causes the fresh ECMAScript object (created in E5.1
 // Section 13.2.2 step 1) to the effective this binding.
 try {
     print('constructor call to func3');

--- a/tests/ecmascript/util-buffer.js
+++ b/tests/ecmascript/util-buffer.js
@@ -267,7 +267,7 @@ function printBuffer(b) {
 
 function bufferToStringRaw(buf) {
     // Prefer the cleaner, explicit custom method.  This is provided by "duk"
-    // and is NOT a part of the default Ecmascript built-ins!
+    // and is NOT a part of the default ECMAScript built-ins!
     return String.fromBufferRaw(buf);
 }
 


### PR DESCRIPTION
Use 'ECMAScript' spelling in testcases, see #1892.