### PR TITLE
Add DUK_WO_UNREACHABLE()

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3554,16 +3554,16 @@ Planned
 
 * Move CBOR extra into an actual Duktape built-in, enabled by default (GH-2163)
 
+* Include "end of input" in error message if SyntaxError occurs at end of
+  file (GH-2152, GH-2165)
+
 * Fix a harmless assert in Math.atan2() when compiling with gcc -m32 (GH-2164)
 
 * Fix (suppress) -Wfloat-equal warnings for GCC and Clang (GH-234, GH-2164)
 
 * Fix compile warning when base64 support disabled (GH-2159)
 
-* Fix some C++ compile warnings (GH-2161)
-
-* Include "end of input" in error message if SyntaxError occurs at end of
-  file (GH-2152, GH-2165)
+* Fix some compile warnings (GH-2161, GH-2172)
 
 * Minor performance and footprint improvements (GH-2167)
 

--- a/config/header-snippets/compiler_fillins.h.in
+++ b/config/header-snippets/compiler_fillins.h.in
@@ -69,12 +69,15 @@
 #define DUK_WO_NORETURN(stmt) do { stmt } while (0)
 #endif
 
-#if !defined(DUK_UNREACHABLE)
+#if defined(DUK_UNREACHABLE)
+#define DUK_WO_UNREACHABLE(stmt) do { } while (0)
+#else
 /* Don't know how to declare unreachable point, so don't do it; this
  * may cause some spurious compilation warnings (e.g. "variable used
  * uninitialized").
  */
 #define DUK_UNREACHABLE()  do { } while (0)
+#define DUK_WO_UNREACHABLE(stmt) do { stmt } while (0)
 #endif
 
 #if !defined(DUK_LOSE_CONST)

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -119,6 +119,7 @@ DUK_INTERNAL duk_bool_t duk_js_toboolean(duk_tval *tv) {
 	}
 	}
 	DUK_UNREACHABLE();
+	DUK_WO_UNREACHABLE(return 0;);
 }
 
 /*
@@ -260,6 +261,7 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 	}
 
 	DUK_UNREACHABLE();
+	DUK_WO_UNREACHABLE(return 0.0;);
 }
 
 /*
@@ -611,7 +613,7 @@ DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, d
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv_x));
 			DUK_ASSERT(DUK_TVAL_IS_NUMBER(tv_y));
 			DUK_UNREACHABLE();
-			return 0;
+			DUK_WO_UNREACHABLE(return 0;);
 		}
 		}
 	}
@@ -1175,11 +1177,9 @@ DUK_LOCAL duk_bool_t duk__js_instanceof_helper(duk_hthread *thr, duk_tval *tv_x,
 		val = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, val);
 	} while (--sanity > 0);
 
-	if (DUK_UNLIKELY(sanity == 0)) {
-		DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
-		DUK_WO_NORETURN(return 0;);
-	}
-	DUK_UNREACHABLE();
+	DUK_ASSERT(sanity == 0);
+	DUK_ERROR_RANGE(thr, DUK_STR_PROTOTYPE_CHAIN_LIMIT);
+	DUK_WO_NORETURN(return 0;);
 
  pop2_and_false:
 	duk_pop_2_unsafe(thr);


### PR DESCRIPTION
Add `DUK_WO_UNREACHABLE()` to make it easier to fix compile warnings.