### PR TITLE
Post-release trivia for 2.5.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1195,16 +1195,14 @@ docker-images: docker-images-x64
 .PHONY: docker-clean
 docker-clean:
 	-rm -f docker/*/gitconfig docker/*/prepare_repo.sh
-	-docker rmi \
-		duktape-release-1-ubuntu-18.04-x64:latest \
-		duktape-shell-ubuntu-18.04-x64:latest \
-		duktape-duk-ubuntu-18.04-x64:latest \
-		duktape-site-ubuntu-18.04-x64:latest \
-		duktape-dist-ubuntu-18.04-x64:latest \
-		duktape-base-ubuntu-18.04-x64:latest
-	-docker rmi \
-		duktape-shell-ubuntu-18.04-s390x:latest \
-		duktape-base-ubuntu-18.04-s390x:latest
+	-docker rmi duktape-release-1-ubuntu-18.04-x64:latest
+	-docker rmi duktape-shell-ubuntu-18.04-x64:latest
+	-docker rmi duktape-duk-ubuntu-18.04-x64:latest
+	-docker rmi duktape-site-ubuntu-18.04-x64:latest
+	-docker rmi duktape-dist-ubuntu-18.04-x64:latest
+	-docker rmi duktape-base-ubuntu-18.04-x64:latest
+	-docker rmi duktape-shell-ubuntu-18.04-s390x:latest
+	-docker rmi duktape-base-ubuntu-18.04-s390x:latest
 	@echo ""
 	@echo "Now run 'docker system prune' to free disk space."
 

--- a/doc/release-checklist.rst
+++ b/doc/release-checklist.rst
@@ -216,9 +216,9 @@ Checklist for ordinary releases
 
   - ``git tag -l -n1`` to list current tags
 
-  - ``git tag -s -m "<one line release description>" vN.N.N`` to set tag
+  - ``git tag -m "<one line release description>" vN.N.N`` to set tag
 
-  - ``git tag -f -s -m "<one line release description>" vN.N.N`` to forcibly
+  - ``git tag -f -m "<one line release description>" vN.N.N`` to forcibly
     reset tag if it needs to be moved
 
 * If release is a stable major/minor release (e.g. 1.1.0), create a maintenance

--- a/docker/duktape-base-ubuntu-18.04-x64/Dockerfile
+++ b/docker/duktape-base-ubuntu-18.04-x64/Dockerfile
@@ -86,10 +86,10 @@ RUN echo "=== Prepare duktape-prep repo ===" && \
 	make clean
 
 # Initialize Emscripten cached bytecode files.
