### PR TITLE
Fix CBOR extra decoding of strings with a lot of concatenated pieces

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3446,6 +3446,9 @@ Planned
 * Fix compile error for extras/eventloop due to missing a header file
   (c_eventloop.h) in the dist package (GH-2090)
 
+* Fix CBOR decoding of text strings and byte strings with a lot of
+  concatenated pieces in the CBOR extra (GH-2093)
+
 * Trivial fixes and cleanups: Windows Date provider return code check
   consistency (GH-1956)
 

--- a/extras/cbor/duk_cbor.c
+++ b/extras/cbor/duk_cbor.c
@@ -718,6 +718,7 @@ static void duk__cbor_decode_and_join_strbuf(duk_cbor_decode_context *dec_ctx, d
 		if (duk__cbor_decode_checkbreak(dec_ctx)) {
 			break;
 		}
+		duk_require_stack(dec_ctx->ctx, 1);
 		duk__cbor_decode_buffer(dec_ctx, expected_base);
 		count++;
 		if (count <= 0) {


### PR DESCRIPTION
The code path was missing a `duk_require_stack()` causing decoding to fail if a text string or a byte string had a lot of pieces.