### PR TITLE
Fix -Wfloat-equal warnings, fix (harmless) gcc -m32 Math.atan2() assert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,7 @@ CCOPTS_SHARED += -Wcast-align
 CCOPTS_SHARED += -Wshadow
 CCOPTS_SHARED += -Wunreachable-code  # on some compilers unreachable code is an error
 CCOPTS_SHARED += -Wmissing-prototypes
-# -Wfloat-equal is too picky, there's no apparent way to compare floats
-# (even when you know it's safe) without triggering warnings
+CCOPTS_SHARED += -Wfloat-equal
 CCOPTS_SHARED += -Wsign-conversion
 CCOPTS_SHARED += -Wsuggest-attribute=noreturn
 CCOPTS_SHARED += -fmax-errors=3  # prevent floods of errors if e.g. parenthesis missing
@@ -1060,6 +1059,7 @@ codepolicycheck:
 		--check-mixed-indent \
 		--check-nonleading-tab \
 		--check-cpp-comment \
+		--check-float-compare \
 		--check-ifdef-ifndef \
 		--check-longlong-constants \
 		--dump-vim-commands \

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3554,6 +3554,10 @@ Planned
 
 * Move CBOR extra into an actual Duktape built-in, enabled by default (GH-2163)
 
+* Fix a harmless assert in Math.atan2() when compiling with gcc -m32 (GH-2164)
+
+* Fix (suppress) -Wfloat-equal warnings for GCC and Clang (GH-234, GH-2164)
+
 * Fix compile warning when base64 support disabled (GH-2159)
 
 * Fix some C++ compile warnings (GH-2161)

--- a/config/compilers/compiler_clang.h.in
+++ b/config/compilers/compiler_clang.h.in
@@ -60,7 +60,7 @@
 #define DUK_USE_FLEX_ZEROSIZE
 #endif
 
-#undef DUK_USE_GCC_PRAGMAS
+#define DUK_USE_CLANG_PRAGMAS
 #define DUK_USE_PACK_CLANG_ATTR
 
 #if defined(__clang__) && defined(__has_builtin)

--- a/config/compilers/compiler_gcc.h.in
+++ b/config/compilers/compiler_gcc.h.in
@@ -79,6 +79,7 @@
 #define DUK_USE_FLEX_ZEROSIZE
 #endif
 
+/* Since 4.6 one can '#pragma GCC diagnostic push/pop'. */
 #if defined(DUK_F_GCC_VERSION) && (DUK_F_GCC_VERSION >= 40600)
 #define DUK_USE_GCC_PRAGMAS
 #else

--- a/config/config-options/DUK_USE_CLANG_PRAGMAS.yaml
+++ b/config/config-options/DUK_USE_CLANG_PRAGMAS.yaml
@@ -1,0 +1,8 @@
+define: DUK_USE_CLANG_PRAGMAS
+introduced: 2.5.0
+default: false
+tags:
+  - portability
+description: >
+  Use Clang-specific pragmas, e.g. "#pragma clang diagnostic" to suppress
+  unnecessary warnings.

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -3004,7 +3004,7 @@ DUK_INTERNAL duk_uint8_t duk_to_uint8clamped(duk_hthread *thr, duk_idx_t idx) {
 	}
 
 	t = d - DUK_FLOOR(d);
