### PR TITLE
Add docker dist/site targets for current repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1186,12 +1186,28 @@ docker-images:
 
 .PHONY: docker-dist-src-master
 docker-dist-src-master:
-	rm -f docker-output.zip
+	rm -f docker-input.zip docker-output.zip
 	docker run --rm -i duktape-dist-ubuntu-18.04 > docker-output.zip
+	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage
+
+.PHONY: docker-dist-src-wd
+docker-dist-src-wd:
+	rm -f docker-input.zip docker-output.zip
+	#git archive --format zip --output docker-input.zip HEAD
+	zip -1 -q -r docker-input.zip .
+	docker run --rm -i -e STDIN_ZIP=1 duktape-dist-ubuntu-18.04 < docker-input.zip > docker-output.zip
 	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage
 
 .PHONY: docker-dist-site-master
 docker-dist-site-master:
-	rm -f docker-output.zip
+	rm -f docker-input.zip docker-output.zip
 	docker run --rm -i duktape-site-ubuntu-18.04 > docker-output.zip
+	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage
+
+.PHONY: docker-dist-site-wd
+docker-dist-site-wd:
+	rm -f docker-input.zip docker-output.zip
+	#git archive --format zip --output docker-input.zip HEAD
+	zip -1 -q -r docker-input.zip .
+	docker run --rm -i -e STDIN_ZIP=1 duktape-site-ubuntu-18.04 < docker-input.zip > docker-output.zip
 	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage

--- a/docker/duktape-base-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-base-ubuntu-18.04/Dockerfile
@@ -40,18 +40,23 @@ RUN echo "=== Repo snapshots ===" && \
 	git clone https://github.com/svaarala/duktape-wiki.git repo-snapshots/duktape-wiki && \
 	git clone https://github.com/svaarala/duktape-releases.git repo-snapshots/duktape-releases
 
-# /build/duktape is the main repo we're working with.  Copy it from the
-# repo snapshot, but leave the snapshot intact.  Try to minimize network
-# traffic by pulling in some dependencies into the image.
-RUN echo "=== Prepare duktape repo ===" && \
-	cp -r repo-snapshots/duktape duktape && \
-	cp -r repo-snapshots/duktape-releases duktape/duktape-releases && \
-	cd duktape && \
+# /build/duktape-prep is prepared to be close to master in case the derived
+# image needs master.  Copy it from the repo snapshot, but leave the snapshot
+# intact.  Try to minimize network traffic by pulling in some dependencies into
+# the image.
+RUN echo "=== Prepare duktape-prep repo ===" && \
+	cp -r repo-snapshots/duktape duktape-prep && \
+	cp -r repo-snapshots/duktape-releases duktape-prep/duktape-releases && \
+	cd duktape-prep && \
 	make runtestsdeps linenoise UglifyJS2 && \
 	make duktape-releases lz-string jquery-1.11.2.js && \
 	make emscripten && emscripten/emcc -s WASM=0 -o /tmp/test_mandel2.js misc/test_mandel2.c && ls -l /tmp/test_mandel2.js && rm /tmp/test_mandel2.* && \
 	make luajs underscore lodash bluebird.js closure-compiler && \
 	make clean
+
+# Shared script for setting up the duktape/ directory.
+COPY prepare_repo.sh .
+RUN chmod 755 prepare_repo.sh
 
 # Dump some versions.
 RUN echo "=== Versions ===" && \

--- a/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
+++ b/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo "WD: `pwd`"
+rm -rf duktape
+if [ $STDIN_ZIP ]; then
+	echo "STDIN_ZIP set, unzip from STDIN"
+	cat > /tmp/duktape.zip
+	mkdir duktape
+	cd duktape
+	unzip -q /tmp/duktape.zip
+else
+	echo "STDIN_ZIP not set, use master"
+	cp -r duktape-prep duktape
+	cd duktape
+	git pull
+	cd duktape-releases
+	git pull
+	cd ..
+fi

--- a/docker/duktape-dist-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-dist-ubuntu-18.04/Dockerfile
@@ -1,14 +1,8 @@
 FROM duktape-base-ubuntu-18.04:latest
 
+COPY run.sh .
+RUN chmod 755 run.sh
+
 # Dist result is written to stdout as a ZIP, which allows caller to extract
 # result without uid issues (ZIP tolerates leading garbage).
-CMD bash -c 'source emsdk-portable/emsdk_env.sh && \
-	rm -rf duktape && \
-	cp -r repo-snapshots/duktape duktape && \
-	cp -r repo-snapshots/duktape-releases duktape/duktape-releases && \
-	cd duktape && git pull && \
-	cd duktape-releases && git pull && cd .. && \
-	make dist-src && \
-	ls -l duktape-*.tar.* && \
-	zip /tmp/out.zip duktape-*.tar.* && \
-	cat /tmp/out.zip'
+CMD /build/run.sh

--- a/docker/duktape-dist-ubuntu-18.04/run.sh
+++ b/docker/duktape-dist-ubuntu-18.04/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+/build/prepare_repo.sh
+
+source emsdk-portable/emsdk_env.sh
+
+cd duktape
+make clean dist-src
+ls -l duktape-*.tar.*
+zip /tmp/out.zip duktape-*.tar.*
+cat /tmp/out.zip

--- a/docker/duktape-site-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-site-ubuntu-18.04/Dockerfile
@@ -1,14 +1,8 @@
 FROM duktape-base-ubuntu-18.04:latest
 
+COPY run.sh .
+RUN chmod 755 run.sh
+
 # Dist result is written to stdout as a ZIP, which allows caller to extract
 # result without uid issues (ZIP tolerates leading garbage).
-CMD bash -c 'source emsdk-portable/emsdk_env.sh && \
-	rm -rf duktape && \
-	cp -r repo-snapshots/duktape duktape && \
-	cp -r repo-snapshots/duktape-releases duktape/duktape-releases && \
-	cd duktape && git pull && \
-	cd duktape-releases && git pull && cd .. && \
-	make dist-site && \
-	ls -l duktape-site-*.tar.* && \
-	zip /tmp/out.zip duktape-site-*.tar.* && \
-	cat /tmp/out.zip'
+CMD /build/run.sh

--- a/docker/duktape-site-ubuntu-18.04/run.sh
+++ b/docker/duktape-site-ubuntu-18.04/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+/build/prepare_repo.sh
+
+source emsdk-portable/emsdk_env.sh
+
+cd duktape
+make clean dist-site
+ls -l duktape-site-*.tar.*
+zip /tmp/out.zip duktape-site-*.tar.*
+cat /tmp/out.zip


### PR DESCRIPTION
Build from current clone rather than master.  Useful when editing but not pushing changes yet.