### PR TITLE
Add some unhandled rejection basics to polyfill

### DIFF
--- a/tests/ecmascript/test-bi-promise-unhandled-difftick-1.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-difftick-1.js
@@ -1,0 +1,73 @@
+// Rejected promise with rejection handled after Promise settled during
+// a different tick.  Test for both callable and non-callable handler.
+//
+// Handle rejection in a different tick which generates both reject and
+// handle callbacks.
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+tick 1
+unhandled/reject: P
+unhandled/reject: Q
+unhandled/reject: R
+tick 2
+nop called
+nop called
+unhandled/handle: P
+unhandled/handle: Q
+unhandled/handle: R
+unhandled/reject: R2
+tick 3
+tick 4
+===*/
+
+var P, Q, R;
+var calls = [];
+
+setupPromiseUnhandledCallbacks(function (p) {
+    print('unhandled/reject:', p.name);
+}, function (p) {
+    print('unhandled/handle:', p.name);
+});
+
+function nop() {
+    print('nop called');
+}
+var T = Promise.resolve();
+T.name = 'T';
+
+T.then(function () {
+    print('tick 1');
+    P = Promise.reject(123);
+    P.name = 'P';
+    Q = Promise.reject(234);
+    Q.name = 'Q';
+    R = Promise.reject(345);
+    R.name = 'R';
+});
+
+promiseNextTick(function () {
+    print('tick 2');
+    P.catch(nop);
+    Q.catch(nop);
+
+    // Here R has already had its 'reject' event and it gets handled by
+    // forwarding the rejection to R2.  So, R gets a 'handle' event, but
+    // R2 is unhandled and gets a 'reject' event.
+    var R2 = R.catch(123);
+    R2.name = 'R2';
+
+    promiseNextTick(function () {
+        print('tick 3');
+        promiseNextTick(function () {
+            print('tick 4');
+        });
+    });
+});

--- a/tests/ecmascript/test-bi-promise-unhandled-difftick-2.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-difftick-2.js
@@ -1,0 +1,76 @@
+// Rejected promise with rejection handled after Promise settled during
+// a different tick (multiple ticks later).
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+tick 1
+unhandled/reject: P
+unhandled/reject: Q
+unhandled/reject: R
+tick 2
+tick 3
+tick 4
+nop called
+nop called
+unhandled/handle: P
+unhandled/handle: Q
+unhandled/handle: R
+unhandled/reject: R2
+tick 5
+tick 6
+===*/
+
+var P, Q, R;
+var calls = [];
+
+setupPromiseUnhandledCallbacks(function (p) {
+    print('unhandled/reject:', p.name);
+}, function (p) {
+    print('unhandled/handle:', p.name);
+});
+
+function nop() {
+    print('nop called');
+}
+var T = Promise.resolve();
+T.name = 'T';
+
+T.then(function () {
+    print('tick 1');
+    P = Promise.reject(123);
+    P.name = 'P';
+    Q = Promise.reject(234);
+    Q.name = 'Q';
+    R = Promise.reject(345);
+    R.name = 'R';
+});
+
+promiseNextTick(function () {
+    print('tick 2');
+    promiseNextTick(function () {
+        print('tick 3');
+        promiseNextTick(function () {
+            print('tick 4');
+
+            P.catch(nop);
+            Q.catch(nop);
+
+            var R2 = R.catch(123);
+            R2.name = 'R2';
+
+            promiseNextTick(function () {
+                print('tick 5');
+                promiseNextTick(function () {
+                    print('tick 6');
+                });
+            });
+        });
+    });
+});

--- a/tests/ecmascript/test-bi-promise-unhandled-nophandler.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-nophandler.js
@@ -1,0 +1,46 @@
+// A nop handler ('Thrower') doesn't count as being handled.
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+234
+unhandled/reject: P2
+tick
+===*/
+
+var P, Q, P2, Q2;
+
+setupPromiseUnhandledCallbacks(function (p) {
+    print('unhandled/reject:', p.name);
+}, function (p) {
+    print('unhandled/handle:', p.name);
+});
+
+P = Promise.reject(123);
+P.name = 'P';
+Q = Promise.reject(234);
+Q.name = 'Q';
+
+// When .then() is applied to P, P's reject handler will be set to P2's
+// reject() function, so P's rejection is considered handled.  However,
+// P2 itself is unhandled because its onRejected is a Thrower.
+P2 = P.then(function (v) {
+    print(v);
+}, void 0);
+P2.name = 'P2';
+Q2 = Q.then(function (v) {
+    print(v);
+}, function (e) {
+    print(e);
+});
+Q2.name = 'Q2';
+
+promiseNextTick(function () {
+    print('tick');
+});

