### PR TITLE
Accept unlabelled function statements outside of top level for strict functions

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3587,3 +3587,7 @@ Planned
 
 * Remove prepared source variants other than src/ (matches Duktape 2.x
   src-noline/) from the distributable (GH-2209)
+
+* Accept unlabelled function statements outside of top level for strict
+  functions (using hoist semantics), previously they were rejected with
+  a SyntaxError (GH-2213)

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -6385,10 +6385,13 @@ DUK_LOCAL void duk__parse_stmt(duk_compiler_ctx *comp_ctx, duk_ivalue *res, duk_
 		 */
 		test_func_decl = allow_source_elem;
 #if defined(DUK_USE_NONSTD_FUNC_STMT)
-		/* Lenient: allow function declarations outside top level in
-		 * non-strict mode but reject them in strict mode.
+		/* Lenient: allow function declarations outside top level in both
+		 * strict and non-strict modes.  However, don't allow labelled
+		 * function declarations in strict mode.
 		 */
-		test_func_decl = test_func_decl || !comp_ctx->curr_func.is_strict;
+		test_func_decl = test_func_decl ||
+		                 !comp_ctx->curr_func.is_strict ||
+		                 label_id < 0;
 #endif  /* DUK_USE_NONSTD_FUNC_STMT */
 		/* Strict: never allow function declarations outside top level. */
 		if (test_func_decl) {

--- a/tests/ecmascript/test-dev-func-decl-outside-top.js
+++ b/tests/ecmascript/test-dev-func-decl-outside-top.js
@@ -172,13 +172,14 @@ try {
 
 /*===
 function declaration inside try (strict)
-SyntaxError
+fun1 undefined
+fun1 undefined
 ===*/
 
 function functionDeclarationInsideTryStrictTest() {
-    /* Same as above, but in strict mode.  V8 behavior is to reject
-     * function declarationts outside top level in strict mode.  We
-     * follow that behavior.
+    /* Same as above, but in strict mode.  V8 used to reject function
+     * declarations outside top level in strict mode but now accepts
+     * them with block level semantics.
      *
      * Rhino allows such declarations even in strict mode, and provides
      * the same semantics as in non-strict mode.
@@ -190,8 +191,9 @@ function functionDeclarationInsideTryStrictTest() {
                  'throw new Error("test");' +
              '} catch (e) {' +
                  'function fun1() { print("fun1", typeof e); }' +
+                 'fun1();' +  // V8: 'fun1 object'
              '}' +
-             'fun1();' +
+             'fun1();' +  // V8: TypeError, fun1 not visible
          '})()');
 }
 

--- a/tests/ecmascript/test-dev-label-source-elem.js
+++ b/tests/ecmascript/test-dev-label-source-elem.js
@@ -6,9 +6,8 @@
  *
  *  This is the E5 standards compliant behavior.  However, this test
  *  case tests for the default Duktape behavior (modelled after V8):
- *  function declarations are allowed outside top level in non-strict
- *  mode, and are treated like ordinary function declarations.  In
- *  strict mode they are not allowed.
+ *  function declarations are allowed outside top level and are
+ *  treated like ordinary function declarations.
  */
 
 /*---
@@ -41,9 +40,10 @@ try {
 }
 
 try {
-    /* Strict mode should have no effect on this, but this test
-     * illustrates V8 behavior (i.e. V8 gives a SyntaxError here
-     * but only in strict mode).
+    /* This test illustrates V8 behavior, i.e. V8 gives a SyntaxError
+     * here but only in strict mode, even in Node.js v12.7.0:
+     * SyntaxError: In strict mode code, functions can only be declared
+     * at top level or inside a block.
      */
     eval("function f1() { 'use strict'; mylabel: function f2() {} }");
     print("try finished");

--- a/tests/ecmascript/test-stmt-func-stmt-nonstrict.js
+++ b/tests/ecmascript/test-stmt-func-stmt-nonstrict.js
@@ -1,0 +1,32 @@
+/*===
+a called
+a called
+b called
+b called
+===*/
+
+try {
+    function a() {
+        print('a called');
+    }
+    a();
+} catch (e) {
+    print(e.stack || e);
+}
+// In Node.js v12.7.0 'a' is still visible here, i.e. declaration
+// is hoisted.
+a();
+
+function test() {
+    try {
+        function b() {
+            print('b called');
+        }
+        b();
+    } catch (e) {
+        print(e.stack || e);
+    }
+    // Also hoisted here.
+    b();
+}
+test();

--- a/tests/ecmascript/test-stmt-func-stmt-strict.js
+++ b/tests/ecmascript/test-stmt-func-stmt-strict.js
@@ -1,0 +1,51 @@
+/*===
+a called
+a called
+b called
+b called
+===*/
+
+/*---
+{
+    "use_strict": true
+}
+---*/
+
+'use strict';
+
+// Duktape 2.5.0 and prior reject strict mode function statements.
+// Duktape >2.5.0 allows them to improve compatibility with existing
+// code base.
+try {
+    function a() {
+        print('a called');
+    }
+    a();
+} catch (e) {
+    print(e.stack || e);
+}
+// In Node.js v12.7.0 'a' is not visible here, i.e. 'a' has block visibility
+// (ReferenceError here).  Duktape 2.x uses hoist semantics.
+try {
+    a();
+} catch (e) {
+    print(e.name);
+}
+
+function test() {
+    try {
+        function b() {
+            print('b called');
+        }
+        b();
+    } catch (e) {
+        print(e.stack || e);
+    }
+    // Same here.
+    try {
+        b();
+    } catch (e) {
+        print(e.name);
+    }
+}
+test();

--- a/tests/ecmascript/test-stmt-labelled-func-stmt-nonstrict.js
+++ b/tests/ecmascript/test-stmt-labelled-func-stmt-nonstrict.js
@@ -1,0 +1,34 @@
+/*===
+a called
+a called
+b called
+b called
+===*/
+
+try {
+ label1:
+    function a() {
+        print('a called');
+    }
+    a();
+} catch (e) {
+    print(e.stack || e);
+}
+// In Node.js v12.7.0 'a' is still visible here, i.e. declaration
+// is hoisted.
+a();
+
+function test() {
+    try {
+     label2:
+        function b() {
+            print('b called');
+        }
+        b();
+    } catch (e) {
+        print(e.stack || e);
+    }
+    // Also hoisted here.
+    b();
+}
+test();

--- a/tests/ecmascript/test-stmt-labelled-func-stmt-strict.js
+++ b/tests/ecmascript/test-stmt-labelled-func-stmt-strict.js
@@ -1,0 +1,37 @@
+/*===
+SyntaxError
+SyntaxError
+===*/
+
+/*---
+{
+    "use_strict": true
+}
+---*/
+
+'use strict';
+
+// Labelled function declarations are rejected altogether.
+
+try {
+     eval('label1:\n' +
+          '  function a() {\n' +
+          '    print("a called");\n' +
+          '  }\n' +
+          'a();\n');
+} catch (e) {
+    print(e.name);
+}
+
+function test() {
+    try {
+        eval('label2:\n' +
+             '  function b() {\n' +
+             '     print("b called");\n' +
+             '  }\n' +
+             'b();\n');
+    } catch (e) {
+        print(e.name);
+    }
+}
+test();


### PR DESCRIPTION
Accept unlabelled function statements outside of top level for strict functions (using hoist semantics), previously they were rejected with a SyntaxError. This improves compatibility with some real world code.