### PR TITLE
Add duk_pull() public API call

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3550,6 +3550,8 @@ Planned
   proposal-global; enable the binding by default; update
   polyfills/global.js (GH-2160)
 
+* Add duk_pull() API call (GH-2184)
+
 * Add experimental duk_cbor_encode() and duk_cbor_decode() API calls (GH-2163)
 
 * Move CBOR extra into an actual Duktape built-in, enabled by default (GH-2163)

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -524,6 +524,7 @@ DUK_EXTERNAL_DECL void duk_swap_top(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL void duk_dup(duk_context *ctx, duk_idx_t from_idx);
 DUK_EXTERNAL_DECL void duk_dup_top(duk_context *ctx);
 DUK_EXTERNAL_DECL void duk_insert(duk_context *ctx, duk_idx_t to_idx);
+DUK_EXTERNAL_DECL void duk_pull(duk_context *ctx, duk_idx_t from_idx);
 DUK_EXTERNAL_DECL void duk_replace(duk_context *ctx, duk_idx_t to_idx);
 DUK_EXTERNAL_DECL void duk_copy(duk_context *ctx, duk_idx_t from_idx, duk_idx_t to_idx);
 DUK_EXTERNAL_DECL void duk_remove(duk_context *ctx, duk_idx_t idx);

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -23,8 +23,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 		return 0;
 	}
 
-	/* Up-to-date for Duktape 1.3.0, alphabetical order:
-	 * $ cd website/api; ls *.yaml
+	/* $ cd website/api; ls *.yaml
 	 */
 
 	(void) duk_alloc_raw(ctx, 0);
@@ -223,6 +222,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_pop_3(ctx);
 	(void) duk_pop_n(ctx, 0);
 	(void) duk_pop(ctx);
+	(void) duk_pull(ctx, 0);
 	(void) duk_push_array(ctx);
 	(void) duk_push_bare_object(ctx);
 	(void) duk_push_boolean(ctx, 0);

--- a/website/api/duk_insert.yaml
+++ b/website/api/duk_insert.yaml
@@ -28,6 +28,7 @@ tags:
   - stack
 
 seealso:
+  - duk_pull
   - duk_replace
 
 introduced: 1.0.0

--- a/website/api/duk_pull.yaml
+++ b/website/api/duk_pull.yaml
@@ -1,0 +1,26 @@
+name: duk_pull
+
+proto: |
+  void duk_pull(duk_context *ctx, duk_idx_t from_idx);
+
+stack: |
+  [ ... val! ... ] -> [ ... val! ]
+
+summary: |
+  <p>Remove value at <code>from_idx</code> and push it on the value stack top.</p>
+  If <code>from_idx</code> is an invalid index, throws an error.</p>
+
+example: |
+  duk_push_int(ctx, 123);
+  duk_push_int(ctx, 234);
+  duk_push_int(ctx, 345);       /* -> [ 123 234 345 ] */
+  duk_pull(ctx, -2);            /* [ 123 234 345 ] -> [ 123 345 234 ] */
+
+tags:
+  - stack
+
+seealso:
+  - duk_insert
+  - duk_remove
+
+introduced: 2.5.0


### PR DESCRIPTION
This was originally suggested (including the name :) by @fatcerberus.

The duk_pull() API call is a counterpart to duk_insert(): it takes an element at a certain index and pushes it on stack top, e.g. `duk_pull(ctx, 2)`:
```
      |
      v =====            =====
[ A B C D E F ] -> [ A B D E F C ]
```

This comes up in some internal call sites (which now just use duk_dup() and duk_remove()) so it might just as well be in the public API.