### PR TITLE
Rename duk_is_null_or_undefined() to duk_is_nullish()

### DIFF
--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1353,6 +1353,7 @@ duktape_releases:
   #release_date: 'XXXX-XX-XX'
   #state: 'planned'
   changes:
+    - "Rename duk_is_null_or_undefined() to duk_is_nullish() to better match new ECMAScript terminology, duk_is_null_or_undefined() is still available as a macro (GH-2313)"
     - "Remove prepared source variants other than src/ (matches Duktape 2.x src-noline/) from the distributable (GH-2209)"
     - "Accept unlabelled function statements outside of top level for strict functions (using hoist semantics), previously they were rejected with a SyntaxError (GH-2213)"
     - "Accept unescaped U+2028 and U+2029 in string literals so that all JSON.stringify() output parses with eval() (ES2019) (GH-2235)"

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -891,7 +891,7 @@ DUK_EXTERNAL duk_bool_t duk_put_global_heapptr(duk_hthread *thr, void *ptr) {
 
 DUK_INTERNAL duk_bool_t duk_get_method_stridx(duk_hthread *thr, duk_idx_t idx, duk_small_uint_t stridx) {
 	(void) duk_get_prop_stridx(thr, idx, stridx);
-	if (duk_is_null_or_undefined(thr, -1)) {
+	if (duk_is_nullish(thr, -1)) {
 		duk_pop_nodecref_unsafe(thr);
 		return 0;
 	}

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4556,9 +4556,7 @@ DUK_LOCAL void duk__push_this_helper(duk_hthread *thr, duk_small_uint_t check_ob
 		/* 'this' binding is just before current activation's bottom */
 		DUK_ASSERT(thr->valstack_bottom > thr->valstack);
 		tv = thr->valstack_bottom - 1;
-		if (check_object_coercible &&
-		    (DUK_TVAL_IS_UNDEFINED(tv) || DUK_TVAL_IS_NULL(tv))) {
-			/* XXX: better macro for DUK_TVAL_IS_UNDEFINED_OR_NULL(tv) */
+		if (check_object_coercible && DUK_TVAL_IS_NULLISH(tv)) {
 			goto type_error;
 		}
 
@@ -6297,7 +6295,7 @@ DUK_INTERNAL duk_idx_t duk_unpack_array_like(duk_hthread *thr, duk_idx_t idx) {
 			duk_get_prop_index(thr, idx, (duk_uarridx_t) i);
 		}
 		return (duk_idx_t) len;
-	} else if (DUK_TVAL_IS_UNDEFINED(tv) || DUK_TVAL_IS_NULL(tv)) {
+	} else if (DUK_TVAL_IS_NULLISH(tv)) {
 		return 0;
 	}
 

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -419,7 +419,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_join_shared(duk_hthread *thr) {
 		}
 
 		duk_get_prop_index(thr, 1, (duk_uarridx_t) idx);
-		if (duk_is_null_or_undefined(thr, -1)) {
+		if (duk_is_nullish(thr, -1)) {
 			duk_pop_nodecref_unsafe(thr);
 			duk_push_hstring_empty(thr);
 		} else {

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -448,7 +448,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textdecoder_constructor(duk_hthread *thr) {
 		/* XXX: For now ignore 'label' (encoding identifier). */
 		duk_to_string(thr, 0);
 	}
-	if (!duk_is_null_or_undefined(thr, 1)) {
+	if (!duk_is_nullish(thr, 1)) {
 		if (duk_get_prop_literal(thr, 1, "fatal")) {
 			fatal = duk_to_boolean(thr, -1);
 		}

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -64,7 +64,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_assign(duk_hthread *thr) {
 	duk_to_object(thr, 0);
 	for (idx = 1; idx < nargs; idx++) {
 		/* E7 19.1.2.1 (step 4a) */
-		if (duk_is_null_or_undefined(thr, idx)) {
+		if (duk_is_nullish(thr, idx)) {
 			continue;
 		}
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -4536,8 +4536,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 	 */
 	entry_top = duk_get_top(thr);
 
-	if (DUK_TVAL_IS_UNDEFINED(tv_obj) ||
-	    DUK_TVAL_IS_NULL(tv_obj)) {
+	if (DUK_TVAL_IS_NULLISH(tv_obj)) {
 		DUK_DDD(DUK_DDDPRINT("base object is undefined or null -> reject"));
 		goto fail_invalid_base_uncond;
 	}

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2608,7 +2608,7 @@ DUK_LOCAL DUK_EXEC_NOINLINE_PERF void duk__handle_op_initenum(duk_hthread *thr, 
 	b = DUK_DEC_B(ins);
 	c = DUK_DEC_C(ins);
 
-	if (duk_is_null_or_undefined(thr, (duk_idx_t) c)) {
+	if (duk_is_nullish(thr, (duk_idx_t) c)) {
 		duk_push_null(thr);
 		duk_replace(thr, (duk_idx_t) b);
 	} else {

--- a/src-input/duk_prop_delete.c
+++ b/src-input/duk_prop_delete.c
@@ -890,7 +890,7 @@ DUK_INTERNAL duk_bool_t duk_prop_deleteoper(duk_hthread *thr, duk_idx_t idx_obj,
 	 * caused by key coercion.
 	 */
 
-	if (DUK_UNLIKELY(duk_is_null_or_undefined(thr, idx_obj))) {
+	if (DUK_UNLIKELY(duk_is_nullish(thr, idx_obj))) {
 		return duk__prop_delete_error_objidx_tvkey(thr, idx_obj, tv_key, DUK_DELPROP_FLAG_THROW);
 	}
 

--- a/src-input/duk_prop_get.c
+++ b/src-input/duk_prop_get.c
@@ -1234,7 +1234,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_outidx(duk_hthread *thr, duk_idx_t idx
 	 * seems acceptable considering the cost of the alternative.
 	 */
 
-	if (DUK_UNLIKELY(duk_is_null_or_undefined(thr, idx_recv))) {
+	if (DUK_UNLIKELY(duk_is_nullish(thr, idx_recv))) {
 		/* Must TypeError before key coercion side effects. */
 		return duk__prop_get_error_objidx_tvkey(thr, idx_recv, tv_key);
 	}

--- a/src-input/duk_prop_set.c
+++ b/src-input/duk_prop_set.c
@@ -2082,7 +2082,7 @@ DUK_INTERNAL duk_bool_t duk_prop_putvalue_inidx(duk_hthread *thr, duk_idx_t idx_
 	}
 	}
 
-	if (duk_is_null_or_undefined(thr, idx_recv)) {
+	if (duk_is_nullish(thr, idx_recv)) {
 		/* Ensure ToObject() coercion error happens before key coercion
 		 * side effects.
 		 */

--- a/src-input/duk_tval.h
+++ b/src-input/duk_tval.h
@@ -598,6 +598,8 @@ DUK_INTERNAL_DECL duk_double_t duk_tval_get_number_unpacked_fastint(duk_tval *tv
 #define DUK_TVAL_STRING_IS_SYMBOL(tv) \
 	DUK_HSTRING_HAS_SYMBOL(DUK_TVAL_GET_STRING((tv)))
 
+#define DUK_TVAL_IS_NULLISH(tv)              (DUK_TVAL_IS_NULL((tv)) || DUK_TVAL_IS_UNDEFINED((tv)))
+
 /* Lightfunc flags packing and unpacking. */
 /* Sign extend: 0x0000##00 -> 0x##000000 -> sign extend to 0xssssss##.
  * Avoid signed shifts due to portability limitations.

--- a/src-input/duktape.h.in
+++ b/src-input/duktape.h.in
@@ -674,8 +674,9 @@ DUK_EXTERNAL_DECL duk_bool_t duk_check_type_mask(duk_context *ctx, duk_idx_t idx
 
 DUK_EXTERNAL_DECL duk_bool_t duk_is_undefined(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_null(duk_context *ctx, duk_idx_t idx);
-#define duk_is_null_or_undefined(ctx, idx) \
+#define duk_is_nullish(ctx, idx) \
 	((duk_get_type_mask((ctx), (idx)) & (DUK_TYPE_MASK_NULL | DUK_TYPE_MASK_UNDEFINED)) ? 1 : 0)
+#define duk_is_null_or_undefined(ctx, idx) duk_is_nullish((ctx), (idx))
 
 DUK_EXTERNAL_DECL duk_bool_t duk_is_boolean(duk_context *ctx, duk_idx_t idx);
 DUK_EXTERNAL_DECL duk_bool_t duk_is_number(duk_context *ctx, duk_idx_t idx);

--- a/tests/api/test-all-public-symbols.c
+++ b/tests/api/test-all-public-symbols.c
@@ -166,6 +166,7 @@ static duk_ret_t test_func(duk_context *ctx, void *udata) {
 	(void) duk_is_lightfunc(ctx, 0);
 	(void) duk_is_nan(ctx, 0);
 	(void) duk_is_null_or_undefined(ctx, 0);
+	(void) duk_is_nullish(ctx, 0);
 	(void) duk_is_null(ctx, 0);
 	(void) duk_is_number(ctx, 0);
 	(void) duk_is_object_coercible(ctx, 0);

--- a/tests/api/test-is-calls.c
+++ b/tests/api/test-is-calls.c
@@ -1,31 +1,31 @@
 /*===
 *** test_1 (duk_safe_call)
-00: valididx=1 und=1 null=0 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
-01: valididx=1 und=0 null=1 noru=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
-02: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-03: valididx=1 und=0 null=0 noru=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-04: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-05: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-06: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=1 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-07: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-08: valididx=1 und=0 null=0 noru=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-09: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-10: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
-11: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-12: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=1 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-13: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-14: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=1 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-15: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=1 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-16: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-17: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=1 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-18: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=1 ext=0 ptr=0 prim=0 objcoerc=1
-19: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=1 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-20: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=0 ext=1 ptr=0 prim=0 objcoerc=1
-21: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=1 prim=1 objcoerc=1
-22: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-23: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=0 call=1 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-24: valididx=1 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
-25: valididx=0 und=0 null=0 noru=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=0
+00: valididx=1 und=1 null=0 noru=1 nullish=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
+01: valididx=1 und=0 null=1 noru=1 nullish=1 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=0
+02: valididx=1 und=0 null=0 noru=0 nullish=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+03: valididx=1 und=0 null=0 noru=0 nullish=0 bool=1 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+04: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+05: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+06: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=1 nan=1 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+07: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+08: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=1 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+09: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+10: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=1 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=1 objcoerc=1
+11: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+12: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=1 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+13: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+14: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=1 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+15: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=1 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+16: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=1 efun=0 bfun=0 call=1 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+17: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=1 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+18: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=1 ext=0 ptr=0 prim=0 objcoerc=1
+19: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=1 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+20: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=1 dyn=0 fix=0 ext=1 ptr=0 prim=0 objcoerc=1
+21: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=1 prim=1 objcoerc=1
+22: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+23: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=0 call=1 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+24: valididx=1 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=1 arr=0 fun=1 cfun=0 efun=0 bfun=0 call=1 construct=1 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=1
+25: valididx=0 und=0 null=0 noru=0 nullish=0 bool=0 num=0 nan=0 str=0 obj=0 arr=0 fun=0 cfun=0 efun=0 bfun=0 call=0 construct=0 thr=0 buf=0 dyn=0 fix=0 ext=0 ptr=0 prim=0 objcoerc=0
 ==> rc=0, result='undefined'
 ===*/
 
@@ -133,6 +133,7 @@ static duk_ret_t test_1(duk_context *ctx, void *udata) {
 		printf(" und=%d", (int) duk_is_undefined(ctx, i));
 		printf(" null=%d", (int) duk_is_null(ctx, i));
 		printf(" noru=%d", (int) duk_is_null_or_undefined(ctx, i));
+		printf(" nullish=%d", (int) duk_is_nullish(ctx, i));
 		printf(" bool=%d", (int) duk_is_boolean(ctx, i));
 		printf(" num=%d", (int) duk_is_number(ctx, i));
 		printf(" nan=%d", (int) duk_is_nan(ctx, i));

--- a/website/api/duk_is_null_or_undefined.yaml
+++ b/website/api/duk_is_null_or_undefined.yaml
@@ -7,11 +7,7 @@ stack: |
   [ ... val! ... ]
 
 summary: |
-  <p>Returns 1 if value at <code>idx</code> is either <code>null</code> or <code>undefined</code>,
-  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
-
-  <p>This API call is similar to a <code>(x == null)</code> comparison in ECMAScript, which
-  is true for both <code>null</code> and <code>undefined</code>.</p>
+  <p>Renamed <code><a href="#duk_is_nullish">duk_is_nullish()</a></code> in Duktape 3.0.</p>
 
 example: |
   if (duk_is_null_or_undefined(ctx, -3)) {
@@ -21,4 +17,8 @@ example: |
 tags:
   - stack
 
+seealso:
+  - duk_is_nullish
+
 introduced: 1.0.0
+deprecated: 3.0.0

--- a/website/api/duk_is_nullish.yaml
+++ b/website/api/duk_is_nullish.yaml
@@ -1,0 +1,27 @@
+name: duk_is_nullish
+
+proto: |
+  duk_bool_t duk_is_nullish(duk_context *ctx, duk_idx_t idx);
+
+stack: |
+  [ ... val! ... ]
+
+summary: |
+  <p>Returns 1 if value at <code>idx</code> is either <code>null</code> or <code>undefined</code>,
+  otherwise returns 0.  If <code>idx</code> is invalid, also returns 0.</p>
+
+  <p>This API call is similar to a <code>(x == null)</code> comparison in ECMAScript, which
+  is true for both <code>null</code> and <code>undefined</code>.</p>
+
+example: |
+  if (duk_is_nullish(ctx, -3)) {
+      /* ... */
+  }
+
+tags:
+  - stack
+
+seealso:
+  - duk_is_null_or_undefined
+
+introduced: 3.0.0


### PR DESCRIPTION
Rename duk_is_null_or_undefined() to duk_is_nullish() to better match current ECMAScript terminology.  Keep duk_is_null_or_undefined() as a deprecated API macro.  Add internal DUK_TVAL_IS_NULLISH().