### PR TITLE
Docker improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /libduktape.*
 /docker-input.zip
 /docker-output.zip
+/docker/duktape-base-ubuntu-18.04/gitconfig
 /build/
 /prep/
 /dist/

--- a/Makefile
+++ b/Makefile
@@ -1180,9 +1180,20 @@ massif-arcfour: massif-test-dev-arcfour
 # docker container for easier reproducibility.
 .PHONY: docker-images
 docker-images:
-	docker build -t duktape-base-ubuntu-18.04 docker/duktape-base-ubuntu-18.04
+	if [ -f ~/.gitconfig ]; then cp ~/.gitconfig docker/duktape-base-ubuntu-18.04/gitconfig; else touch docker/duktape-base-ubuntu-18.04/gitconfig; fi
+	docker build --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t duktape-base-ubuntu-18.04 docker/duktape-base-ubuntu-18.04
 	docker build -t duktape-dist-ubuntu-18.04 docker/duktape-dist-ubuntu-18.04
 	docker build -t duktape-site-ubuntu-18.04 docker/duktape-site-ubuntu-18.04
+	docker build -t duktape-shell-ubuntu-18.04 docker/duktape-shell-ubuntu-18.04
+
+.PHONY: docker-clean
+docker-clean:
+	-docker rmi duktape-shell-ubuntu-18.04:latest
+	-docker rmi duktape-site-ubuntu-18.04:latest
+	-docker rmi duktape-dist-ubuntu-18.04:latest
+	-docker rmi duktape-base-ubuntu-18.04:latest
+	@echo ""
+	@echo "Now run 'docker system prune' to free disk space."
 
 .PHONY: docker-dist-src-master
 docker-dist-src-master:
@@ -1211,3 +1222,11 @@ docker-dist-site-wd:
 	zip -1 -q -r docker-input.zip .
 	docker run --rm -i -e STDIN_ZIP=1 duktape-site-ubuntu-18.04 < docker-input.zip > docker-output.zip
 	unzip -t docker-output.zip ; true  # avoid failure due to leading garbage
+
+.PHONY: docker-shell-master
+docker-shell-master:
+	docker run --rm -ti duktape-shell-ubuntu-18.04
+
+.PHONY: docker-shell-wdmount
+docker-shell-wdmount:
+	docker run -v $(shell pwd):/work/duktape --rm -ti duktape-shell-ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ Other development stuff, such as building the website and running test cases,
 is based on a `Makefile` **intended for Linux only**.  See detailed
 instructions in http://wiki.duktape.org/DevelopmentSetup.html.
 
+There are some Docker images which can simplify the development setup.
+These are also **intended for Linux only**.  For example:
+
+    # Build Docker images.  This takes a long time.
+    $ make docker-images
+
+    # Equivalent of 'make dist', but runs inside a container.
+    $ make docker-dist-src-wd
+
+    # Run a shell with /work/duktape containing a disposable master snapshot.
+    $ make docker-shell-master
+
+    # Run a shell with /work/duktape mounted from current directory.
+    # This allows editing, building, testing, etc with an interactive
+    # shell running in the container.
+    $ make docker-shell-wdmount
+
 Branch policy
 -------------
 

--- a/docker/duktape-base-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-base-ubuntu-18.04/Dockerfile
@@ -1,5 +1,10 @@
 FROM ubuntu:18.04
 
+# Username is assumed to be 'duktape' for now, change only UID/GID if required.
+ARG USERNAME=duktape
+ARG UID=1000
+ARG GID=1000
+
 # Set timezone to Europe/Helsinki, some tests depend on it.  Must be done
 # first to avoid interactive prompts in tzdata install.
 RUN echo "=== Timezone setup ===" && \
@@ -11,15 +16,44 @@ RUN echo "=== Timezone setup ===" && \
 RUN echo "=== Node.js and package install ===" && \
 	apt-get update && apt-get install -qy curl && \
 	curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+	dpkg --add-architecture i386 && \
 	apt-get update && \
 	apt-get install -qy \