-	if (t == 0.5) {
+	if (duk_double_equals(t, 0.5)) {
 		/* Exact halfway, round to even. */
 		ret = (duk_uint8_t) d;
 		ret = (ret + 1) & 0xfe;  /* Example: d=3.5, t=0.5 -> ret = (3 + 1) & 0xfe = 4 & 0xfe = 4

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -155,7 +155,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_constructor(duk_hthread *thr) {
 		/* XXX: expensive check (also shared elsewhere - so add a shared internal API call?) */
 		d = duk_get_number(thr, 0);
 		len = duk_to_uint32(thr, 0);
-		if (((duk_double_t) len) != d) {
+		if (!duk_double_equals((duk_double_t) len, d)) {
 			DUK_DCERROR_RANGE_INVALID_LENGTH(thr);
 		}
 

--- a/src-input/duk_bi_cbor.c
+++ b/src-input/duk_bi_cbor.c
@@ -194,7 +194,7 @@ DUK_LOCAL void duk__cbor_encode_double_fp(duk_cbor_encode_context *enc_ctx, doub
 		 * double: seeeeeee eeeemmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm
 		 * half:         seeeee mmmm mmmmmm00 00000000 00000000 00000000 00000000 00000000
 		 */
-		int use_half_float;
+		duk_bool_t use_half_float;
 
 		use_half_float =
 		    (u.uc[0] == 0 && u.uc[1] == 0 && u.uc[2] == 0 && u.uc[3] == 0 &&
@@ -225,7 +225,7 @@ DUK_LOCAL void duk__cbor_encode_double_fp(duk_cbor_encode_context *enc_ctx, doub
 		 * double: seeeeeee eeeemmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm
 		 * float:     seeee eeeemmmm mmmmmmmm mmmmmmmm mmm00000 00000000 00000000 00000000
 		 */
-		int use_float;
+		duk_bool_t use_float;
 		duk_float_t d_float;
 
 		/* We could do this explicit mantissa check, but doing
@@ -238,7 +238,7 @@ DUK_LOCAL void duk__cbor_encode_double_fp(duk_cbor_encode_context *enc_ctx, doub
 		    (u.uc[0] == 0 && u.uc[1] == 0 && u.uc[2] == 0 && (u.uc[3] & 0xe0U) == 0);
 #endif
 		d_float = (duk_float_t) d;
-		use_float = ((duk_double_t) d_float == d);
+		use_float = duk_double_equals((duk_double_t) d_float, d);
 		if (use_float) {
 			p = enc_ctx->ptr;
 			*p++ = 0xfaU;
@@ -351,7 +351,7 @@ DUK_LOCAL void duk__cbor_encode_double(duk_cbor_encode_context *enc_ctx, double 
 	 * for Inf too (but not NaN).
 	 */
 	d_floor = DUK_FLOOR(d);  /* identity if d is +/- 0.0, NaN, or +/- Infinity */
-	if (DUK_LIKELY(d_floor == d)) {
+	if (DUK_LIKELY(duk_double_equals(d_floor, d) != 0)) {
 		DUK_ASSERT(!DUK_ISNAN(d));  /* NaN == NaN compares false. */
 		if (DUK_SIGNBIT(d)) {
 			if (d >= -4294967296.0) {
@@ -443,7 +443,7 @@ DUK_LOCAL void duk__cbor_encode_string_top(duk_cbor_encode_context *enc_ctx) {
 	duk__cbor_encode_uint32(enc_ctx, (duk_uint32_t) len, 0x40U);
 #else
 	duk__cbor_encode_uint32(enc_ctx, (duk_uint32_t) len,
-	                        (DUK_LIKELY(duk_unicode_is_utf8_compatible(str, len)) ? 0x60U : 0x40U));
+	                        (DUK_LIKELY(duk_unicode_is_utf8_compatible(str, len) != 0) ? 0x60U : 0x40U));
 #endif
 	duk__cbor_encode_ensure(enc_ctx, len);
 	p = enc_ctx->ptr;

--- a/src-input/duk_bi_date.c
+++ b/src-input/duk_bi_date.c
@@ -622,7 +622,7 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 
 	DUK_ASSERT(DUK_ISFINITE(d));    /* caller checks */
 	d = DUK_FLOOR(d);  /* remove fractions if present */
-	DUK_ASSERT(DUK_FLOOR(d) == d);
+	DUK_ASSERT(duk_double_equals(DUK_FLOOR(d), d));
 
 	/* The timevalue must be in valid ECMAScript range, but since a local
 	 * time offset can be applied, we need to allow a +/- 24h leeway to
@@ -641,13 +641,13 @@ DUK_INTERNAL void duk_bi_date_timeval_to_parts(duk_double_t d, duk_int_t *parts,
 		d1 += (duk_double_t) DUK_DATE_MSEC_DAY;
 	}
 	d2 = DUK_FLOOR((double) (d / (duk_double_t) DUK_DATE_MSEC_DAY));
-	DUK_ASSERT(d2 * ((duk_double_t) DUK_DATE_MSEC_DAY) + d1 == d);
+	DUK_ASSERT(duk_double_equals(d2 * ((duk_double_t) DUK_DATE_MSEC_DAY) + d1, d));
 	/* now expected to fit into a 32-bit integer */
 	t1 = (duk_int_t) d1;
 	t2 = (duk_int_t) d2;
 	day_since_epoch = t2;
-	DUK_ASSERT((duk_double_t) t1 == d1);
-	DUK_ASSERT((duk_double_t) t2 == d2);
+	DUK_ASSERT(duk_double_equals((duk_double_t) t1, d1));
+	DUK_ASSERT(duk_double_equals((duk_double_t) t2, d2));
 
 	/* t1 = milliseconds within day (fits 32 bit)
 	 * t2 = day number from epoch (fits 32 bit, may be negative)
@@ -1504,7 +1504,7 @@ DUK_INTERNAL duk_ret_t duk_bi_date_constructor_now(duk_hthread *thr) {
 	duk_double_t d;
 
 	d = duk_time_get_ecmascript_time_nofrac(thr);
-	DUK_ASSERT(duk__timeclip(d) == d);  /* TimeClip() should never be necessary */
+	DUK_ASSERT(duk_double_equals(duk__timeclip(d), d));  /* TimeClip() should never be necessary */
 	duk_push_number(thr, d);
 	return 1;
 }

--- a/src-input/duk_bi_math.c
+++ b/src-input/duk_bi_math.c
@@ -53,7 +53,7 @@ DUK_LOCAL double duk__fmin_fixed(double x, double y) {
 	/* fmin() with args -0 and +0 is not guaranteed to return
 	 * -0 as ECMAScript requires.
 	 */
-	if (x == 0 && y == 0) {
+	if (duk_double_equals(x, 0.0) && duk_double_equals(y, 0.0)) {
 		duk_double_union du1, du2;
 		du1.d = x;
 		du2.d = y;
@@ -80,7 +80,7 @@ DUK_LOCAL double duk__fmax_fixed(double x, double y) {
 	/* fmax() with args -0 and +0 is not guaranteed to return
 	 * +0 as ECMAScript requires.
 	 */
-	if (x == 0 && y == 0) {
+	if (duk_double_equals(x, 0.0) && duk_double_equals(y, 0.0)) {
 		if (DUK_SIGNBIT(x) == 0 || DUK_SIGNBIT(y) == 0) {
 			return +0.0;
 		} else {
@@ -247,10 +247,11 @@ DUK_LOCAL double duk__atan2_fixed(double x, double y) {
 	}
 #else
 	/* Some ISO C assumptions. */
-	DUK_ASSERT(DUK_ATAN2(DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY) == 0.7853981633974483);
-	DUK_ASSERT(DUK_ATAN2(-DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY) == -0.7853981633974483);
-	DUK_ASSERT(DUK_ATAN2(DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY) == 2.356194490192345);
-	DUK_ASSERT(DUK_ATAN2(-DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY) == -2.356194490192345);
+
+	DUK_ASSERT(duk_double_equals(DUK_ATAN2(DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY), 0.7853981633974483));
+	DUK_ASSERT(duk_double_equals(DUK_ATAN2(-DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY), -0.7853981633974483));
+	DUK_ASSERT(duk_double_equals(DUK_ATAN2(DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY), 2.356194490192345));
+	DUK_ASSERT(duk_double_equals(DUK_ATAN2(-DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY), -2.356194490192345));
 #endif
 
 	return DUK_ATAN2(x, y);
@@ -390,13 +391,13 @@ DUK_INTERNAL duk_ret_t duk_bi_math_object_hypot(duk_hthread *thr) {
 	}
 
 	/* Early return cases. */
-	if (max == DUK_DOUBLE_INFINITY) {
+	if (duk_double_equals(max, DUK_DOUBLE_INFINITY)) {
 		duk_push_number(thr, DUK_DOUBLE_INFINITY);
 		return 1;
 	} else if (found_nan) {
 		duk_push_number(thr, DUK_DOUBLE_NAN);
 		return 1;
-	} else if (max == 0.0) {
+	} else if (duk_double_equals(max, 0.0)) {
 		duk_push_number(thr, 0.0);
 		/* Otherwise we'd divide by zero. */
 		return 1;
@@ -431,7 +432,7 @@ DUK_INTERNAL duk_ret_t duk_bi_math_object_sign(duk_hthread *thr) {
 		DUK_ASSERT(duk_is_nan(thr, -1));
 		return 1;  /* NaN input -> return NaN */
 	}
-	if (d == 0.0) {
+	if (duk_double_equals(d, 0.0)) {
 		/* Zero sign kept, i.e. -0 -> -0, +0 -> +0. */
 		return 1;
 	}

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -102,7 +102,7 @@ DUK_LOCAL duk_uint32_t duk__tval_number_to_arr_idx(duk_tval *tv) {
 	 */
 	dbl = DUK_TVAL_GET_NUMBER(tv);
 	idx = (duk_uint32_t) dbl;
-	if ((duk_double_t) idx == dbl) {
+	if (duk_double_equals((duk_double_t) idx, dbl)) {
 	        /* Is whole and within 32 bit range.  If the value happens to be 0xFFFFFFFF,
 		 * it's not a valid array index but will then match DUK__NO_ARRAY_INDEX.
 		 */
@@ -3185,7 +3185,7 @@ DUK_LOCAL duk_uint32_t duk__to_new_array_length_checked(duk_hthread *thr, duk_tv
 	 * 32-bit range.  Negative zero is accepted as zero.
 	 */
 	res = duk_double_to_uint32_t(d);
-	if ((duk_double_t) res != d) {
+	if (!duk_double_equals((duk_double_t) res, d)) {
 		goto fail_range;
 	}
 

--- a/src-input/duk_js_arith.c
+++ b/src-input/duk_js_arith.c
@@ -19,11 +19,11 @@ DUK_INTERNAL double duk_js_arith_mod(double d1, double d2) {
 		} else {
 			return d1;
 		}
-	} else if (d1 == 0.0) {
+	} else if (duk_double_equals(d1, 0.0)) {
 		/* d1 +/-0 is returned as is (preserving sign) except when
 		 * d2 is zero or NaN.
 		 */
-		if (d2 == 0.0 || DUK_ISNAN(d2)) {
+		if (duk_double_equals(d2, 0.0) || DUK_ISNAN(d2)) {
 			return DUK_DOUBLE_NAN;
 		} else {
 			return d1;
@@ -31,20 +31,20 @@ DUK_INTERNAL double duk_js_arith_mod(double d1, double d2) {
 	}
 #else
 	/* Some ISO C assumptions. */
-	DUK_ASSERT(DUK_FMOD(1.0, DUK_DOUBLE_INFINITY) == 1.0);
-	DUK_ASSERT(DUK_FMOD(-1.0, DUK_DOUBLE_INFINITY) == -1.0);
-	DUK_ASSERT(DUK_FMOD(1.0, -DUK_DOUBLE_INFINITY) == 1.0);
-	DUK_ASSERT(DUK_FMOD(-1.0, -DUK_DOUBLE_INFINITY) == -1.0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(1.0, DUK_DOUBLE_INFINITY), 1.0));
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(-1.0, DUK_DOUBLE_INFINITY), -1.0));
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(1.0, -DUK_DOUBLE_INFINITY), 1.0));
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(-1.0, -DUK_DOUBLE_INFINITY), -1.0));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY)));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY)));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(-DUK_DOUBLE_INFINITY, DUK_DOUBLE_INFINITY)));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(-DUK_DOUBLE_INFINITY, -DUK_DOUBLE_INFINITY)));
-	DUK_ASSERT(DUK_FMOD(0.0, 1.0) == 0.0 && DUK_SIGNBIT(DUK_FMOD(0.0, 1.0)) == 0);
-	DUK_ASSERT(DUK_FMOD(-0.0, 1.0) == 0.0 && DUK_SIGNBIT(DUK_FMOD(-0.0, 1.0)) != 0);
-	DUK_ASSERT(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY) == 0.0 && DUK_SIGNBIT(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY)) == 0);
-	DUK_ASSERT(DUK_FMOD(-0.0, DUK_DOUBLE_INFINITY) == 0.0 && DUK_SIGNBIT(DUK_FMOD(-0.0, DUK_DOUBLE_INFINITY)) != 0);
-	DUK_ASSERT(DUK_FMOD(0.0, -DUK_DOUBLE_INFINITY) == 0.0 && DUK_SIGNBIT(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY)) == 0);
-	DUK_ASSERT(DUK_FMOD(-0.0, -DUK_DOUBLE_INFINITY) == 0.0 && DUK_SIGNBIT(DUK_FMOD(-0.0, -DUK_DOUBLE_INFINITY)) != 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(0.0, 1.0), 0.0) && DUK_SIGNBIT(DUK_FMOD(0.0, 1.0)) == 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(-0.0, 1.0), 0.0) && DUK_SIGNBIT(DUK_FMOD(-0.0, 1.0)) != 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY), 0.0) && DUK_SIGNBIT(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY)) == 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(-0.0, DUK_DOUBLE_INFINITY), 0.0) && DUK_SIGNBIT(DUK_FMOD(-0.0, DUK_DOUBLE_INFINITY)) != 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(0.0, -DUK_DOUBLE_INFINITY), 0.0) && DUK_SIGNBIT(DUK_FMOD(0.0, DUK_DOUBLE_INFINITY)) == 0);
+	DUK_ASSERT(duk_double_equals(DUK_FMOD(-0.0, -DUK_DOUBLE_INFINITY), 0.0) && DUK_SIGNBIT(DUK_FMOD(-0.0, -DUK_DOUBLE_INFINITY)) != 0);
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(0.0, 0.0)));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(-0.0, 0.0)));
 	DUK_ASSERT(DUK_ISNAN(DUK_FMOD(0.0, -0.0)));
