### PR TITLE
Security Fix for Arbitrary Code Execution - huntr.dev (in genconfig.py tool)

### DIFF
--- a/doc/compiler.rst
+++ b/doc/compiler.rst
@@ -95,7 +95,7 @@ Compiler
 The compiler component uses a hand crafted recursive descent statement parser,
 with somewhat tricky handling of a few ECMAScript constructs (like the
 "for/for-in" statement).  In contrast, top-down operator parsing is used for
-parsing expressions (see http://javascript.crockford.com/tdop/tdop.html)
+parsing expressions (see https://www.crockford.com/javascript/tdop/tdop.html)
 which is nice in that it allows single pass parsing while generating mostly
 nice bytecode.
 
@@ -380,7 +380,7 @@ Compilation state is encapsulated into ``duk_compiler_ctx``, which includes:
 * Various control flags which operate at the entry point level
 
 Intermediate values are represented by ``duk_ivalue`` and ``duk_ispec``.
-These need value value stack slots for storing values such as strings.
+These need value stack slots for storing values such as strings.
 
 A function being compiled is represented by the inner representation
 ``duk_compiler_func`` which is converted into an actual function object

--- a/tools/genconfig.py
+++ b/tools/genconfig.py
@@ -504,7 +504,7 @@ def scan_use_defs(dirname):
         if not root.startswith('DUK_USE_') or ext != '.yaml':
             continue
         with open(os.path.join(dirname, fn), 'rb') as f:
-            doc = yaml.load(f)
+            doc = yaml.safe_load(f)
             if doc.get('example', False):
                 continue
             if doc.get('unimplemented', False):


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the Arbitrary Code Execution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/duktape/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/other/duktape/1/README.md

### User Comments:

### 📊 Metadata *
Arbitrary code exec vulnerability 

#### Bounty URL:  https://www.huntr.dev/bounties/1-other-duktape

### ⚙️ Description *

Arbitrary Code Excecution in svaarala/duktape/tools/genconfig.py. Duktape - embeddable Javascript engine with a focus on portability and compact footprint. Genconfig is a Process Duktape option metadata and produce various useful outputs.

### 💻 Technical Description *

This package was vulnerable to Arbitrary code execution due to the use of a known vulnerable function load() in YAML. Changing that to safe_load or using SafeLoader will fix the issue.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```python
import os
from duktape.tools import genconfig
os.system('git clone https://github.com/svaarala/duktape.git')
#os.chdir('duktape/tools/')
exploit = """!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
open('DUK_USE_.yaml','w+').write(exploit)
path = os.getcwd()
genconfig.scan_use_defs(path)
os.system('rm DUK_USE_.yaml')
```


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again, `calc` wont pop and no code will be executed. Hence code exec is mitigated.


### 👍 User Acceptance Testing (UAT)

Only `safe_load` is used, which is the safer function, no breaking changes introduced.