--- a/tests/ecmascript/test-bi-promise-unhandled-ordering-1.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-ordering-1.js
@@ -1,0 +1,86 @@
+// For tick N, the list of potentially unhandled rejections cause a callback
+// for each such Promise.  If new unhandled rejections are created by those
+// callbacks, and are not handled by the end of tick N, they also require
+// callbacks.
+//
+// Also, if a promise is unhandled when the unhandled rejections checking
+// begins, one unhandled rejection callback may handle it before we get to
+// it.  In this case no callback is desired.
+
+// P1: base case, unhandled rejection, gets callback.
+// P2: unhandled rejection, but callback for P1 handles it.
+// P3: base case, unhandled rejection, gets callback (needed for other tests).
+// P4: created by P1 unhandled rejection, remains unhandled to tick 2; handled in tick 2
+// P5: created by P1 unhandled rejection, handled by P3 unhandled rejection
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+TICK 1
+unhandled/reject: P1
+unhandled/reject: P3
+unhandled/reject: P4
+P2.catch: 234
+P5.catch: 567
+TICK 2
+P4.catch: 456
+unhandled/handle: P4
+TICK 3
+done
+===*/
+
+var P1, P2, P3, P4, P5;
+
+function unhandledRejection(promise) {
+    print('unhandled/reject:', promise.name);
+    if (promise === P1) {
+        P2.catch(function (e) {
+            print('P2.catch:', e);
+        });
+        P4 = Promise.reject(456);
+        P4.name = 'P4';
+        P5 = Promise.reject(567);
+        P5.name = 'P5';
+    } else if (promise === P3) {
+        P5.catch(function (e) {
+            print('P5.catch:', e);
+        });
+    }
+}
+function rejectionHandled(promise) {
+    print('unhandled/handle:', promise.name);
+}
+
+setupPromiseUnhandledCallbacks(unhandledRejection, rejectionHandled);
+
+function tick1() {
+    print('TICK 1');
+    P1 = Promise.reject(123);
+    P1.name = 'P1';
+    P2 = Promise.reject(234);
+    P2.name = 'P2';
+    P3 = Promise.reject(345);
+    P3.name = 'P3';
+    promiseNextTick(tick2);
+}
+
+function tick2() {
+    print('TICK 2');
+    P4.catch(function (e) {
+        print('P4.catch:', e);
+    });
+    promiseNextTick(tick3);
+}
+
+function tick3() {
+    print('TICK 3');
+    print('done');
+}
+
+tick1();

--- a/tests/ecmascript/test-bi-promise-unhandled-presettle-1.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-presettle-1.js
@@ -1,0 +1,47 @@
+// Rejected promise with rejection handled before Promise settled.
+// Test for both callable and non-callable handler.
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+nop called
+nop called
+unhandled/reject: R2
+tick
+===*/
+
+var P, Q, R;
+
+setupPromiseUnhandledCallbacks(function (p) {
+    print('unhandled/reject:', p.name);
+}, function (p) {
+    print('unhandled/handle:', p.name);
+});
+
+function nop() {
+    print('nop called');
+}
+
+P = Promise.reject(123);
+P.name = 'P';
+Q = Promise.reject(234);
+Q.name = 'Q';
+R = Promise.reject(345);
+R.name = 'R';
+
+P.catch(nop);
+Q.catch(nop);
+// Handler is not callable.  R itself is considered handled because
+// it is directly bound to R2.  However, R2 will be unhandled.
+var R2 = R.catch(123)
+R2.name = 'R2';
+
+promiseNextTick(function (cb) {
+    print('tick');
+});