@@ -73,7 +73,7 @@ DUK_INTERNAL double duk_js_arith_pow(double x, double y) {
 	if (cy == DUK_FP_NAN) {
 		goto ret_nan;
 	}
-	if (DUK_FABS(x) == 1.0 && cy == DUK_FP_INFINITE) {
+	if (duk_double_equals(DUK_FABS(x), 1.0) && cy == DUK_FP_INFINITE) {
 		goto ret_nan;
 	}
 
@@ -115,7 +115,7 @@ DUK_INTERNAL double duk_js_arith_pow(double x, double y) {
 			}
 		}
 	} else if (cx == DUK_FP_NAN) {
-		if (y == 0.0) {
+		if (duk_double_equals(y, 0.0)) {
 			/* NaN ** +/- 0 should always be 1, but is NaN on
 			 * at least some Cygwin/MinGW versions.
 			 */
@@ -124,7 +124,7 @@ DUK_INTERNAL double duk_js_arith_pow(double x, double y) {
 	}
 #else
 	/* Some ISO C assumptions. */
-	DUK_ASSERT(DUK_POW(DUK_DOUBLE_NAN, 0.0) == 1.0);
+	DUK_ASSERT(duk_double_equals(DUK_POW(DUK_DOUBLE_NAN, 0.0), 1.0));
 	DUK_ASSERT(DUK_ISINF(DUK_POW(0.0, -1.0)) && DUK_SIGNBIT(DUK_POW(0.0, -1.0)) == 0);
 	DUK_ASSERT(DUK_ISINF(DUK_POW(-0.0, -2.0)) && DUK_SIGNBIT(DUK_POW(-0.0, -2.0)) == 0);
 	DUK_ASSERT(DUK_ISINF(DUK_POW(-0.0, -3.0)) && DUK_SIGNBIT(DUK_POW(-0.0, -3.0)) != 0);

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -3712,12 +3712,12 @@ DUK_LOCAL void duk__expr_nud(duk_compiler_ctx *comp_ctx, duk_ivalue *res) {
 			if (DUK_TVAL_IS_NUMBER(tv_val)) {
 				duk_double_t d;
 				d = DUK_TVAL_GET_NUMBER(tv_val);
-				if (d == 0.0) {
+				if (duk_double_equals(d, 0.0)) {
 					/* Matches both +0 and -0 on purpose. */
 					DUK_DDD(DUK_DDDPRINT("inlined lnot: !0 -> true"));
 					DUK_TVAL_SET_BOOLEAN_TRUE(tv_val);
 					return;
-				} else if (d == 1.0) {
+				} else if (duk_double_equals(d, 1.0)) {
 					DUK_DDD(DUK_DDDPRINT("inlined lnot: !1 -> false"));
 					DUK_TVAL_SET_BOOLEAN_FALSE(tv_val);
 					return;

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -362,7 +362,7 @@ DUK_INTERNAL duk_int32_t duk_js_toint32(duk_hthread *thr, duk_tval *tv) {
 	d = duk__toint32_touint32_helper(d, 1);
 	DUK_ASSERT(DUK_FPCLASSIFY(d) == DUK_FP_ZERO || DUK_FPCLASSIFY(d) == DUK_FP_NORMAL);
 	DUK_ASSERT(d >= -2147483648.0 && d <= 2147483647.0);  /* [-0x80000000,0x7fffffff] */
-	DUK_ASSERT(d == ((duk_double_t) ((duk_int32_t) d)));  /* whole, won't clip */
+	DUK_ASSERT(duk_double_equals(d, (duk_double_t) ((duk_int32_t) d)));  /* whole, won't clip */
 	return (duk_int32_t) d;
 }
 
@@ -380,7 +380,7 @@ DUK_INTERNAL duk_uint32_t duk_js_touint32(duk_hthread *thr, duk_tval *tv) {
 	d = duk__toint32_touint32_helper(d, 0);
 	DUK_ASSERT(DUK_FPCLASSIFY(d) == DUK_FP_ZERO || DUK_FPCLASSIFY(d) == DUK_FP_NORMAL);
 	DUK_ASSERT(d >= 0.0 && d <= 4294967295.0);  /* [0x00000000, 0xffffffff] */
-	DUK_ASSERT(d == ((duk_double_t) ((duk_uint32_t) d)));  /* whole, won't clip */
+	DUK_ASSERT(duk_double_equals(d, (duk_double_t) ((duk_uint32_t) d)));  /* whole, won't clip */
 	return (duk_uint32_t) d;
 
 }
@@ -439,7 +439,7 @@ DUK_LOCAL duk_bool_t duk__js_equals_number(duk_double_t x, duk_double_t y) {
 	 * equal regardless of sign.  Could also use a macro, but this inlines
 	 * already nicely (no difference on gcc, for instance).
 	 */
-	if (x == y) {
+	if (duk_double_equals(x, y)) {
 		/* IEEE requires that NaNs compare false */
 		DUK_ASSERT(DUK_FPCLASSIFY(x) != DUK_FP_NAN);
 		DUK_ASSERT(DUK_FPCLASSIFY(y) != DUK_FP_NAN);
@@ -486,7 +486,7 @@ DUK_LOCAL duk_bool_t duk__js_samevalue_number(duk_double_t x, duk_double_t y) {
 	duk_small_int_t cx = (duk_small_int_t) DUK_FPCLASSIFY(x);
 	duk_small_int_t cy = (duk_small_int_t) DUK_FPCLASSIFY(y);
 
-	if (x == y) {
+	if (duk_double_equals(x, y)) {
 		/* IEEE requires that NaNs compare false */
 		DUK_ASSERT(DUK_FPCLASSIFY(x) != DUK_FP_NAN);
 		DUK_ASSERT(DUK_FPCLASSIFY(y) != DUK_FP_NAN);

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -1594,8 +1594,8 @@ DUK_LOCAL DUK_NOINLINE void duk__numconv_stringify_raw(duk_hthread *thr, duk_sma
 	 */
 
 	uval = duk_double_to_uint32_t(x);
-	if (((double) uval) == x &&  /* integer number in range */
-	    flags == 0) {            /* no special formatting */
+	if (duk_double_equals((double) uval, x) &&  /* integer number in range */
+	    flags == 0) {                           /* no special formatting */
 		/* use bigint area as a temp */
 		duk_uint8_t *buf = (duk_uint8_t *) (&nc_ctx->f);
 		duk_uint8_t *p = buf;

--- a/src-input/duk_selftest.c
+++ b/src-input/duk_selftest.c
@@ -174,7 +174,7 @@ DUK_LOCAL duk_uint_t duk__selftest_byte_order(void) {
 		DUK__FAILED("duk_uint32_t byte order");
 	}
 
-	if (u2.d != (double) 102030405060.0) {
+	if (!duk_double_equals(u2.d, 102030405060.0)) {
 		DUK__FAILED("double byte order");
 	}
 
@@ -549,7 +549,7 @@ DUK_LOCAL duk_uint_t duk__selftest_cast_double_to_small_uint(void) {
 	u = (duk_small_uint_t) d1;
 	d2 = (duk_double_t) u;
 
-	if (!(d1 == 1.0 && u == 1 && d2 == 1.0 && d1 == d2)) {
+	if (!(duk_double_equals(d1, 1.0) && u == 1 && duk_double_equals(d2, 1.0) && duk_double_equals(d1, d2))) {
 		DUK__FAILED("double to duk_small_uint_t cast failed");
 	}
 
@@ -559,7 +559,7 @@ DUK_LOCAL duk_uint_t duk__selftest_cast_double_to_small_uint(void) {
 	uv = (duk_small_uint_t) d1v;
 	d2v = (duk_double_t) uv;
 
-	if (!(d1v == 1.0 && uv == 1 && d2v == 1.0 && d1v == d2v)) {
+	if (!(duk_double_equals(d1v, 1.0) && uv == 1 && duk_double_equals(d2v, 1.0) && duk_double_equals(d1v, d2v))) {
 		DUK__FAILED("double to duk_small_uint_t cast failed");
 	}
 

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -708,6 +708,8 @@ DUK_INTERNAL_DECL duk_uint_t duk_double_to_uint_t(duk_double_t x);
 DUK_INTERNAL_DECL duk_int32_t duk_double_to_int32_t(duk_double_t x);
 DUK_INTERNAL_DECL duk_uint32_t duk_double_to_uint32_t(duk_double_t x);
 DUK_INTERNAL_DECL duk_float_t duk_double_to_float_t(duk_double_t x);
+DUK_INTERNAL_DECL duk_bool_t duk_double_equals(duk_double_t x, duk_double_t y);
+DUK_INTERNAL_DECL duk_bool_t duk_float_equals(duk_float_t x, duk_float_t y);
 
 /*
  *  Miscellaneous


### PR DESCRIPTION
Use internal helpers for double/float equality comparisons, and add GCC and Clang pragmas to avoid -Wfloat-equal warnings in them. Using explicit helpers ensure types for comparison are known (and match). This also fixes a harmless Math.atan2() assert with gcc -m32. Fixes #234. Re-enable -Wfloat-equal in Makefile to ensure new comparisons are not introduced without going through the helpers.