### PR TITLE
Minor improvements to duk_to_stacktrace() and duk_safe_to_stacktrace()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3396,6 +3396,9 @@ Planned
 2.4.0 (XXXX-XX-XX)
 ------------------
 
+* Add duk_to_stacktrace() and duk_safe_to_stacktrace() to make it easier to
+  get stacktraces in C code (GH-2059, GH-2086)
+
 * Add duk_push_bare_array() to push an Array instance which doesn't
   inherit from anything (GH-2064)
 
@@ -3434,8 +3437,6 @@ Planned
 * Fix MSVC ARM64 detection (GH-2078)
 
 * Various portability fixes (GH-1931, GH-1976)
-
-* Add duk_to_stacktrace() and duk_safe_to_stacktrace() to make it easier to get stacktraces in C
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/doc/release-notes-v2-4.rst
+++ b/doc/release-notes-v2-4.rst
@@ -8,7 +8,12 @@ Release overview
 TBD.
 
 * Symbol built-in is now enabled by default.
-* Add duk_to_stacktrace() and duk_safe_to_stacktrace() to make it easier to get stacktraces in C
+
+* Add duk_push_bare_array() API call which pushes a bare Array, i.e. one
+  that doesn't inherit from Array.prototype.
+
+* Add duk_to_stacktrace() and duk_safe_to_stacktrace() to make it easier
+  to get stacktraces in C code.
 
 Upgrading from Duktape 2.3
 ==========================

--- a/examples/eval/eval.c
+++ b/examples/eval/eval.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
 	duk_context *ctx;
 	int i;
 	const char *res;
