### PR TITLE
Fix incorrect assertion in heap destruction finalizer runs

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3479,6 +3479,11 @@ Planned
   function chains with a Proxy object (rather than a plain function)
   as the final non-bound function (GH-2049, GH-2103)
 
+* Fix incorrect assertion with no underlying bug for "thr == heap_thread"
+  during heap destruction finalizer runs; the assert is untrue when a
+  finalizer (executed during heap destruction) resumes a coroutine (GH-2030,
+  GH-2132)
+
 * Fix compile error for extras/eventloop due to missing a header file
   (c_eventloop.h) in the dist package (GH-2090)
 

--- a/src-input/duk_bi_thread.c
+++ b/src-input/duk_bi_thread.c
@@ -135,6 +135,18 @@ DUK_INTERNAL duk_ret_t duk_bi_thread_resume(duk_hthread *ctx) {
 		duk_pop(thr);
 	}
 
+#if 0
+	/* This check would prevent a heap destruction time finalizer from
+	 * launching a coroutine, which would ensure that during finalization
+	 * 'thr' would always equal heap_thread.  Normal runtime finalizers
+	 * run with ms_running == 0, i.e. outside mark-and-sweep.  See GH-2030.
+	 */
+	if (thr->heap->ms_running) {
+		DUK_D(DUK_DPRINT("refuse Duktape.Thread.resume() when ms_running == 1"));
+		goto state_error;
+	}
+#endif
+
 	/*
 	 *  The error object has been augmented with a traceback and other
 	 *  info from its creation point -- usually another thread.  The

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -257,8 +257,14 @@ DUK_LOCAL void duk__free_run_finalizers(duk_heap *heap) {
 
 	/* Prevent finalize_list processing and mark-and-sweep entirely.
 	 * Setting ms_running = 1 also prevents refzero handling from moving
-	 * objects away from the heap_allocated list (the flag name is a bit
-	 * misleading here).
+	 * objects away from the heap_allocated list.  The flag name is a bit
+	 * misleading here.
+	 *
+	 * We're running finalizers with ms_running == 1 here, something that
+	 * doesn't happen with normal mark-and-sweep.  This is unfortunate, as
+	 * it caused GH-2030 and makes runtime assertions weaker.  It would be
+	 * better to use a different flag or mark heap destruction state
+	 * specially so the asserts could be stronger.
 	 */
 	DUK_ASSERT(heap->pf_prevent_count == 0);
 	heap->pf_prevent_count = 1;

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1202,6 +1202,8 @@ DUK_LOCAL duk_hobject *duk__resolve_target_func_and_this_binding(duk_hthread *th
 		tv_func = DUK_GET_TVAL_POSIDX(thr, idx_func);
 		DUK_ASSERT(tv_func != NULL);
 
+		DUK_DD(DUK_DDPRINT("target func: %!iT", tv_func));
+
 		if (DUK_TVAL_IS_OBJECT(tv_func)) {
 			func = DUK_TVAL_GET_OBJECT(tv_func);
 

--- a/tests/ecmascript/test-bug-finalizer-coroutine-resume-gh2030-1.js
+++ b/tests/ecmascript/test-bug-finalizer-coroutine-resume-gh2030-1.js
@@ -1,0 +1,17 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2030
+ */
+
+/*===
+done
+===*/
+
+Duktape.fin(
+    Proxy, function( ) {
+        function f( ) {
+            performance ('g called', isFinite(Error), TypeError(g));
+        }
+        Duktape.Thread.resume(new Duktape.Thread(f));
+});
+
+print('done');

--- a/tests/ecmascript/test-bug-finalizer-coroutine-resume-gh2030-2.js
+++ b/tests/ecmascript/test-bug-finalizer-coroutine-resume-gh2030-2.js
@@ -1,0 +1,22 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2030
+ *
+ *  Testcase adapted a bit in this version.
+ */
+
+/*===
+done
+finalizer called
+f called
+===*/
+
+Duktape.fin(Proxy, function( ) {
+    function f() {
+        print('f called');
+        performance();  // Throws.
+    }
+    print('finalizer called');
+    Duktape.Thread.resume(new Duktape.Thread(f));
+});
+
+print('done');


### PR DESCRIPTION
When the heap is being destroyed we run finalizers with ms_running set to 1 (normally this never happens, as finalizers execute outside of mark-and-sweeps). If a finalizer resumes a coroutine in this situation, an assertion for `(ms_running == 0 || thr == thr->heap->heap_thread)` no longer holds.

Disable the assertion for now and add some code comments explaining why. A better fix in a follow-up would be to cover the situation separately in assertions.

Fixes #2030.