### PR TITLE
Docker base image improvements

### DIFF
--- a/docker/duktape-base-ubuntu-18.04/Dockerfile
+++ b/docker/duktape-base-ubuntu-18.04/Dockerfile
@@ -52,20 +52,27 @@ USER $USERNAME
 # Use /work for builds, temporaries, etc.
 WORKDIR /work
 
+# Emscripten.  Source emsdk-portable/emsdk_env.sh to get 'emcc' into PATH.
+#RUN echo "=== Emscripten (emsdk-portable) ===" && \
+#	wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz && \
+#	tar xvfz emsdk-portable.tar.gz && \
+#	cd emsdk-portable && \
+#	./emsdk update && \
+#	./emsdk install latest && \
+#	./emsdk activate latest && \
+#	cd .. && \
+#	rm emsdk-portable.tar.gz
+
+# Emscripten.  Source emsdk/emsdk_env.sh to get 'emcc' into PATH.
+RUN echo "=== Emscripten (emsdk) ===" && \
+	git clone https://github.com/emscripten-core/emsdk && \
+	cd emsdk && \
+	./emsdk install latest && \
+	./emsdk activate latest
+
 # Shared script for setting up the duktape/ directory.
 COPY --chown=duktape:duktape prepare_repo.sh .
 RUN chmod 755 prepare_repo.sh
-
-# Emscripten.  Source emsdk-portable/emsdk_env.sh to get 'emcc' into PATH.
-RUN echo "=== Emscripten ===" && \
-	wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz && \
-	tar xvfz emsdk-portable.tar.gz && \
-	cd emsdk-portable && \
-	./emsdk update && \
-	./emsdk install latest && \
-	./emsdk activate latest && \
-	cd .. && \
-	rm emsdk-portable.tar.gz
 
 # Clone some useful repositories into 'repo-snapshots' to reduce network
 # traffic.  Derived images can then just 'git pull' to get them up to date.
@@ -91,11 +98,11 @@ RUN echo "=== Prepare duktape-prep repo ===" && \
 # Initialize Emscripten cached bytecode files.
 RUN echo "=== Prepare Emscripten cached bytecode files ===" && \
 	cp -r duktape-prep /tmp/duktape-emcc-init && \
-	bash -c '. emsdk-portable/emsdk_env.sh && cd /tmp/duktape-emcc-init && make emscriptenluatest dukweb.js' && \
+	bash -c '. emsdk/emsdk_env.sh && cd /tmp/duktape-emcc-init && make emscriptenluatest dukweb.js' && \
 	rm -rf /tmp/duktape-emcc-init /tmp/duk-emcc*
 
 # Dump some versions.
 RUN echo "=== Versions ===" && \
 	echo "GCC:" && gcc -v && \
 	echo "CLANG:" && clang -v && \
-	bash -c 'echo "EMCC:" && . emsdk-portable/emsdk_env.sh && emcc -v'
+	bash -c 'echo "EMCC:" && . emsdk/emsdk_env.sh && emcc -v'

--- a/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
+++ b/docker/duktape-base-ubuntu-18.04/prepare_repo.sh
@@ -2,18 +2,26 @@
 
 set -e
 
+echo "--- Setting up /work/duktape ---"
 echo "WD: `pwd`"
 if [ -d duktape ]; then
-	echo "duktape/ already exists, use as is"
+	echo "duktape/ already exists: use as is"
 	cd duktape
 elif [ $STDIN_ZIP ]; then
-	echo "STDIN_ZIP set, unzip from STDIN"
+	echo "STDIN_ZIP set: unzip from STDIN"
 	cat > /tmp/duktape.zip
 	mkdir duktape
 	cd duktape
 	unzip -q /tmp/duktape.zip
+	# Reduce I/O for some common cases.
+	if [ ! -d duktape-releases ]; then
+		cp -r ../repo-snapshots/duktape-releases duktape-releases
+		cd duktape-releases
+		git pull
+		cd ..
+	fi
 else
-	echo "STDIN_ZIP not set, use master"
+	echo "STDIN_ZIP not set: use master"
 	cp -r duktape-prep duktape
 	cd duktape
 	git pull
@@ -21,3 +29,5 @@ else
 	git pull
 	cd ..
 fi
+echo "--- Done setting up /work/duktape ---"
+echo ""

--- a/docker/duktape-dist-ubuntu-18.04/run.sh
+++ b/docker/duktape-dist-ubuntu-18.04/run.sh
@@ -4,7 +4,7 @@ set -e
 
 /work/prepare_repo.sh
 
-source emsdk-portable/emsdk_env.sh
+source emsdk/emsdk_env.sh
 
 cd duktape
 make clean dist-src

--- a/docker/duktape-shell-ubuntu-18.04/run.sh
+++ b/docker/duktape-shell-ubuntu-18.04/run.sh
@@ -4,7 +4,7 @@ set -e
 
 /work/prepare_repo.sh
 
-source emsdk-portable/emsdk_env.sh
+source emsdk/emsdk_env.sh
 
 cd duktape
 /bin/bash --login

--- a/docker/duktape-site-ubuntu-18.04/run.sh
+++ b/docker/duktape-site-ubuntu-18.04/run.sh
@@ -4,7 +4,7 @@ set -e
 
 /work/prepare_repo.sh
 
-source emsdk-portable/emsdk_env.sh
+source emsdk/emsdk_env.sh
 
 cd duktape
 make clean dist-site


### PR DESCRIPTION
* Use emscripten-core/emsdk for emcc init.
* Better emcc cache warming in init so that emcc targets then build without compiling library bc files.
* Reduce I/O for STDIN_ZIP case by copying duktape-releases from repo snapshots.