### PR TITLE
Add JS-based tooling main and Makefile

### DIFF
--- a/src-tools/Makefile
+++ b/src-tools/Makefile
@@ -1,0 +1,36 @@
+.PHONY: all
+all: duktool.js
+
+.PHONY: eslint
+eslint:
+	npx eslint .
+
+.PHONY: clean
+clean:
+	-@rm -f duktool.js
+	-@rm -rf lib/extdeps
+
+.PHONY: cleanall
+cleanall: clean
+	-@rm -rf js-yaml
+	-@rm -rf from-xml
+	-@rm -rf node_modules
+
+.PHONY: reformat
+reformat:
+	npx js-beautify --quiet --replace `git ls-files | grep -E '*.js$$'`
+
+.PHONY: duktool.js
+duktool.js: from-xml js-yaml
+	npm install
+	mkdir -p lib/extdeps
+	cp from-xml/from-xml.js lib/extdeps/from-xml.js
+	cp js-yaml/dist/js-yaml.js lib/extdeps/js-yaml.js
+	npx webpack
+	ls -l duktool.js
+
+from-xml:
+	git clone https://github.com/svaarala/from-xml
+
+js-yaml:
+	git clone https://github.com/svaarala/js-yaml

--- a/src-tools/lib/duktool/main.js
+++ b/src-tools/lib/duktool/main.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { miscPolyfills } = require('./misc_polyfill');
+miscPolyfills();
+
+const { getArgs } = require('../extbindings/args');
+const { parseCommandLine } = require('../util/cmdline');
+const { configureCommand, configureCommandSpec } = require('../command/configure');
+const { distCommand, distCommandSpec } = require('../command/dist');
+const { dirname, pathJoin, fileExists } = require('../util/fs');
+const { createBareObject } = require('../util/bare');
+
+// Command line parsing spec.
+const commandSpec = {
+    options: createBareObject({
+    }),
+    commands: createBareObject({
+        configure: configureCommandSpec,
+        dist: distCommandSpec
+    })
+};
+
+// Locate src-input, in a Duktape repository or a dist directory, based on
+// module.filename and some guesswork.
+function locateDuktapeRoot() {
+    if (!module || !module.filename) {
+        return;
+    }
+    var currDir = dirname(module.filename);
+    for (let i = 0; i < 5; i++) {  // sanity max levels
+        console.debug('locate duktape root, currDir:', currDir);
+        if (currDir === '') {
+            break;
+        }
+        if (fileExists(pathJoin(currDir, 'src-input', 'duktape.h.in')) &&
+            fileExists(pathJoin(currDir, 'AUTHORS.rst')) &&
+            fileExists(pathJoin(currDir, 'LICENSE.txt'))) {
+            return currDir;
+        }
+        currDir = pathJoin(currDir, '..');
+    }
+}
+
+function main() {
+    const enableDebug = false;
+
+    if (!enableDebug) {
+        console.debug = function nop() {};
+        console.trace = function nop() {};
+    }
+
+    var args = getArgs();
+    console.debug('args: ' + JSON.stringify(args));
+    var cmdline = parseCommandLine(args, commandSpec);
+    console.debug('cmdline: ' + JSON.stringify(cmdline));
+
+    // Command line --help handling.
+    if (cmdline.help) {
+        console.log(cmdline.help);
+        return;
+    }
+
+    // Locate Duktape root (used as a default by some commands).
+    var autoDuktapeRoot = locateDuktapeRoot();
+
+    // Commands.
+    var commandMap = createBareObject({
+        // Main commands: configure and prepare sources, dist.
+        configure: () => {
+            configureCommand(cmdline, autoDuktapeRoot);
+        },
+        dist: () => {
+            distCommand(cmdline, autoDuktapeRoot);
+        }
+    });
+
+    // Command switch.
+    var commandString = cmdline.command;
+    if (!commandString) {
+        console.log('Missing command, see --help');
+    } else {
+        var command = commandMap[commandString];
+        if (command) {
+            command();
+        } else {
+            console.log('UNKNOWN COMMAND: ' + commandString);
+        }
+    }
+}
+exports.main = main;

