### PR TITLE
Allow DUK_USE_EXEC_TIMEOUT_CHECK to be called from within the main loop of a long lived regular expression

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Luis de Bethencourt (https://github.com/luisbg)
 * Ian Whyman (https://github.com/v00d00)
 * Rick Sayre (https://github.com/whorfin)
+* Craig Edwards (https://github.com/braindigitalis)
 
 Other contributions
 ===================


### PR DESCRIPTION
I am using duktape in an environment where it may be asked to run untrusted code as part of a platform as a service, and the function ``duk__match_regexp()`` can potentially run for a very long time if an abusive or broken regular expression is passed to it. This is somewhat mitigated by the value of ``DUK_RE_EXECUTE_STEPS_LIMIT``, lowering this can solve the problem but it seems this cannot be lowered from duk_config.h, and i would have to edit my duktape.c to fix it.

Based upon this i decided on this fix instead - i am already using ``DUK_USE_EXEC_TIMEOUT_CHECK`` with an interrupt function to prevent cpu consumption and various forms of resource abuse, but it seems the timeout function is not called from within the ``duk__match_regexp()`` function.

This PR adds support for calling the interrupt function from within the loop, this doesnt change any specification i'm aware of, as the docs say just that the interrupt function is 'called periodically' while running the script. 

Please consider either merging this PR in some form, or allowing user configuration of ``DUK_RE_EXECUTE_STEPS_LIMIT`` and ``DUK_RE_COMPILE_TOKEN_LIMIT``.

Thanks!