### PR TITLE
Reject constructor calls to Promise resolve/reject functions

### DIFF
--- a/polyfills/promise.js
+++ b/polyfills/promise.js
@@ -121,12 +121,14 @@
         // with a [[AlreadyResolved]] slot.  Here we use an in-scope variable.
         var alreadyResolved = false;
         var reject = function (err) {
+            if (new.target) { throw new TypeError('reject is not constructable'); }
             if (alreadyResolved) { return; }
             alreadyResolved = true;  // neutralize resolve/reject
             if (p.state !== void 0) { return; }
             doReject(p, err);
         };
         var resolve = function (val) {
+            if (new.target) { throw new TypeError('resolve is not constructable'); }
             if (alreadyResolved) { return; }
             alreadyResolved = true;  // neutralize resolve/reject
             if (p.state !== void 0) { return; }

--- a/tests/ecmascript/test-bi-promise-reject-constructable.js
+++ b/tests/ecmascript/test-bi-promise-reject-constructable.js
@@ -1,0 +1,34 @@
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-base.js@*/
+
+/*===
+function
+TypeError
+done
+===*/
+
+var rejectFn;
+
+var P = new Promise(function (resolve_unused, reject) {
+    print(typeof reject);
+    rejectFn = reject;
+});
+P.then(function (val) {
+    print('fulfill:', val);
+}, function (err) {
+    print('reject:', err);
+});
+
+try {
+    var tmp = new rejectFn(123);
+    print('constructor result:', typeof tmp);
+} catch (e) {
+    print(e.name);
+}
+
+print('done');

--- a/tests/ecmascript/test-bi-promise-resolve-constructable.js
+++ b/tests/ecmascript/test-bi-promise-resolve-constructable.js
@@ -1,0 +1,34 @@
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-base.js@*/
+
+/*===
+function
+TypeError
+done
+===*/
+
+var resolveFn;
+
+var P = new Promise(function (resolve, reject_unused) {
+    print(typeof resolve);
+    resolveFn = resolve;
+});
+P.then(function (val) {
+    print('fulfill:', val);
+}, function (err) {
+    print('reject:', err);
+});
+
+try {
+    var tmp = new resolveFn(123);
+    print('constructor result:', typeof tmp);
+} catch (e) {
+    print(e.name);
+}
+
+print('done');

--- a/util/runtest.py
+++ b/util/runtest.py
@@ -429,6 +429,10 @@ def prepare_ecmascript_testcase(data, meta):
     if meta.get('use_strict', False):
         data = "'use strict'; " + data
 
+    # Manually enabled Promise hack.
+    if False:
+        data = data + '\n' + "if (typeof Promise === 'function' && typeof Promise.runQueue === 'function') { Promise.runQueue(); }"
+
     return data
 
 # Similar preparation for API testcases.


### PR DESCRIPTION
The specifications seem pretty vague whether resolve/reject functions should reject constructor calls, but in practice engines (at least Node.js and Firefox) seem to do so, so change the Promise polyfill to match that behavior.