### PR TITLE
Cleanups for extras/console stdout/stderr flags

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3155,7 +3155,12 @@ Miscellaneous:
 * Add some statistics dumps to mark-and-sweep with debug logging enabled
   (GH-1579, GH-1640, GH-1677)
 
-* Add DUK_CONSOLE_FLUSH flag to extras/duktape-console (GH-1587, GH-1588)
+* Add DUK_CONSOLE_FLUSH flag to extras/console (GH-1587, GH-1588)
+
+* Use stdout for info and below, and stderr for warn and above in
+  extras/console; previous behavior was to use stdout only, use
+  DUK_CONSOLE_STDOUT_ONLY init flag to restore previous behavior (GH-1890,
+  GH-1903)
 
 * Compile warning fixes and Duktape 1.x compatibility fix to module-node
   (GH-1605)

--- a/doc/release-notes-v2-3.rst
+++ b/doc/release-notes-v2-3.rst
@@ -67,3 +67,8 @@ from Duktape v2.2.x.  Note the following:
   configurations).  Note, however, that recent gcc/clang versions are
   optimizing around undefined behavior so while relying on undefined behavior
   may work in one version, it may break with newer compiler versions.
+
+* The console extra (extras/console) now by default uses ``stdout`` for log
+  levels up to info, and ``stderr`` for warn and above.  To restore previous
+  behavior (stdout only) use the ``DUK_CONSOLE_STDOUT_ONLY`` flag in
+  ``duk_console_init()``.

--- a/extras/console/README.rst
+++ b/extras/console/README.rst
@@ -28,3 +28,8 @@ contains an example binding:
 
 * After these steps, ``console`` will be registered to the global object
   and is ready to use.
+
+* By default the console object will use ``stdout`` for log levels up to
+  info, and ``stderr`` for warning and above.  You can change this by
+  providing either ``DUK_CONSOLE_STDOUT_ONLY`` or ``DUK_CONSOLE_STDERR_ONLY``
+  in ``duk_console_init()`` flags.

--- a/extras/console/duk_console.c
+++ b/extras/console/duk_console.c
@@ -22,7 +22,7 @@
 
 static duk_ret_t duk__console_log_helper(duk_context *ctx, const char *error_name) {
 	duk_uint_t flags = (duk_uint_t) duk_get_current_magic(ctx);
-	FILE *output = (flags & DUK_CONSOLE_TO_STDOUT) ? stdout : stderr;
+	FILE *output = (flags & DUK_CONSOLE_STDOUT_ONLY) ? stdout : stderr;
 	duk_idx_t n = duk_get_top(ctx);
 	duk_idx_t i;
 
@@ -106,11 +106,11 @@ static void duk__console_reg_vararg_func(duk_context *ctx, duk_c_function func, 
 void duk_console_init(duk_context *ctx, duk_uint_t flags) {
 	duk_uint_t flags_orig;
 
-	/* If both DUK_CONSOLE_TO_STDOUT and DUK_CONSOLE_TO_STDERR where specified,
-	 * just turn off DUK_CONSOLE_TO_STDOUT and keep DUK_CONSOLE_TO_STDERR. */
-	if ((flags & DUK_CONSOLE_TO_STDOUT) &&
-	    (flags & DUK_CONSOLE_TO_STDERR)) {
-	    flags &= ~DUK_CONSOLE_TO_STDOUT;
+	/* If both DUK_CONSOLE_STDOUT_ONLY and DUK_CONSOLE_STDERR_ONLY where specified,
+	 * just turn off DUK_CONSOLE_STDOUT_ONLY and keep DUK_CONSOLE_STDERR_ONLY.
+	 */
+	if ((flags & DUK_CONSOLE_STDOUT_ONLY) && (flags & DUK_CONSOLE_STDERR_ONLY)) {
+	    flags &= ~DUK_CONSOLE_STDOUT_ONLY;
 	}
 	/* Remember the (possibly corrected) flags we received. */
 	flags_orig = flags;
@@ -134,10 +134,9 @@ void duk_console_init(duk_context *ctx, duk_uint_t flags) {
 	duk_put_prop_string(ctx, -2, "format");
 
 	flags = flags_orig;
-	if (!(flags & DUK_CONSOLE_TO_STDOUT) &&
-	    !(flags & DUK_CONSOLE_TO_STDERR)) {
+	if (!(flags & DUK_CONSOLE_STDOUT_ONLY) && !(flags & DUK_CONSOLE_STDERR_ONLY)) {
 	    /* No output indicators were specified; these levels go to stdout. */
-	    flags |= DUK_CONSOLE_TO_STDOUT;
+	    flags |= DUK_CONSOLE_STDOUT_ONLY;
 	}
 	duk__console_reg_vararg_func(ctx, duk__console_assert, "assert", flags);
 	duk__console_reg_vararg_func(ctx, duk__console_log, "log", flags);
@@ -146,10 +145,9 @@ void duk_console_init(duk_context *ctx, duk_uint_t flags) {
 	duk__console_reg_vararg_func(ctx, duk__console_info, "info", flags);
 
 	flags = flags_orig;
-	if (!(flags & DUK_CONSOLE_TO_STDOUT) &&
-	    !(flags & DUK_CONSOLE_TO_STDERR)) {
+	if (!(flags & DUK_CONSOLE_STDOUT_ONLY) && !(flags & DUK_CONSOLE_STDERR_ONLY)) {
 	    /* No output indicators were specified; these levels go to stderr. */
-	    flags |= DUK_CONSOLE_TO_STDERR;
+	    flags |= DUK_CONSOLE_STDERR_ONLY;
 	}
 	duk__console_reg_vararg_func(ctx, duk__console_warn, "warn", flags);
 	duk__console_reg_vararg_func(ctx, duk__console_error, "error", flags);

--- a/extras/console/duk_console.h
+++ b/extras/console/duk_console.h
@@ -13,11 +13,11 @@ extern "C" {
 /* Flush output after every call. */
 #define DUK_CONSOLE_FLUSH          (1 << 1)
 
-/* Send output to stdout. */
-#define DUK_CONSOLE_TO_STDOUT      (1 << 2)
+/* Send output to stdout only (default is mixed stdout/stderr). */
+#define DUK_CONSOLE_STDOUT_ONLY    (1 << 2)
 
-/* Send output to stderr. */
-#define DUK_CONSOLE_TO_STDERR      (1 << 3)
+/* Send output to stderr only (default is mixed stdout/stderr). */
+#define DUK_CONSOLE_STDERR_ONLY    (1 << 3)
 
 /* Initialize the console system */
 extern void duk_console_init(duk_context *ctx, duk_uint_t flags);


### PR DESCRIPTION
- Rename flags to `DUK_CONSOLE_STDOUT_ONLY` and `DUK_CONSOLE_STDERR_ONLY` for clarity.
- Comment style fix.
- Add documentation to extras/console/README.rst.
- Add 2.3 migration note to use `DUK_CONSOLE_STDOUT_ONLY` to get previous stdout-only behavior.
- Releases entry.