### PR TITLE
Disable tracebacks crash

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Fabrice Fontaine (https://github.com/ffontaine)
 * Christopher Hiller (https://github.com/boneskull)
 * Gonzalo Diethelm (https://github.com/gonzus)
+* Michal Kasperek (https://github.com/michalkas)
 
 Other contributions
 ===================

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -354,7 +354,6 @@ DUK_LOCAL void duk__add_fileline(duk_hthread *thr, duk_hthread *thr_callstack, c
 			DUK_UNREF(pc);
 			DUK_ASSERT_DISABLE(pc >= 0);  /* unsigned */
 			DUK_ASSERT((duk_double_t) pc < DUK_DOUBLE_2TO32);  /* assume PC is at most 32 bits and non-negative */
-			act = NULL;  /* invalidated by pushes, so get out of the way */
 
 			duk_push_hobject(thr, func);
 


### PR DESCRIPTION
Prerequisites:
#undef DUK_USE_TRACEBACKS and 'depth' >1
 
During the second loop iteration the exception is thrown:
- Read access violation while executing => 'act = act->parent'