### PR TITLE
Fix unused-parameter warning in duk_push_class_string_tval

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,6 +52,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Christopher Hiller (https://github.com/boneskull)
 * Gonzalo Diethelm (https://github.com/gonzus)
 * Michal Kasperek (https://github.com/michalkas)
+* Andrew Janke (https://github.com/apjanke)
 
 Other contributions
 ===================

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3287,6 +3287,8 @@ DUK_INTERNAL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv, duk
 		}
 		duk_pop_unsafe(thr);
 	}
+#else
+	DUK_UNREF(avoid_side_effects);
 #endif
 
 	h_obj = duk_known_hobject(thr, -1);


### PR DESCRIPTION
When I build Duktape from master + https://github.com/svaarala/duktape/pull/1922 on macOS 10.13, I get the following warning.

```
[~/local/repos/duktape/dist on ⇄ sharedlibrary-respect-prefix]
$ make -f Makefile.sharedlibrary INSTALL_PREFIX=/tmp/test-duktape all
gcc -shared -fPIC -Wall -Wextra -Os -Wl,-install_name,libduktape.202.so \
		-o libduktape.202.20299.so ./src/duktape.c
duk_api_stack.c:3229:89: warning: unused parameter 'avoid_side_effects' [-Wunused-parameter]
DUK_INTERNAL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv, duk_bool_t avoid_side_effects) {
                                                                                        ^
1 warning generated.
gcc -shared -fPIC -g -Wall -Wextra -Os -Wl,-install_name,libduktaped.202.so \
		-o libduktaped.202.20299.so ./src/duktape.c
duk_api_stack.c:3229:89: warning: unused parameter 'avoid_side_effects' [-Wunused-parameter]
DUK_INTERNAL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv, duk_bool_t avoid_side_effects) {
                                                                                        ^
1 warning generated.
```

This PR cleans up that warning by declaring the unused parameter.