-RUN echo "=== Prepare Emscripten cached bytecode files ===" && \
-	cp -r duktape-prep /tmp/duktape-emcc-init && \
-	bash -c '. emsdk/emsdk_env.sh && cd /tmp/duktape-emcc-init && make emscriptenluatest dukweb.js' && \
-	rm -rf /tmp/duktape-emcc-init /tmp/duk-emcc*
+#RUN echo "=== Prepare Emscripten cached bytecode files ===" && \
+#	cp -r duktape-prep /tmp/duktape-emcc-init && \
+#	bash -c '. emsdk/emsdk_env.sh && cd /tmp/duktape-emcc-init && make emscriptenluatest dukweb.js' && \
+#	rm -rf /tmp/duktape-emcc-init /tmp/duk-emcc*
 
 # Dump some versions.
 RUN echo "=== Versions ===" && \

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -606,7 +606,7 @@ DUK_LOCAL void duk__dump_type_sizes(void) {
 	DUK__DUMPSZ(void *);
 	DUK__DUMPSZ(size_t);
 
-	/* basic types from duk_features.h */
+	/* basic types from duk_config.h */
 	DUK__DUMPSZ(duk_uint8_t);
 	DUK__DUMPSZ(duk_int8_t);
 	DUK__DUMPSZ(duk_uint16_t);

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -750,7 +750,7 @@ struct duk_hobject {
 	 *  'props' contains {key,value,flags} entries, optional array entries, and
 	 *  an optional hash lookup table for non-array entries in a single 'sliced'
 	 *  allocation.  There are several layout options, which differ slightly in
-	 *  generated code size/speed and alignment/padding; duk_features.h selects
+	 *  generated code size/speed and alignment/padding; duk_config.h selects
 	 *  the layout used.
 	 *
 	 *  Layout 1 (DUK_USE_HOBJECT_LAYOUT_1):

--- a/src-input/duk_internal.h
+++ b/src-input/duk_internal.h
@@ -26,7 +26,7 @@
 #include "duktape.h"
 
 /*
- *  Duktape includes (other than duk_features.h)
+ *  Duktape includes (other than duk_config.h)
  *
  *  The header files expect to be included in an order which satisfies header
  *  dependencies correctly (the headers themselves don't include any other

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -38,7 +38,7 @@
  * development snapshots have 99 for patch level (e.g. 0.10.99 would be a
  * development version after 0.10.0 but before the next official release).
  */
-#define DUK_VERSION                       20500L
+#define DUK_VERSION                       29999L
 
 /* Git commit, describe, and branch for Duktape build.  Useful for
  * non-official snapshot builds so that application code can easily log

--- a/website/download/download.html
+++ b/website/download/download.html
@@ -54,7 +54,8 @@
 <tr><td class="reldate">2017-09-23</td><td class="filename"><a href="duktape-2.2.0.tar.xz">duktape-2.2.0.tar.xz</a></td><td class="description">call handling, API improvements, performance, <a href="https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-2.rst">release notes</a></td><td class="hash">XXX</td></tr>
 <tr><td class="reldate">2018-04-26</td><td class="filename"><a href="duktape-2.2.1.tar.xz">duktape-2.2.1.tar.xz</a></td><td class="description">maintenance release (no longer maintained)</td><td class="hash">XXX</td></tr>
 <tr><td class="reldate">2018-08-04</td><td class="filename"><a href="duktape-2.3.0.tar.xz">duktape-2.3.0.tar.xz</a></td><td class="description">ES2015 improvements, <a href="https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-3.rst">release notes</a> (no longer maintained)</td><td class="hash">XXX</td></tr>
-<tr class="latest"><td class="reldate">2019-07-28</td><td class="filename"><a href="duktape-2.4.0.tar.xz">duktape-2.4.0.tar.xz</a></td><td class="description">minor fixes and improvements, <a href="https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-4.rst">release notes</a></td><td class="hash">XXX</td></tr>
+<tr><td class="reldate">2019-07-28</td><td class="filename"><a href="duktape-2.4.0.tar.xz">duktape-2.4.0.tar.xz</a></td><td class="description">minor fixes and improvements, <a href="https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-4.rst">release notes</a></td><td class="hash">XXX</td></tr>
+<tr class="latest"><td class="reldate">2019-11-24</td><td class="filename"><a href="duktape-2.5.0.tar.xz">duktape-2.5.0.tar.xz</a></td><td class="description">CBOR support, minor fixes and improvements, <a href="https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-5.rst">release notes</a></td><td class="hash">XXX</td></tr>
 </tbody>
 </table>
 

--- a/website/guide/errorobjects.html
+++ b/website/guide/errorobjects.html
@@ -120,7 +120,7 @@ try {
 </pre>
 
 <p>An attempt to write to <code>stack</code> is captured by an inherited
-setter which will create an own property as if a normal assignment was done.</p>
+setter which will create an own property as if a normal assignment was done.
 This behavior differs from V8 where <code>stack</code> is an own property
 of the Error instance.</p>
 


### PR DESCRIPTION
Trivia:
* Bump DUK_VERSION to 2.99.99.
* Makefile docker rmi fix.
* Source comment trivia.
* Disable emscriptenluatest in docker base image as it fails now.
* Add 2.5.0 download link.
* Tidy fix to guide.

**Master will now get incompatible changes for an eventual 3.0.0 release.** If you're tracking master, consider tracking `v2-maintenance` instead.