### PR TITLE
Use bare arrays in compiler, fixing some assertions with memory unsafe behavior

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3422,6 +3422,9 @@ Planned
   '-DFOO(bar)=quux', which were used in some examples but were not
   actually functional (GH-2013, GH-2014)
 
+* Fix several assertion failures with possible memory unsafe behavior
+  (GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036, GH-2065)
+
 * Trivial fixes and cleanups: Windows Date provider return code check
   consistency (GH-1956)
 

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -542,23 +542,23 @@ DUK_LOCAL void duk__init_func_valstack_slots(duk_compiler_ctx *comp_ctx) {
 	DUK_BW_INIT_PUSHBUF(thr, &func->bw_code, DUK__BC_INITIAL_INSTS * sizeof(duk_compiler_instr));
 	/* code_idx = entry_top + 0 */
 
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	func->consts_idx = entry_top + 1;
 	func->h_consts = DUK_GET_HOBJECT_POSIDX(thr, entry_top + 1);
 	DUK_ASSERT(func->h_consts != NULL);
 
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	func->funcs_idx = entry_top + 2;
 	func->h_funcs = DUK_GET_HOBJECT_POSIDX(thr, entry_top + 2);
 	DUK_ASSERT(func->h_funcs != NULL);
 	DUK_ASSERT(func->fnum_next == 0);
 
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	func->decls_idx = entry_top + 3;
 	func->h_decls = DUK_GET_HOBJECT_POSIDX(thr, entry_top + 3);
 	DUK_ASSERT(func->h_decls != NULL);
 
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	func->labelnames_idx = entry_top + 4;
 	func->h_labelnames = DUK_GET_HOBJECT_POSIDX(thr, entry_top + 4);
 	DUK_ASSERT(func->h_labelnames != NULL);
@@ -569,7 +569,7 @@ DUK_LOCAL void duk__init_func_valstack_slots(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(func->h_labelinfos != NULL);
 	DUK_ASSERT(DUK_HBUFFER_HAS_DYNAMIC(func->h_labelinfos) && !DUK_HBUFFER_HAS_EXTERNAL(func->h_labelinfos));
 
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	func->argnames_idx = entry_top + 6;
 	func->h_argnames = DUK_GET_HOBJECT_POSIDX(thr, entry_top + 6);
 	DUK_ASSERT(func->h_argnames != NULL);

--- a/tests/ecmascript/test-bug-compiler-gh2025.js
+++ b/tests/ecmascript/test-bug-compiler-gh2025.js
@@ -1,0 +1,13 @@
+/*===
+A
+B
+done
+===*/
+
+var j;
+var str;
+print('A');
+Object.defineProperty(Array.prototype, "0", { set: function () {}, configurable: true });
+print('B');
+eval( 'for (j in this){\nstr+=j;\n}' );
+print('done');

--- a/tests/ecmascript/test-bug-compiler-gh2026.js
+++ b/tests/ecmascript/test-bug-compiler-gh2026.js
@@ -1,0 +1,11 @@
+/*===
+A
+B
+done
+===*/
+
+print('A');
+Object.defineProperty(Array.prototype, 0, { set: function () {} });
+print('B');
+eval("function\u0009\u2029w(\u000c)\u00a0{\u000d};");
+print('done');

--- a/tests/ecmascript/test-bug-compiler-gh2031.js
+++ b/tests/ecmascript/test-bug-compiler-gh2031.js
@@ -1,0 +1,15 @@
+/*===
+A
+B
+ReferenceError
+===*/
+
+try {
+    print('A');
+    Object.defineProperty(Array.prototype, 0, { set : function ( ) { } } ) ;
+    print('B');
+    eval('var x; for (x++ in [0,1]) {}');
+    print('done');
+} catch (e) {
+    print(e.name);
+}

--- a/tests/ecmascript/test-bug-compiler-gh2033.js
+++ b/tests/ecmascript/test-bug-compiler-gh2033.js
@@ -1,0 +1,11 @@
+/*===
+A
+B
+done
+===*/
+
+print('A');
+Object.defineProperty(Array.prototype, 0, { set : function( ) {} });
+print('B');
+eval('if (true) {} /foo/.test("foo")');
+print('done');

--- a/tests/ecmascript/test-bug-compiler-gh2035.js
+++ b/tests/ecmascript/test-bug-compiler-gh2035.js
@@ -1,0 +1,11 @@
+/*===
+A
+B
+done
+===*/
+
+print('A');
+Object.defineProperty(Array.prototype, 2, { get : Math.random, set : function f ( ) { } } ) ;
+print('B');
+eval ( "function\u0009\u2029w(\u000C)\u00A0{\u000D};" ) ;
+print('done');

--- a/tests/ecmascript/test-bug-compiler-gh2036.js
+++ b/tests/ecmascript/test-bug-compiler-gh2036.js
@@ -1,0 +1,11 @@
+/*===
+A
+B
+done
+===*/
+
+print('A');
+Object.defineProperty(Array.prototype, 0, { get : Math.asin, set : function f( ) { } });
+print('B');
+eval('([ 123 ] / 2)');
+print('done');


### PR DESCRIPTION
The root cause in the assertions errors was that the compiler was not using "bare" arrays but rather standard arrays inheriting from Array.prototype. If the Array.prototype had numeric index entries, it might lead to unintended behavior in the compiler.

Fixes #2025, #2026, #2031, #2033, #2035, #2036.