### PR TITLE
Remove header from LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,6 @@
-===============
-Duktape license
-===============
+The MIT License (MIT)
 
-(http://opensource.org/licenses/MIT)
-
-Copyright (c) 2013-2020 by Duktape authors (see AUTHORS.rst)
+Copyright (c) 2013-present, Duktape authors (see AUTHORS.rst)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #2295 

To be sure, with these changes, Github recognizes the license for the fork https://github.com/sheetjsdev/duktape/ :

<img width="429" alt="sheetjsdev duktape license" src="https://user-images.githubusercontent.com/6070939/88021372-5c28c800-cafb-11ea-813d-9f34100fb324.png">

(the `-present` as the end date also avoids the yearly update to the license, and follows the same pattern as vuejs, sheetjs and other projects)