### PR TITLE
Expose DUK_INTERNAL_SYMBOL() macro

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3425,6 +3425,10 @@ Planned
   compiled functions), context dump array for duk_push_context_dump(),
   and error tracedata (GH-2089)
 
+* Expose DUK_INTERNAL_SYMBOL() macro; while an application shouldn't
+  normally need to use this macro at all, it may be useful in some cases
+  to peek into Duktape internals (with no versioning guarantees) (GH-2118)
+
 * Accept non-plain buffer types in some examples/extras (cmdline, eventloop,
   logging, print-alert) (GH-2107)
 

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -6,8 +6,6 @@
 #if !defined(DUK_API_INTERNAL_H_INCLUDED)
 #define DUK_API_INTERNAL_H_INCLUDED
 
-#define DUK_INTERNAL_SYMBOL(x)     ("\x82" x)
-
 /* duk_push_sprintf constants */
 #define DUK_PUSH_SPRINTF_INITIAL_SIZE  256L
 #define DUK_PUSH_SPRINTF_SANITY_LIMIT  (1L * 1024L * 1024L * 1024L)

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -321,18 +321,24 @@ struct duk_time_components {
  *  Macros to create Symbols as C statically constructed strings.
  *
  *  Call e.g. as DUK_HIDDEN_SYMBOL("myProperty") <=> ("\xFF" "myProperty").
+ *
  *  Local symbols have a unique suffix, caller should take care to avoid
  *  conflicting with the Duktape internal representation by e.g. prepending
  *  a '!' character: DUK_LOCAL_SYMBOL("myLocal", "!123").
  *
  *  Note that these can only be used for string constants, not dynamically
  *  created strings.
+ *
+ *  You shouldn't normally use DUK_INTERNAL_SYMBOL() at all.  It is reserved
+ *  for Duktape internal symbols only.  There are no versioning guarantees
+ *  for internal symbols.
  */
 
 #define DUK_HIDDEN_SYMBOL(x)     ("\xFF" x)
 #define DUK_GLOBAL_SYMBOL(x)     ("\x80" x)
 #define DUK_LOCAL_SYMBOL(x,uniq) ("\x81" x "\xff" uniq)
 #define DUK_WELLKNOWN_SYMBOL(x)  ("\x81" x "\xff")
+#define DUK_INTERNAL_SYMBOL(x)   ("\x82" x)
 
 /*
  *  If no variadic macros, __FILE__ and __LINE__ are passed through globals

--- a/website/api/defines.html
+++ b/website/api/defines.html
@@ -376,6 +376,12 @@ values:</p>
 <td><code>DUK_WELLKNOWN_SYMBOL(x)</code></td>
 <td>A C literal for a well-known symbol like <code>Symbol.iterator</code></td>
 </tr>
+<tr>
+<td><code>DUK_INTERNAL_SYMBOL(x)</code></td>
+<td>A C literal for a Duktape internal symbol; an application shouldn't
+    normally use this macro at all, it is reserved for Duktape internal
+    symbols only (with no versioning guarantees)</td>
+</tr>
 </table>
 
 <h2>Misc defines</h2>


### PR DESCRIPTION
While normal applications don't need to (and shouldn't) access Duktape internal symbols, there are some cases where access to internal symbols from C code may be useful, so expose the DUK_INTERNAL_SYMBOL() macro. There are no versioning guarantees for such access.