### PR TITLE
Use 'ECMAScript' spelling in misc places

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To make a code contribution to Duktape
 * Test your changes as thoroughly as possible.  At the very minimum:
 
   - Travis test run must pass, which covers both a code policy check, and
-    runs basic API and Ecmascript test case set.
+    runs basic API and ECMAScript test case set.
 
   - If some test cases are invalidated by the changes, fix the test cases as
     part of the branch.  If you add new functionality, you should add test

--- a/Makefile
+++ b/Makefile
@@ -638,7 +638,7 @@ releasetest: xmldoctest closuretest bluebirdtest luajstest jsinterpretertest lod
 	@echo ""
 	@echo "### Release tests successful!"  # These tests now have output checks.
 
-# Runtests-based Ecmascript and API tests.
+# Runtests-based ECMAScript and API tests.
 .PHONY:	runtestsdeps
 runtestsdeps:	runtests/node_modules UglifyJS2
 runtests/node_modules:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ with a focus on **portability** and **compact** footprint.
 
 Duktape is easy to integrate into a C/C++ project: add `duktape.c`,
 `duktape.h`, and `duk_config.h` to your build, and use the Duktape API
-to call Ecmascript functions from C code and vice versa.
+to call ECMAScript functions from C code and vice versa.
 
 Main features:
 
 * Embeddable, portable, compact
