### PR TITLE
Fix Proxy ownKeys() postprocess array index bug

### DIFF
--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1369,3 +1369,4 @@ duktape_releases:
     - "Fix unstable pointer in 'putvar' which could trigger e.g. in a with(proxy) statement (GH-2323)"
     - "Fix unsafe behavior in JSON.stringify() when replacer argument is an array and Array.prototype has inherited index properties (GH-2202, GH-2324)"
     - "Fix RegExp exec() result object creation bug when Array.prototype has index properties (GH-2203, GH-2325)"
+    - "Fix Proxy 'ownKeys' trap postprocessing bug when Array.prototype has index properties (GH-2207, GH-2326)"

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -63,7 +63,9 @@ DUK_INTERNAL void duk_proxy_ownkeys_postprocess(duk_hthread *thr, duk_hobject *h
 		}
 
 		/* [ obj trap_result res_arr propname ] */
-		duk_put_prop_index(thr, -2, idx++);
+		duk_push_uarridx(thr, idx++);
+		duk_insert(thr, -2);
+		duk_def_prop(thr, -3, DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_SET_WEC);
 		continue;
 
 	 skip_key:

--- a/tests/ecmascript/test-bug-proxy-ownkeys-arridx-inherit-gh2207.js
+++ b/tests/ecmascript/test-bug-proxy-ownkeys-arridx-inherit-gh2207.js
@@ -1,0 +1,17 @@
+// https://github.com/svaarala/duktape/issues/2207
+
+/*===
+{"foo":0,"nonEnumerable":0}
+done
+===*/
+
+Object.defineProperty(Array.prototype, 0, { set: function () { } });
+
+function jsonStringifyOwnKeysProxyTest () {
+  target = { foo: 0, nonEnumerable: 0 };
+  proxy = new Proxy(target, { $: function () { }, ownKeys: function () { return [ 'foo', 'nonEnumerable' ] } });
+  print(String(JSON.stringify(proxy)));
+}
+
+jsonStringifyOwnKeysProxyTest();
+print('done');


### PR DESCRIPTION
Triggered when Array.prototype has index properties, e.g. a setter.

Fixes #2207.