### PR TITLE
Remove arguments.caller for strict mode argument objects to match revised ES2017 behavior

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3398,6 +3398,9 @@ Planned
 
 * Enable Symbol built-in by default (DUK_USE_SYMBOL_BUILTIN) (GH-1969)
 
+* Remove arguments.caller for strict argument objects to match revised
+  ES2017 behavior (GH-2009)
+
 * Fix Object.getOwnPropertySymbols() behavior for the virtual properties
   of arrays, Strings, and buffer objects: string keys were incorrectly
   included in the result (GH-1978, GH-1979)

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -355,7 +355,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 
 		DUK_DDD(DUK_DDDPRINT("strict function, setting caller/callee to throwers"));
 
-		duk_xdef_prop_stridx_thrower(thr, i_arg, DUK_STRIDX_CALLER);
+		/* In ES2017 .caller is no longer set at all. */
 		duk_xdef_prop_stridx_thrower(thr, i_arg, DUK_STRIDX_CALLEE);
 	} else {
 		DUK_DDD(DUK_DDDPRINT("non-strict function, setting callee to actual value"));

--- a/tests/ecmascript/test-arguments-caller-es2017.js
+++ b/tests/ecmascript/test-arguments-caller-es2017.js
@@ -1,0 +1,29 @@
+// arguments.caller was removed in ES2017 for strict arguments objects.
+// arguments.callee remains a thrower for strict argument objects.
+
+/*===
+arguments.caller: undefined
+TypeError
+===*/
+
+function testCaller() {
+    'use strict';
+    print('arguments.caller:', arguments.caller);
+}
+
+try {
+    testCaller();
+} catch (e) {
+    print(e.stack || e);
+}
+
+function testCallee() {
+    'use strict';
+    print('arguments.callee:', arguments.callee);
+}
+
+try {
+    testCallee();
+} catch (e) {
+    print(e.name);
+}

--- a/tests/ecmascript/test-arguments-throwers.js
+++ b/tests/ecmascript/test-arguments-throwers.js
@@ -2,22 +2,19 @@
  *  E5 Section 10.6, main algorithm step 14 requires that a strict
  *  arguments object 'callee' and 'caller' throwers must be the specific
  *  thrower defined in E5 Section 13.2.3.
+ *
+ *  ES2017 removes the strict mode .caller thrower, test revised for ES2017.
  */
 
 /*===
 test get and set
+undefined
 object
+undefined
 object
-object
-object
 true
 true
 true
-true
-true
-true
-true
-TypeError
 TypeError
 ===*/
 
@@ -40,20 +37,9 @@ print(typeof pd4);
 
 // all of these should print true
 
-print(pd1.get === pd1.set);
 print(pd2.get === pd2.set);
-print(pd3.get === pd3.set);
+print(pd2.get === pd4.set);
 print(pd4.get === pd4.set);
-
-print(pd1.get === pd2.get);
-print(pd2.get === pd3.get);
-print(pd3.get === pd4.get);
-
-try {
-    pd1.get();
-} catch (e) {
-    print(e.name);
-}
 
 try {
     pd2.get();

--- a/tests/ecmascript/test-dev-strict-func-as-caller-prop-value.js
+++ b/tests/ecmascript/test-dev-strict-func-as-caller-prop-value.js
@@ -35,6 +35,9 @@
  *      Arguments object even when the callee has formal arguments
  *      (which is supposed to enable the special behaviors for the
  *      [[ParameterMap]] handling and "caller").
+ *
+ *  ES2017 removes the arguments.caller thrower for strict argument objects,
+ *  test case has been updated to reflect this.
  */
 
 /*===
@@ -92,10 +95,12 @@ undefined
 4 TypeError
 strict arguments, no formals
 bar
-TypeError
+undefined
+pass in es2017
 strict arguments, with formals
 bar
-TypeError
+undefined
+pass in es2017
 ===*/
 
 var baseFunctionCreators = [
@@ -283,6 +288,7 @@ try {
 print('strict arguments, no formals');
 try {
     testArgumentsStrictNoFormals('foo', 'bar', 'quux');
+    print('pass in es2017');
 } catch (e) {
     print(e);
 }
@@ -290,6 +296,7 @@ try {
 print('strict arguments, with formals');
 try {
     testArgumentsStrictWithFormals('foo', 'bar', 'quux');
+    print('pass in es2017');
 } catch (e) {
     print(e);
 }


### PR DESCRIPTION
Fixes #2008.