### PR TITLE
Array handling improvements, fix GH-2023

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3459,6 +3459,11 @@ Planned
 * Add --no-auto-complete option to 'duk' to disable linenoise auto
   completion (GH-2131)
 
+* Add support for keeping an array's internal array part in
+  Object.defineProperty(), previously the array part was always
+  abandoned if an array index was defined using Object.defineProperty()
+  (even if property attributes were correct) (GH-2146)
+
 * Fix incorrect parsing of post-increment/post-decrement followed by
   division (e.g. "z++ / 20"), the slash was interpreted as beginning
   a regexp (GH-2140)
@@ -3490,8 +3495,8 @@ Planned
   backstop when call handling triggers a Proxy trap (GH-2032, GH-2108)
 
 * Fix several assertion failures with possible memory unsafe behavior
-  (GH-2022, GH-2024, GH-2025, GH-2026, GH-2031, GH-2033, GH-2035, GH-2036,
-  GH-2065, GH-2115, GH-2138)
+  (GH-2022, GH-2023, GH-2024, GH-2025, GH-2026, GH-2031, GH-2033, GH-2035,
+  GH-2036, GH-2065, GH-2115, GH-2138, GH-2146)
 
 * Fix incorrect assertion with no underlying bug for resolving bound
   function chains with a Proxy object (rather than a plain function)

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -229,7 +229,7 @@ static duk_ret_t wrapped_compile_execute(duk_context *ctx, void *udata) {
 			memcpy(buf, (const void *) src_data, src_len);
 			duk_load_function(ctx);
 		} else {
-			duk_type_error(ctx, "bytecode input rejected (use -b to allow bytecode inputs)");
+			(void) duk_type_error(ctx, "bytecode input rejected (use -b to allow bytecode inputs)");
 		}
 	} else {
 		/* Source code. */

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2952,7 +2952,7 @@ DUK_INTERNAL void duk_js_execute_bytecode(duk_hthread *exec_thr) {
 #endif
 			DUK_DDD(DUK_DDDPRINT("after setjmp, delayed catch setup: %ld\n", (long) delayed_catch_setup));
 
-			if (DUK_UNLIKELY(delayed_catch_setup)) {
+			if (DUK_UNLIKELY(delayed_catch_setup != 0)) {
 				duk_hthread *thr = entry_thread->heap->curr_thread;
 
 				delayed_catch_setup = 0;

--- a/tests/ecmascript/test-bi-array-proto-map-sparse.js
+++ b/tests/ecmascript/test-bi-array-proto-map-sparse.js
@@ -1,0 +1,21 @@
+/*===
+10000001
+10000001
+25
+call count: 1
+done
+===*/
+
+try {
+    var callCount = 0;
+    var a = []; a[1e7] = 5;
+    print(a.length);
+    var b = a.map(function (v) { callCount++; return v*v; });
+    print(b.length);
+    print(b[1e7]);
+    print('call count: ' + callCount);
+} catch (e) {
+    print(e.stack || e);
+}
+
+print('done');

--- a/tests/ecmascript/test-bi-object-defineproperty-arridx.js
+++ b/tests/ecmascript/test-bi-object-defineproperty-arridx.js
@@ -1,0 +1,68 @@
+/*
+ *  Object.defineProperty() array part behavior coverage.
+ */
+
+/*===
+1000
+foo foo undefined undefined
+1000000001
+foo foo undefined bar
+1000
+foo foo undefined undefined
+1001
+foo foo bar undefined
+999
+foo undefined foo undefined undefined undefined
+done
+===*/
+
+function test() {
+    var A;
+    var i;
+
+    // These maintain the array part.
+    A = [];
+    for (i = 0; i < 1000; i++) {
+        Object.defineProperty(A, i, { value: 'foo', writable: true, enumerable: true, configurable: true });
+    }
+    print(A.length);
+    print(A[0], A[999], A[1000], A[1e9]);
+    //print(JSON.stringify(Duktape.info(A)));
+
+    // This abandons it, array would become too sparse.
+    Object.defineProperty(A, 1e9, { value: 'bar', writable: true, enumerable: true, configurable: true });
+    print(A.length);
+    print(A[0], A[999], A[1000], A[1e9]);
+    //print(JSON.stringify(Duktape.info(A)));
+
+    // These maintain the array part.
+    A = [];
+    for (i = 0; i < 1000; i++) {
+        Object.defineProperty(A, i, { value: 'foo', writable: true, enumerable: true, configurable: true });
+    }
+    print(A.length);
+    print(A[0], A[999], A[1000], A[1e9]);
+    //print(JSON.stringify(Duktape.info(A)));
+
+    // This abandons it, non-standard attributes.
+    Object.defineProperty(A, 1000, { value: 'bar', writable: true, enumerable: false, configurable: true });
+    print(A.length);
+    print(A[0], A[999], A[1000], A[1e9]);
+    //print(JSON.stringify(Duktape.info(A)));
+
+    // These maintain the array part, despite there being gaps.
+    A = [];
+    for (i = 0; i < 1000; i += 2) {
+        Object.defineProperty(A, i, { value: 'foo', writable: true, enumerable: true, configurable: true });
+    }
+    print(A.length);
+    print(A[0], A[1], A[998], A[999], A[1000], A[1e9]);
+    //print(JSON.stringify(Duktape.info(A)));
+}
+
+try {
+    test();
+} catch (e) {
+    print(e.stack || e);
+}
+print('done');

--- a/tests/ecmascript/test-bug-props-asize-gh2023-2.js
+++ b/tests/ecmascript/test-bug-props-asize-gh2023-2.js
@@ -1,0 +1,15 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2023
+ *
+ *  Modified variant.
+ */
+
+/*===
+done
+===*/
+
+var input = [];
+input[65536] = 0;
+var output = input.map(Math.cos);
+
+print('done');

--- a/tests/ecmascript/test-bug-props-asize-gh2023.js
+++ b/tests/ecmascript/test-bug-props-asize-gh2023.js
@@ -1,0 +1,16 @@
+/*
+ *  https://github.com/svaarala/duktape/issues/2023
+ */
+
+/*===
+done
+===*/
+
+function mapchar ( v ) { }
+var input ;
+var round ;
+input = [ ] ;
+input[ 65536 ] = 0 ;
+input.map( mapchar ).join( '' );
+
+print('done');


### PR DESCRIPTION
- Fix #2023.
- Add support for keeping array part in Object.defineProperty(); previously array part was abandoned when defining array indices with Object.defineProperty().
- Add support for abandoning array part to internal variants of defineProperty(); previously array part was never dropped, affecting e.g. Array .map() behavior.
- Misc logging and compile warning fixes.