### PR TITLE
Pass Python executable to runtests.js explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ EMDUKOPTS += -DEMSCRIPTEN  # enable stdin workaround in duk_cmdline.c
 MAND_BASE64 = dyA9IDgwOyBoID0gNDA7IGl0ZXIgPSAxMDA7IGZvciAoaSA9IDA7IGkgLSBoOyBpICs9IDEpIHsgeTAgPSAoaSAvIGgpICogNC4wIC0gMi4wOyByZXMgPSBbXTsgZm9yIChqID0gMDsgaiAtIHc7IGogKz0gMSkgeyB4MCA9IChqIC8gdykgKiA0LjAgLSAyLjA7IHh4ID0gMDsgeXkgPSAwOyBjID0gIiMiOyBmb3IgKGsgPSAwOyBrIC0gaXRlcjsgayArPSAxKSB7IHh4MiA9IHh4Knh4OyB5eTIgPSB5eSp5eTsgaWYgKE1hdGgubWF4KDAsIDQuMCAtICh4eDIgKyB5eTIpKSkgeyB5eSA9IDIqeHgqeXkgKyB5MDsgeHggPSB4eDIgLSB5eTIgKyB4MDsgfSBlbHNlIHsgYyA9ICIuIjsgYnJlYWs7IH0gfSByZXNbcmVzLmxlbmd0aF0gPSBjOyB9IHByaW50KHJlcy5qb2luKCIiKSk7IH0K
 
 # Options for runtests.js.
-RUNTESTSOPTS = --prep-test-path util/prep_test.py --minify-uglifyjs2 UglifyJS2/bin/uglifyjs --util-include-path tests/ecmascript --known-issues doc/testcase-known-issues.yaml
+RUNTESTSOPTS = --python-command $(PYTHON) --prep-test-path util/prep_test.py --minify-uglifyjs2 UglifyJS2/bin/uglifyjs --util-include-path tests/ecmascript --known-issues doc/testcase-known-issues.yaml
 
 # Compile 'duk' only by default
 .PHONY: all

--- a/runtests/runtests.js
+++ b/runtests/runtests.js
@@ -21,6 +21,7 @@ var TIMEOUT_NORMAL_VALGRIND = 3600 * 1000;
 var TIMEOUT_NORMAL = 600 * 1000;
 
 // Global options from command line
+var optPythonCommand;
 var optPrepTestPath;
 var optMinifyClosure;
 var optMinifyUglifyJS;
@@ -325,7 +326,7 @@ function executeTest(options, callback) {
         args.push('--output', tempInput)
         args.push('--prologue', tempPrologue)
 
-        child_process.execFile('python', args, {}, compileDone)
+        child_process.execFile(optPythonCommand, args, {}, compileDone)
     }
 
     if (options.engine.name === 'api') {
@@ -475,6 +476,7 @@ function testRunnerMain() {
         .usage('Execute one or multiple test cases; dirname to execute all tests in a directory.')
         .default('num-threads', 4)
         .default('test-sleep', 0)
+        .default('python-command', 'python2')
         .boolean('run-duk')
         .boolean('run-nodejs')
         .boolean('run-rhino')
@@ -485,6 +487,7 @@ function testRunnerMain() {
         .boolean('emduk-trailing-line-hack')
         .describe('num-threads', 'number of threads to use for testcase execution')
         .describe('test-sleep', 'sleep time (milliseconds) between testcases, avoid overheating :)')
+        .describe('python-command', 'python2 executable to use')
         .describe('run-duk', 'run testcase with Duktape')
         .describe('cmd-duk', 'path for "duk" command')
         .describe('run-nodejs', 'run testcase with Node.js (V8)')
@@ -700,7 +703,7 @@ function testRunnerMain() {
                parts.push('valgrind ' + JSON.stringify(vgerrors));
                need = true;
            }
-           if (need) { 
+           if (need) {
                lines.push(parts);
            }
         }, null);
@@ -745,6 +748,8 @@ function testRunnerMain() {
 
         fs.writeFileSync(logFile, lines.join('\n') + '\n');
     }
+
+    optPythonCommand = argv['python-command'];
 
     if (argv['prep-test-path']) {
         optPrepTestPath = argv['prep-test-path'];


### PR DESCRIPTION
This allows Makefile detection to be used without hardcoding the Python executable path into runtests.js.