### PR TITLE
Add duk_fatal_exception, used for C++ fatal/uncaught errors

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3233,6 +3233,10 @@ Planned
 2.3.0 (XXXX-XX-XX)
 ------------------
 
+* When DUK_USE_CPP_EXCEPTIONS is enabled: use duk_fatal_exception when
+  propagating a fatal error out of Duktape; use duk_fatal_exception also
+  in the default fatal error handler (GH-1915)
+
 * Update UnicodeData.txt and SpecialCasing.txt used for building internal
   Unicode control data to Unicode version 10.0.0 (GH-1851)
 

--- a/config/header-snippets/platform_conditionalincludes.h.in
+++ b/config/header-snippets/platform_conditionalincludes.h.in
@@ -1,3 +1,4 @@
 #if defined(DUK_F_CPP) && defined(DUK_USE_CPP_EXCEPTIONS)
 #include <exception>  /* std::exception */
+#include <stdexcept>  /* std::runtime_error */
 #endif

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -2710,7 +2710,7 @@ DUK_LOCAL void duk__to_primitive_helper(duk_hthread *thr, duk_idx_t idx, duk_int
 	 * which mimic objects.
 	 */
 	if (check_symbol && duk_get_method_stridx(thr, idx, DUK_STRIDX_WELLKNOWN_SYMBOL_TO_PRIMITIVE)) {
-		DUK_ASSERT(hint >= 0 && hint < sizeof(duk__toprim_hint_strings) / sizeof(const char *));
+		DUK_ASSERT(hint >= 0 && (duk_size_t) hint < sizeof(duk__toprim_hint_strings) / sizeof(const char *));
 		duk_dup(thr, idx);
 		duk_push_string(thr, duk__toprim_hint_strings[hint]);
 		duk_call_method(thr, 1);  /* [ ... method value hint ] -> [ ... res] */

--- a/src-input/duk_error_longjmp.c
+++ b/src-input/duk_error_longjmp.c
@@ -76,14 +76,9 @@ DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 
 	DUK_DD(DUK_DDPRINT("about to longjmp, pf_prevent_count=%ld", (long) thr->heap->pf_prevent_count));
 
-#if !defined(DUK_USE_CPP_EXCEPTIONS)
 	/* If we don't have a jmpbuf_ptr, there is little we can do except
 	 * cause a fatal error.  The caller's expectation is that we never
 	 * return.
-	 *
-	 * With C++ exceptions we now just propagate an uncaught error
-	 * instead of invoking the fatal error handler.  Because there's
-	 * a dummy jmpbuf for C++ exceptions now, this could be changed.
 	 */
 	if (!thr->heap->lj.jmpbuf_ptr) {
 		DUK_D(DUK_DPRINT("uncaught error: type=%d iserror=%d value1=%!T value2=%!T",
@@ -97,16 +92,12 @@ DUK_INTERNAL void duk_err_longjmp(duk_hthread *thr) {
 #endif
 		DUK_UNREACHABLE();
 	}
-#endif  /* DUK_USE_CPP_EXCEPTIONS */
 
 #if defined(DUK_USE_CPP_EXCEPTIONS)
-	{
-		duk_internal_exception exc;  /* dummy */
-		throw exc;
-	}
-#else  /* DUK_USE_CPP_EXCEPTIONS */
+	throw duk_internal_exception();  /* dummy */
+#else
 	DUK_LONGJMP(thr->heap->lj.jmpbuf_ptr->jb);
-#endif  /* DUK_USE_CPP_EXCEPTIONS */
+#endif
 
 	DUK_UNREACHABLE();
 }

--- a/src-input/duk_error_macros.c
+++ b/src-input/duk_error_macros.c
@@ -113,10 +113,18 @@ DUK_INTERNAL DUK_COLD void duk_default_fatal_handler(void *udata, const char *ms
 	DUK_UNREF(udata);
 	DUK_UNREF(msg);
 
+	msg = msg ? msg : "NULL";
+
 #if defined(DUK_USE_FATAL_HANDLER)
 	/* duk_config.h provided a custom default fatal handler. */
-	DUK_D(DUK_DPRINT("custom default fatal error handler called: %s", msg ? msg : "NULL"));
+	DUK_D(DUK_DPRINT("custom default fatal error handler called: %s", msg));
 	DUK_USE_FATAL_HANDLER(udata, msg);
+#elif defined(DUK_USE_CPP_EXCEPTIONS)
+	/* With C++ use a duk_fatal_exception which user code can catch in
+	 * a natural way.
+	 */
+	DUK_D(DUK_DPRINT("built-in default C++ fatal error handler called: %s", msg));
+	throw duk_fatal_exception(msg);
 #else
 	/* Default behavior is to abort() on error.  There's no printout
 	 * which makes this awkward, so it's always recommended to use an
@@ -133,7 +141,7 @@ DUK_INTERNAL DUK_COLD void duk_default_fatal_handler(void *udata, const char *ms
 	 *   - http://duktape.org/api.html#taglist-protected
 	 * ====================================================================
 	 */
-	DUK_D(DUK_DPRINT("built-in default fatal error handler called: %s", msg ? msg : "NULL"));
+	DUK_D(DUK_DPRINT("built-in default fatal error handler called: %s", msg));
 	DUK_ABORT();
 #endif
 

--- a/src-input/duk_exception.h
+++ b/src-input/duk_exception.h
@@ -1,17 +1,29 @@
 /*
- *  Exception for Duktape internal throws when C++ exceptions are used
+ *  Exceptions for Duktape internal throws when C++ exceptions are used
  *  for long control transfers.
- *
- *  Doesn't inherit from any exception base class to minimize the chance
- *  that user code would accidentally catch this exception.
  */
 
 #if !defined(DUK_EXCEPTION_H_INCLUDED)
 #define DUK_EXCEPTION_H_INCLUDED
 
 #if defined(DUK_USE_CPP_EXCEPTIONS)
+/* Internal exception used as a setjmp-longjmp replacement.  User code should
+ * NEVER see or catch this exception, so it doesn't inherit from any base
+ * class which should minimize the chance of user code accidentally catching
+ * the exception.
+ */
 class duk_internal_exception {
 	/* intentionally empty */
+};
+
+/* Fatal error, thrown as a specific C++ exception with C++ exceptions
+ * enabled.  It is unsafe to continue; doing so may cause crashes or memory
+ * leaks.  This is intended to be either uncaught, or caught by user code
+ * aware of the "unsafe to continue" semantics.
+ */
+class duk_fatal_exception : public virtual std::runtime_error {
+ public:
+	duk_fatal_exception(const char *message) : std::runtime_error(message) {}
 };
 #endif
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -2724,7 +2724,10 @@ DUK_INTERNAL duk_int_t duk_handle_safe_call(duk_hthread *thr,
 		retval = DUK_EXEC_ERROR;
 	}
 #if defined(DUK_USE_CPP_EXCEPTIONS)
-	catch (std::exception &exc) {
+	catch (duk_fatal_exception &exc) {
+		DUK_D(DUK_DPRINT("rethrow duk_fatal_exception"));
+		throw;
+	} catch (std::exception &exc) {
 		const char *what = exc.what();
 		DUK_ASSERT((duk_size_t) ((duk_uint8_t *) thr->valstack_end - (duk_uint8_t *) thr->valstack) >= entry_valstack_end_byteoff);
 		DUK_STATS_INC(thr->heap, stats_safecall_throw);

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2937,7 +2937,10 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 			                           entry_jmpbuf_ptr);
 		}
 #if defined(DUK_USE_CPP_EXCEPTIONS)
-		catch (std::exception &exc) {
+		catch (duk_fatal_exception &exc) {
+			DUK_D(DUK_DPRINT("rethrow duk_fatal_exception"));
+			throw;
+		} catch (std::exception &exc) {
 			const char *what = exc.what();
 			if (!what) {
 				what = "unknown";

--- a/tools/genconfig.py
+++ b/tools/genconfig.py
@@ -980,7 +980,11 @@ def generate_duk_config_header(opts, meta_dir):
     forced_opts = get_forced_options(opts)
     for doc in use_defs_list:
         if doc.get('warn_if_missing', False) and not forced_opts.has_key(doc['define']):
-            logger.warning('Recommended config option ' + doc['define'] + ' not provided')
+            # Awkward handling for DUK_USE_CPP_EXCEPTIONS + DUK_USE_FATAL_HANDLER.
+            if doc['define'] == 'DUK_USE_FATAL_HANDLER' and forced_opts.has_key('DUK_USE_CPP_EXCEPTIONS'):
+                pass  # DUK_USE_FATAL_HANDLER not critical with DUK_USE_CPP_EXCEPTIONS
+            else:
+                logger.warning('Recommended config option ' + doc['define'] + ' not provided')
 
     # Gather a map of "active options" for genbuiltins.py.  This is used to
     # implement proper optional built-ins, e.g. if a certain config option


### PR DESCRIPTION
With C++ exceptions Duktape currently uses a single exception type, `duk_internal_exception` as a setjmp/longjmp replacement. It's intended to only be seen internally (i.e. the catch site is always internal to Duktape). However, it does propagate to calling code (at least up to Duktape 2.2) in uncaught error situations. Fatal errors caused by e.g. assertion errors or manual calls to duk_fatal() also don't use the C++ exception mechanism right now.

Make a few changes to make fatal/uncaught error handling more C++ native:
- Add a separate `duk_fatal_exception` class which is used for uncaught errors and other fatal errors in C++ exception mode. However, if a user provides an explicit fatal error handler, it will be used instead.
- Change the longjmp code to detect a missing catch point in C++ mode too, and use `duk_fatal()` in C++ mode too. Change internal C++ catch sites to handle `duk_fatal_exception` by rethrowing it.
- Change the default fatal error to support `duk_fatal_exception`.
- Don't warn about missing `DUK_USE_FATAL_HANDLER` with C++ exception support enabled

Tasks:
- [x] Code changes
- [x] Remove warning for missing `DUK_USE_FATAL_HANDLER` if `DUK_USE_CPP_EXCEPTIONS` defined
- [x] Inheritance for `duk_fatal_exception` - std::exception, std::runtime_error, none? => std::runtime_error
- [x] Test -std=xxx for old standard versions
- [x] Test uncaught error
- [x] Test assertion error
- [x] Test generic duk_fatal() call
- [x] 2.3 release note
- [x] Documentation changes => separate pull

@mike-lischke Moving this C++ exception discussion here.