### PR TITLE
Bump native recursion count early in call handling

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3452,6 +3452,9 @@ Planned
 * Fix possible out-of-memory in call stack unwind by preallocating the
   environment property table on creation (GH-476, GH-2021, GH-2106)
 
+* Fix possibility for unbounded native recursion without call stack limit
+  backstop when call handling triggers a Proxy trap (GH-2032, GH-2108)
+
 * Fix several assertion failures with possible memory unsafe behavior
   (GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036, GH-2065)
 

--- a/tests/ecmascript/test-bug-valstack-assert-gh2032.js
+++ b/tests/ecmascript/test-bug-valstack-assert-gh2032.js
@@ -1,0 +1,41 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2032
+ */
+
+/*===
+RangeError
+done
+===*/
+
+try {
+    f = function( ) { };
+    Object.defineProperty(f, 'length', { get : new Proxy ( Uint32Array , TextEncoder )});
+
+    // Expected result is call stack exhaustion, due to call handling
+    // triggering a Proxy trap (= another call), and that trap then
+    // triggering another Proxy trap, etc.
+    //
+    // In more detail:
+    //
+    //   1. The .bind() call reads f.length which is a getter.
+    //   2. The getter is a callable Proxy (Uint32Array constructor) so
+    //      its 'apply' trap is read.
+    //   3. Because the handler object is TextEncoder, also callable,
+    //      it has an 'apply' function which is identified as the trap
+    //      (although it's not intended to be used as one).
+    //   4. The apply "trap" (Function.prototype.apply) gets called
+    //      (this is handled inline by duk_js_call.c in practice),
+    //      with arguments: (target, thisArg, argArray).
+    //   5. Function.prototype.apply identifies its first parameter
+    //      as a 'this' binding, and the second parameter as an argument
+    //      array (or array-like), here 'f'.  It will then try to unpack
+    //      the "argument array" (here 'f') to the value stack, and to
+    //      do that, f.length is read again.  This causes a proxy trap,
+    //      leading back to step 2, and infinite loop.
+
+    JSON = f.bind(null, /x{11,111111111}/ );
+} catch (e) {
+    print(e.name);
+}
+
+print('done');


### PR DESCRIPTION
If the native recursion depth is not bumped early in call handling, we may trigger a getter or a Proxy trap before we've increased the recursion depth leading to another native call. This process may continue unchecked by the native call limit in the worst case (such as #2032).

For similar reasons, ensure value stack space early in the call handling -- even before the target function is known and value stack is actually configured for the new function. This is not ideal because each call now involves two value stack resize checks, but if this isn't done, early recursion in call handling may consume the expected value stack reserve (which is the actually triggered effect in #2032).

Fixes #2032.