-* Ecmascript E5/E5.1 compliant, with some semantics updated from ES2015+
-* Partial support for Ecmascript 2015 (E6) and Ecmascript 2016 (E7),
+* ECMAScript E5/E5.1 compliant, with some semantics updated from ES2015+
+* Partial support for ECMAScript 2015 (E6) and ECMAScript 2016 (E7),
   [Post-ES5 feature status](http://wiki.duktape.org/PostEs5Features.html),
   [kangax/compat-table](https://kangax.github.io/compat-table)
 * ES2015 TypedArray and Node.js Buffer bindings
@@ -28,7 +28,7 @@ Main features:
 * Minimal platform dependencies
 * Combined reference counting and mark-and-sweep garbage collection with finalization
 * Custom features like co-routines
-* Property virtualization using a subset of Ecmascript E2015 Proxy object
+* Property virtualization using a subset of ECMAScript E2015 Proxy object
 * Bytecode dump/load for caching compiled functions
 * Distributable includes an optional logging framework, CommonJS-based module
   loading implementations, etc
@@ -155,7 +155,7 @@ Duktape uses [Semantic Versioning](http://semver.org/) for official
 releases.  Builds from Duktape repo are not official releases and don't
 follow strict semver, mainly because `DUK_VERSION` needs to have some
 compromise value that won't be strictly semver conforming.
-Because Duktape tracks the latest Ecmascript specification versions,
+Because Duktape tracks the latest ECMAScript specification versions,
 compliance fixes are made in minor versions even when they are technically
 not backwards compatible.  See
 [Versioning](http://duktape.org/guide.html#versioning) for details.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -81,7 +81,7 @@ Released
 * Enforce string/buffer length limits to avoid corner cases with strings
   and buffers close to size_t limit
 
-* Ecmascript E5.1 test cases and fixes
+* ECMAScript E5.1 test cases and fixes
 
 * Mark-and-sweep stringtable leak fixed, affected mostly builds without
   reference counting
@@ -108,7 +108,7 @@ Released
 * Added support for function declarations outside function or program top
   level (also known as "function statements"), with V8-like semantics
 
-* Renamed __duk__ to Duktape for more consistency with Ecmascript conventions
+* Renamed __duk__ to Duktape for more consistency with ECMAScript conventions
 
 * Removed somewhat useless Duktape.build property and added Duktape.env
 
@@ -205,7 +205,7 @@ Released
 
 * Add duk_push_heap_stash(), duk_push_global_stash(), and
   duk_push_thread_stash() to provide C code with stashes for storing
-  values invisible to Ecmascript code
+  values invisible to ECMAScript code
 
 * Add duk_safe_to_string() and duk_safe_to_lstring() to make it easier
   to write result printing in C
@@ -221,10 +221,10 @@ Released
 
 * Add Duktape.compact(), Duktape.line(), and Duktape.act()
 
-* Add a "use duk notail" directive which indicates that an Ecmascript
+* Add a "use duk notail" directive which indicates that an ECMAScript
   function should never be tail called
 
-* Add a barebones built-in logging framework with both Ecmascript and C
+* Add a barebones built-in logging framework with both ECMAScript and C
   APIs and easy customization
 
 * Add a message argument to fatal handler function callback, simplify
@@ -454,7 +454,7 @@ Released
   duk_xmove())
 
 * Change strictness behavior for Duktape API calls: all API calls now have
-  Ecmascript strict semantics, even when a call is made with an empty call
+  ECMAScript strict semantics, even when a call is made with an empty call
   stack outside of any Duktape/C function
 
 * Change strictness handling of duk_eval() and variants so that all code is
@@ -469,7 +469,7 @@ Released
 
 * Add API call duk_set_global_object() which allows the global object of a
   context to be replaced; this is useful as an initial mechanism for proper
-  sandboxing of Ecmascript code
+  sandboxing of ECMAScript code
 
 * Add API calls duk_get_prototype() and duk_set_prototype() for getting and
   setting an object's "internal prototype" from C code
@@ -515,7 +515,7 @@ Released
   there will be no API to use it
 
 * Fix value stack reserve handling for function calls: a function call
-  (Ecmascript or Duktape/C) might reduce the valstack "checked size" which
+  (ECMAScript or Duktape/C) might reduce the valstack "checked size" which
   was previously requested by user code (for more detail, see API test case
   test-dev-valstack-checked-size-call.c)
 
@@ -524,7 +524,7 @@ Released
   would also be executed for the Proxy object
 
 * Fix a few Date bugs for large out-of-range years which caused some assert
-  failures and incorrect behavior when year was out of Ecmascript range (e.g.
+  failures and incorrect behavior when year was out of ECMAScript range (e.g.
   year 870e6 and year -200e6)
 
 * Minor compile warnings fixes for non-default options (e.g. when reference
@@ -656,7 +656,7 @@ Released
 
 * Add duk_def_prop() which allows creation of accessor (getter/setter)
   properties and other custom properties from C code (instead of using
-  Object.defineProperty() from Ecmascript code)
+  Object.defineProperty() from ECMAScript code)
 
 * Add duk_is_error() API call to check if a value inherits from Error
 
@@ -671,7 +671,7 @@ Released
 * Add vararg variants duk_error_va(), duk_push_error_object_va(), and
   duk_log_va()
 
-* Add DUK_GIT_DESCRIBE macro to the C API (with no Ecmascript equivalent)
+* Add DUK_GIT_DESCRIBE macro to the C API (with no ECMAScript equivalent)
   to allow application code to e.g. log more detailed version information
   relevant for non-official snapshot builds
 
@@ -778,7 +778,7 @@ Released
   body was not checked and Duktape would accept e.g. "function () [}"
   (GH-106)
 
-* Fix compiler register limit bug where an Ecmascript function with
+* Fix compiler register limit bug where an ECMAScript function with
   [65536,262143] VM registers would be compiled into incorrect bytecode
   instead of being rejected with an internal error (GH-111)
 
@@ -873,7 +873,7 @@ Released
   body was not checked and Duktape would accept e.g. "function () [}"
   (GH-106)
 
-* Fix compiler register limit bug where an Ecmascript function with
+* Fix compiler register limit bug where an ECMAScript function with
   [65536,262143] VM registers would be compiled into incorrect bytecode
   instead of being rejected with an internal error (GH-111)
 
@@ -1477,7 +1477,7 @@ Released
   notifications (AppNotify) (GH-596, GH-563)
 
 * Add duk_debugger_pause() API which allows the target to quickly pause
-  Ecmascript execution and break into the debugger (GH-615)
+  ECMAScript execution and break into the debugger (GH-615)
 
 * Add sizeof void pointer to the BasicInfo debugger command (GH-611)
 
@@ -1873,18 +1873,18 @@ Configuration:
 
 Buffers:
 
-* Incompatible change: rework buffer types and their Ecmascript and C API
+* Incompatible change: rework buffer types and their ECMAScript and C API
   behavior: remove Duktape.Buffer; provide Uint8Array.allocPlain() and
   Uint8Array.plainOf() to replace Duktape.Buffer; plain buffers now behave
   like Uint8Arrays and inherit from Uint8Array.prototype; plain buffers now
   test false in duk_is_primitive() which is more consistent with their
-  Ecmascript coercion behavior; many small changes in how built-in functions
+  ECMAScript coercion behavior; many small changes in how built-in functions
   behave for plain buffer arguments e.g. in enumeration, JSON serialization,
   and Object.prototype.toString() output (GH-875, GH-1005, GH-864, GH-1197)
 
 * Incompatible change: remove the ability to do a 1:1 buffer-to-string
   coercion (using buffer data directly as the internal string representation)
-  from the default Ecmascript bindings, an encoding (usually UTF-8) is now
+  from the default ECMAScript bindings, an encoding (usually UTF-8) is now
   always applied (GH-875, GH-1005)
 
 * Incompatible change: remove non-standard properties from ArrayBuffer
@@ -1947,7 +1947,7 @@ Other type changes:
   (plainPointer instanceof Duktape.Pointer === true) (GH-864)
 
 * Incompatible change: lightfunc values now test false in duk_is_primitive()
-  which is more consistent with how they behave in Ecmascript coercions
+  which is more consistent with how they behave in ECMAScript coercions
   (GH-864)
 
 * Incompatible change: lightfunc value as a "this" binding is ToObject()
@@ -1984,7 +1984,7 @@ Debugger:
 * Rename debugger protocol artificial property "bound" to "boundfunc" for
   consistency with an internal flag rename (GH-703)
 
-Ecmascript 2015+ and real world compatibility:
+ECMAScript 2015+ and real world compatibility:
 
 * Change Object constructor argument coercion policy to match ES2015
   requirements for .keys(), .getOwnPropertyNames(),
@@ -2015,7 +2015,7 @@ Ecmascript 2015+ and real world compatibility:
 
 * Add support for ES2016 exponentiation and exponentiation assignment
   operators, e.g. "2 \*\* 10" evaluates to 1024, avoiding the cost of an
-  Ecmascript call to Math.pow() while also being more readable (GH-987,
+  ECMAScript call to Math.pow() while also being more readable (GH-987,
   GH-997)
 
 * Add a Reflect built-in, provides Reflect.construct() etc. from ES2015; some
@@ -2118,7 +2118,7 @@ Ecmascript 2015+ and real world compatibility:
 WHATWG Encoding API:
 
 * Add TextEncoder and TextDecoder built-ins (the Encoding API) which allow
-  Ecmascript code to convert between buffers and strings using the UTF-8
+  ECMAScript code to convert between buffers and strings using the UTF-8
   encoding (GH-975)
 
 Other C API changes:
@@ -2154,8 +2154,8 @@ Other C API changes:
   DUK_ERR_UNSUPPORTED_ERROR; use standard error types instead (GH-827)
 
 * Incompatible change: map API related errors (which previously used
-  DUK_ERR_API_ERROR and a plain Error for Ecmascript representation) into
-  TypeErrors and RangeErrors to match common Ecmascript conventions (GH-827)
+  DUK_ERR_API_ERROR and a plain Error for ECMAScript representation) into
+  TypeErrors and RangeErrors to match common ECMAScript conventions (GH-827)
 
 * Incompatible change: remove duk_to_defaultvalue() which invoked the
   [[DefaultValue]] specification algorithm removed in ES2015 (it was folded
@@ -2193,7 +2193,7 @@ Other C API changes:
 
 * Add time functions to the C API (duk_get_now(), duk_time_to_components(),
   duk_components_to_time()) to allow C code to conveniently work with the
-  same time provider as seen by Ecmascript code (GH-771, GH-1209, GH-1211,
+  same time provider as seen by ECMAScript code (GH-771, GH-1209, GH-1211,
   GH-1226)
 
 * Add duk_push_bare_object() API call which pushes an object without an
@@ -2214,7 +2214,7 @@ Other C API changes:
 * Remove duk_{get,put,has,del}_var() calls from API header; they were not
   fully implemented and not part of the documented public API (GH-762)
 
-Other Ecmascript binding changes:
+Other ECMAScript binding changes:
 
 * Incompatible change: remove built-in print() and alert() bindings which,
   being dependent on stdout/stderr, are often a portability issue (GH-745)
@@ -2229,7 +2229,7 @@ Other Ecmascript binding changes:
   (which is difficult to version and work with) to an object with named
   properties; the properties are not under versioning guarantees (GH-1125)
 
-* Allow a bound Ecmascript function as an argument to new Duktape.Thread()
+* Allow a bound ECMAScript function as an argument to new Duktape.Thread()
   (GH-1134, GH-1157)
 
 Extras:
@@ -2338,7 +2338,7 @@ Footprint:
   lexenv/varenv fields in duk_hcompfunc struct (GH-1132); omit duk_hcompfunc
   _Formals array when it is safe to do so (GH-1141); omit duk_hcompfunc
   _Varmap in more cases when it is safe to do so (GH-1146); reduce initial
-  bytecode allocation in Ecmascript compiler for low memory targets (GH-1146);
+  bytecode allocation in ECMAScript compiler for low memory targets (GH-1146);
   packed arguments for some internal helper calls (GH-1158, GH-1172); misc
   internal helpers to reduce call site size (GH-1166, GH-1173); config options
   for function .name and .fileName control (GH-1153); internal helper
@@ -2436,7 +2436,7 @@ Other bug fixes:
 Miscellaneous:
 
 * Incompatible change: bytecode opcode format reworks drop maximum function
-  and constructor call argument count from 511 to 255, and maximum Ecmascript
+  and constructor call argument count from 511 to 255, and maximum ECMAScript
   function constant count from 262144 to 65536 (GH-903)
 
 * Add a human readable summary of 'new MyConstructor()' constructor call
@@ -2939,11 +2939,11 @@ Miscellaneous:
 * Function.prototype.call(), Function.prototype.apply(), Reflect.apply(),
   and Reflect.construct() can now be used in tailcalls (e.g.
   'return func.call(null, 123);'), don't grow the native C stack when doing an
-  Ecmascript-to-Ecmascript call, and no longer prevent coroutine yielding
+  ECMAScript-to-ECMAScript call, and no longer prevent coroutine yielding
   (GH-1421, GH-1545, GH-1557)
 
 * Constructor calls (new Func()) can be used in tailcalls, don't grow
-  the native C stack when doing an Ecmascript-to-Ecmascript call, and no
+  the native C stack when doing an ECMAScript-to-ECMAScript call, and no
   longer prevent coroutine yielding (GH-1523)
 
 * Increase maximum call argument count from 255 to ~64k (GH-1292, GH-1586)
@@ -3050,11 +3050,11 @@ Miscellaneous:
 
 * Use monotonic time (if available) for debugger transport peeking, so that
   the peek callback is called with the same realtime rate even if the
-  Ecmascript time source jumps or doesn't advance in realtime (GH-1659)
+  ECMAScript time source jumps or doesn't advance in realtime (GH-1659)
 
 * Allow sub-millisecond resolution for DUK_USE_DATE_GET_NOW() Date provider;
   the extra resolution is visible through duk_get_now() but not through Date
-  instances because Ecmascript requires Date instances to have integer
+  instances because ECMAScript requires Date instances to have integer
   millisecond timestamps (GH-773, GH-1660, GH-1669)
 
 * Add sub-millisecond resolution to the default POSIX and Windows Date
@@ -3253,7 +3253,7 @@ Planned
   internal algorithm and duk_to_primitive() API call (GH-1825)
 
 * Add duk_random() to allow C code access to the same random number source
-  as Ecmascript code (GH-1815)
+  as ECMAScript code (GH-1815)
 
 * Add duk_push_new_target() to allow C code to access new.target; at present
   this is for completeness because without actual class support it's only
@@ -3326,7 +3326,7 @@ Planned
 
 * Add Makefile.jsoncbor to the distributable (GH-1885)
 
-* Change spelling from Ecmascript to ECMAScript throughout the internal source
+* Change spelling from ECMAScript to ECMAScript throughout the internal source
   code; as far as external behavior is concerned this only affects a few
   debug prints (GH-1894)
 

--- a/config/tags.yaml
+++ b/config/tags.yaml
@@ -4,19 +4,19 @@
 #
 
 ecmascript:
-  title: Ecmascript Edition 5 (ES5) options
+  title: ECMAScript Edition 5 (ES5) options
 
 ecmascript2015:
-  title: Ecmascript 2015 (ES6) options
+  title: ECMAScript 2015 (ES6) options
 
 ecmascript2016:
-  title: Ecmascript 2016 (ES7) options
+  title: ECMAScript 2016 (ES7) options
 
 ecmascript2017:
-  title: Ecmascript 2017 (ES8) options
+  title: ECMAScript 2017 (ES8) options
 
 ecmascript2018:
-  title: Ecmascript 2018 (ES9) options
+  title: ECMAScript 2018 (ES9) options
 
 duktape:
   title: Duktape specific options

--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -417,7 +417,7 @@ RateLimited.prototype.trigger = function () {
 /*
  *  Source file manager
  *
- *  Scan the list of search directories for Ecmascript source files and
+ *  Scan the list of search directories for ECMAScript source files and
  *  build an index of them.  Provides a mechanism to find a source file
  *  based on a raw 'fileName' property provided by the debug target, and
  *  to provide a file list for the web UI.

--- a/dist-files/README.rst
+++ b/dist-files/README.rst
@@ -2,13 +2,13 @@
 Duktape
 =======
 
-Duktape is a small and portable Ecmascript E5/E5.1 implementation.  It is
+Duktape is a small and portable ECMAScript E5/E5.1 implementation.  It is
 intended to be easily embeddable into C programs, with a C API similar in
 spirit to Lua's.
 
 Duktape supports the full E5/E5.1 feature set (with some semantics updated
 from ES2015+) including errors, Unicode strings, and regular expressions,
-a subset of Ecmascript 2015 (E6) and Ecmascript 2016 (E7) features (e.g.
+a subset of ECMAScript 2015 (E6) and ECMAScript 2016 (E7) features (e.g.
 computed property names, Proxy objects, exponentiation operator, Reflect),
 ES2015 ArrayBuffer/TypedView, Node.js Buffer, performance.now(), and WHATWG
 Encoding API living standard.

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -1,5 +1,5 @@
 /*
- *  Test case runner.  Supports both Ecmascript tests and Duktape API
+ *  Test case runner.  Supports both ECMAScript tests and Duktape API
  *  C tests.  Duktape API C tests are compiled on-the-fly against a
  *  dynamic or static library.
  *

--- a/src-input/duk_js_compiler.h
+++ b/src-input/duk_js_compiler.h
@@ -5,7 +5,7 @@
 #if !defined(DUK_JS_COMPILER_H_INCLUDED)
 #define DUK_JS_COMPILER_H_INCLUDED
 
-/* ecmascript compiler limits */
+/* ECMAScript compiler limits */
 #define DUK_COMPILER_TOKEN_LIMIT           100000000L  /* 1e8: protects against deeply nested inner functions */
 
 /* maximum loopcount for peephole optimization */

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1042,7 +1042,7 @@ DUK_LOCAL void duk__handle_yield(duk_hthread *thr, duk_hthread *resumer, duk_tva
 	act_resumer = resumer->callstack_curr;
 	DUK_ASSERT(act_resumer != NULL);
 	DUK_ASSERT(DUK_ACT_GET_FUNC(act_resumer) != NULL);
-	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(act_resumer)));  /* resume caller must be an ecmascript func */
+	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(act_resumer)));  /* resume caller must be an ECMAScript func */
 
 	tv1 = (duk_tval *) (void *) ((duk_uint8_t *) resumer->valstack + act_resumer->retval_byteoff);  /* return value from Duktape.Thread.resume() */
 	DUK_TVAL_SET_TVAL_UPDREF(thr, tv1, tv_val_unstable);  /* side effects */  /* XXX: avoid side effects */
@@ -1601,7 +1601,7 @@ DUK_LOCAL duk_small_uint_t duk__handle_return(duk_hthread *thr, duk_activation *
 
 		DUK_ASSERT(thr->callstack_curr != NULL);
 		DUK_ASSERT(thr->callstack_curr->parent != NULL);
-		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));   /* must be ecmascript */
+		DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC(DUK_ACT_GET_FUNC(thr->callstack_curr->parent)));   /* must be ECMAScript */
 
 #if defined(DUK_USE_ES6_PROXY)
 		if (thr->callstack_curr->flags & (DUK_ACT_FLAG_CONSTRUCT | DUK_ACT_FLAG_CONSTRUCT_PROXY)) {

--- a/tools/create_spdx_license.py
+++ b/tools/create_spdx_license.py
@@ -177,7 +177,7 @@ def main():
     g.add((pkg_node, SPDX.licenseDeclared, mit_license))
     g.add((pkg_node, SPDX.licenseComments, Literal('Duktape is copyrighted by its authors and licensed under the MIT license.  MurmurHash2 is used internally, it is also under the MIT license. Duktape module loader is based on the CommonJS module loading specification (without sharing any code), CommonJS is under the MIT license.')))
     g.add((pkg_node, SPDX.copyrightText, duktape_copyright))
-    g.add((pkg_node, SPDX.summary, Literal('Duktape Ecmascript interpreter')))
+    g.add((pkg_node, SPDX.summary, Literal('Duktape ECMAScript interpreter')))
     g.add((pkg_node, SPDX.description, Literal('Duktape is an embeddable Javascript engine, with a focus on portability and compact footprint')))
     # hasFile properties added separately below
 

--- a/tools/extract_caseconv.py
+++ b/tools/extract_caseconv.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python2
 #
 #  Extract rules for Unicode case conversion, specifically the behavior
-#  required by Ecmascript E5 in Sections 15.5.4.16 to 15.5.4.19.  The
+#  required by ECMAScript E5 in Sections 15.5.4.16 to 15.5.4.19.  The
 #  bitstream encoded rules are used for the slow path at run time, so
 #  compactness is favored over speed.
 #
 #  There is no support for context or locale sensitive rules, as they
 #  are handled directly in C code before consulting tables generated
-#  here.  Ecmascript requires case conversion both with and without
+#  here.  ECMAScript requires case conversion both with and without
 #  locale/language specific rules (e.g. String.prototype.toLowerCase()
 #  and String.prototype.toLocaleLowerCase()), so they are best handled
 #  in C anyway.
 #
 #  Case conversion rules for ASCII are also excluded as they are handled
 #  by the C fast path.  Rules for non-BMP characters (codepoints above
-#  U+FFFF) are omitted as they're not required for standard Ecmascript.
+#  U+FFFF) are omitted as they're not required for standard ECMAScript.
 #
 
 import os

--- a/tools/extract_chars.py
+++ b/tools/extract_chars.py
@@ -12,7 +12,7 @@
 #  typically contains an ASCII fast path so ASCII characters don't need
 #  to be considered in the Unicode tables.  "NONBMP" excludes codepoints
 #  above U+FFFF which is useful because such codepoints don't need to be
-#  supported in standard Ecmascript.
+#  supported in standard ECMAScript.
 #
 
 import os

--- a/tools/genbuiltins.py
+++ b/tools/genbuiltins.py
@@ -115,7 +115,7 @@ def recursive_bytes_to_strings(doc):
 
     return f(doc)
 
-# Check if string is an "array index" in Ecmascript terms.
+# Check if string is an "array index" in ECMAScript terms.
 def string_is_arridx(v):
     is_arridx = False
     try:

--- a/tools/scan_strings.py
+++ b/tools/scan_strings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-#  Scan potential external strings from Ecmascript and C files.
+#  Scan potential external strings from ECMAScript and C files.
 #
 #  Very simplistic example with a lot of limitations:
 #
@@ -17,28 +17,28 @@ import json
 
 strmap = {}
 
-# Ecmascript function declaration
+# ECMAScript function declaration
 re_funcname = re.compile(r'function\s+(\w+)', re.UNICODE)
 
-# Ecmascript variable declaration
+# ECMAScript variable declaration
 # XXX: doesn't handle multiple variables
 re_vardecl = re.compile(r'var\s+(\w+)', re.UNICODE)
 
-# Ecmascript variable assignment
+# ECMAScript variable assignment
 re_varassign = re.compile(r'(\w+)\s*=\s*', re.UNICODE)
 
-# Ecmascript dotted property reference (also matches numbers like
+# ECMAScript dotted property reference (also matches numbers like
 # '4.0', which are separately rejected below)
 re_propref = re.compile(r'(\w+(?:\.\w+)+)', re.UNICODE)
 re_digits = re.compile(r'^\d+$', re.UNICODE)
 
-# Ecmascript or C string literal
+# ECMAScript or C string literal
 re_strlit_dquot = re.compile(r'("(?:\\"|\\\\|[^"])*")', re.UNICODE)
 re_strlit_squot = re.compile(r'(\'(?:\\\'|\\\\|[^\'])*\')', re.UNICODE)
 
 def strDecode(x):
     # Need to decode hex, unicode, and other escapes.  Python syntax
-    # is close enough to C and Ecmascript so use eval for now.
+    # is close enough to C and ECMAScript so use eval for now.
 
     try:
         return eval('u' + x)  # interpret as unicode string

--- a/util/example_user_builtins1.yaml
+++ b/util/example_user_builtins1.yaml
@@ -23,7 +23,7 @@
 # U+0000...U+00FF are identified with exact bytes in the string (allows
 # invalid UTF-8 so that internal strings can be represented).  Placing
 # strings in ROM avoids interning them if they're encountered at run time;
-# you can e.g. add function and constant names used in custom Ecmascript
+# you can e.g. add function and constant names used in custom ECMAScript
 # bindings.
 #
 # NOTE: You don't need to list any keys of custom built-in objects here

--- a/util/genequivyear.py
+++ b/util/genequivyear.py
@@ -29,9 +29,9 @@ def eqyear(weekday, isleap):
 
     # some assertions
     #
-    # Note that Ecmascript internal weekday (0=Sunday) matches neither
+    # Note that ECMAScript internal weekday (0=Sunday) matches neither
     # Python weekday() (0=Monday) nor isoweekday() (1=Monday, 7=Sunday).
-    # Python isoweekday() % 7 matches the Ecmascript weekday.
+    # Python isoweekday() % 7 matches the ECMAScript weekday.
     # https://docs.python.org/2/library/datetime.html#datetime.date.isoweekday
 
     dt = datetime.datetime(year, 1, 1, 0, 0, 0, 0, pytz.UTC)  # Jan 1 00:00:00.000 UTC

--- a/util/prep_test.py
+++ b/util/prep_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python2
 #
-#  Prepare an Ecmascript or API testcase file for execution.
+#  Prepare an ECMAScript or API testcase file for execution.
 #
-#  For Ecmascript testcases:
+#  For ECMAScript testcases:
 #
 #    - Lift a 'use strict' statement to top of file if present
 #    - Add a prologue which handles engine differences
@@ -96,7 +96,7 @@ class TestcasePreparer:
 
     def minifyOneLine(self, fn):
         # Closure is very slow to start so it's not ideal for test case use.
-        # The only thing we really need is to make Ecmascript a one-liner.
+        # The only thing we really need is to make ECMAScript a one-liner.
 
         if self.minify_provider == 'closure':
             return self.minifyClosure(fn)

--- a/util/runtest.py
+++ b/util/runtest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-#  Prepare a single Ecmascript testcase for execution and (optionally) execute
+#  Prepare a single ECMAScript testcase for execution and (optionally) execute
 #  it with Duktape or another engine.  Interpret testcase results against the
 #  expect string and known issues.
 #
@@ -81,7 +81,7 @@ args = []
 testcase_filename = None
 
 #
-#  Ecmascript test framework injected into Ecmascript test cases.
+#  ECMAScript test framework injected into ECMAScript test cases.
 #
 
 # Init code to run which allows the testcase to run on multiple engines.
@@ -365,7 +365,7 @@ def read_include_file(filename):
     data = read_file(abs_fn)
     return '/* Included: %r -> %r */ ' % (filename, abs_fn) + data
 
-# Minify Ecmascript code either using an external minifier or a simple built-in
+# Minify ECMAScript code either using an external minifier or a simple built-in
 # minifier which replaces single line comments with /* */ comments and then
 # replaces newlines with space.  This works in most cases, but assumes that
 # semicolons are used in the source and that RegExps don't contain '//'
@@ -724,7 +724,7 @@ def main():
     # Parse options.
     parser = optparse.OptionParser(
         usage='Usage: %prog [options] testcase',
-        description='Prepare an Ecmascript or API testcase for execution and (optionally) execute the testcase, print a summary, and write a JSON result file for further user.  Testcase can be given using a full path or using just the test name in which case it is looked up from ../tests/ecmascript/ relative to the runtest.py script.'
+        description='Prepare an ECMAScript or API testcase for execution and (optionally) execute the testcase, print a summary, and write a JSON result file for further user.  Testcase can be given using a full path or using just the test name in which case it is looked up from ../tests/ecmascript/ relative to the runtest.py script.'
     )
     parser.add_option('--known-issues', dest='known_issues', default=None, help='Path to known issues directory, default is autodetect')
     parser.add_option('--ignore-skip', dest='ignore_skip', default=False, action='store_true', help='Ignore skip=true in metadata')
@@ -780,7 +780,7 @@ def main():
     meta = parse_metadata(data)
     expect = parse_expected_result(data)
 
-    # Prepare runnable testcase by injecting an Ecmascript test framework
+    # Prepare runnable testcase by injecting an ECMAScript test framework
     # and processing @include lines.
     data = prepare_ecmascript_testcase(data, meta)
     if opts.output_prepared is not None:

--- a/website/guide/intro.html
+++ b/website/guide/intro.html
@@ -17,7 +17,7 @@ if you wish to tinker with them.</p>
 
 <h2>What is Duktape?</h2>
 
-<p>Duktape is an embeddable ECMAScript engine with a focus on portability
+<p>Duktape is an embeddable ECMAScript&#174; engine with a focus on portability
 and compact footprint.  By integrating Duktape into your C/C++ program you
 can easily extend its functionality through scripting.  You can also build
 the main control flow of your program in ECMAScript and use fast C code


### PR DESCRIPTION
Use 'ECMAScript' spelling in misc places not covered by previous pulls.

Fixes #1892.