### PR TITLE
Specify python2.7 in runtests, as Python 3 is `python` these days

### DIFF
--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -325,7 +325,7 @@ function executeTest(options, callback) {
         args.push('--output', tempInput)
         args.push('--prologue', tempPrologue)
 
-        child_process.execFile('python', args, {}, compileDone)
+        child_process.execFile('python2.7', args, {}, compileDone)
     }
 
     if (options.engine.name === 'api') {


### PR DESCRIPTION
This is a breakout PR from #2219.

`runtests` require Python 2.7 however these days Python 3 is the default runtime on most linux distributions, making it difficult to run the tests locally.
