### PR TITLE
Add derived Docker images and Makefile targets for dist-src and dist-site from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 /duk-low-norefc
 /duk-low-rom
 /libduktape.*
+/docker-input.zip
+/docker-output.zip
 /build/
 /prep/
 /dist/

--- a/Makefile
+++ b/Makefile
@@ -1175,3 +1175,23 @@ massif-%: tests/ecmascript/%.js duk
 massif-helloworld: massif-test-dev-hello-world
 massif-deepmerge: massif-test-dev-deepmerge
 massif-arcfour: massif-test-dev-arcfour
+
+# Docker targets for building images and running specific targets in a
+# docker container for easier reproducibility.
+.PHONY: docker-images
+docker-images:
+	docker build -t duktape-base-ubuntu-18.04 docker/duktape-base-ubuntu-18.04
+	docker build -t duktape-dist-ubuntu-18.04 docker/duktape-dist-ubuntu-18.04
+	docker build -t duktape-site-ubuntu-18.04 docker/duktape-site-ubuntu-18.04
+
+.PHONY: docker-dist-src-master
+docker-dist-src-master:
+	rm -f docker-output.zip
+	docker run --rm -i duktape-dist-ubuntu-18.04 > docker-output.zip
+	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage
+
+.PHONY: docker-dist-site-master
+docker-dist-site-master:
+	rm -f docker-output.zip
+	docker run --rm -i duktape-site-ubuntu-18.04 > docker-output.zip
+	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage

--- a/docker/duktape-dist-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-dist-ubuntu-18.04/Dockerfile
@@ -1,0 +1,14 @@
+FROM duktape-base-ubuntu-18.04:latest
+
+# Dist result is written to stdout as a ZIP, which allows caller to extract
+# result without uid issues (ZIP tolerates leading garbage).
+CMD bash -c 'source emsdk-portable/emsdk_env.sh && \
+	rm -rf duktape && \
+	cp -r repo-snapshots/duktape duktape && \
+	cp -r repo-snapshots/duktape-releases duktape/duktape-releases && \
+	cd duktape && git pull && \
+	cd duktape-releases && git pull && cd .. && \
+	make dist-src && \
+	ls -l duktape-*.tar.* && \
+	zip /tmp/out.zip duktape-*.tar.* && \
+	cat /tmp/out.zip'

--- a/docker/duktape-site-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-site-ubuntu-18.04/Dockerfile
@@ -1,0 +1,14 @@
+FROM duktape-base-ubuntu-18.04:latest
+
+# Dist result is written to stdout as a ZIP, which allows caller to extract
+# result without uid issues (ZIP tolerates leading garbage).
+CMD bash -c 'source emsdk-portable/emsdk_env.sh && \
+	rm -rf duktape && \
+	cp -r repo-snapshots/duktape duktape && \
+	cp -r repo-snapshots/duktape-releases duktape/duktape-releases && \
+	cd duktape && git pull && \
+	cd duktape-releases && git pull && cd .. && \
+	make dist-site && \
+	ls -l duktape-site-*.tar.* && \
+	zip /tmp/out.zip duktape-site-*.tar.* && \
+	cat /tmp/out.zip'


### PR DESCRIPTION
* Add Makefile target 'docker-images' to build the images, in the desired order.
* Add Makefile targets and Docker images for source and website dist from (public) master.
* Trivial .gitignore update.