### PR TITLE
Fix compile warning for duk_console.c

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3162,6 +3162,8 @@ Miscellaneous:
   DUK_CONSOLE_STDOUT_ONLY init flag to restore previous behavior (GH-1890,
   GH-1903)
 
+* Compile warning fix to extras/console (GH-1906)
+
 * Compile warning fixes and Duktape 1.x compatibility fix to module-node
   (GH-1605)
 

--- a/extras/console/duk_console.h
+++ b/extras/console/duk_console.h
@@ -8,16 +8,16 @@ extern "C" {
 #endif
 
 /* Use a proxy wrapper to make undefined methods (console.foo()) no-ops. */
-#define DUK_CONSOLE_PROXY_WRAPPER  (1 << 0)
+#define DUK_CONSOLE_PROXY_WRAPPER  (1U << 0)
 
 /* Flush output after every call. */
-#define DUK_CONSOLE_FLUSH          (1 << 1)
+#define DUK_CONSOLE_FLUSH          (1U << 1)
 
 /* Send output to stdout only (default is mixed stdout/stderr). */
-#define DUK_CONSOLE_STDOUT_ONLY    (1 << 2)
+#define DUK_CONSOLE_STDOUT_ONLY    (1U << 2)
 
 /* Send output to stderr only (default is mixed stdout/stderr). */
-#define DUK_CONSOLE_STDERR_ONLY    (1 << 3)
+#define DUK_CONSOLE_STDERR_ONLY    (1U << 3)
 
 /* Initialize the console system */
 extern void duk_console_init(duk_context *ctx, duk_uint_t flags);


### PR DESCRIPTION
Fix signed vs. unsigned warning in flags handling:
```
extras/console/duk_console.c:113:12: warning: negative integer implicitly converted to unsigned type [-Wsign-conversion]
      flags &= ~DUK_CONSOLE_STDOUT_ONLY;
            ^~
```

Fix by making flags unsigned which matches the init call argument type.