### PR TITLE
Add duk_push_bare_array() API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3396,6 +3396,9 @@ Planned
 2.4.0 (XXXX-XX-XX)
 ------------------
 
+* Add duk_push_bare_array() to push an Array instance which doesn't
+  inherit from anything (GH-2064)
+
 * Enable Symbol built-in by default (DUK_USE_SYMBOL_BUILTIN) (GH-1969)
 
 * Remove arguments.caller for strict argument objects to match revised

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4935,6 +4935,33 @@ DUK_EXTERNAL duk_idx_t duk_push_array(duk_hthread *thr) {
 	return ret;
 }
 
+DUK_EXTERNAL duk_idx_t duk_push_bare_array(duk_hthread *thr) {
+	duk_uint_t flags;
+	duk_harray *obj;
+	duk_idx_t ret;
+	duk_tval *tv_slot;
+
+	DUK_ASSERT_API_ENTRY(thr);
+
+	flags = DUK_HOBJECT_FLAG_EXTENSIBLE |
+	        DUK_HOBJECT_FLAG_FASTREFS |
+	        DUK_HOBJECT_FLAG_ARRAY_PART |
+	        DUK_HOBJECT_FLAG_EXOTIC_ARRAY |
+	        DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_ARRAY);
+
+	obj = duk_harray_alloc(thr, flags);
+	DUK_ASSERT(obj != NULL);
+
+	tv_slot = thr->valstack_top;
+	DUK_TVAL_SET_OBJECT(tv_slot, (duk_hobject *) obj);
+	DUK_HOBJECT_INCREF(thr, obj);  /* XXX: could preallocate with refcount = 1 */
+	ret = (duk_idx_t) (thr->valstack_top - thr->valstack_bottom);
+	thr->valstack_top++;
+
+	DUK_ASSERT(obj->length == 0);  /* Array .length starts at zero. */
+	return ret;
+}
+
 DUK_INTERNAL duk_harray *duk_push_harray(duk_hthread *thr) {
 	/* XXX: API call could do this directly, cast to void in API macro. */
 	duk_harray *a;

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -577,6 +577,7 @@ DUK_EXTERNAL_DECL void duk_push_thread_stash(duk_context *ctx, duk_context *targ
 DUK_EXTERNAL_DECL duk_idx_t duk_push_object(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_bare_object(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_array(duk_context *ctx);
+DUK_EXTERNAL_DECL duk_idx_t duk_push_bare_array(duk_context *ctx);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_c_function(duk_context *ctx, duk_c_function func, duk_idx_t nargs);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_c_lightfunc(duk_context *ctx, duk_c_function func, duk_idx_t nargs, duk_idx_t length, duk_int_t magic);
 DUK_EXTERNAL_DECL duk_idx_t duk_push_thread_raw(duk_context *ctx, duk_uint_t flags);

--- a/tests/api/test-push-bare-array.c
+++ b/tests/api/test-push-bare-array.c
@@ -1,7 +1,8 @@
 /*===
 arr_idx = 1
+prototype is undefined: 1
 duk_is_array(1) = 1
-arr[5] = 'inherit'
+arr[5] = 'undefined'
 json encoded: ["foo","bar"]
 top=2
 ===*/
@@ -11,8 +12,11 @@ void test(duk_context *ctx) {
 
 	duk_push_int(ctx, 123);  /* dummy */
 
-	arr_idx = duk_push_array(ctx);
+	arr_idx = duk_push_bare_array(ctx);
 	printf("arr_idx = %ld\n", (long) arr_idx);
+	duk_get_prototype(ctx, -1);
+	printf("prototype is undefined: %ld\n", (long) duk_is_undefined(ctx, -1));
+	duk_pop(ctx);
 
 	duk_push_string(ctx, "foo");
 	duk_put_prop_index(ctx, arr_idx, 0);
@@ -20,7 +24,8 @@ void test(duk_context *ctx) {
 	duk_put_prop_index(ctx, arr_idx, 1);
 
 	/* Array is now: [ "foo", "bar" ], and array.length is 2 (automatically
-	 * updated for ECMAScript arrays).
+	 * updated for ECMAScript arrays).  The array being bare does not affect
+	 * JSON serialization.
 	 */
 
 	printf("duk_is_array(%ld) = %d\n", (long) arr_idx, (int) duk_is_array(ctx, arr_idx));

--- a/tests/api/test-push-bare-object.c
+++ b/tests/api/test-push-bare-object.c
@@ -1,6 +1,8 @@
 /*===
+obj_idx = 1
 duk_is_object(1) = 1
 .toString rc=0 -> undefined
+obj.inherited = 'undefined'
 json encoded: {"meaningOfLife":42}
 top=2
 ===*/
@@ -12,6 +14,7 @@ void test(duk_context *ctx) {
 	duk_push_int(ctx, 123);  /* dummy */
 
 	obj_idx = duk_push_bare_object(ctx);
+	printf("obj_idx = %ld\n", (long) obj_idx);
 	duk_push_int(ctx, 42);
 	duk_put_prop_string(ctx, obj_idx, "meaningOfLife");
 
@@ -21,8 +24,12 @@ void test(duk_context *ctx) {
 	printf(".toString rc=%ld -> %s\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 
-	duk_json_encode(ctx, obj_idx);  /* in-place */
+	duk_eval_string_noresult(ctx, "Object.prototype.inherited = 'inherit';");
+	(void) duk_get_prop_string(ctx, obj_idx, "inherited");
+	printf("obj.inherited = '%s'\n", duk_to_string(ctx, -1));
+	duk_pop(ctx);
 
+	duk_json_encode(ctx, obj_idx);  /* in-place */
 	printf("json encoded: %s\n", duk_get_string(ctx, obj_idx));
 
 	printf("top=%ld\n", (long) duk_get_top(ctx));

--- a/tests/api/test-push-object.c
+++ b/tests/api/test-push-object.c
@@ -1,6 +1,8 @@
 /*===
+obj_idx = 1
 duk_is_object(1) = 1
 .toString rc=1 -> function toString() { [native code] }
+obj.inherited = 'inherit'
 json encoded: {"meaningOfLife":42}
 top=2
 ===*/
@@ -12,6 +14,7 @@ void test(duk_context *ctx) {
 	duk_push_int(ctx, 123);  /* dummy */
 
 	obj_idx = duk_push_object(ctx);
+	printf("obj_idx = %ld\n", (long) obj_idx);
 	duk_push_int(ctx, 42);
 	duk_put_prop_string(ctx, obj_idx, "meaningOfLife");
 
@@ -23,8 +26,12 @@ void test(duk_context *ctx) {
 	printf(".toString rc=%ld -> %s\n", (long) rc, duk_safe_to_string(ctx, -1));
 	duk_pop(ctx);
 
-	duk_json_encode(ctx, obj_idx);  /* in-place */
+	duk_eval_string_noresult(ctx, "Object.prototype.inherited = 'inherit';");
+	(void) duk_get_prop_string(ctx, obj_idx, "inherited");
+	printf("obj.inherited = '%s'\n", duk_to_string(ctx, -1));
+	duk_pop(ctx);
 
+	duk_json_encode(ctx, obj_idx);  /* in-place */
 	printf("json encoded: %s\n", duk_get_string(ctx, obj_idx));
 
 	printf("top=%ld\n", (long) duk_get_top(ctx));

--- a/website/api/duk_push_bare_array.yaml
+++ b/website/api/duk_push_bare_array.yaml
@@ -1,0 +1,28 @@
+name: duk_push_bare_array
+
+proto: |
+  duk_idx_t duk_push_bare_array(duk_context *ctx);
+
+stack: |
+  [ ... ] -> [ ... arr! ]
+
+summary: |
+  <p>Similar to <code><a href="#duk_push_array">duk_push_array()</a></code>
+  but the pushed array doesn't inherit from any other object, i.e. its internal
+  prototype is <code>null</code>.  Returns non-negative index (relative to
+  stack bottom) of the pushed array.</p>
+
+example: |
+  duk_idx_t arr_idx;
+
+  arr_idx = duk_push_bare_array(ctx);
+
+tags:
+  - stack
+  - object
+
+seealso:
+  - duk_push_array
+  - duk_push_bare_object
+
+introduced: 2.4.0

--- a/website/api/duk_push_bare_object.yaml
+++ b/website/api/duk_push_bare_object.yaml
@@ -24,5 +24,6 @@ tags:
 
 seealso:
   - duk_push_object
+  - duk_push_bare_array
 
 introduced: 2.0.0


### PR DESCRIPTION
The new API call is similar to `duk_push_bare_object()`, pushing an Array instance with no internal prototype.