### PR TITLE
Rewrite Makefiles for Examples

### DIFF
--- a/dist-files/Makefile.cmdline
+++ b/dist-files/Makefile.cmdline
@@ -3,45 +3,57 @@
 #  The example program here is the Duktape command line tool.
 #
 
-DUKTAPE_SOURCES = src/duktape.c
+DUKTAPE_SOURCES = src/duktape.o
 
 CMDLINE_SOURCES = \
-	examples/cmdline/duk_cmdline.c
+	examples/cmdline/duk_cmdline.o
 
 CC = gcc
-CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
-CCOPTS += -I./examples/cmdline -I./src   # duktape.h and duk_config.h must be in include path
-CCLIBS = -lm
+LD = $(CC)
+CFLAGS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CFLAGS += -I./examples/cmdline -I./src   # duktape.h and duk_config.h must be in include path
+LDFLAGS = -lm
+EXTRA_TARGETS =
+
+RM = rm -f
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
 
 # Enable print() and alert() for command line using an optional extra module.
-CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
-CMDLINE_SOURCES += extras/print-alert/duk_print_alert.c
+CFLAGS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
+CMDLINE_SOURCES += extras/print-alert/duk_print_alert.o
 
 # Enable console object (console.log() etc) for command line.
-CCOPTS += -DDUK_CMDLINE_CONSOLE_SUPPORT -I./extras/console
-CMDLINE_SOURCES += extras/console/duk_console.c
+CFLAGS += -DDUK_CMDLINE_CONSOLE_SUPPORT -I./extras/console
+CMDLINE_SOURCES += extras/console/duk_console.o
 
 # Enable Duktape.Logger for command line.
-CCOPTS += -DDUK_CMDLINE_LOGGING_SUPPORT -I./extras/logging
-CMDLINE_SOURCES += extras/logging/duk_logging.c
+CFLAGS += -DDUK_CMDLINE_LOGGING_SUPPORT -I./extras/logging
+CMDLINE_SOURCES += extras/logging/duk_logging.o
 
 # Enable Duktape 1.x module loading for command line.
-CCOPTS += -DDUK_CMDLINE_MODULE_SUPPORT -I./extras/module-duktape
-CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.c
+CFLAGS += -DDUK_CMDLINE_MODULE_SUPPORT -I./extras/module-duktape
+CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.o
 
 # If you want linenoise, you can enable these.  At the moment linenoise
 # will cause some harmless compilation warnings.
-#CCOPTS += -DDUK_CMDLINE_FANCY -I./linenoise
-#CMDLINE_SOURCES += linenoise/linenoise.c
-#duk: linenoise
+#CFLAGS += -DDUK_CMDLINE_FANCY -I./linenoise -D_POSIX_C_SOURCE=200809L 
+#CMDLINE_SOURCES += linenoise/linenoise.o
+#EXTRA_TARGETS += linenoise
 
 # Use the tools/configure.py utility to modify Duktape default configuration:
 # http://duktape.org/guide.html#compiling
 # http://wiki.duktape.org/Configuring.html
 
-duk: $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)
-	$(CC) -o $@ $(DEFINES) $(CCOPTS) $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) $(CCLIBS)
+duk: $(EXTRA_TARGETS) $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)
+	$(LD) -o $@ $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) $(LDFLAGS)
 
-linenoise/linenoise.c: linenoise
+all: duk
+
+clean:
+	$(RM) $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) duk
+	$(RM) -r linenoise
+
 linenoise:
-	git clone https://github.com/antirez/linenoise.git
+	git clone -b fix-compile-warnings-duktape https://github.com/svaarala/linenoise.git

--- a/dist-files/Makefile.codepage
+++ b/dist-files/Makefile.codepage
@@ -1,6 +1,19 @@
 CC = gcc
+LD = $(CC)
 
-codepage:
-	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
-		src/duktape.c examples/codepage-conv/duk_codepage_conv.c \
-		examples/codepage-conv/test.c -lm
+RM = rm -f
+
+CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc
+LDFLAGS = -lm
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = src/duktape.o examples/codepage-conv/duk_codepage_conv.o \
+	examples/codepage-conv/test.o
+
+codepage: $(OBJECTS)
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+
+clean:
+	$(RM) $(OBJECTS) codepage

--- a/dist-files/Makefile.dukdebug
+++ b/dist-files/Makefile.dukdebug
@@ -2,40 +2,58 @@
 #  Duktape command line tool with debugger support.
 #
 
-DUKTAPE_SOURCES = prep/duktape.c
+DUKTAPE_SOURCES = src-debug/duktape.o
 
-# Windows (MinGW): use examples/debug-trans-socket/duk_trans_socket_windows.c
-# and link with -lws2_32.
 CMDLINE_SOURCES = \
-	examples/cmdline/duk_cmdline.c \
-	examples/debug-trans-socket/duk_trans_socket_unix.c
+	examples/cmdline/duk_cmdline.o
 
 CC = gcc
-CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
-CCOPTS += -I./prep -I./examples/cmdline -I./examples/debug-trans-socket
-CCOPTS += -DDUK_CMDLINE_DEBUGGER_SUPPORT     # enable --debugger in ./duk
-CCLIBS = -lm
+LD = $(CC)
+CFLAGS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CFLAGS += -I./src-debug -I./examples/cmdline -I./examples/debug-trans-socket
+CFLAGS += -DDUK_CMDLINE_DEBUGGER_SUPPORT # enable --debugger in ./dukd
+LDFLAGS = -lm
+
+# If compiling for Windows, pass WINDOWS=1 to make.
+ifeq ($(WINDOWS),1)
+	CMDLINE_SOURCES += examples/debug-trans-socket/duk_trans_socket_windows.o
+	LDFLAGS += -lws2_32
+else
+	CMDLINE_SOURCES += examples/debug-trans-socket/duk_trans_socket_unix.o
+endif
+
+RM = rm -f
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
 
 # Enable a few optional modules.
-CCOPTS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
-CMDLINE_SOURCES += extras/print-alert/duk_print_alert.c
-CCOPTS += -DDUK_CMDLINE_CONSOLE_SUPPORT -I./extras/console
-CMDLINE_SOURCES += extras/console/duk_console.c
-CCOPTS += -DDUK_CMDLINE_LOGGING_SUPPORT -I./extras/logging
-CMDLINE_SOURCES += extras/logging/duk_logging.c
-CCOPTS += -DDUK_CMDLINE_MODULE_SUPPORT -I./extras/module-duktape
-CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.c
+CFLAGS += -DDUK_CMDLINE_PRINTALERT_SUPPORT -I./extras/print-alert
+CMDLINE_SOURCES += extras/print-alert/duk_print_alert.o
+CFLAGS += -DDUK_CMDLINE_CONSOLE_SUPPORT -I./extras/console
+CMDLINE_SOURCES += extras/console/duk_console.o
+CFLAGS += -DDUK_CMDLINE_LOGGING_SUPPORT -I./extras/logging
+CMDLINE_SOURCES += extras/logging/duk_logging.o
+CFLAGS += -DDUK_CMDLINE_MODULE_SUPPORT -I./extras/module-duktape
+CMDLINE_SOURCES += extras/module-duktape/duk_module_duktape.o
+
+all: dukd
 
 # Use tools/configure.py to prepare Duktape config header and sources with
 # custom configuration.
-duk: $(CMDLINE_SOURCES)
-	@rm -rf prep
+src-debug:
 	python2 tools/configure.py \
 		--source-directory src-input \
-		--output-directory prep \
+		--output-directory $@ \
 		--config-metadata config \
 		-DDUK_USE_DEBUGGER_SUPPORT \
 		-DDUK_USE_INTERRUPT_COUNTER \
 		-DDUK_USE_DEBUGGER_DUMPHEAP \
 		-DDUK_USE_DEBUGGER_INSPECT
-	$(CC) -o $@ $(DEFINES) $(CCOPTS) $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) $(CCLIBS)
+
+dukd: src-debug $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES)
+	$(LD) -o $@ $(DUKTAPE_SOURCES) $(CMDLINE_SOURCES) $(LDFLAGS)
+
+clean:
+	$(RM) $(OBJECTS) dukd
+	$(RM) -r src-debug

--- a/dist-files/Makefile.eval
+++ b/dist-files/Makefile.eval
@@ -3,7 +3,22 @@
 #
 
 CC = gcc
+LD = $(CC)
 
-eval:
-	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
-		src/duktape.c examples/eval/eval.c -lm
+RM = rm -f
+
+CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc
+LDFLAGS = -lm
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = src/duktape.o examples/eval/eval.o
+
+eval: $(OBJECTS)
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+
+all: eval
+
+clean:
+	$(RM) $(OBJECTS) eval

--- a/dist-files/Makefile.eventloop
+++ b/dist-files/Makefile.eventloop
@@ -3,22 +3,37 @@
 #
 
 CC = gcc
+LD = $(CC)
 
-evloop:
+RM = rm -f
+
+CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc
+LDFLAGS = -lm -lncurses
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = \
+	examples/eventloop/main.o \
+	examples/eventloop/c_eventloop.o \
+	examples/eventloop/poll.o \
+	examples/eventloop/socket.o \
+	examples/eventloop/fileio.o \
+	examples/eventloop/ncurses.o \
+	src/duktape.o \
+
+all: evloop
+
+evloop: $(OBJECTS)
 	@echo "NOTE: The eventloop is example is intended to be used on Linux"
-	@echo "      or other common UNIX variants.  It is not fully portable."
+	@echo "	  or other common UNIX variants.  It is not fully portable."
 	@echo ""
 
-	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
-		examples/eventloop/main.c \
-		examples/eventloop/c_eventloop.c \
-		examples/eventloop/poll.c \
-		examples/eventloop/socket.c \
-		examples/eventloop/fileio.c \
-		examples/eventloop/ncurses.c \
-		src/duktape.c \
-		-lm -lncurses
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
 
 	@echo ""
 	@echo "NOTE: You must 'cd examples/eventloop' before you execute the"
