### PR TITLE
Use bare arrays/objects in more places internally

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3417,6 +3417,11 @@ Planned
 * Update UnicodeData.txt and SpecialCasing.txt used for building internal
   Unicode control data to Unicode version 12.1.0 (GH-2085)
 
+* Use bare objects/arrays in more places internally: variable map and
+  formals array of functions loaded from bytecode (to match behavior of
+  compiled functions), context dump array for duk_push_context_dump(),
+  and error tracedata (GH-2089)
+
 * Fix incorrect handling of zero-length dynamic buffer in base-64 fast path
   decoder (GH-2027, GH-2088)
 

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -626,9 +626,11 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 
 	if (DUK_HOBJECT_HAS_CONSTRUCTABLE((duk_hobject *) h_fun)) {
 		/* Restore empty external .prototype only for constructable
-		 * functions.
+		 * functions.  The prototype object should inherit from
+		 * Object.prototype.
 		 */
 		duk_push_object(thr);
+		DUK_ASSERT(!duk_is_bare_object(thr, -1));
 		duk_dup_m2(thr);
 		duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_CONSTRUCTOR, DUK_PROPDESC_FLAGS_WC);  /* func.prototype.constructor = func */
 		duk_compact_m1(thr);
@@ -640,7 +642,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_PC2LINE, DUK_PROPDESC_FLAGS_WC);
 #endif  /* DUK_USE_PC2LINE */
 
