### PR TITLE
Fix navbar spacing after github corner change

### DIFF
--- a/website/style-middle.css
+++ b/website/style-middle.css
@@ -6,7 +6,7 @@
 	width: 100%;
 	padding: 0;
 	border: 0;
-	margin: 0;
+	margin: 10ex 0 10ex 0;
 	background: #ffffff;
 	color: #000000;
 	overflow: auto;  /* clear fix */


### PR DESCRIPTION
Add site-middle margin back to ensure `<h1>` level heading is not directly after nav bar.