### PR TITLE
Fix hash part handling in enum sorting

### DIFF
--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1365,3 +1365,4 @@ duktape_releases:
     - "Fix nested error handling bug for out-of-memory during error creation (GH-2278, GH-2290)"
     - "Fix failing assert for CBOR.encode() when argument is a zero-size dynamic plain array (GH-2316, GH-2318)"
     - "Fix pointer overflow in String.prototype.startsWith/endsWith() with certain arguments (GH-2320)"
+    - "Fix assertion failure and incorrect behavior in some enumeration cases involving inherited duplicate keys (GH-2322)"

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -165,6 +165,13 @@ DUK_LOCAL void duk__sort_enum_keys_es6(duk_hthread *thr, duk_hobject *h_obj, duk
 			keys[idx_insert] = h_curr;
 		}
 	}
+
+	/* Entry part has been reordered now with no side effects.
+	 * If the object has a hash part, it will now be incorrect
+	 * and we need to rehash.  Do that by forcing a resize to
+	 * the current size.
+	 */
+	duk_hobject_resize_entrypart(thr, h_obj, DUK_HOBJECT_GET_ESIZE(h_obj));
 }
 
 /*

--- a/tests/ecmascript/test-bug-assert-property-add-gh2315.js
+++ b/tests/ecmascript/test-bug-assert-property-add-gh2315.js
@@ -1,0 +1,18 @@
+// https://github.com/svaarala/duktape/issues/2315
+
+/*===
+done
+===*/
+
+function main() {
+    var v1 = [13.37,13.37,13.37];
+    var v2 = [13.37];
+    var v3 = {a:v2,length:v2};
+    var v4 = v3;
+    v4.__proto__ = v1;
+    var v5 = v4.sort();
+    for (var v6 in v5) {
+    }
+}
+main();
+print('done');


### PR DESCRIPTION
If enum temporary object has a hash part, in-place key sorting invalidates that hash.  The fix is to rebuild the hash after sorting keys.

Fixes #2315.