--- a/src-tools/lib/duktool/misc_polyfill.js
+++ b/src-tools/lib/duktool/misc_polyfill.js
@@ -1,0 +1,52 @@
+// Miscellaneous polyfills needed to run with Duktape and old Node.js.
+// Ideally handled by transpiling.
+
+'use strict';
+
+function miscPolyfills() {
+    if (typeof Array.prototype[Symbol.iterator] === 'undefined') {
+        Array.prototype[Symbol.iterator] = function arrayIterator() {
+            var arg = this;
+            var index = 0;
+            return {
+                next: function arrayNext() {
+                    if (index >= arg.length) { return { done: true }; }
+                    return { value: arg[index++], done: false };
+                }
+            }
+        };
+    }
+
+    if (typeof Array.prototype.flatMap === 'undefined') {
+        Array.prototype.flatMap = function flatMap(fn) {
+            var arg = this;
+            var tmp = Array.prototype.map.call(arg, fn);
+            var res = [];
+            tmp.forEach(function (v) {
+                if (Array.isArray(v)) {
+                    res = res.concat(v);
+                } else {
+                    res.push(v);
+                }
+            });
+            return res;
+        };
+    }
+
+    if (typeof Array.prototype.includes === 'undefined') {
+        Array.prototype.includes = function includes(v) {
+            var arg = this;
+            for (var i = 0; i < arg.length; i++) {
+                if (arg[i] === v) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    if (typeof Object.getPrototypeOf(new Uint8Array(0)).map === 'undefined') {
+        Object.getPrototypeOf(new Uint8Array(0)).map = Array.prototype.map;
+    }
+}
+exports.miscPolyfills = miscPolyfills;


### PR DESCRIPTION
With this JS-based tooling for configure and dist are now minimally working on both Node.js and self-hosted with Duktape. The only external package dependency at present is a pure Javascript YAML parser (js-yaml, MIT licensed). The tooling is not yet integrated to the rest of the repo.

Usage at present: first, pull in dependencies:
```
$ cd src-tools
$ make
[...]
-rw-r--r-- 1 sva sva 590556 Apr 12 16:27 duktool.js
```

Then, one can execute the tooling using `index.js` (Node.js) or a single file `duktool.js` created using Webpack (Duktape or Node.js).

Node.js:
```
$ time nodejs index.js dist --output-directory /tmp/dist-nodejs --repo-directory ..
created temp directory: /tmp/tmp.duk-k8x36pg2-W9tsT6
recommended config option DUK_USE_FATAL_HANDLER not provided
deleted 6 unreachable objects, 4 unreachable strings
prepared RAM metadata: 396 objects, 51 objects with bidx, 389 strings, 167 strings with stridx, 0 strings added (0 property key references, 0 user strings)
deleted 6 unreachable objects, 4 unreachable strings
prepared ROM metadata: 396 objects, 51 objects with bidx, 446 strings, 167 strings with stridx, 57 strings added (57 property key references, 0 user strings)

real	0m3.014s
user	0m3.384s
sys	0m0.572s
```

Duktape self-hosted:
```
$ time ../duk duktool.js -- dist --output-directory /tmp/dist-duktape --repo-directory ..
created temp directory: /tmp/tmp.duk-k8x36zs0-ZShenq
recommended config option DUK_USE_FATAL_HANDLER not provided
deleted 6 unreachable objects, 4 unreachable strings
prepared RAM metadata: 396 objects, 51 objects with bidx, 389 strings, 167 strings with stridx, 0 strings added (0 property key references, 0 user strings)
deleted 6 unreachable objects, 4 unreachable strings
prepared ROM metadata: 396 objects, 51 objects with bidx, 446 strings, 167 strings with stridx, 57 strings added (57 property key references, 0 user strings)

real	0m42.791s
user	0m36.020s
sys	0m4.396s
```

A lot of small fixes are still needed (e.g. automatic cleanup of temp dirs, integration to existing Makefile, removing old Python tooling, etc).

Duktape self-hosting is important to ensure portability of the tooling to a wide variety of targets, so I plan to keep it running at all times from this point onwards. When running on Duktape, the tooling currently relies on a small set of Unix commands (`ls`, `test`, etc) for some filesystem operations. This is not a fundamental limitation and is easy to fix going forward as the dependencies are cleanly separated in the JS source tree.