### PR TITLE
quiet "maybe-uninitialized" error in src-input/duk_js_compiler.c

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Luis de Bethencourt (https://github.com/luisbg)
 * Ian Whyman (https://github.com/v00d00)
 * Rick Sayre (https://github.com/whorfin)
+* Craig Leres (https://github.com/leres)
 
 Other contributions
 ===================

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -1961,7 +1961,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 	duk_idx_t nargs;            /* # argument registers target function wants (< 0 => "as is") */
 	duk_idx_t nregs;            /* # total registers target function wants on entry (< 0 => "as is") */
 	duk_size_t vs_min_bytes;    /* minimum value stack size (bytes) for handling call */
-	duk_hobject *func;          /* 'func' on stack (borrowed reference) */
+	duk_hobject *func = NULL;   /* 'func' on stack (borrowed reference) */
 	duk_activation *act;
 	duk_ret_t rc;
 	duk_small_uint_t use_tailcall;
@@ -2264,7 +2264,7 @@ DUK_LOCAL duk_int_t duk__handle_call_raw(duk_hthread *thr,
 		DUK_ASSERT(thr->ptr_curr_pc == NULL);
 
 		/* XXX: native funcptr could come out of call setup. */
-		if (func) {
+		if (func != NULL) {
 			rc = ((duk_hnatfunc *) func)->func(thr);
 		} else {
 			duk_tval *tv_func;


### PR DESCRIPTION
After openvehicles/Open-Vehicle-Monitoring-System-3 upgraded to duktape 2.5.0 the xtensa-esp32-elf-gcc toolchain (gcc 5.2.0) start giving this warning:
```
    duk_js_call.c: In function 'duk__handle_call_raw':
    duk_js_call.c:2268:32: error: 'func' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    cc1: some warnings being treated as errors
    gmake[1]: *** [/home/ice/u0/leres/esp/openvehicles-xtensa-esp32-elf/make/component_wrapper.mk:290: src/duktape.o] Error 1
    gmake: *** [/home/ice/u0/leres/esp/esp-idf/make/project.mk:552: component-duktape-build] Error 2 
```
Initializing `func` to null at the start of the function solves this.