### PR TITLE
Use wasm for dukweb.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@
 /massif-*.out
 /ms_print.*
 /dukweb.js
+/dukweb.wasm
 /debugger/jquery-ui-1.11.2.zip
 /debugger/jquery-ui-1.11.2/
 /debugger/node_modules/

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -3597,3 +3597,6 @@ Planned
 
 * Don't treat U+180E as whitespace e.g. for String trim() purposes,
   (ES2016, requires Unicode 8.0.0 or higher) (GH-2236)
+
+* Use wasm for dukweb.js compilation (including duktape.org site),
+  fix async loading of emcc-compiled code in dukweb.html (GH-2244)

--- a/dukweb/dukweb.html
+++ b/dukweb/dukweb.html
@@ -12,11 +12,11 @@
 
 <div id="content-middle">
 
-<p id="dukweb-intro">Works in Chrome/Chromium/Firefox.  There is much to
-improve in the Duktape/browser bindings and errors are not handled nicely
-yet, so keep your Javascript Console open.  Also note that this page takes
-a few seconds to (re)load.  You can embed code in the Dukweb link as a
-fragment identifier: <a href="http://duktape.org/dukweb.html#print('Hello%20world!')%3B">http://duktape.org/dukweb.html#print('Hello%20world!')%3B</a>.</p>
+<p id="dukweb-intro">Duktape compiled using emcc into JS + wasm (can
+also be compiled into pure JS), should work in Chrome/Chromium/Firefox.
+See Web Console for details and errors.  This page takes a a few seconds
+to (re)load.  You can embed code in the Dukweb link as a fragment identifier:
+<a href="http://duktape.org/dukweb.html#print('Hello%20world!')%3B">http://duktape.org/dukweb.html#print('Hello%20world!')%3B</a>.</p>
 
 <div id="dukweb-input-wrapper">
 <textarea id="dukweb-input">
@@ -117,15 +117,15 @@ $(document).ready(function () {
         alert(e);
     }
 
-    try {
+    Duktape.getInitializedPromise().then(function () {
         dukwebSetup();
-    } catch (e) {
+    }).catch(function (e) {
         $('#dukweb-output')
             .addClass('error')
             .text(
                 'Dukweb.js initialization failed (perhaps your browser is not compatible?):\n\n' +
                 String(e.stack || e) + '\n\n');
-    }
+    });
 });
 
 //]]>

--- a/website/buildsite.py
+++ b/website/buildsite.py
@@ -1167,6 +1167,7 @@ def main():
 
     print 'Copying dukweb.js files'
     for i in [ '../dukweb.js',
+               '../dukweb.wasm',
                '../jquery-1.11.2.js',
                '../dukweb/dukweb.css',
                '../dukweb/dukweb.html' ]:


### PR DESCRIPTION
Also fix async load handling in dukweb: delay dukwebSetup() until the emcc-compiled Duktape code is fully initialized.  This matters with wasm compilation because loading is actually asynchronous.