### PR TITLE
Fix Object.getOwnPropertySymbols() handling of some virtual properties

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3398,6 +3398,10 @@ Planned
 
 * Enable Symbol built-in by default (DUK_USE_SYMBOL_BUILTIN) (GH-1969)
 
+* Fix Object.getOwnPropertySymbols() behavior for the virtual properties
+  of arrays, Strings, and buffer objects: string keys were incorrectly
+  included in the result (GH-1978, GH-1979)
+
 * Trivial fixes and cleanups: Windows Date provider return code check
   consistency (GH-1956)
 

--- a/tests/ecmascript/test-bi-object-getownpropsymbols.js
+++ b/tests/ecmascript/test-bi-object-getownpropsymbols.js
@@ -1,0 +1,75 @@
+print=console.log
+
+/*===
+test 1
+0 Symbol(foo)
+1 Symbol(bar)
+test 2
+test 3
+0 Symbol(foo)
+test 4
+0 Symbol(foo)
+test 5
+test 6
+test 7
+done
+===*/
+
+function basicTest() {
+    var S1 = Symbol('foo');
+    var S2 = Symbol.for('bar');
+    var S3 = Symbol.for('quux');
+    var O;
+
+    Object.prototype[S3] = 'inherited';
+
+    print('test 1');
+    O = { foo: 'a', [S1]: 'b', [S2]: 'c', bar: 'd' };
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 2');
+    O = [ 1, 2, 3 ];
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 3');
+    O = [ 1, 2, 3 ];
+    O[S1] = 'a';
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 4');
+    O = { [S1]: 'a' };
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 5');
+    O = 'foo';
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 6');
+    O = Object('foo');
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+
+    print('test 7');
+    O = new Uint8Array(10);
+    Object.getOwnPropertySymbols(O).forEach(function (v, i) {
+        print(i, String(v));
+    });
+}
+
+try {
+    basicTest();
+} catch (e) {
+    print(e.stack || e);
+}
+print('done');


### PR DESCRIPTION
Virtual non-Symbol properties were included in the result for:
- plain Strings
- buffer objects (views)
- arrays like [1,2,3]

Fixes #1978.