### PR TITLE
Fix typo in examples/README.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,6 +61,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Jesse Doyle (https://github.com/jessedoyle)
 * Gero Kuehn (https://github.com/dc6jgk)
 * James Swift (https://github.com/phraemer)
+* Luis de Bethencourt (https://github.com/luisbg)
 
 Other contributions
 ===================

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -6,5 +6,5 @@ Examples for using Duktape.  These support user documentation and are
 intended as informative illustrations only.
 
 Examples are unmaintained and are not production quality code.  Bugs are
-not not necessarily fixed, unless the bug makes the example misleading
-as documentation.
+not necessarily fixed, unless the bug makes the example misleading as
+documentation.


### PR DESCRIPTION
Fixing a small typo. Unless the typo is a joke about bugs not being fixed 😄 