### PR TITLE
Add minimum size check for abandoning array

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3572,7 +3572,7 @@ Planned
 * Add RISC-V architecture detection in duk_config.h; previous versions
   also compiled on RISC-V but identified as "generic" (GH-2174)
 
-* Minor performance and footprint improvements (GH-2167)
+* Minor performance and footprint improvements (GH-2167, GH-2177)
 
 3.0.0 (XXXX-XX-XX)
 ------------------

--- a/config/config-options/DUK_USE_HOBJECT_ARRAY_ABANDON_LIMIT.yaml
+++ b/config/config-options/DUK_USE_HOBJECT_ARRAY_ABANDON_LIMIT.yaml
@@ -5,7 +5,8 @@ tags:
   - performance
   - lowmemory
 description: >
-  Abandon array part if its density is below L.  The limit L is expressed as
+  Abandon array part if its density is below L and array is larger than
+  DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE.  The limit L is expressed as
   a .3 fixed point point, e.g. 2 means 2/8 = 25%.
 
   The default limit is quite low: one array entry with packed duk_tval is 8

--- a/config/config-options/DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE.yaml
+++ b/config/config-options/DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE.yaml
@@ -1,0 +1,11 @@
+define: DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE
+introduced: 2.5.0
+default: 257
+tags:
+  - performance
+  - lowmemory
+description: >
+  Minimum array size required for array to be abandoned.  For example, a value
+  of 257 means arrays up to 256 long are never abandoned.  The default value
+  ensures 8-bit lookups are not abandoned even if sparse or initialized in
+  random order.

--- a/config/examples/low_memory.yaml
+++ b/config/examples/low_memory.yaml
@@ -81,6 +81,8 @@ DUK_USE_HSTRING_LAZY_CLEN: false  # non-lazy charlen is smaller
 # lower memory targets usually drop hash part support entirely.
 DUK_USE_HOBJECT_HASH_PROP_LIMIT: 64
 
+DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE: 32
+
 # Disable freelist caching.
 DUK_USE_CACHE_ACTIVATION: false
 DUK_USE_CACHE_CATCHER: false

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -326,6 +326,8 @@ DUK_LOCAL duk_bool_t duk__abandon_array_density_check(duk_uint32_t a_used, duk_u
 
 /* Fast check for extending array: check whether or not a slow density check is required. */
 DUK_LOCAL duk_bool_t duk__abandon_array_slow_check_required(duk_uint32_t arr_idx, duk_uint32_t old_size) {
+	duk_uint32_t new_size_min;
+
 	/*
 	 *  In a fast check we assume old_size equals old_used (i.e., existing
 	 *  array is fully dense).
@@ -347,7 +349,9 @@ DUK_LOCAL duk_bool_t duk__abandon_array_slow_check_required(duk_uint32_t arr_idx
 	 *    arr_idx > limit'' * ((old_size + 7) / 8)
 	 */
 
-	return (arr_idx > DUK_USE_HOBJECT_ARRAY_FAST_RESIZE_LIMIT * ((old_size + 7) >> 3));
+	new_size_min = arr_idx + 1;
+	return (new_size_min >= DUK_USE_HOBJECT_ARRAY_ABANDON_MINSIZE) &&
+	       (arr_idx > DUK_USE_HOBJECT_ARRAY_FAST_RESIZE_LIMIT * ((old_size + 7) >> 3));
 }
 
 DUK_LOCAL duk_bool_t duk__abandon_array_check(duk_hthread *thr, duk_uint32_t arr_idx, duk_hobject *obj) {

--- a/tests/ecmascript/test-misc-array-fast-write.js
+++ b/tests/ecmascript/test-misc-array-fast-write.js
@@ -112,6 +112,8 @@ function arrayFastWriteTest() {
 
     print('sparse array');
     arr = [];
+    arr[1e6] = 123;
+    arr.length = 20;
     arr[20] = 'quux';
     print(arr[17], arr[18]);
 


### PR DESCRIPTION
Add a minimum size below which array items part is not abandoned, with default value 257. The default allows 8-bit lookup arrays to be constructed in arbitrary order without the array becoming abandoned in the process.