### PR TITLE
Add RISC-V architecture detection

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3565,6 +3565,9 @@ Planned
 
 * Fix some compile warnings (GH-2161, GH-2172)
 
+* Add RISC-V architecture detection in duk_config.h; previous versions
+  also compiled on RISC-V but identified as "generic" (GH-2174)
+
 * Minor performance and footprint improvements (GH-2167)
 
 3.0.0 (XXXX-XX-XX)

--- a/config/architectures.yaml
+++ b/config/architectures.yaml
@@ -46,6 +46,14 @@ autodetect:
     check: DUK_F_SPARC64
     include: architecture_sparc64.h.in
   -
+    name: RISC-V 32-bit
+    check: DUK_F_RISCV32
+    include: architecture_riscv32.h.in
+  -
+    name: RISC-V 64-bit
+    check: DUK_F_RISCV64
+    include: architecture_riscv64.h.in
+  -
     name: SuperH
     check: DUK_F_SUPERH
     include: architecture_superh.h.in

--- a/config/architectures/architecture_riscv32.h.in
+++ b/config/architectures/architecture_riscv32.h.in
@@ -1,0 +1,3 @@
+#define DUK_USE_ARCH_STRING "riscv32"
+#define DUK_USE_BYTEORDER 1
+#define DUK_USE_PACKED_TVAL

--- a/config/architectures/architecture_riscv64.h.in
+++ b/config/architectures/architecture_riscv64.h.in
@@ -1,0 +1,3 @@
+#define DUK_USE_ARCH_STRING "riscv64"
+#define DUK_USE_BYTEORDER 1
+#undef DUK_USE_PACKED_TVAL

--- a/config/helper-snippets/DUK_F_RISCV.h.in
+++ b/config/helper-snippets/DUK_F_RISCV.h.in
@@ -1,0 +1,15 @@
+/* RISC-V, https://github.com/riscv/riscv-toolchain-conventions#cc-preprocessor-definitions */
+#if defined(__riscv)
+#define DUK_F_RISCV
+#if defined(__riscv_xlen)
+#if (__riscv_xlen == 32)
+#define DUK_F_RISCV32
+#elif (__riscv_xlen == 64)
+#define DUK_F_RISCV64
+#else
+#error __riscv_xlen has unsupported value (not 32 or 64)
+#endif
+#else
+#error __riscv defined without __riscv_xlen
+#endif
+#endif  /* __riscv */


### PR DESCRIPTION
This allows the architecture to identify as "riscv32" or "riscv64" rather than "generic". Master compiles correctly on RISC-V 64-bit at least before this pull also so this is just cosmetic for now.