### PR TITLE
Fix parsing of division following a post-increment/post-decrement

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3459,6 +3459,10 @@ Planned
 * Add --no-auto-complete option to 'duk' to disable linenoise auto
   completion (GH-2131)
 
+* Fix incorrect parsing of post-increment/post-decrement followed by
+  division (e.g. "z++ / 20"), the slash was interpreted as beginning
+  a regexp (GH-2140)
+
 * Fix incorrect handling of zero-length dynamic buffer in base-64 fast path
   decoder (GH-2027, GH-2088)
 

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -368,8 +368,8 @@ DUK_LOCAL const duk_uint8_t duk__token_lbp[] = {
 	DUK__MK_LBP(DUK__BP_MULTIPLICATIVE),                      /* DUK_TOK_DIV */
 	DUK__MK_LBP(DUK__BP_MULTIPLICATIVE),                      /* DUK_TOK_MOD */
 	DUK__MK_LBP(DUK__BP_EXPONENTIATION),                      /* DUK_TOK_EXP */
-	DUK__MK_LBP(DUK__BP_POSTFIX),                             /* DUK_TOK_INCREMENT */
-	DUK__MK_LBP(DUK__BP_POSTFIX),                             /* DUK_TOK_DECREMENT */
+	DUK__MK_LBP_FLAGS(DUK__BP_POSTFIX, DUK__TOKEN_LBP_FLAG_NO_REGEXP),  /* DUK_TOK_INCREMENT */
+	DUK__MK_LBP_FLAGS(DUK__BP_POSTFIX, DUK__TOKEN_LBP_FLAG_NO_REGEXP),  /* DUK_TOK_DECREMENT */
 	DUK__MK_LBP(DUK__BP_SHIFT),                               /* DUK_TOK_ALSHIFT */
 	DUK__MK_LBP(DUK__BP_SHIFT),                               /* DUK_TOK_ARSHIFT */
 	DUK__MK_LBP(DUK__BP_SHIFT),                               /* DUK_TOK_RSHIFT */

--- a/tests/ecmascript/test-bug-regexp-postincr.js
+++ b/tests/ecmascript/test-bug-regexp-postincr.js
@@ -1,0 +1,52 @@
+/*
+ *  Regexp vs. division parsing bug repro.
+ */
+
+/*===
+67
+5
+5
+5.05
+4.95
+0.000004166666666666667
+0.000004166666666666667
+0.000004163077043181538
+0.0000041700190039138786
+0.000004163232000266447
+0.5
+SyntaxError
+/foo/
+done
+===*/
+
+try {
+    // Original issue found in the wild.
+    print(eval('z = 0; [67,69,71][0|z++/20]'));
+
+    // Coverage for similar issues.
+    print(eval('z = 100; z++/20'));
+    print(eval('z = 100; z--/20'));
+    print(eval('z = 100; ++z/20'));
+    print(eval('z = 100; --z/20'));
+
+    // Other related tests.
+    print(eval('x = 100; y = 200; z = 300; w = 400; x++/y++/z++/w++;'));
+    print(eval('x = 100; y = 200; z = 300; w = 400; x--/y--/z--/w--;'));
+    print(eval('x = 100; y = 200; z = 300; w = 400; ++x/++y/++z/++w;'));
+    print(eval('x = 100; y = 200; z = 300; w = 400; --x/--y/--z/--w;'));
+    print(eval('x = 100; y = 200; z = 300; w = 400; x++/y--/++z/--w;'));
+    print(eval('x = 100; y = 200; x++/y;'));
+    try {
+        print(String(eval('x = 100; y = 200; x++\n/foo/')));
+    } catch (e) {
+        print(e.name);
+    }
+    try {
+        print(String(eval('x = 100; y = 200; x++;\n/foo/')));
+    } catch (e) {
+        print(e.name);
+    }
+} catch (e) {
+    print(e.stack || e);
+}
+print('done');

--- a/tests/ecmascript/test-dev-regexp-parse.js
+++ b/tests/ecmascript/test-dev-regexp-parse.js
@@ -25,11 +25,13 @@ try {
 }
 
 /*===
-ReferenceError
+SyntaxError
 ReferenceError
 ===*/
 
-/* These parse as RegExp literals and cause an "invalid LHS" ReferenceError. */
+/* This is a SyntaxError, as the ++ has no base value.  (V8 seems to
+ * cause a ReferenceError for this.)
+ */
 
 try {
     eval("++/foo/");
@@ -37,6 +39,8 @@ try {
 } catch (e) {
     print(e.name);
 }
+
+/* This parses as a RegExp literal and causes an "invalid LHS" ReferenceError. */
 
 try {
     eval("/foo/++");


### PR DESCRIPTION
Fix parsing of a division following a post-increment/post-decrement. For example, `x++/20` was parsed as a post-increment followed by an unterminated RegExp instead of a post-increment followed by division as it should.