### PR TITLE
Fix incorrect assert (with no underlying bug) when bound function chain resolves to a Proxy object

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3446,6 +3446,10 @@ Planned
 * Fix several assertion failures with possible memory unsafe behavior
   (GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036, GH-2065)
 
+* Fix incorrect assertion with no underlying bug for resolving bound
+  function chains with a Proxy object (rather than a plain function)
+  as the final non-bound function (GH-2049, GH-2103)
+
 * Fix compile error for extras/eventloop due to missing a header file
   (c_eventloop.h) in the dist package (GH-2090)
 

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -462,6 +462,7 @@ static duk_uint8_t *duk__load_func(duk_hthread *thr, duk_uint8_t *p, duk_uint8_t
 	DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(&h_fun->obj));
 	DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(&h_fun->obj));
 	DUK_ASSERT(!DUK_HOBJECT_IS_THREAD(&h_fun->obj));
+	DUK_ASSERT(!DUK_HOBJECT_IS_PROXY(&h_fun->obj));
 	DUK_ASSERT(!DUK_HOBJECT_HAS_EXOTIC_ARRAY(&h_fun->obj));
 	DUK_ASSERT(!DUK_HOBJECT_HAS_EXOTIC_STRINGOBJ(&h_fun->obj));
 	DUK_ASSERT(!DUK_HOBJECT_HAS_EXOTIC_ARGUMENTS(&h_fun->obj));

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -362,6 +362,7 @@ DUK_INTERNAL void duk_hthread_create_builtin_objects(duk_hthread *thr) {
 		DUK_ASSERT(!DUK_HOBJECT_HAS_COMPFUNC(h));
 		/* DUK_HOBJECT_FLAG_NATFUNC varies */
 		DUK_ASSERT(!DUK_HOBJECT_IS_THREAD(h));
+		DUK_ASSERT(!DUK_HOBJECT_IS_PROXY(h));
 		DUK_ASSERT(!DUK_HOBJECT_HAS_ARRAY_PART(h) || class_num == DUK_HOBJECT_CLASS_ARRAY);
 		/* DUK_HOBJECT_FLAG_STRICT varies */
 		DUK_ASSERT(!DUK_HOBJECT_HAS_NATFUNC(h) ||  /* all native functions have NEWENV */

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -626,7 +626,8 @@ DUK_LOCAL void duk__handle_bound_chain_for_call(duk_hthread *thr,
 		DUK_ASSERT(func != NULL);
 		DUK_ASSERT(!DUK_HOBJECT_HAS_BOUNDFUNC(func));
 		DUK_ASSERT(DUK_HOBJECT_HAS_COMPFUNC(func) ||
-		           DUK_HOBJECT_HAS_NATFUNC(func));
+		           DUK_HOBJECT_HAS_NATFUNC(func) ||
+		           DUK_HOBJECT_IS_PROXY(func));
 	}
 #endif
 }

--- a/tests/ecmascript/test-bug-proxy-bound-assert-gh2049.js
+++ b/tests/ecmascript/test-bug-proxy-bound-assert-gh2049.js
@@ -1,0 +1,44 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2049
+ */
+
+/*===
+still here
+===*/
+
+try {
+    // Note: variable names don't make much sense.
+    var origEval = new Proxy(Function, {});
+    eval = origEval.bind();
+    eval();
+    print('still here');
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+function called
+this: mythis
+args: 1 2 3 4 undefined
+still here
+===*/
+
+try {
+    // Extend original repro case, ensure target gets called.
+    var origEval = new Proxy(function (a, b, c, d, e) {
+        print('function called');
+        print('this:', this);
+        print('args:', a, b, c, d, e);
+    }, {});
+    eval = origEval.bind('mythis', 1);
+    eval(2, 3, 4);
+    print('still here');
+} catch (e) {
+    print(e.stack || e);
+}
+
+/*===
+done
+===*/
+
+print('done');


### PR DESCRIPTION
Fixes #2049.