-	duk_push_object(thr);  /* _Varmap */
+	duk_push_bare_object(thr);  /* _Varmap */
 	for (;;) {
 		/* XXX: awkward */
 		p = duk__load_string_raw(thr, p);
@@ -660,7 +662,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	 */
 	arr_limit = DUK_RAW_READ_U32_BE(p);
 	if (arr_limit != DUK__NO_FORMALS) {
-		duk_push_array(thr);  /* _Formals */
+		duk_push_bare_array(thr);  /* _Formals */
 		for (arr_idx = 0; arr_idx < arr_limit; arr_idx++) {
 			p = duk__load_string_raw(thr, p);
 			duk_put_prop_index(thr, -2, arr_idx);

--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -16,7 +16,7 @@ DUK_EXTERNAL void duk_push_context_dump(duk_hthread *thr) {
 	 */
 
 	top = duk_get_top(thr);
-	duk_push_array(thr);
+	duk_push_bare_array(thr);
 	for (idx = 0; idx < top; idx++) {
 		duk_dup(thr, idx);
 		duk_put_prop_index(thr, -2, (duk_uarridx_t) idx);

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -100,6 +100,8 @@ DUK_INTERNAL_DECL duk_bool_t duk_is_string_notsymbol(duk_hthread *thr, duk_idx_t
 
 DUK_INTERNAL_DECL duk_bool_t duk_is_callable_tval(duk_hthread *thr, duk_tval *tv);
 
+DUK_INTERNAL_DECL duk_bool_t duk_is_bare_object(duk_hthread *thr, duk_idx_t idx);
+
 DUK_INTERNAL_DECL duk_hstring *duk_get_hstring(duk_hthread *thr, duk_idx_t idx);
 DUK_INTERNAL_DECL duk_hstring *duk_get_hstring_notsymbol(duk_hthread *thr, duk_idx_t idx);
 DUK_INTERNAL_DECL const char *duk_get_string_notsymbol(duk_hthread *thr, duk_idx_t idx);
@@ -326,6 +328,8 @@ DUK_INTERNAL_DECL duk_int_t duk_pcall_method_flags(duk_hthread *thr, duk_idx_t n
 #if defined(DUK_USE_SYMBOL_BUILTIN)
 DUK_INTERNAL_DECL void duk_to_primitive_ordinary(duk_hthread *thr, duk_idx_t idx, duk_int_t hint);
 #endif
+
+DUK_INTERNAL_DECL void duk_clear_prototype(duk_hthread *thr, duk_idx_t idx);
 
 /* Raw internal valstack access macros: access is unsafe so call site
  * must have a guarantee that the index is valid.  When that is the case,

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -901,6 +901,37 @@ DUK_EXTERNAL void duk_set_prototype(duk_hthread *thr, duk_idx_t idx) {
 	duk_pop(thr);
 }
 
+DUK_INTERNAL void duk_clear_prototype(duk_hthread *thr, duk_idx_t idx) {
+	duk_hobject *obj;
+
+	DUK_ASSERT_API_ENTRY(thr);
+
+	obj = duk_require_hobject(thr, idx);
+	DUK_ASSERT(obj != NULL);
+
+#if defined(DUK_USE_ROM_OBJECTS)
+	if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) obj)) {
+		DUK_ERROR_TYPE(thr, DUK_STR_NOT_CONFIGURABLE);  /* XXX: "read only object"? */
+		DUK_WO_NORETURN(return;);
+	}
+#endif
+
+	DUK_HOBJECT_SET_PROTOTYPE_UPDREF(thr, obj, NULL);
+}
+
+DUK_INTERNAL duk_bool_t duk_is_bare_object(duk_hthread *thr, duk_idx_t idx) {
+	duk_hobject *obj;
+	duk_hobject *proto;
+
+	DUK_ASSERT_API_ENTRY(thr);
+
+	obj = duk_require_hobject(thr, idx);
+	DUK_ASSERT(obj != NULL);
+
+	proto = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, obj);
+	return (proto == NULL);
+}
+
 /*
  *  Object finalizer
  */

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -6238,6 +6238,7 @@ DUK_INTERNAL void duk_pop_3_nodecref_unsafe(duk_hthread *thr) {
  */
 
 /* XXX: pack index range? array index offset? */
+/* XXX: need ability to pack into a bare array? */
 DUK_INTERNAL void duk_pack(duk_hthread *thr, duk_idx_t count) {
 	duk_tval *tv_src;
 	duk_tval *tv_dst;
@@ -6266,6 +6267,7 @@ DUK_INTERNAL void duk_pack(duk_hthread *thr, duk_idx_t count) {
 
 	tv_dst = duk_push_harray_with_size_outptr(thr, (duk_uint32_t) count);  /* XXX: uninitialized would be OK */
 	DUK_ASSERT(count == 0 || tv_dst != NULL);
+	DUK_ASSERT(!duk_is_bare_object(thr, -1));
 
 	/* Copy value stack values directly to the array part without
 	 * any refcount updates: net refcount changes are zero.

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -165,6 +165,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_constructor(duk_hthread *thr) {
 		len_prealloc = len < 64 ? len : 64;
 		a = duk_push_harray_with_size(thr, len_prealloc);
 		DUK_ASSERT(a != NULL);
+		DUK_ASSERT(!duk_is_bare_object(thr, -1));
 		a->length = len;
 		return 1;
 	}

--- a/src-input/duk_bi_buffer.c
+++ b/src-input/duk_bi_buffer.c
@@ -1265,6 +1265,7 @@ DUK_INTERNAL duk_ret_t duk_bi_nodejs_buffer_tojson(duk_hthread *thr) {
 	/* XXX: uninitialized would be OK */
 	DUK_ASSERT_DISABLE((duk_size_t) h_this->length <= (duk_size_t) DUK_UINT32_MAX);
 	tv = duk_push_harray_with_size_outptr(thr, (duk_uint32_t) h_this->length);  /* XXX: needs revision with >4G buffers */
+	DUK_ASSERT(!duk_is_bare_object(thr, -1));
 
 	DUK_ASSERT(h_this->buf != NULL);
 	buf = DUK_HBUFOBJ_GET_SLICE_BASE(thr->heap, h_this);

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -194,9 +194,13 @@ DUK_LOCAL void duk__add_traceback(duk_hthread *thr, duk_hthread *thr_callstack, 
 		arr_size += 2;
 	}
 
-	/* XXX: uninitialized would be OK */
+	/* XXX: Uninitialized would be OK.  Maybe add internal primitive to
+	 * push bare duk_harray with size?
+	 */
 	DUK_D(DUK_DPRINT("preallocated _Tracedata to %ld items", (long) arr_size));
 	tv = duk_push_harray_with_size_outptr(thr, (duk_uint32_t) arr_size);
+	duk_clear_prototype(thr, -1);
+	DUK_ASSERT(duk_is_bare_object(thr, -1));
 	DUK_ASSERT(arr_size == 0 || tv != NULL);
 
 	/* Compiler SyntaxErrors (and other errors) come first, and are
@@ -273,6 +277,7 @@ DUK_LOCAL void duk__add_traceback(duk_hthread *thr, duk_hthread *thr_callstack, 
 		DUK_ASSERT(a != NULL);
 		DUK_ASSERT((duk_uint32_t) (tv - DUK_HOBJECT_A_GET_BASE(thr->heap, (duk_hobject *) a)) == a->length);
 		DUK_ASSERT(a->length == (duk_uint32_t) arr_size);
+		DUK_ASSERT(duk_is_bare_object(thr, -1));
 	}
 #endif
 

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -679,6 +679,7 @@ DUK_INTERNAL duk_ret_t duk_hobject_get_enumerated_keys(duk_hthread *thr, duk_sma
 	/* XXX: uninit would be OK */
 	tv = duk_push_harray_with_size_outptr(thr, (duk_uint32_t) count);
 	DUK_ASSERT(count == 0 || tv != NULL);
+	DUK_ASSERT(!duk_is_bare_object(thr, -1));
 
 	/* Fill result array, no side effects. */
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -212,8 +212,8 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	/*
 	 *  Create required objects:
 	 *    - 'arguments' object: array-like, but not an array
-	 *    - 'map' object: internal object, tied to 'arguments'
-	 *    - 'mappedNames' object: temporary value used during construction
+	 *    - 'map' object: internal object, tied to 'arguments' (bare)
+	 *    - 'mappedNames' object: temporary value used during construction (bare)
 	 */
 
 	arg = duk_push_object_helper(thr,
@@ -236,6 +236,9 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr,
 	i_arg = duk_get_top(thr) - 3;
 	i_map = i_arg + 1;
 	i_mappednames = i_arg + 2;
+	DUK_ASSERT(!duk_is_bare_object(thr, -3));  /* arguments */
+	DUK_ASSERT(duk_is_bare_object(thr, -2));  /* map */
+	DUK_ASSERT(duk_is_bare_object(thr, -1));  /* mappedNames */
 
 	/* [ ... formals arguments map mappedNames ] */
 
@@ -918,6 +921,7 @@ DUK_LOCAL void duk__handle_proxy_for_call(duk_hthread *thr, duk_idx_t idx_func, 
 	duk_push_hobject(thr, h_proxy->target);
 	duk_insert(thr, idx_func + 3);
 	duk_pack(thr, duk_get_top(thr) - (idx_func + 5));
+	DUK_ASSERT(!duk_is_bare_object(thr, -1));
 
 	/* Here:
 	 * idx_func + 0: Proxy object

--- a/tests/api/test-dump-load-constructor-proto.c
+++ b/tests/api/test-dump-load-constructor-proto.c
@@ -1,0 +1,42 @@
+/*
+ *  Dump/load a constructor, check e.g. .prototype.
+ */
+
+/*===
+*** test_1 (duk_safe_call)
+dump
+load
+call
+constructor called
+object
+true
+final top: 1
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_eval_string(ctx,
+		"(function MyConstructor() {\n"
+		"    print('constructor called');\n"
+		"    print(typeof MyConstructor.prototype);\n"
+		"    print(Object.getPrototypeOf(MyConstructor.prototype) === Object.prototype);\n"
+		"})\n");
+
+	printf("dump\n");
+	duk_dump_function(ctx);
+
+	printf("load\n");
+	duk_load_function(ctx);
+
+	printf("call\n");
+	duk_new(ctx, 0);
+
+	printf("final top: %ld\n", (long) duk_get_top(ctx));
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/tests/ecmascript/test-bi-nodejs-buffer-tojson.js
+++ b/tests/ecmascript/test-bi-nodejs-buffer-tojson.js
@@ -7,7 +7,9 @@
 /*===
 node.js Buffer toJSON() test
 object string Buffer object [65,66,67]
+true
 object string Buffer object []
+true
 {"foo":"bar","my_buffer":{"type":"Buffer","data":[241,242,243]}}
 {"foo":"bar","my_buffer":{"type":"Buffer","data":[]}}
 still here
@@ -25,10 +27,12 @@ function nodejsBufferToJsonTest() {
     b[0] = 0x41; b[1] = 0x42; b[2] = 0x43;
     v = b.toJSON();
     print(typeof v, typeof v.type, v.type, typeof v.data, JSON.stringify(v.data));
+    print(Object.getPrototypeOf(v.data) === Array.prototype);
 
     b = new Buffer(0);
     v = b.toJSON();
     print(typeof v, typeof v.type, v.type, typeof v.data, JSON.stringify(v.data));
+    print(Object.getPrototypeOf(v.data) === Array.prototype);
 
     // As part of JSON.stringify()
 

--- a/tests/ecmascript/test-bi-proxy-apply.js
+++ b/tests/ecmascript/test-bi-proxy-apply.js
@@ -16,6 +16,7 @@ true
 true
 undefined
 object 2 123 234 undefined
+true
 VALUE
 - .call(), .apply(), Reflect.apply()
 apply trap
@@ -23,18 +24,21 @@ true
 true
 myThisCall
 object 4 123 234 345
+true
 VALUE
 apply trap
 true
 true
 myThisApply
 object 2 123 234 undefined
+true
 VALUE
 apply trap
 true
 true
 myThisReflectApply
 object 2 123 234 undefined
+true
 VALUE
 - bound function as trap
 function
@@ -111,6 +115,7 @@ function test() {
             print(targ === target);
             print(thisArg);
             print(typeof argArray, argArray.length, argArray[0], argArray[1], argArray[2]);
+            print(Object.getPrototypeOf(argArray) === Array.prototype);
             return 'VALUE';
         }
     };


### PR DESCRIPTION
Reduces impact of a modified Array.prototype.