### PR TITLE
Avoid potential out-of-memory on call stack unwind by preallocating env property table

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3443,6 +3443,9 @@ Planned
   caused an error and Duktape.errCreate returned a callable value (such
   as Float64Array); this caused an assertion failure (GH-2061, GH-2087)
 
+* Fix possible out-of-memory in call stack unwind by preallocating the
+  environment property table on creation (GH-476, GH-2021, GH-2106)
+
 * Fix several assertion failures with possible memory unsafe behavior
   (GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036, GH-2065)
 

--- a/src-input/duk_heap.h
+++ b/src-input/duk_heap.h
@@ -634,6 +634,11 @@ struct duk_heap {
 	duk_int_t stats_putprop_proxy;
 	duk_int_t stats_getvar_all;
 	duk_int_t stats_putvar_all;
+	duk_int_t stats_envrec_delayedcreate;
+	duk_int_t stats_envrec_create;
+	duk_int_t stats_envrec_newenv;
+	duk_int_t stats_envrec_oldenv;
+	duk_int_t stats_envrec_pushclosure;
 #endif
 };
 

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -1177,6 +1177,12 @@ DUK_LOCAL void duk__dump_stats(duk_heap *heap) {
 	                 (long) heap->stats_getvar_all));
 	DUK_D(DUK_DPRINT("stats putvar: all=%ld",
 	                 (long) heap->stats_putvar_all));
+	DUK_D(DUK_DPRINT("stats envrec: delayedcreate=%ld, create=%ld, newenv=%ld, oldenv=%ld, pushclosure=%ld",
+	                 (long) heap->stats_envrec_delayedcreate,
+	                 (long) heap->stats_envrec_create,
+	                 (long) heap->stats_envrec_newenv,
+	                 (long) heap->stats_envrec_oldenv,
+	                 (long) heap->stats_envrec_pushclosure));
 }
 #endif  /* DUK_USE_DEBUG */
 

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1820,6 +1820,7 @@ DUK_LOCAL void duk__call_env_setup(duk_hthread *thr, duk_hobject *func, duk_acti
 
 	if (DUK_LIKELY(func != NULL)) {
 		if (DUK_LIKELY(DUK_HOBJECT_HAS_NEWENV(func))) {
+			DUK_STATS_INC(thr->heap, stats_envrec_newenv);
 			if (DUK_LIKELY(!DUK_HOBJECT_HAS_CREATEARGS(func))) {
 				/* Use a new environment but there's no 'arguments' object;
 				 * delayed environment initialization.  This is the most
@@ -1856,6 +1857,7 @@ DUK_LOCAL void duk__call_env_setup(duk_hthread *thr, duk_hobject *func, duk_acti
 
 			DUK_ASSERT(!DUK_HOBJECT_HAS_CREATEARGS(func));
 
+			DUK_STATS_INC(thr->heap, stats_envrec_oldenv);
 			duk__handle_oldenv_for_call(thr, func, act);
 
 			DUK_ASSERT(act->lex_env != NULL);
@@ -1865,6 +1867,7 @@ DUK_LOCAL void duk__call_env_setup(duk_hthread *thr, duk_hobject *func, duk_acti
 		/* Lightfuncs are always native functions and have "newenv". */
 		DUK_ASSERT(act->lex_env == NULL);
 		DUK_ASSERT(act->var_env == NULL);
+		DUK_STATS_INC(thr->heap, stats_envrec_newenv);
 	}
 }
 

--- a/tests/ecmascript/test-bug-unwind-gh2021.js
+++ b/tests/ecmascript/test-bug-unwind-gh2021.js
@@ -1,0 +1,28 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2021
+ */
+
+/*===
+error
+done
+===*/
+
+function basicTest() {
+    function test(x) {
+        t = new basicTest( 'i' );
+    }
+    var values = [];
+    var i;
+    test(values [0]);
+}
+
+try {
+    basicTest();
+    print('success');
+} catch (e) {
+    // Ignore specific error, expectation is to run out of
+    // call stack.
+    print('error');
+}
+
+print('done');

--- a/tests/perf/test-call-closure-1.js
+++ b/tests/perf/test-call-closure-1.js
@@ -1,0 +1,47 @@
+/*
+ *  Nested function causes an actual scope object to be
+ *  created and closed.
+ */
+
+if (typeof print !== 'function') { print = console.log; }
+
+function func() {
+    var v0 = true;
+    var v1 = true;
+    var v2 = true;
+    var v3 = true;
+    var v4 = true;
+    var v5 = true;
+    var v6 = true;
+    var v7 = true;
+    var v8 = true;
+    var v9 = true;
+
+    // This forces the the scope of 'func' to be preserved
+    // when func() is closed.
+    return function (x) { return eval(x); };
+}
+
+function test() {
+    var i;
+    var ign;
+
+    for (var i = 0; i < 1e5; i++) {
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+        ign = func();
+    }
+}
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+    throw e;
+}

--- a/util/time_multi.py
+++ b/util/time_multi.py
@@ -58,11 +58,7 @@ def main():
     for i in xrange(opts.count):
         time.sleep(opts.sleep)
 
-        cmd = [
-            'time',
-            '-f', '%U',
-            '--quiet'
-        ]
+        cmd = []
         cmd = cmd + args
         #print(repr(cmd))
 
@@ -74,6 +70,7 @@ def main():
 
         killed = False
         retval = -1
+        time_start = time.time()
         try:
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
@@ -87,6 +84,7 @@ def main():
             os.kill(p.pid, signal.SIGKILL)
             retval = p.wait()
             time.sleep(opts.kill_wait)
+        time_end = time.time()
 
         run = {
             'cmd': cmd,
@@ -114,7 +112,7 @@ def main():
             doc['failed'] = True
             break
 
-        time_this = float(stderr)
+        time_this = time_end - time_start
         #print(i, time_this)
 
         if time_min is None:


### PR DESCRIPTION
Fixes #476. Fixes #2021.