### PR TITLE
[wip] "external" stack value support

### DIFF
--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -72,7 +72,7 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 	tv = duk_get_tval_or_unused(thr, idx);
 	h = (DUK_TVAL_IS_HEAP_ALLOCATED(tv) ? DUK_TVAL_GET_HEAPHDR(tv) : NULL);
 
-	vals[DUK__IDX_TYPE] = duk_get_type_tval(tv);
+	vals[DUK__IDX_TYPE] = duk_get_type_tval(thr, tv);
 	vals[DUK__IDX_ITAG] = (duk_int_t) DUK_TVAL_GET_TAG(tv);
 
 	duk_push_bare_object(thr);  /* Invalidates 'tv'. */

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -64,8 +64,8 @@ DUK_INTERNAL_DECL void duk_remove_m2(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_remove_n(duk_hthread *thr, duk_idx_t idx, duk_idx_t count);
 DUK_INTERNAL_DECL void duk_remove_n_unsafe(duk_hthread *thr, duk_idx_t idx, duk_idx_t count);
 
-DUK_INTERNAL_DECL duk_int_t duk_get_type_tval(duk_tval *tv);
-DUK_INTERNAL_DECL duk_uint_t duk_get_type_mask_tval(duk_tval *tv);
+DUK_INTERNAL_DECL duk_int_t duk_get_type_tval(duk_hthread *thr, duk_tval *tv);
+DUK_INTERNAL_DECL duk_uint_t duk_get_type_mask_tval(duk_hthread *thr, duk_tval *tv);
 
 #if defined(DUK_USE_VERBOSE_ERRORS) && defined(DUK_USE_PARANOID_ERRORS)
 DUK_INTERNAL_DECL const char *duk_get_type_name(duk_hthread *thr, duk_idx_t idx);

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -898,9 +898,9 @@ DUK_INTERNAL void duk_debug_write_tval(duk_hthread *thr, duk_tval *tv) {
 	case DUK_TAG_UNDEFINED:
 		duk_debug_write_byte(thr, DUK_DBG_IB_UNDEFINED);
 		break;
-	case DUK_TAG_UNUSED:
-		duk_debug_write_byte(thr, DUK_DBG_IB_UNUSED);
-		break;
+	//case DUK_TAG_UNUSED:
+	//	duk_debug_write_byte(thr, DUK_DBG_IB_UNUSED);
+	//	break;
 	case DUK_TAG_NULL:
 		duk_debug_write_byte(thr, DUK_DBG_IB_NULL);
 		break;

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -538,6 +538,10 @@ DUK_LOCAL duk_bool_t duk__init_heap_thread(duk_heap *heap) {
 		return 0;
 	}
 	thr->state = DUK_HTHREAD_STATE_INACTIVE;
+
+	//FIXME(jc) initialize function pointers with default implementations
+	thr->extval_handlers.get_length_func = NULL;
+
 #if defined(DUK_USE_ROM_STRINGS)
 	/* No strs[] pointer. */
 #else  /* DUK_USE_ROM_STRINGS */

--- a/src-input/duk_hthread.h
+++ b/src-input/duk_hthread.h
@@ -264,6 +264,24 @@ struct duk_catcher {
 	 */
 };
 
+//FIXME (jc) promote as public API, add public `void duk_set_extval_handlers(duk_context *ctx, duk_extval_handlers handlers)`,
+// initialize the pointers to their default implementations in duk_thread
+typedef duk_size_t (*duk_extval_size_function) (duk_hthread *thr, duk_small_uint_t proto_id, void *udata);
+typedef duk_int_t (*duk_extval_int_function) (duk_hthread *thr, duk_small_uint_t proto_id, void *udata);
+typedef void (*duk_extval_void_function) (duk_hthread *thr, duk_small_uint_t proto_id, void *udata);
+
+struct duk_extval_handlers {
+    duk_extval_int_function get_type_func;
+    duk_extval_size_function get_length_func;
+    duk_extval_void_function push_class_name_func;
+    duk_extval_void_function to_primitive_func;
+    duk_extval_void_function to_string_func;
+    duk_extval_void_function to_number_func;
+    duk_extval_void_function to_boolean_func;
+    duk_extval_void_function to_object_func;
+};
+//----
+
 struct duk_hthread {
 	/* Shared object part */
 	duk_hobject obj;
@@ -334,6 +352,9 @@ struct duk_hthread {
 
 	/* Current compiler state (if any), used for augmenting SyntaxErrors. */
 	duk_compiler_ctx *compile_ctx;
+
+	/* Handlers for external values */
+	struct duk_extval_handlers extval_handlers;
 
 #if defined(DUK_USE_INTERRUPT_COUNTER)
 	/* Interrupt counter for triggering a slow path check for execution

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -522,6 +522,7 @@ DUK_LOCAL duk_bool_t duk__js_samevalue_number(duk_double_t x, duk_double_t y) {
 #endif  /* DUK_USE_PARANOID_MATH */
 }
 
+//FIXME (jc) handle external values
 DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, duk_tval *tv_y, duk_small_uint_t flags) {
 	duk_uint_t type_mask_x;
 	duk_uint_t type_mask_y;
@@ -631,8 +632,8 @@ DUK_INTERNAL duk_bool_t duk_js_equals_helper(duk_hthread *thr, duk_tval *tv_x, d
 	 *  code size.
 	 */
 
-	type_mask_x = duk_get_type_mask_tval(tv_x);
-	type_mask_y = duk_get_type_mask_tval(tv_y);
+	type_mask_x = duk_get_type_mask_tval(thr, tv_x);
+	type_mask_y = duk_get_type_mask_tval(thr, tv_y);
 
 	/* Undefined/null are considered equal (e.g. "null == undefined" -> true). */
 	if ((type_mask_x & (DUK_TYPE_MASK_UNDEFINED | DUK_TYPE_MASK_NULL)) &&

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -344,7 +344,8 @@ typedef struct {
 #define DUK_TAG_BOOLEAN               4
 #define DUK_TAG_POINTER               5
 #define DUK_TAG_LIGHTFUNC             6
-#define DUK_TAG_UNUSED                7  /* marker; not actual tagged type */
+#define DUK_TAG_EXTVAL                7  /* externally handled stack value */
+#define DUK_TAG_UNUSED                DUK_TAG_UNDEFINED
 #define DUK_TAG_STRING                8  /* first heap allocated, match bit boundary */
 #define DUK_TAG_OBJECT                9
 #define DUK_TAG_BUFFER                10
@@ -510,6 +511,14 @@ typedef struct {
 		duk__tv->v.d = DUK_DOUBLE_NAN; \
 	} while (0)
 
+#define DUK_TVAL_SET_EXTVAL(tv,proto_id,udata)  do { \
+		duk_tval *duk__tv; \
+		duk__tv = (tv); \
+		duk__tv->t = DUK_TAG_EXTVAL; \
+		duk__tv->v_extra = (proto_id); \
+		duk__tv->v.voidptr = (udata); \
+	} while (0)
+
 #define DUK_TVAL_SET_TVAL(tv,x)            do { *(tv) = *(x); } while (0)
 
 /* getters */
@@ -545,6 +554,8 @@ typedef struct {
 #define DUK_TVAL_GET_OBJECT(tv)            ((tv)->v.hobject)
 #define DUK_TVAL_GET_BUFFER(tv)            ((tv)->v.hbuffer)
 #define DUK_TVAL_GET_HEAPHDR(tv)           ((tv)->v.heaphdr)
+#define DUK_TVAL_GET_EXTVAL_PROTO_ID(tv)   ((duk_small_uint_t) ((tv)->v_extra))
+#define DUK_TVAL_GET_EXTVAL_UDATA(tv)      ((tv)->v.voidptr)
 
 /* decoding */
 #define DUK_TVAL_GET_TAG(tv)               ((tv)->t)
@@ -568,6 +579,7 @@ typedef struct {
 #define DUK_TVAL_IS_STRING(tv)             ((tv)->t == DUK_TAG_STRING)
 #define DUK_TVAL_IS_OBJECT(tv)             ((tv)->t == DUK_TAG_OBJECT)
 #define DUK_TVAL_IS_BUFFER(tv)             ((tv)->t == DUK_TAG_BUFFER)
+#define DUK_TVAL_IS_EXTVAL(tv)             ((tv)->t == DUK_TAG_EXTVAL)
 
 /* This is performance critical because it's needed for every DECREF.
  * Take advantage of the fact that the first heap allocated tag is 8,


### PR DESCRIPTION
This PR is an early attempt to add and API for externally handled stack values, as mentioned in #2190 

This is preliminary work to see if such a change is viable to be merged into this project.

Basic idea is that we have an additional stack value type with a tag `DUK_TAG_EXTVAL`, available only for an unpacked stack value representation (as it requires 16 byte length for stack values).
Whenever a type/conversion of such value is needed, external API (modeled as a number of function pointers in `duk_hthread` struct) is used. At the moment a few performance penalties were introduced (like in `duk_get_type_tval`) in form of an additional condition.

This code was not tested, and it is definitely not ready to be merged. It is only meant to provide a background for a discussion, whether such an API has its place in duktape, and whether I should proceed with this development.

Regards.