-	@echo "      eventloop binary: it relies on finding .js files in CWD"
+	@echo "	  eventloop binary: it relies on finding .js files in CWD"
+
+clean:
+	$(RM) $(OBJECTS) evloop

--- a/dist-files/Makefile.hello
+++ b/dist-files/Makefile.hello
@@ -8,19 +8,26 @@
 #  Makefile uses the combined source file.
 #
 
-DUKTAPE_SOURCES = src/duktape.c
+DUKTAPE_SOURCES = src/duktape.o
 
 # Compiler options are quite flexible.  GCC versions have a significant impact
 # on the size of -Os code, e.g. gcc-4.6 is much worse than gcc-4.5.
 
 CC = gcc
-CCOPTS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
-CCOPTS += -I./src  # for combined sources
-CCLIBS = -lm
-DEFINES =
+LD = $(CC)
+CFLAGS = -Os -pedantic -std=c99 -Wall -fstrict-aliasing -fomit-frame-pointer
+CFLAGS += -I./src  # for combined sources
+LDFLAGS = -lm
 
 # If you want a 32-bit build on a 64-bit host
-#CCOPTS += -m32
+#CFLAGS += -m32
+
+RM = rm -f
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = examples/hello/hello.o
 
 # Use the tools/configure.py utility to modify Duktape default configuration:
 # http://duktape.org/guide.html#compiling
@@ -28,5 +35,10 @@ DEFINES =
 
 # For debugging, use -O0 -g -ggdb, and don't add -fomit-frame-pointer
 
-hello: $(DUKTAPE_SOURCES) examples/hello/hello.c
-	$(CC) -o $@ $(DEFINES) $(CCOPTS) $(DUKTAPE_SOURCES) examples/hello/hello.c $(CCLIBS)
+hello: $(DUKTAPE_SOURCES) $(OBJECTS)
+	$(LD) -o $@ $(DUKTAPE_SOURCES) $(OBJECTS) $(LDFLAGS)
+
+all: hello
+
+clean:
+	$(RM) $(DUKTAPE_SOURCES) $(OBJECTS) hello

--- a/dist-files/Makefile.jsoncbor
+++ b/dist-files/Makefile.jsoncbor
@@ -3,8 +3,20 @@
 #
 
 CC = gcc
+LD = $(CC)
+CFLAGS = -std=c99 -Wall -Wextra -O2
+CFLAGS += -Isrc -Iextras/cbor  # for combined sources
+LDFLAGS = -lm
 
-jsoncbor:
-	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc -Iextras/cbor \
-		src/duktape.c extras/cbor/duk_cbor.c extras/cbor/jsoncbor.c \
-		-lm
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = src/duktape.o extras/cbor/duk_cbor.o extras/cbor/jsoncbor.o
+
+jsoncbor: $(OBJECTS)
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+
+all: jsoncbor
+
+clean:
+	$(RM) $(OBJECTS) jsoncbor

--- a/dist-files/Makefile.jxpretty
+++ b/dist-files/Makefile.jxpretty
@@ -3,8 +3,20 @@
 #
 
 CC = gcc
+LD = $(CC)
+CFLAGS = -std=c99 -Wall -Wextra -O2
+CFLAGS += -Isrc  # for combined sources
+LDFLAGS = -lm
 
-jxpretty:
-	$(CC) -o $@ -std=c99 -Wall -Wextra -O2 -Isrc \
-		src/duktape.c examples/jxpretty/jxpretty.c \
-		-lm
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = src/duktape.o examples/jxpretty/jxpretty.o
+
+jxpretty: $(OBJECTS)
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+
+all: jxpretty
+
+clean:
+	$(RM) $(OBJECTS) jxpretty

--- a/dist-files/Makefile.sandbox
+++ b/dist-files/Makefile.sandbox
@@ -3,7 +3,20 @@
 #
 
 CC = gcc
+LD = $(CC)
+CFLAGS = -std=c99 -Wall -Wextra -O2
+CFLAGS += -Isrc  # for combined sources
+LDFLAGS = -lm
 
-sandbox:
-	$(CC) -o $@ -std=c99 -O2 -Wall -Wextra -Isrc/ \
-		src/duktape.c examples/sandbox/sandbox.c -lm
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+OBJECTS = src/duktape.o examples/sandbox/sandbox.o
+
+sandbox: $(OBJECTS)
+	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+
+all: sandbox
+
+clean:
+	$(RM) $(OBJECTS) sandbox


### PR DESCRIPTION
This changes the Makefiles so that they now build incrementally. Previously if you wanted to rebuild an example yo would have to manually delete the binary, and rebuild the entire example, including duktape. This will only rebuild the files that have changed, so duktape will no longer be rebuilt every time, as well, as no longer requiring the user to delete the output binary manually when they want to rebuild the example. It changes the name of the output binary of ```Makefile.dukdebug``` from ```duk``` to ```dukd``` so that the command line example and the debug command line example don't produce the same binary.