-		build-essential gcc gcc-multilib clang clang-tools llvm valgrind \
-		python python-yaml make git bc ant diffstat colordiff nodejs \
+		build-essential llvm valgrind libc6-dbg libc6-dbg:i386 \
+		gcc gcc-multilib g++-multilib gcc-4.8 gcc-5 gcc-6 \
+		clang clang-tools clang-3.9 clang-4.0 clang-5.0 clang-6.0 clang-7 \
+		python python-yaml make tig git bc ant diffstat colordiff nodejs \
 		python-bs4 tidy wget curl source-highlight rst2pdf openjdk-11-jre \
-		zip unzip genisoimage vim w3m screen tzdata
+		zip unzip genisoimage vim w3m screen tzdata cdecl
 
-# Use /build for builds, temporaries, etc.
-WORKDIR /build
+# Add non-root uid/gid to image, replicating host uid/gid if possible.
+# Setup the /home/$USERNAME user with some convenience stuff like a .gitconfig,
+# replicating the host setup if possible.  Also set prompts so that it's easy
+# to see when we're running inside a container.
+#
+# https://stackoverflow.com/questions/44683119/dockerfile-replicate-the-host-user-uid-and-gid-to-the-image
+RUN echo "=== User setup, /work directory creation ===" && \
+	groupadd -g $GID -o $USERNAME && \
+	useradd -m -u $UID -g $GID -o -s /bin/bash $USERNAME && \
+	mkdir /work && chown $UID:$GID /work && chmod 755 /work && \
+	echo "PS1='\033[40;37mDOCKER\033[0;34m \u@\h [\w] >>>\033[0m '" > /root/.profile && \
+	echo "PS1='\033[40;37mDOCKER\033[0;34m \u@\h [\w] >>>\033[0m '" > /home/$USERNAME/.profile && \
+	chown $UID:$GID /home/$USERNAME/.profile
+COPY --chown=duktape:duktape gitconfig /home/$USERNAME/.gitconfig
+RUN chmod 644 /home/$USERNAME/.gitconfig
+
+# Switch to non-root user.  (Note that COPY will still copy files as root,
+# so use COPY --chown for files copied.)
+#RUN echo "WHOAMI: `whoami`, UID: `id -u`, GID: `id -g`, HOME: $HOME"
+USER $USERNAME
+#RUN echo "WHOAMI: `whoami`, UID: `id -u`, GID: `id -g`, HOME: $HOME"
+
+# Use /work for builds, temporaries, etc.
+WORKDIR /work
+
+# Shared script for setting up the duktape/ directory.
+COPY --chown=duktape:duktape prepare_repo.sh .
+RUN chmod 755 prepare_repo.sh
 
 # Emscripten.  Source emsdk-portable/emsdk_env.sh to get 'emcc' into PATH.
 RUN echo "=== Emscripten ===" && \
@@ -35,12 +69,12 @@ RUN echo "=== Emscripten ===" && \
 # Clone some useful repositories into 'repo-snapshots' to reduce network
 # traffic.  Derived images can then just 'git pull' to get them up to date.
 RUN echo "=== Repo snapshots ===" && \
-	mkdir /build/repo-snapshots && \
+	mkdir /work/repo-snapshots && \
 	git clone https://github.com/svaarala/duktape.git repo-snapshots/duktape && \
 	git clone https://github.com/svaarala/duktape-wiki.git repo-snapshots/duktape-wiki && \
 	git clone https://github.com/svaarala/duktape-releases.git repo-snapshots/duktape-releases
 
-# /build/duktape-prep is prepared to be close to master in case the derived
+# /work/duktape-prep is prepared to be close to master in case the derived
 # image needs master.  Copy it from the repo snapshot, but leave the snapshot
 # intact.  Try to minimize network traffic by pulling in some dependencies into
 # the image.
