### PR TITLE
Include "end of input" in error message if SyntaxError happens at end of file

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3554,6 +3554,8 @@ Planned
 
 * Fix some C++ compile warnings (GH-2161)
 
+* Include "end of input" in error message if SyntaxError occurs at end of file (GH-2152)
+
 3.0.0 (XXXX-XX-XX)
 ------------------
 

--- a/src-input/duk_error_augment.c
+++ b/src-input/duk_error_augment.c
@@ -433,7 +433,11 @@ DUK_LOCAL void duk__add_compiler_error_line(duk_hthread *thr) {
 	                     (duk_tval *) duk_get_tval(thr, -1)));
 
 	if (duk_get_prop_stridx_short(thr, -1, DUK_STRIDX_MESSAGE)) {
-		duk_push_sprintf(thr, " (line %ld)", (long) thr->compile_ctx->curr_token.start_line);
+                if (thr->compile_ctx->curr_token.start_offset + 1 >= thr->compile_ctx->lex.input_length) {
+			duk_push_sprintf(thr, " (line %ld, end of input)", (long) thr->compile_ctx->curr_token.start_line);
+		} else {
+			duk_push_sprintf(thr, " (line %ld)", (long) thr->compile_ctx->curr_token.start_line);
+		}
 		duk_concat(thr, 2);
 		duk_put_prop_stridx_short(thr, -2, DUK_STRIDX_MESSAGE);
 	} else {

--- a/tests/api/test-compile-string.c
+++ b/tests/api/test-compile-string.c
@@ -10,7 +10,7 @@ return value is: '123'
 compile rc=0
 myFile.js
 return value is: '234'
-compile rc=1 -> SyntaxError: invalid object literal (line 1)
+compile rc=1 -> SyntaxError: invalid object literal (line 1, end of input)
 top: 0
 ==> rc=0, result='undefined'
 *** test_lstring (duk_safe_call)
@@ -24,7 +24,7 @@ return value is: '123'
 compile rc=0
 myFile.js
 return value is: '234'
-compile rc=1 -> SyntaxError: invalid object literal (line 1)
+compile rc=1 -> SyntaxError: invalid object literal (line 1, end of input)
 top: 0
 ==> rc=0, result='undefined'
 ===*/

--- a/tests/api/test-compile.c
+++ b/tests/api/test-compile.c
@@ -13,7 +13,7 @@ function result: 11.000000
 final top: 0
 ==> rc=0, result='undefined'
 *** test_syntax_error (duk_safe_call)
-compile result: SyntaxError: invalid object literal (line 3) (rc=1)
+compile result: SyntaxError: invalid object literal (line 3, end of input) (rc=1)
 final top: 0
 ==> rc=0, result='undefined'
 *** test_constructable_and_name (duk_safe_call)

--- a/tests/api/test-eval-string.c
+++ b/tests/api/test-eval-string.c
@@ -6,7 +6,7 @@ result is: 'TESTSTRING'
 Hello world!
 return value is: 123 (rc=0)
 return value is: Error: eval error (rc=1)
-return value is: SyntaxError: invalid object literal (line 1) (rc=1)
+return value is: SyntaxError: invalid object literal (line 1, end of input) (rc=1)
 top=0
 Hello world!
 top=0
@@ -23,7 +23,7 @@ result is: 'TESTSTRING'
 Hello world!
 return value is: 123 (rc=0)
 return value is: Error: eval error (rc=1)
-return value is: SyntaxError: invalid object literal (line 1) (rc=1)
+return value is: SyntaxError: invalid object literal (line 1, end of input) (rc=1)
 top=0
 Hello world!
 top=0

--- a/tests/api/test-eval.c
+++ b/tests/api/test-eval.c
@@ -5,7 +5,7 @@ adder(123, 234) -> 357.000000
 Hello world!
 return value is: 123 (rc=0)
 return value is: Error: eval error (rc=1)
-return value is: SyntaxError: invalid object literal (line 1) (rc=1)
+return value is: SyntaxError: invalid object literal (line 1, end of input) (rc=1)
 top=0
 doing eval
 top=0

--- a/tests/api/test-syntax-error-end-of-input.c
+++ b/tests/api/test-syntax-error-end-of-input.c
@@ -1,0 +1,24 @@
+/*===
+*** test_1 (duk_safe_call)
+end of input: 'SyntaxError: invalid object literal (line 1, end of input)'
+before end of input: 'SyntaxError: parse error (line 2)'
+==> rc=0, result='undefined'
+===*/
+
+static duk_ret_t test_1(duk_context *ctx, void *udata) {
+	(void) udata;
+
+	duk_peval_string(ctx, "var obj = {");
+	printf("end of input: '%s'\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	duk_peval_string(ctx, "var obj = {\n2+2;");
+	printf("before end of input: '%s'\n", duk_safe_to_string(ctx, -1));
+	duk_pop(ctx);
+
+	return 0;
+}
+
+void test(duk_context *ctx) {
+	TEST_SAFE_CALL(test_1);
+}

--- a/tests/ecmascript/test-dev-syntax-error-line.js
+++ b/tests/ecmascript/test-dev-syntax-error-line.js
@@ -21,7 +21,10 @@ function test(inp) {
         print('never here');
     } catch (e) {
         // Match against current syntax
-        res = /^.*\(line (\d+)\)$/.exec(e.message);
+        res = /^.*\(line (\d+), end of input\)$/.exec(e.message);
+        if (!res) {
+            res = /^.*\(line (\d+)\)$/.exec(e.message);
+        }
         print('line', res ? res[1] : 'n/a');
     }
 }


### PR DESCRIPTION
Fixes #2151