### PR TITLE
Fix NaN normalization bug for packed tval

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -9,7 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git
       - name: Build
         run: |
           make build/duk build/dukd build/duk-g++ build/duk-clang build/duk-fuzzilli

--- a/.github/workflows/dist-tag-workflow.yaml
+++ b/.github/workflows/dist-tag-workflow.yaml
@@ -11,7 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git
       - name: Dist source
         run: |
           make dist-source
@@ -28,7 +29,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git
       - name: Build Docker images
         run: |
           make docker-images

--- a/.github/workflows/dist-workflow.yaml
+++ b/.github/workflows/dist-workflow.yaml
@@ -9,7 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git
       - name: Dist source
         run: |
           make dist-source

--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -9,7 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git nodejs
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git nodejs
       - name: Build
         run: |
           make build/duk
@@ -24,7 +25,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git nodejs
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git nodejs
       - name: Build
         run: |
           make build/duk
@@ -39,7 +41,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git nodejs valgrind
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git nodejs valgrind
       - name: Configure test
         run: |
           make configuretest
@@ -54,7 +57,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         run: |
-          sudo apt install build-essential make python python-yaml bc git tidy
+          sudo apt -qqy update
+          sudo apt -qqy install build-essential make python python-yaml bc git tidy
       - name: Codepolicycheck
         run: |
           CI=1 make codepolicycheck

--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1375,4 +1375,5 @@ duktape_releases:
     - "Fix potentially unbounded recursion and assertion failure in JSON.parse() reviver walk by adding duk_native_stack_check() and depth limits (GH-2338, GH-2341)"
     - "Fix pointer handling bug in String.prototype.replace() which could be triggered when search string was longer than the input string (GH-2358)"
     - "Compile warning fixes (GH-2349)"
-    - "Improve warning for missing PyYAML in configure.py (GH-2361)
+    - "Improve warning for missing PyYAML in configure.py (GH-2361)"
+    - "Fix NaN normalization bug when using packed tval (32-bit target) (GH-2362)"

--- a/src-input/duk_dblunion.h
+++ b/src-input/duk_dblunion.h
@@ -322,7 +322,8 @@ typedef union duk_double_union duk_double_union;
 	} while (0)
 
 #define DUK__DBLUNION_NORMALIZE_NAN_CHECK_NOTFULL(u)  do { \
-		if (DUK__DBLUNION_IS_NAN_NOTFULL((u))) { \
+		/* Check must be full. */ \
+		if (DUK__DBLUNION_IS_NAN_FULL((u))) { \
 			DUK__DBLUNION_SET_NAN_NOTFULL((u)); \
 		} \
 	} while (0)
@@ -334,12 +335,11 @@ typedef union duk_double_union duk_double_union;
  */
 
 #if defined(DUK_USE_PACKED_TVAL)
-#if defined(DUK_USE_FULL_TVAL)
 #define DUK_DBLUNION_NORMALIZE_NAN_CHECK(u)  DUK__DBLUNION_NORMALIZE_NAN_CHECK_FULL((u))
 #define DUK_DBLUNION_IS_NAN(u)               DUK__DBLUNION_IS_NAN_FULL((u))
 #define DUK_DBLUNION_IS_NORMALIZED_NAN(u)    DUK__DBLUNION_IS_NORMALIZED_NAN_FULL((u))
 #define DUK_DBLUNION_SET_NAN(d)              DUK__DBLUNION_SET_NAN_FULL((d))
-#else
+#if 0
 #define DUK_DBLUNION_NORMALIZE_NAN_CHECK(u)  DUK__DBLUNION_NORMALIZE_NAN_CHECK_NOTFULL((u))
 #define DUK_DBLUNION_IS_NAN(u)               DUK__DBLUNION_IS_NAN_NOTFULL((u))
 #define DUK_DBLUNION_IS_NORMALIZED_NAN(u)    DUK__DBLUNION_IS_NORMALIZED_NAN_NOTFULL((u))

--- a/tests/ecmascript/test-bug-packed-tval-nan-normalize.js
+++ b/tests/ecmascript/test-bug-packed-tval-nan-normalize.js
@@ -1,0 +1,19 @@
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+NaN
+done
+===*/
+
+try {
+    var val = CBOR.decode(new Uint8Array([ 0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 ]));
+    print(val);
+} catch (e) {
+    print(e.stack || e);
+}
+
+print('done');


### PR DESCRIPTION
NaN normalization check should use a full NaN check to decide when to normalize, even when using partial NaN initialization.  The fix here is to switch to full NaN initialization in general.