@@ -53,10 +87,6 @@ RUN echo "=== Prepare duktape-prep repo ===" && \
 	make emscripten && emscripten/emcc -s WASM=0 -o /tmp/test_mandel2.js misc/test_mandel2.c && ls -l /tmp/test_mandel2.js && rm /tmp/test_mandel2.* && \
 	make luajs underscore lodash bluebird.js closure-compiler && \
 	make clean
-
-# Shared script for setting up the duktape/ directory.
-COPY prepare_repo.sh .
-RUN chmod 755 prepare_repo.sh
 
 # Dump some versions.
 RUN echo "=== Versions ===" && \

--- a/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
+++ b/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
@@ -3,8 +3,10 @@
 set -e
 
 echo "WD: `pwd`"
-rm -rf duktape
-if [ $STDIN_ZIP ]; then
+if [ -d duktape ]; then
+	echo "duktape/ already exists, use as is"
+	cd duktape
+elif [ $STDIN_ZIP ]; then
 	echo "STDIN_ZIP set, unzip from STDIN"
 	cat > /tmp/duktape.zip
 	mkdir duktape

--- a/docker/duktape-dist-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-dist-ubuntu-18.04/Dockerfile
@@ -1,8 +1,8 @@
 FROM duktape-base-ubuntu-18.04:latest
 
-COPY run.sh .
+COPY --chown=duktape:duktape run.sh .
 RUN chmod 755 run.sh
 
 # Dist result is written to stdout as a ZIP, which allows caller to extract
 # result without uid issues (ZIP tolerates leading garbage).
-CMD /build/run.sh
+CMD /work/run.sh

--- a/docker/duktape-dist-ubuntu-18.04/run.sh
+++ b/docker/duktape-dist-ubuntu-18.04/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-/build/prepare_repo.sh
+/work/prepare_repo.sh
 
 source emsdk-portable/emsdk_env.sh
 

--- a/docker/duktape-shell-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-shell-ubuntu-18.04/Dockerfile
@@ -1,0 +1,6 @@
+FROM duktape-base-ubuntu-18.04:latest
+
+COPY --chown=duktape:duktape run.sh .
+RUN chmod 755 run.sh
+
+CMD /work/run.sh

--- a/docker/duktape-shell-ubuntu-18.04/run.sh
+++ b/docker/duktape-shell-ubuntu-18.04/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+/work/prepare_repo.sh
+
+source emsdk-portable/emsdk_env.sh
+
+cd duktape
+/bin/bash --login

--- a/docker/duktape-site-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-site-ubuntu-18.04/Dockerfile
@@ -1,8 +1,8 @@
 FROM duktape-base-ubuntu-18.04:latest
 
-COPY run.sh .
+COPY --chown=duktape:duktape run.sh .
 RUN chmod 755 run.sh
 
 # Dist result is written to stdout as a ZIP, which allows caller to extract
 # result without uid issues (ZIP tolerates leading garbage).
-CMD /build/run.sh
+CMD /work/run.sh

--- a/docker/duktape-site-ubuntu-18.04/run.sh
+++ b/docker/duktape-site-ubuntu-18.04/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-/build/prepare_repo.sh
+/work/prepare_repo.sh
 
 source emsdk-portable/emsdk_env.sh
 


### PR DESCRIPTION
* Use /work instead of /build inside Docker image.
* If /work/duktape exists, use it as is.  This is useful if docker call site mounts /work/duktape manually.
* Add GCC and Clang versions to docker base image, and some small useful packages.
* Add a 'shell' image for testing stuff in a container.
* Run as non-root in Docker containers.
* Colorized prompts to distinguish in-docker vs. out-of-docker easily.
* Gitignore and Makefile updates.  Add 'docker-clean' Makefile target to delete images.  Add 'docker-shell-master' and 'docker-shell-wdmount' targets to use the shell container.
* Short README entry on Docker images.