### PR TITLE
Dc6jgk file time to system time/system time to tz specific local time fix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,6 +54,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Michal Kasperek (https://github.com/michalkas)
 * Andrew Janke (https://github.com/apjanke)
 * Steve Fan (https://github.com/stevefan1999)
+* Gero Kuehn (support@gkware.com,https://github.com/dc6jgk)
 
 Other contributions
 ===================


### PR DESCRIPTION
Avoid calling SystemTimeToTzSpecificLocalTime with bad/uninitialized st2 parameters (potential crash/stack-corruption on Win2k3)