### PR TITLE
Trivial getOwnPropertySymbols() testcase fix

### DIFF
--- a/tests/ecmascript/test-bi-object-getownpropsymbols.js
+++ b/tests/ecmascript/test-bi-object-getownpropsymbols.js
@@ -1,5 +1,3 @@
-print=console.log
-
 /*===
 test 1
 0 Symbol(foo)


### PR DESCRIPTION
Remove print=console.log.