### PR TITLE
Require duk -b to run bytecode files

### DIFF
--- a/doc/bytecode.rst
+++ b/doc/bytecode.rst
@@ -76,7 +76,7 @@ The command line tool can also execute bytecode functions; it will just load
 a function and call it without arguments, as if a program function was being
 executed::
 
-    ./duk /tmp/program.bin
+    ./duk -b /tmp/program.bin
 
 When to use bytecode dump/load
 ==============================


### PR DESCRIPTION
When bytecode files are loaded, there are no memory safety guarantees for invalid inputs.  Reject bytecode files unless -b is given to explicitly allow automatic bytecode file detection.