-	int rc;
+	duk_int_t rc;
 
 	if (argc < 2) {
 		usage_exit();

--- a/tests/api/test-safe-to-stacktrace.c
+++ b/tests/api/test-safe-to-stacktrace.c
@@ -1,41 +1,86 @@
 /*===
 *** test_1 (duk_safe_call)
-duk_get_top[0] = '0'
-duk_safe_to_stacktrace[0] = 'Error
+top: 0
+duk_safe_to_stacktrace: 'Error: aiee
     at err (eval:1)
     at eval (eval:1) preventsyield'
-duk_get_top[1] = '0'
-duk_safe_to_stacktrace[1] = '4'
-duk_get_top[2] = '0'
-duk_safe_to_stacktrace[2] = 'Error
-    at [anon] (eval:1) preventsyield'
-duk_get_top[3] = '0'
+top: 0
+duk_safe_to_stacktrace: '4'
+top: 0
+duk_safe_to_stacktrace: '[object Object]'
+top: 0
+duk_safe_to_stacktrace: 'oops'
+top: 0
+duk_safe_to_stacktrace: '[object Object]'
+get 1
+duk_safe_to_stacktrace: 'Error: aiee 2
+    at [anon] (eval:2) preventsyield'
+get 1
+get 2
+duk_safe_to_stacktrace: 'Error'
+final top: 0
 ==> rc=0, result='undefined'
 ===*/
 
 static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	(void) udata;
 
-	printf("duk_get_top[0] = '%ld'\n", (long) duk_get_top(ctx));
-
-	duk_peval_string(ctx, "function err() { throw new Error(); }; err();");
-	printf("duk_safe_to_stacktrace[0] = '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	/* Normal case: normal error throw. */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_peval_string(ctx, "(function err() { throw new Error('aiee'); })();");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
 	duk_pop(ctx);
 
-	printf("duk_get_top[1] = '%ld'\n", (long) duk_get_top(ctx));
-
+	/* Uncommon case: coercion argument is not an Error (or even an object). */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
 	duk_peval_string(ctx, "2+2");
-	printf("duk_safe_to_stacktrace[1] = '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
 	duk_pop(ctx);
 
-	printf("duk_get_top[2] = '%ld'\n", (long) duk_get_top(ctx));
-
-	duk_peval_string(ctx, "var err = new Error(); Object.defineProperty(err, 'stack', {get: function() { throw new Error(); }}); throw err;");
-	printf("duk_safe_to_stacktrace[2] = '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	/* Uncommon case: coercion argument is an Object without .stack. */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ foo: 'bar' })");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
 	duk_pop(ctx);
 
-	printf("duk_get_top[3] = '%ld'\n", (long) duk_get_top(ctx));
+	/* Uncommon case: coercion argument is an Object with .stack, but not
+	 * an Error.
+	 */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ stack: 'oops' })");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
 
+	/* Uncommon case: coercion argument is an Object with .stack, but not
+	 * a string.
+	 */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ stack: 123 })");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	/* Uncommon case: coercion fails once. */
+	duk_peval_string(ctx, "var err = new Error('aiee 1'); Object.defineProperty(err, 'stack', {\n"
+	                      "    get: function() { print('get 1'); throw new Error('aiee 2'); }\n"
+	                      "}); throw err;\n");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	/* Uncommon case: coercion fails twice. */
+	duk_peval_string(ctx, "var err = new Error('aiee 1'); Object.defineProperty(err, 'stack', {\n"
+	                      "    get: function() {\n"
+	                      "        print('get 1');\n"
+	                      "        var e = new Error('aiee 2');\n"
+	                      "        Object.defineProperty(e, 'stack', {\n"
+	                      "            get: function() { print('get 2'); throw new Error('aiee 3'); }\n"
+	                      "        });\n"
+	                      "        throw e;\n"
+	                      "    }\n"
+	                      "}); throw err;\n");
+	printf("duk_safe_to_stacktrace: '%s'\n", duk_safe_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 

--- a/tests/api/test-to-stacktrace.c
+++ b/tests/api/test-to-stacktrace.c
@@ -1,35 +1,153 @@
 /*===
 *** test_1 (duk_safe_call)
-duk_get_top[0] = '0'
-duk_to_stacktrace[0] = 'Error
+top: 0
+duk_to_stacktrace: 'Error: aiee
     at err (eval:1)
     at eval (eval:1) preventsyield'
-duk_get_top[1] = '0'
-duk_to_stacktrace[1] = '4'
-duk_get_top[2] = '0'
+final top: 0
 ==> rc=0, result='undefined'
+*** test_2 (duk_safe_call)
+top: 0
+duk_to_stacktrace: '4'
+final top: 0
+==> rc=0, result='undefined'
+*** test_3 (duk_safe_call)
+top: 0
+duk_to_stacktrace: '[object Object]'
+final top: 0
+==> rc=0, result='undefined'
+*** test_4 (duk_safe_call)
+top: 0
+duk_to_stacktrace: 'oops'
+final top: 0
+==> rc=0, result='undefined'
+*** test_5 (duk_safe_call)
+top: 0
+duk_to_stacktrace: '[object Object]'
+final top: 0
+==> rc=0, result='undefined'
+*** test_6 (duk_safe_call)
+get 1
+==> rc=1, result='Error: aiee 2'
+*** test_7 (duk_safe_call)
+get 1
+==> rc=1, result='Error: aiee 2'
 ===*/
 
 static duk_ret_t test_1(duk_context *ctx, void *udata) {
 	(void) udata;
 
-	printf("duk_get_top[0] = '%ld'\n", (long) duk_get_top(ctx));
-
-	duk_peval_string(ctx, "function err() { throw new Error(); }; err();");
-	printf("duk_to_stacktrace[0] = '%s'\n", duk_to_stacktrace(ctx, -1));
+	/* Normal case: normal error throw. */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_peval_string(ctx, "(function err() { throw new Error('aiee'); })();");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
 	duk_pop(ctx);
 
-	printf("duk_get_top[1] = '%ld'\n", (long) duk_get_top(ctx));
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
 
+static duk_ret_t test_2(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion argument is not an Error (or even an object). */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
 	duk_peval_string(ctx, "2+2");
-	printf("duk_to_stacktrace[1] = '%s'\n", duk_to_stacktrace(ctx, -1));
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
 	duk_pop(ctx);
 
-	printf("duk_get_top[2] = '%ld'\n", (long) duk_get_top(ctx));
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
 
+static duk_ret_t test_3(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion argument is an Object without .stack. */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ foo: 'bar' })");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_4(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion argument is an Object with .stack, but not
+	 * an Error.
+	 */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ stack: 'oops' })");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_5(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion argument is an Object with .stack, but not
+	 * a string.
+	 */
+	printf("top: %ld\n", (long) duk_get_top(ctx));
+	duk_eval_string(ctx, "({ stack: 123 })");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_6(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion fails once.  The non-safe variant passes
+	 * the initial error through as is.
+	 */
+	duk_peval_string(ctx, "var err = new Error('aiee 1'); Object.defineProperty(err, 'stack', {\n"
+	                      "    get: function() { print('get 1'); throw new Error('aiee 2'); }\n"
+	                      "}); throw err;\n");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+static duk_ret_t test_7(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	/* Uncommon case: coercion fails twice.  The non-safe variant passes
+	 * the initial error through as is.
+	 */
+	duk_peval_string(ctx, "var err = new Error('aiee 1'); Object.defineProperty(err, 'stack', {\n"
+	                      "    get: function() {\n"
+	                      "        print('get 1');\n"
+	                      "        var e = new Error('aiee 2');\n"
+	                      "        Object.defineProperty(e, 'stack', {\n"
+	                      "            get: function() { print('get 2'); throw new Error('aiee 3'); }\n"
+	                      "        });\n"
+	                      "        throw e;\n"
+	                      "    }\n"
+	                      "}); throw err;\n");
+	printf("duk_to_stacktrace: '%s'\n", duk_to_stacktrace(ctx, -1));
+	duk_pop(ctx);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
 	return 0;
 }
 
 void test(duk_context *ctx) {
 	TEST_SAFE_CALL(test_1);
+	TEST_SAFE_CALL(test_2);
+	TEST_SAFE_CALL(test_3);
+	TEST_SAFE_CALL(test_4);
+	TEST_SAFE_CALL(test_5);
+	TEST_SAFE_CALL(test_6);
+	TEST_SAFE_CALL(test_7);
 }

--- a/website/api/duk_safe_to_stacktrace.yaml
+++ b/website/api/duk_safe_to_stacktrace.yaml
@@ -7,35 +7,34 @@ stack: |
   [ ... val! ... ] -> [ ... val.stack! ... ]
 
 summary: |
-  <p>Like <code><a href="#duk_safe_to_string">duk_safe_to_string()</a></code> but
-  instead of converting a value to a string, it converts an error to a stacktrace.
-  If the object is not an error, it will fallback to duk_safe_to_string(). If there
-  is an error when reading .stack, it will return the stacktrace of that error.</p>
+  <p>Like <code><a href="#duk_to_stacktrace">duk_to_stacktrace()</a></code>
+  but if the coercion fails, duk_to_stacktrace() is applied to the coercion
+  error.  If that also fails, a fixed pre-allocated error string <code>"Error"</code>
+  is used instead (because the string is pre-allocated, this cannot fail due to
+  out-of-memory).</p>
+
+  <p>ECMAScript equivalent:</p>
+  <pre class="ecmascript-code">
+  function duk_safe_to_stacktrace(val) {
+      try {
+          return duk_to_stacktrace(val);
+      } catch (e) {
+          try {
+              return duk_to_stacktrace(e);
+          } catch (e2) {
+              return 'Error';
+          }
+      }
+  }
+  </pre>
 
 example: |
-  /* Throw Error and print stacktrace */
-  duk_eval_string(ctx, "function err() { throw new Error(); }; err();");
-  printf("stacktrace: %s\n", duk_safe_to_stacktrace(ctx, -1));  /* -> "Error at err (eval:1)" */
-  duk_pop(ctx);
-
-  /* Equivalent ECMAScript */
-  try {
-    function err() {
-      throw new Error();
-    }
-    err();
-  } catch (e) {
-    if (e instanceof Error) {
-      var stack = e.stack;
-      if (stack) {
-        console.log(stack);
-      } else {
-        console.log(e.toString());
-      }
-    } else {
-      console.log(e.toString());
-    }
+  if (duk_peval_string(ctx, "1 + 2 +") != 0) {  /* => SyntaxError */
+      printf("failed: %s\n", duk_safe_to_stacktrace(ctx, -1));
+  } else {
+      printf("success\n");
   }
+  duk_pop(ctx);
 
 tags:
   - stack

--- a/website/api/duk_safe_to_string.yaml
+++ b/website/api/duk_safe_to_string.yaml
@@ -18,6 +18,36 @@ summary: |
   <code>printf()</code>.  The only uncaught errors possible are internal
   errors which trigger fatal error handling anyway.</p>
 
+  <p>ECMAScript equivalent:</p>
+  <pre class="ecmascript-code">
+  function duk_safe_to_string(val) {
+      function tostr(x) {
+          try {
+              return String(x);
+          } catch (e) {
+              return e;
+          }
+      }
+
+      // Initial coercion attempt.
+      var t = tostr(val);
+      if (typeof t === 'string') {
+          // ToString() coercion succeeded with a string result, or
+          // coercion failed with a plain string error value; return as is.
+          return t;
+      }
+
+      // Result was an Error or a non-string, try to coerce again.
+      t = tostr(t);
+      if (typeof t === 'string') {
+          return t;
+      }
+
+      // Still an Error or a non-string, return fixed value.
+      return 'Error';
+  }
+  </pre>
+
   <div class="note">
   While the string coercion is safe from error throws, it may have side
   effects in the current implementation.  In particular, the string coercion

--- a/website/api/duk_to_stacktrace.yaml
+++ b/website/api/duk_to_stacktrace.yaml
@@ -7,14 +7,41 @@ stack: |
   [ ... val! ... ] -> [ ... val.stack! ... ]
 
 summary: |
-  <p>Like <code><a href="#duk_to_string">duk_to_string()</a></code> but
-  instead of converting a value to a string, it converts an error to a stacktrace.
-  If the object is not an error, it will fallback to duk_to_string().</p>
+  <p>Coerce an arbitrary value to a stack trace.  The value at <code>idx</code>
+  is expected but not required to be an Error instance.  If the argument is an
+  object, the call looks up the argument's <code>.stack</code> property which
+  becomes the result if the property value is a string.  Otherwise the argument
+  is replaced with <code>duk_to_string(val)</code> to ensure a string result.
+  An error may also be thrown if the coercion fails e.g. due to side effects or
+  out-of-memory.</p>
+
+  <p>There is a safe variant of this API call,
+  <code><a href="#duk_safe_to_stacktrace">duk_safe_to_stacktrace()</a></code>,
+  which may be more useful when dealing with errors.</p>
+
+  <p>ECMAScript equivalent of the value coercion:</p>
+  <pre class="ecmascript-code">
+  function duk_to_stacktrace(val) {
+      if (typeof val === 'object' && val !== null) {  // Require val to be an object.
+          var t = val.stack;  // Side effects, may throw.
+          if (typeof t === 'string') {  // Require .stack to be a string.
+              return t;
+          }
+      }
+      return String(val);  // Side effects, may throw.
+  }
+  </pre>
+
+  <p>The coercion intentionally avoids an <code>instanceof</code> check
+  (based on inheritance) so that the call can also work on foreign Error
+  objects created in another global environment (Realm).</p>
 
 example: |
-  /* Throw Error and print stacktrace */
-  duk_eval_string(ctx, "function err() { throw new Error(); }; err();");
-  printf("stacktrace: %s\n", duk_to_stacktrace(ctx, -1));  /* -> "Error at err (eval:1)" */
+  if (duk_peval_string(ctx, "1 + 2 +") != 0) {  /* => SyntaxError */
+      printf("failed: %s\n", duk_to_stacktrace(ctx, -1));  /* Note: may throw */
+  } else {
+      printf("success\n");
+  }
   duk_pop(ctx);
 
 tags:


### PR DESCRIPTION
- Use duck typing without inheritance check to allow the calls to work on foreign Errors.
- If coercion fails, reduce potential for unbounded recursion in duk_safe_to_stacktrace().
- Documentation and testcase improvements.