### PR TITLE
Fix some API documentation lstring examples

### DIFF
--- a/website/api/duk_del_prop_lstring.yaml
+++ b/website/api/duk_del_prop_lstring.yaml
@@ -13,7 +13,7 @@ summary: |
 example: |
   duk_bool_t rc;
 
-  rc = duk_del_prop_lstring(ctx, -3, "internal" "\x00" "nul");
+  rc = duk_del_prop_lstring(ctx, -3, "internal" "\x00" "nul", 12);
   printf("delete obj.internal[00]nul -> rc=%d\n", (int) rc);
 
 tags:

--- a/website/api/duk_get_global_lstring.yaml
+++ b/website/api/duk_get_global_lstring.yaml
@@ -12,7 +12,7 @@ summary: |
   but the key is given as a string with explicit length.</p>
 
 example: |
-  (void) duk_get_global_lstring(ctx, "internal" "\x00" "nul");
+  (void) duk_get_global_lstring(ctx, "internal" "\x00" "nul", 12);
 
 tags:
   - property

--- a/website/api/duk_put_global_lstring.yaml
+++ b/website/api/duk_put_global_lstring.yaml
@@ -12,7 +12,7 @@ summary: |
 
 example: |
   duk_push_string(ctx, "1.2.3");
-  (void) duk_put_global_lstring(ctx, "internal" "\x00" "nul");
+  (void) duk_put_global_lstring(ctx, "internal" "\x00" "nul", 12);
 
 tags:
   - property


### PR DESCRIPTION
Some lstring examples were missing a length argument.