### PR TITLE
Fixes to internal property handling, e.g. inheritance of _Formals

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -104,6 +104,7 @@ bugs, provided ideas, etc; roughly in order of appearance):
 * Wilhelm Wanecek (https://github.com/wanecek)
 * Andrew Janke (https://github.com/apjanke)
 * Unamer (https://github.com/unamer)
+* Karl Dahlke
 
 If you are accidentally missing from this list, send me an e-mail
 (``sami.vaarala@iki.fi``) and I'll fix the omission.

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ clean:
 	@rm -f libduktape*.so*
 	@rm -f duktape-*.tar.*
 	@rm -f duktape-*.iso
+	@rm -f docker-input.zip docker-output.zip
 	@rm -f doc/*.html
 	@rm -f src-input/*.pyc tools/*.pyc util/*.pyc
 	@rm -rf massif.out.* ms_print.tmp.*

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3464,6 +3464,9 @@ Planned
   abandoned if an array index was defined using Object.defineProperty()
   (even if property attributes were correct) (GH-2146)
 
+* Rework some internal property handling call sites and helpers to e.g.
+  avoid inheriting internal properties when not intended (GH-2149)
+
 * Fix incorrect parsing of post-increment/post-decrement followed by
   division (e.g. "z++ / 20"), the slash was interpreted as beginning
   a regexp (GH-2140)
@@ -3474,6 +3477,9 @@ Planned
 * Fix Object.getOwnPropertySymbols() behavior for the virtual properties
   of arrays, Strings, and buffer objects: string keys were incorrectly
   included in the result (GH-1978, GH-1979)
+
+* Fix Date .setTime(), setYear(), etc behavior for a frozen Date instance;
+  they should be allowed, but were rejected with a TypeError (GH-2149)
 
 * Fix compile error (missing DUK_DCERROR_UNSUPPORTED macro) when compiling
   with RegExp support disabled (GH-1990, GH-1991)

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -86,7 +86,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_string_prop(duk_hthread *thr, duk_uint8_t *p, d
 	duk_hstring *h_str;
 	duk_tval *tv;
 
-	tv = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) func, DUK_HTHREAD_GET_STRING(thr, stridx));
+	tv = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, (duk_hobject *) func, stridx);
 	if (tv != NULL && DUK_TVAL_IS_STRING(tv)) {
 		h_str = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h_str != NULL);
@@ -103,7 +103,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_string_prop(duk_hthread *thr, duk_uint8_t *p, d
 DUK_LOCAL duk_uint8_t *duk__dump_buffer_prop(duk_hthread *thr, duk_uint8_t *p, duk_bufwriter_ctx *bw_ctx, duk_hobject *func, duk_small_uint_t stridx) {
 	duk_tval *tv;
 
-	tv = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) func, DUK_HTHREAD_GET_STRING(thr, stridx));
+	tv = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, (duk_hobject *) func, stridx);
 	if (tv != NULL && DUK_TVAL_IS_BUFFER(tv)) {
 		duk_hbuffer *h_buf;
 		h_buf = DUK_TVAL_GET_BUFFER(tv);
@@ -122,7 +122,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_uint32_prop(duk_hthread *thr, duk_uint8_t *p, d
 	duk_tval *tv;
 	duk_uint32_t val;
 
-	tv = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) func, DUK_HTHREAD_GET_STRING(thr, stridx));
+	tv = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, (duk_hobject *) func, stridx);
 	if (tv != NULL && DUK_TVAL_IS_NUMBER(tv)) {
 		val = (duk_uint32_t) DUK_TVAL_GET_NUMBER(tv);
 	} else {
@@ -134,15 +134,11 @@ DUK_LOCAL duk_uint8_t *duk__dump_uint32_prop(duk_hthread *thr, duk_uint8_t *p, d
 }
 
 DUK_LOCAL duk_uint8_t *duk__dump_varmap(duk_hthread *thr, duk_uint8_t *p, duk_bufwriter_ctx *bw_ctx, duk_hobject *func) {
-	duk_tval *tv;
+	duk_hobject *h;
 
-	tv = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) func, DUK_HTHREAD_STRING_INT_VARMAP(thr));
-	if (tv != NULL && DUK_TVAL_IS_OBJECT(tv)) {
-		duk_hobject *h;
+	h = duk_hobject_get_varmap(thr, (duk_hobject *) func);
+	if (h != NULL) {
 		duk_uint_fast32_t i;
-
-		h = DUK_TVAL_GET_OBJECT(tv);
-		DUK_ASSERT(h != NULL);
 
 		/* We know _Varmap only has own properties so walk property
 		 * table directly.  We also know _Varmap is dense and all
@@ -180,11 +176,10 @@ DUK_LOCAL duk_uint8_t *duk__dump_varmap(duk_hthread *thr, duk_uint8_t *p, duk_bu
 }
 
 DUK_LOCAL duk_uint8_t *duk__dump_formals(duk_hthread *thr, duk_uint8_t *p, duk_bufwriter_ctx *bw_ctx, duk_hobject *func) {
-	duk_tval *tv;
+	duk_harray *h;
 
-	tv = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) func, DUK_HTHREAD_STRING_INT_FORMALS(thr));
-	if (tv != NULL && DUK_TVAL_IS_OBJECT(tv)) {
-		duk_harray *h;
+	h = duk_hobject_get_formals(thr, (duk_hobject *) func);
+	if (h != NULL) {
 		duk_uint32_t i;
 
 		/* Here we rely on _Formals being a dense array containing
@@ -192,10 +187,6 @@ DUK_LOCAL duk_uint8_t *duk__dump_formals(duk_hthread *thr, duk_uint8_t *p, duk_b
 		 * tweaked by the application (which we don't support right
 		 * now).
 		 */
-		h = (duk_harray *) DUK_TVAL_GET_OBJECT(tv);
-		DUK_ASSERT(h != NULL);
-		DUK_ASSERT(DUK_HOBJECT_IS_ARRAY((duk_hobject *) h));
-		DUK_ASSERT(h->length <= DUK_HOBJECT_GET_ASIZE((duk_hobject *) h));
 
 		p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U, p);
 		DUK_ASSERT(h->length != DUK__NO_FORMALS);  /* limits */

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -226,6 +226,14 @@ DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_short_raw(duk_hthread *thr, duk
 	 duk_get_prop_stridx_short_raw((thr), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
 DUK_INTERNAL_DECL duk_bool_t duk_get_prop_stridx_boolean(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_bool_t *out_has_prop);  /* [] -> [] */
 
+DUK_INTERNAL_DECL duk_bool_t duk_xget_owndataprop(duk_hthread *thr, duk_idx_t obj_idx);
+DUK_INTERNAL_DECL duk_bool_t duk_xget_owndataprop_stridx(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx);
+DUK_INTERNAL_DECL duk_bool_t duk_xget_owndataprop_stridx_short_raw(duk_hthread *thr, duk_uint_t packed_args);
+#define duk_xget_owndataprop_stridx_short(thr,obj_idx,stridx) \
+	(DUK_ASSERT_EXPR((duk_int_t) (obj_idx) >= -0x8000L && (duk_int_t) (obj_idx) <= 0x7fffL), \
+	 DUK_ASSERT_EXPR((duk_int_t) (stridx) >= 0 && (duk_int_t) (stridx) <= 0xffffL), \
+	 duk_xget_owndataprop_stridx_short_raw((thr), (((duk_uint_t) (obj_idx)) << 16) + ((duk_uint_t) (stridx))))
+
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx);     /* [val] -> [] */
 DUK_INTERNAL_DECL duk_bool_t duk_put_prop_stridx_short_raw(duk_hthread *thr, duk_uint_t packed_args);
 #define duk_put_prop_stridx_short(thr,obj_idx,stridx) \

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4773,7 +4773,7 @@ DUK_EXTERNAL void duk_push_global_object(duk_hthread *thr) {
 
 /* XXX: size optimize */
 DUK_LOCAL void duk__push_stash(duk_hthread *thr) {
-	if (!duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE)) {
+	if (!duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE)) {
 		DUK_DDD(DUK_DDDPRINT("creating heap/global/thread stash on first use"));
 		duk_pop_unsafe(thr);
 		duk_push_bare_object(thr);
@@ -6818,7 +6818,7 @@ DUK_LOCAL const char *duk__push_string_tval_readable(duk_hthread *thr, duk_tval 
 				 * but traverse inheritance chain.
 				 */
 				duk_tval *tv_msg;
-				tv_msg = duk_hobject_find_existing_entry_tval_ptr(thr->heap, h, DUK_HTHREAD_STRING_MESSAGE(thr));
+				tv_msg = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, h, DUK_STRIDX_MESSAGE);
 				if (tv_msg != NULL && DUK_TVAL_IS_STRING(tv_msg)) {
 					/* It's critical to avoid recursion so
 					 * only summarize a string .message.

--- a/src-input/duk_bi_boolean.c
+++ b/src-input/duk_bi_boolean.c
@@ -30,7 +30,7 @@ DUK_INTERNAL duk_ret_t duk_bi_boolean_prototype_tostring_shared(duk_hthread *thr
 		DUK_ASSERT(h != NULL);
 
 		if (DUK_HOBJECT_GET_CLASS_NUMBER(h) == DUK_HOBJECT_CLASS_BOOLEAN) {
-			duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
+			duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 			DUK_ASSERT(duk_is_boolean(thr, -1));
 			goto type_ok;
 		}

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -127,7 +127,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 	DUK_ASSERT_TOP(thr, 0);  /* fixed arg count */
 
 	duk_push_this(thr);
-	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_TRACEDATA);
+	duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_TRACEDATA);
 	idx_td = duk_get_top_index(thr);
 
 	duk_push_hstring_stridx(thr, DUK_STRIDX_NEWLINE_4SPACE);

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2087,7 +2087,7 @@ DUK_LOCAL duk_bool_t duk__enc_value(duk_json_enc_ctx *js_ctx, duk_idx_t idx_hold
 #endif
 		case DUK_HOBJECT_CLASS_BOOLEAN: {
 			DUK_DDD(DUK_DDDPRINT("value is a Boolean/Buffer/Pointer object -> get internal value"));
-			duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
+			duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 			duk_remove_m2(thr);
 			break;
 		}

--- a/src-input/duk_bi_number.c
+++ b/src-input/duk_bi_number.c
@@ -25,7 +25,7 @@ DUK_LOCAL duk_double_t duk__push_this_number_plain(duk_hthread *thr) {
 		DUK_ERROR_TYPE(thr, "number expected");
 		DUK_WO_NORETURN(return 0.0;);
 	}
-	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
+	duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 	DUK_ASSERT(duk_is_number(thr, -1));
 	DUK_DDD(DUK_DDDPRINT("number object: %!T, internal value: %!T",
 	                     (duk_tval *) duk_get_tval(thr, -2), (duk_tval *) duk_get_tval(thr, -1)));

--- a/src-input/duk_bi_pointer.c
+++ b/src-input/duk_bi_pointer.c
@@ -28,7 +28,7 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_constructor(duk_hthread *thr) {
 		                              DUK_HOBJECT_CLASS_AS_FLAGS(DUK_HOBJECT_CLASS_POINTER),
 		                              DUK_BIDX_POINTER_PROTOTYPE);
 
-		/* Pointer object internal value is immutable */
+		/* Pointer object internal value is immutable. */
 		duk_dup_0(thr);
 		duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	}
@@ -60,7 +60,7 @@ DUK_INTERNAL duk_ret_t duk_bi_pointer_prototype_tostring_shared(duk_hthread *thr
 			goto type_error;
 		}
 
-		duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
+		duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 	} else {
 		goto type_error;
 	}

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -169,8 +169,8 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_shared_getter(duk_hthread *thr) {
 	magic = duk_get_current_magic(thr);
 
 	if (DUK_HOBJECT_GET_CLASS_NUMBER(h) == DUK_HOBJECT_CLASS_REGEXP) {
-		duk_get_prop_stridx_short(thr, 0, DUK_STRIDX_INT_SOURCE);
-		duk_get_prop_stridx_short(thr, 0, DUK_STRIDX_INT_BYTECODE);
+		duk_xget_owndataprop_stridx_short(thr, 0, DUK_STRIDX_INT_SOURCE);
+		duk_xget_owndataprop_stridx_short(thr, 0, DUK_STRIDX_INT_BYTECODE);
 		h_bc = duk_require_hstring(thr, -1);
 		re_flags = (duk_small_uint_t) DUK_HSTRING_GET_DATA(h_bc)[0];  /* Safe even if h_bc length is 0 (= NUL) */
 		duk_pop(thr);

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -246,7 +246,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_to_string(duk_hthread *thr) {
 			goto type_error;
 		}
 
-		duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
+		duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_VALUE);
 		DUK_ASSERT(duk_is_string(thr, -1));
 	} else {
 		goto type_error;

--- a/src-input/duk_bi_symbol.c
+++ b/src-input/duk_bi_symbol.c
@@ -73,7 +73,6 @@ DUK_INTERNAL duk_ret_t duk_bi_symbol_constructor_shared(duk_hthread *thr) {
 
 DUK_LOCAL duk_hstring *duk__auto_unbox_symbol(duk_hthread *thr, duk_tval *tv_arg) {
 	duk_tval *tv;
-	duk_tval tv_val;
 	duk_hobject *h_obj;
 	duk_hstring *h_str;
 
@@ -87,10 +86,10 @@ DUK_LOCAL duk_hstring *duk__auto_unbox_symbol(duk_hthread *thr, duk_tval *tv_arg
 		h_obj = DUK_TVAL_GET_OBJECT(tv);
 		DUK_ASSERT(h_obj != NULL);
 		if (DUK_HOBJECT_GET_CLASS_NUMBER(h_obj) == DUK_HOBJECT_CLASS_SYMBOL) {
-			if (!duk_hobject_get_internal_value(thr->heap, h_obj, &tv_val)) {
+			tv = duk_hobject_get_internal_value_tval_ptr(thr->heap, h_obj);
+			if (tv == NULL) {
 				return NULL;
 			}
-			tv = &tv_val;
 		} else {
 			return NULL;
 		}

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -93,9 +93,9 @@ DUK_LOCAL void duk__err_augment_user(duk_hthread *thr, duk_small_uint_t stridx_c
 		DUK_DD(DUK_DDPRINT("error occurred when DUK_BIDX_DUKTAPE is NULL, ignoring"));
 		return;
 	}
-	tv_hnd = duk_hobject_find_existing_entry_tval_ptr(thr->heap,
-	                                                  thr->builtins[DUK_BIDX_DUKTAPE],
-	                                                  DUK_HTHREAD_GET_STRING(thr, stridx_cb));
+	tv_hnd = duk_hobject_find_entry_tval_ptr_stridx(thr->heap,
+	                                                thr->builtins[DUK_BIDX_DUKTAPE],
+	                                                stridx_cb);
 	if (tv_hnd == NULL) {
 		DUK_DD(DUK_DDPRINT("error handler does not exist or is not a plain value: %!T",
 		                   (duk_tval *) tv_hnd));
@@ -468,9 +468,9 @@ DUK_LOCAL void duk__err_augment_builtin_create(duk_hthread *thr, duk_hthread *th
 #if defined(DUK_USE_TRACEBACKS)
 	/* If tracebacks are enabled, the '_Tracedata' property is the only
 	 * thing we need: 'fileName' and 'lineNumber' are virtual properties
-	 * which use '_Tracedata'.
+	 * which use '_Tracedata'.  (Check _Tracedata only as own property.)
 	 */
-	if (duk_hobject_hasprop_raw(thr, obj, DUK_HTHREAD_STRING_INT_TRACEDATA(thr))) {
+	if (duk_hobject_find_entry_tval_ptr_stridx(thr->heap, obj, DUK_STRIDX_INT_TRACEDATA) != NULL) {
 		DUK_DDD(DUK_DDDPRINT("error value already has a '_Tracedata' property, not modifying it"));
 	} else {
 		duk__add_traceback(thr, thr_callstack, c_filename, c_line, flags);

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -889,17 +889,12 @@ DUK_INTERNAL_DECL void duk_hobject_resize_arraypart(duk_hthread *thr,
 #endif
 
 /* low-level property functions */
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_find_existing_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *e_idx, duk_int_t *h_idx);
-DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_hstring *key);
-DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_uint_t *out_attrs);
-DUK_INTERNAL_DECL duk_tval *duk_hobject_find_existing_array_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_uarridx_t i);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_find_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_int_t *e_idx, duk_int_t *h_idx);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_find_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_hstring *key);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_find_entry_tval_ptr_stridx(duk_heap *heap, duk_hobject *obj, duk_small_uint_t stridx);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_find_entry_tval_ptr_and_attrs(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_uint_t *out_attrs);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_find_array_entry_tval_ptr(duk_heap *heap, duk_hobject *obj, duk_uarridx_t i);
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_get_own_propdesc(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_propdesc *out_desc, duk_small_uint_t flags);
-
-/* XXX: when optimizing for guaranteed property slots, use a guaranteed
- * slot for internal value; this call can then access it directly.
- */
-#define duk_hobject_get_internal_value_tval_ptr(heap,obj) \
-	duk_hobject_find_existing_entry_tval_ptr((heap), (obj), DUK_HEAP_STRING_INT_VALUE((heap)))
 
 /* core property functions */
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key);
@@ -944,8 +939,10 @@ DUK_INTERNAL_DECL duk_bool_t duk_hobject_object_is_sealed_frozen_helper(duk_hthr
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_object_ownprop_helper(duk_hthread *thr, duk_small_uint_t required_desc_flags);
 
 /* internal properties */
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_get_internal_value(duk_heap *heap, duk_hobject *obj, duk_tval *tv);
+DUK_INTERNAL_DECL duk_tval *duk_hobject_get_internal_value_tval_ptr(duk_heap *heap, duk_hobject *obj);
 DUK_INTERNAL_DECL duk_hstring *duk_hobject_get_internal_value_string(duk_heap *heap, duk_hobject *obj);
+DUK_INTERNAL_DECL duk_harray *duk_hobject_get_formals(duk_hthread *thr, duk_hobject *obj);
+DUK_INTERNAL_DECL duk_hobject *duk_hobject_get_varmap(duk_hthread *thr, duk_hobject *obj);
 
 /* hobject management functions */
 DUK_INTERNAL_DECL void duk_hobject_compact_props(duk_hthread *thr, duk_hobject *obj);

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -217,11 +217,11 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_hthread *thr, duk_small_uint
 	 * real object to check against.
 	 */
 	duk_push_hobject(thr, enum_target);
-	duk_put_prop_stridx_short(thr, -2, DUK_STRIDX_INT_TARGET);
+	duk_put_prop_stridx_short(thr, -2, DUK_STRIDX_INT_TARGET);  /* Target is bare, plain put OK. */
 
 	/* Initialize index so that we skip internal control keys. */
 	duk_push_int(thr, DUK__ENUM_START_INDEX);
-	duk_put_prop_stridx_short(thr, -2, DUK_STRIDX_INT_NEXT);
+	duk_put_prop_stridx_short(thr, -2, DUK_STRIDX_INT_NEXT);  /* Target is bare, plain put OK. */
 
 	/*
 	 *  Proxy object handling
@@ -255,7 +255,7 @@ DUK_INTERNAL void duk_hobject_enumerator_create(duk_hthread *thr, duk_small_uint
 		enum_target = h_proxy_target;
 
 		duk_push_hobject(thr, enum_target);  /* -> [ ... enum_target res handler undefined target ] */
-		duk_put_prop_stridx_short(thr, -4, DUK_STRIDX_INT_TARGET);
+		duk_put_prop_stridx_short(thr, -4, DUK_STRIDX_INT_TARGET);  /* Target is bare, plain put OK. */
 
 		duk_pop_2(thr);  /* -> [ ... enum_target res ] */
 		goto skip_proxy;
@@ -582,7 +582,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_enumerator_next(duk_hthread *thr, duk_bool_t
 	 * be the proxy, and checking key existence against the proxy is not
 	 * required (or sensible, as the keys may be fully virtual).
 	 */
-	duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_INT_TARGET);
+	duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_TARGET);
 	enum_target = duk_require_hobject(thr, -1);
 	DUK_ASSERT(enum_target != NULL);
 #if defined(DUK_USE_ES6_PROXY)

--- a/src-input/duk_hobject_pc2line.c
+++ b/src-input/duk_hobject_pc2line.c
@@ -228,7 +228,7 @@ DUK_INTERNAL duk_uint_fast32_t duk_hobject_pc2line_query(duk_hthread *thr, duk_i
 	 * future work in debugger.rst).
 	 */
 
-	duk_get_prop_stridx(thr, idx_func, DUK_STRIDX_INT_PC2LINE);
+	duk_xget_owndataprop_stridx_short(thr, idx_func, DUK_STRIDX_INT_PC2LINE);
 	pc2line = (duk_hbuffer_fixed *) (void *) duk_get_hbuffer(thr, -1);
 	if (pc2line != NULL) {
 		DUK_ASSERT(!DUK_HBUFFER_HAS_DYNAMIC((duk_hbuffer *) pc2line) && !DUK_HBUFFER_HAS_EXTERNAL((duk_hbuffer *) pc2line));

--- a/src-input/duk_hthread_stacks.c
+++ b/src-input/duk_hthread_stacks.c
@@ -181,7 +181,7 @@ DUK_LOCAL void duk__activation_unwind_nofree_norz(duk_hthread *thr) {
 		duk_tval tv_tmp;
 		duk_hobject *h_tmp;
 
-		tv_caller = duk_hobject_find_existing_entry_tval_ptr(thr->heap, func, DUK_HTHREAD_STRING_CALLER(thr));
+		tv_caller = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, func, DUK_STRIDX_CALLER);
 
 		/* The act->prev_caller should only be set if the entry for 'caller'
 		 * exists (as it is only set in that case, and the property is not

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -780,7 +780,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx) {
 	p_const = (duk_tval *) (void *) DUK_HBUFFER_FIXED_GET_DATA_PTR(thr->heap, h_data);
 	for (i = 0; i < consts_count; i++) {
 		DUK_ASSERT(i <= DUK_UARRIDX_MAX);  /* const limits */
-		tv = duk_hobject_find_existing_array_entry_tval_ptr(thr->heap, func->h_consts, (duk_uarridx_t) i);
+		tv = duk_hobject_find_array_entry_tval_ptr(thr->heap, func->h_consts, (duk_uarridx_t) i);
 		DUK_ASSERT(tv != NULL);
 		DUK_TVAL_SET_TVAL(p_const, tv);
 		p_const++;
@@ -794,7 +794,7 @@ DUK_LOCAL void duk__convert_to_func_template(duk_compiler_ctx *comp_ctx) {
 	for (i = 0; i < funcs_count; i++) {
 		duk_hobject *h;
 		DUK_ASSERT(i * 3 <= DUK_UARRIDX_MAX);  /* func limits */
-		tv = duk_hobject_find_existing_array_entry_tval_ptr(thr->heap, func->h_funcs, (duk_uarridx_t) (i * 3));
+		tv = duk_hobject_find_array_entry_tval_ptr(thr->heap, func->h_funcs, (duk_uarridx_t) (i * 3));
 		DUK_ASSERT(tv != NULL);
 		DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv));
 		h = DUK_TVAL_GET_OBJECT(tv);

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2083,7 +2083,7 @@ DUK_LOCAL void duk__executor_recheck_debugger(duk_hthread *thr, duk_activation *
 	bp_active = heap->dbg_breakpoints_active;
 	act->flags &= ~DUK_ACT_FLAG_BREAKPOINT_ACTIVE;
 
-	tv_tmp = duk_hobject_find_existing_entry_tval_ptr(thr->heap, (duk_hobject *) fun, DUK_HTHREAD_STRING_FILE_NAME(thr));
+	tv_tmp = duk_hobject_find_entry_tval_ptr_stridx(thr->heap, (duk_hobject *) fun, DUK_STRIDX_FILE_NAME);
 	if (tv_tmp && DUK_TVAL_IS_STRING(tv_tmp)) {
 		filename = DUK_TVAL_GET_STRING(tv_tmp);
 

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -718,7 +718,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	h_input = duk_to_hstring(thr, -1);
 	DUK_ASSERT(h_input != NULL);
 
-	duk_get_prop_stridx_short(thr, -2, DUK_STRIDX_INT_BYTECODE);  /* [ ... re_obj input ] -> [ ... re_obj input bc ] */
+	duk_xget_owndataprop_stridx_short(thr, -2, DUK_STRIDX_INT_BYTECODE);  /* [ ... re_obj input ] -> [ ... re_obj input bc ] */
 	h_bytecode = duk_require_hstring(thr, -1);  /* no regexp instance should exist without a non-configurable bytecode property */
 	DUK_ASSERT(h_bytecode != NULL);
 

--- a/tests/ecmascript/test-bi-date-frozen-set.js
+++ b/tests/ecmascript/test-bi-date-frozen-set.js
@@ -1,0 +1,49 @@
+/*
+ *  If a Date instance is frozen, setTime(), setUTCFullYear() etc must still work as
+ *  they operate on an internal slot which is not bound by normal property access
+ *  controls.
+ */
+
+/*===
+1970-01-01T00:00:00.123Z
+1970-01-01T00:00:00.234Z
+1970-01-01T00:00:00.345Z
+1970-01-01T00:00:00.123Z
+1000-01-01T00:00:00.123Z
+2000-01-01T00:00:00.123Z
+done
+===*/
+
+function test1() {
+    var d = new Date(123);
+    print(d.toISOString());
+    d.setTime(234);
+    print(d.toISOString());
+    Object.freeze(d);
+    d.setTime(345);
+    print(d.toISOString());
+}
+
+function test2() {
+    var d = new Date(123);
+    print(d.toISOString());
+    d.setUTCFullYear(1000);
+    print(d.toISOString());
+    Object.freeze(d);
+    d.setUTCFullYear(2000);
+    print(d.toISOString());
+}
+
+try {
+    test1();
+} catch (e) {
+    print(e.stack || e);
+}
+
+try {
+    test2();
+} catch (e) {
+    print(e.stack || e);
+}
+
+print('done');

--- a/tests/ecmascript/test-bi-regexp-getter-inherit.js
+++ b/tests/ecmascript/test-bi-regexp-getter-inherit.js
@@ -1,0 +1,13 @@
+/*===
+TypeError
+done
+===*/
+
+try {
+    var R = /foo/;
+    var O = Object.create(R);
+    print(O.source);
+} catch (e) {
+    print(e.name);
+}
+print('done');

--- a/website/api/duk_set_finalizer.yaml
+++ b/website/api/duk_set_finalizer.yaml
@@ -15,6 +15,9 @@ summary: |
 
   <div class="note">
   Finalizer on a Proxy object is currently unsupported.
+  At present the finalizer is stored as a hidden Symbol; a finalizer cannot
+  be set if the object is non-extensible (sealed or frozen), so set the
+  finalizer before sealing/freezing the object.
   </div>
 
 example: |


### PR DESCRIPTION
Original issue reported by Karl Dahlke re: a website not working. This pull fixes the root cause and a few potentially similar issues. Changes:
- Review call sites where internal properties like _Varmap, _Formals, _Tracedata, etc were looked up. In some cases inheritance is desired (e.g. _Finalizer) and in some cases not (most of the other internal properties).
- Add internal helpers to do convenient side effect free non-inheriting property lookups for properties.
- Change call sites to use non-inheriting lookups where necessary. This seems to fix the originally reported issue.
- Also fix a Date bug where a frozen Date instance would refuse .setTime(), .setYear() etc with a TypeError. They should be allowed even on a frozen Date instance because the internal value is an internal "slot" which doesn't obey normal property access control rules.