### PR TITLE
Enable `extras/module-node` and `examples/debug-trans-socket` to be used in DLLs

### DIFF
--- a/examples/debug-trans-socket/duk_trans_socket.h
+++ b/examples/debug-trans-socket/duk_trans_socket.h
@@ -3,13 +3,21 @@
 
 #include "duktape.h"
 
-void duk_trans_socket_init(void);
-void duk_trans_socket_finish(void);
-void duk_trans_socket_waitconn(void);
-duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length);
-duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t length);
-duk_size_t duk_trans_socket_peek_cb(void *udata);
-void duk_trans_socket_read_flush_cb(void *udata);
-void duk_trans_socket_write_flush_cb(void *udata);
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+DUK_EXTERNAL_DECL void duk_trans_socket_init(void);
+DUK_EXTERNAL_DECL void duk_trans_socket_finish(void);
+DUK_EXTERNAL_DECL void duk_trans_socket_waitconn(void);
+DUK_EXTERNAL_DECL duk_size_t duk_trans_socket_read_cb(void *udata, char *buffer, duk_size_t length);
+DUK_EXTERNAL_DECL duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t length);
+DUK_EXTERNAL_DECL duk_size_t duk_trans_socket_peek_cb(void *udata);
+DUK_EXTERNAL_DECL void duk_trans_socket_read_flush_cb(void *udata);
+DUK_EXTERNAL_DECL void duk_trans_socket_write_flush_cb(void *udata);
+
+#if defined(__cplusplus)
+}
+#endif  /* end 'extern "C"' wrapper */
 
 #endif  /* DUK_TRANS_SOCKET_H_INCLUDED */

--- a/examples/debug-trans-socket/duk_trans_socket_unix.c
+++ b/examples/debug-trans-socket/duk_trans_socket_unix.c
@@ -9,6 +9,8 @@
  *  defining USE_SELECT.  See https://daniel.haxx.se/docs/poll-vs-select.html.
  */
 
+#define DUK_COMPILING_DUKTAPE
+
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>

--- a/examples/debug-trans-socket/duk_trans_socket_windows.c
+++ b/examples/debug-trans-socket/duk_trans_socket_windows.c
@@ -31,6 +31,8 @@
  *          prep/duktape.c -lm -lws2_32
  */
 
+#define DUK_COMPILING_DUKTAPE
+
 #undef UNICODE
 #if !defined(WIN32_LEAN_AND_MEAN)
 #define WIN32_LEAN_AND_MEAN

--- a/extras/module-node/duk_module_node.c
+++ b/extras/module-node/duk_module_node.c
@@ -4,6 +4,8 @@
  *  https://nodejs.org/api/modules.html
  */
 
+#define DUK_COMPILING_DUKTAPE
+
 #include "duktape.h"
 #include "duk_module_node.h"
 

--- a/extras/module-node/duk_module_node.h
+++ b/extras/module-node/duk_module_node.h
@@ -7,8 +7,8 @@
 extern "C" {
 #endif
 
-extern duk_ret_t duk_module_node_peval_main(duk_context *ctx, const char *path);
-extern void duk_module_node_init(duk_context *ctx);
+DUK_EXTERNAL_DECL duk_ret_t duk_module_node_peval_main(duk_context *ctx, const char *path);
+DUK_EXTERNAL_DECL void duk_module_node_init(duk_context *ctx);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
When deploying Duktape as a DLL it is sometimes useful to bundle some extra functionality, compared to what vanilla `duktape.h` provides. In my case I wanted to be able to deploy `duktape.dll` with support for Node.js modules and debugging out of the box . However, it seems that these extra modules are not ready to be used that way because of missing `__declspec` specifiers.

I understand I could put these modules in separate DLLs (like `duktape-module-node.dll` etc), but it seems a bit overkill, and even then I would need to resolve `__declspec` specifiers, which would require me to modify sources that come with Duktape, which isn't perfect from maintenance perspective.

My solution might not be the most elegant, but it shouldn't break things either. Even if it isn't accepted then maybe it could start a discussion on how to make goodies from `extra/` and `examples/` more reusable.