--- a/tests/ecmascript/test-bi-promise-unhandled-sametick-1.js
+++ b/tests/ecmascript/test-bi-promise-unhandled-sametick-1.js
@@ -1,0 +1,66 @@
+// Rejected promise with rejection handled after Promise settled during
+// same tick.  Test for both callable and non-callable handler.
+//
+// Rejected Promises are created in the first T fulfill reaction, and
+// resolved in the next.  Two callbacks (promise jobs) are involved, but
+// since they're both "runnable" at the same time, they are considered to
+// happen in the same "tick", suppressing the unhandled rejection notify.
+// (At least in Node.js.)
+
+/*---
+{
+    "skip": true
+}
+---*/
+
+/*@include util-promise.js@*/
+
+/*===
+T1.then
+T2.then
+nop called
+nop called
+unhandled/reject: R2
+tick
+===*/
+
+var P, Q, R;
+
+setupPromiseUnhandledCallbacks(function (p) {
+    print('unhandled/reject:', p.name);
+}, function (p) {
+    print('unhandled/handle:', p.name);
+});
+
+function nop() {
+    print('nop called');
+}
+var T = Promise.resolve();
+T.name = 'T';
+
+var T1 = T.then(function () {
+    print('T1.then');
+    P = Promise.reject(123);
+    P.name = 'P';
+    Q = Promise.reject(234);
+    Q.name = 'Q';
+    R = Promise.reject(345);
+    R.name = 'R';
+});
+T1.name = 'T1';
+
+var T2 = T.then(function () {
+    print('T2.then');
+    P.catch(nop);
+    Q.catch(nop);
+
+    // Handler is not callable.  R itself is considered handled because
+    // it is directly bound to R2.  However, R2 will be unhandled.
+    var R2 = R.catch(123)
+    R2.name = 'R2';
+});
+T2.name = 'T2';
+
+promiseNextTick(function (cb) {
+    print('tick');
+});

--- a/tests/ecmascript/util-promise.js
+++ b/tests/ecmascript/util-promise.js
@@ -1,0 +1,33 @@
+function setupPromiseUnhandledCallbacks(unhandledRejection, rejectionHandled) {
+    if (typeof Duktape === 'object' && typeof Promise === 'function' && Promise.isPolyfill) {
+        Promise.unhandledRejection = function (args) {
+            if (args.event === 'reject') {
+                unhandledRejection(args.promise);
+            } else if (args.event === 'handle') {
+                rejectionHandled(args.promise);
+            }
+        };
+    } else if (typeof process === 'object') {
+        // https://nodejs.org/api/process.html#process_event_unhandledrejection
+        // https://nodejs.org/api/process.html#process_event_rejectionhandled
+        process.on('unhandledRejection', function (reason, promise) {
+            unhandledRejection(promise);
+        });
+        process.on('rejectionHandled', function (promise) {
+            rejectionHandled(promise);
+        });
+    } else {
+        throw new TypeError('failed to setup Promise unhandled rejection callbacks');
+    }
+}
+
+function promiseNextTick(cb) {
+    if (typeof Duktape === 'object' && typeof Promise === 'function' && Promise.isPolyfill) {
+        Promise.runQueue();
+        cb();
+    } else if (typeof setTimeout === 'function') {
+        setTimeout(cb, 0);
+    } else {
+        throw new TypeError('failed to schedule callback for next Promise tick');
+    }
+}


### PR DESCRIPTION
Not intended as a full solution, but some unhandled rejection drafting for the Promise polyfill. Consistency with the WHATWG specification to be checked. Tasks:

- [x] Add unhandled rejection and rejection handled notification tracking
- [x] Add a simple unhandled rejection callback for the polyfill
- [x] Fix handling of pre-settle Thrower reactions
- [x] Decide on unhandledRejection callback arguments for now
- [x] Testcase for handled within a tick
- [x] Testcase for handled after a tick
- [x] Testcase for Promise with Thrower (non-callable) rejection handlers prior to settle
- [x] Testcase for Promise with non-Thrower (callable) rejection handlers prior to settle
- [x] Testcase for Promise with Thrower rejection handler after settle, same tick
- [x] Testcase for Promise with non-Thrower rejection handler after settle, same tick
- [x] Testcase for Promise with Thrower rejection handler after settle, different tick
- [x] Testcase for Promise with non-Thrower rejection handler after settle, different tick

Fixes #1934.