### PR TITLE
Problem: Linking duktape on NixOS with musl

### DIFF
--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -24,6 +24,10 @@
 
 @DUK_SINGLE_FILE@
 
+#ifndef __GLIBC__
+#undef _FORTIFY_SOURCE
+#endif
+
 /*
  *  BEGIN PUBLIC API
  */


### PR DESCRIPTION
This is a little bit of a subtle issue. The way NixOS/Nixpkgs work, they typically
wrap binaries (such as the compiler) with more complicated wrappers to handle
the paths established in Nixpkgs store and other features. In this case, the feature
that's interfering with normal flow is hardening. Without going into too much detail,
there's no way to disable _FORTIFY_SOURCE as it is always passed after any passed
arguments. Something like `gcc <PARAMETERS> -D_FORTIFY_SOURCE`.

However, this doesn't play well with musl (see https://wiki.musl-libc.org/future-ideas.html)

Solution: disable `_FORTIFY_SOURCE` if glibc is not present

---

I've been using this patch for quite a while in SIT https://github.com/sit-fyi/sit/blob/master/sit-core/src/duktape/duktape.h#L144-L146 but I keep transferring it during upgrades and this isn't particularly robust.

I am not sure this is the best way to solve but at least it have worked for a good while. 

Any thoughts?