### PR TITLE
Fix incorrect handling of zero-length dynamic buffer in base64 fast path decoder

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3417,6 +3417,9 @@ Planned
 * Update UnicodeData.txt and SpecialCasing.txt used for building internal
   Unicode control data to Unicode version 12.1.0 (GH-2085)
 
+* Fix incorrect handling of zero-length dynamic buffer in base-64 fast path
+  decoder (GH-2027, GH-2088)
+
 * Fix Object.getOwnPropertySymbols() behavior for the virtual properties
   of arrays, Strings, and buffer objects: string keys were incorrectly
   included in the result (GH-1978, GH-1979)

--- a/tests/ecmascript/test-bug-base64-dec-zerolen-dynamic-buffer-gh2027.js
+++ b/tests/ecmascript/test-bug-base64-dec-zerolen-dynamic-buffer-gh2027.js
@@ -1,0 +1,11 @@
+/*===
+t1
+t2
+done
+===*/
+
+print('t1');
+var t1 = Duktape.dec('base64', '');  // create zero-size dynamic plain buffer
+print('t2');
+var t2 = Duktape.dec('base64', t1);  // segfault
+print('done');


### PR DESCRIPTION
Fixes #2027.