### PR TITLE
Fix assertion failure for property-based call errors when Duktape.errCreate returns a callable value

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3425,6 +3425,10 @@ Planned
   '-DFOO(bar)=quux', which were used in some examples but were not
   actually functional (GH-2013, GH-2014)
 
+* Fix error handling corner case when a property-based call (foo.bar())
+  caused an error and Duktape.errCreate returned a callable value (such
+  as Float64Array); this caused an assertion failure (GH-2061, GH-2087)
+
 * Fix several assertion failures with possible memory unsafe behavior
   (GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036, GH-2065)
 

--- a/src-input/duk_api_call.c
+++ b/src-input/duk_api_call.c
@@ -97,18 +97,16 @@ DUK_LOCAL void duk__call_prop_prep_stack(duk_hthread *thr, duk_idx_t normalized_
 
 #if defined(DUK_USE_VERBOSE_ERRORS)
 	if (DUK_UNLIKELY(!duk_is_callable(thr, -1))) {
-		duk_tval *tv_targ;
 		duk_tval *tv_base;
 		duk_tval *tv_key;
 
-		tv_targ = DUK_GET_TVAL_NEGIDX(thr, -1);
+		/* tv_targ is passed on stack top (at index -1). */
 		tv_base = DUK_GET_TVAL_POSIDX(thr, normalized_obj_idx);
 		tv_key = DUK_GET_TVAL_NEGIDX(thr, -nargs - 2);
-		DUK_ASSERT(tv_targ >= thr->valstack_bottom && tv_targ < thr->valstack_top);
 		DUK_ASSERT(tv_base >= thr->valstack_bottom && tv_base < thr->valstack_top);
 		DUK_ASSERT(tv_key >= thr->valstack_bottom && tv_key < thr->valstack_top);
 
-		duk_call_setup_propcall_error(thr, tv_targ, tv_base, tv_key);
+		duk_call_setup_propcall_error(thr, tv_base, tv_key);
 	}
 #endif
 

--- a/src-input/duk_js.h
+++ b/src-input/duk_js.h
@@ -104,7 +104,7 @@ DUK_INTERNAL_DECL duk_int_t duk_handle_call_unprotected_nargs(duk_hthread *thr, 
 DUK_INTERNAL_DECL duk_int_t duk_handle_safe_call(duk_hthread *thr, duk_safe_call_function func, void *udata, duk_idx_t num_stack_args, duk_idx_t num_stack_res);
 DUK_INTERNAL_DECL void duk_call_construct_postprocess(duk_hthread *thr, duk_small_uint_t proxy_invariant);
 #if defined(DUK_USE_VERBOSE_ERRORS)
-DUK_INTERNAL_DECL void duk_call_setup_propcall_error(duk_hthread *thr, duk_tval *tv_targ, duk_tval *tv_base, duk_tval *tv_key);
+DUK_INTERNAL_DECL void duk_call_setup_propcall_error(duk_hthread *thr, duk_tval *tv_base, duk_tval *tv_key);
 #endif
 
 /* bytecode execution */

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -4152,7 +4152,7 @@ DUK_LOCAL DUK_NOINLINE DUK_HOT void duk__js_execute_bytecode_inner(duk_hthread *
 			 * arguments to deal with potentially changed \
 			 * valstack base pointer! \
 			 */ \
-			duk_call_setup_propcall_error(thr, tv__targ, (barg), (carg)); \
+			duk_call_setup_propcall_error(thr, (barg), (carg)); \
 		} \
 		DUK__REPLACE_TOP_A_BREAK(); \
 	}

--- a/tests/ecmascript/test-bug-getpropc-errcreate-gh2061.js
+++ b/tests/ecmascript/test-bug-getpropc-errcreate-gh2061.js
@@ -1,0 +1,18 @@
+/*
+ *  Cleaned up repro from https://github.com/svaarala/duktape/issues/2061.
+ */
+
+/*===
+true
+done
+===*/
+
+try {
+    Duktape.errCreate = function(e) {
+        return Float64Array;
+    };
+    100000 .foo();
+} catch (e) {
+    print(e === Float64Array);
+}
+print('done');


### PR DESCRIPTION
Fix error handling corner case where a property-based call (e.g. `foo.bar()`) causes an error, Duktape.errCreate is defined, and the errCreate() handler returns a callable value (e.g.  `Float64Array`). This caused an assertion failure described in #2061.

Fixes #2061.