### PR TITLE
Minor fixes to dump_bytecode.py and duk_debug.js

### DIFF
--- a/debugger/duk_debug.js
+++ b/debugger/duk_debug.js
@@ -1138,9 +1138,9 @@ Debugger.prototype.decodeBytecodeFromBuffer = function (buf, consts, funcs) {
         }
 
         if (args.length > 0) {
-            str = sprintf('%05d %08x   %-10s %s', pc, ins, op.name, args.join(', '));
+            str = sprintf('%05d %08x   %-12s %s', pc, ins, op.name, args.join(', '));
         } else {
-            str = sprintf('%05d %08x   %-10s', pc, ins, op.name);
+            str = sprintf('%05d %08x   %-12s', pc, ins, op.name);
         }
         if (comments.length > 0) {
             str = sprintf('%-44s ; %s', str, comments.join(', '));


### PR DESCRIPTION
- Add script path relative resolution for duk_opcodes.py so that one can run tools/dump_bytecode.py from repo root.
- Use os.path.join() rather than hardcoded separators.
- Use wider opcode name (12 chars) in duk_debug.js.
- Use matching format for opcodes, arguments, and comments in dump_bytecode.py.