### PR TITLE
Add a placeholder repo package.json, Makefile trivia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ ms_print.*
 /*.gcda
 /*.su
 /_*
+/node_modules
+/package-lock.json
 /duk
 /runtests/package-lock.json
 /docker/*/gitconfig

--- a/debugger/package.json
+++ b/debugger/package.json
@@ -1,27 +1,28 @@
 {
-  "name": "duk-debug",
-  "version": "0.1.0",
-  "description": "Duktape debugger",
-  "author": {
-    "name": "Sami Vaarala",
-    "email": "sami.vaarala@iki.fi"
-  },
-  "dependencies": {
-    "bluebird": "~2.6.4",
-    "body-parser": "~1.9.3",
-    "byline": "~4.2.1",
-    "events": "~1.0.2",
-    "express": "~4.10.1",
-    "http": "0.0.0",
-    "minimist": "~1.2.5",
-    "readline": "0.0.5",
-    "recursive-readdir-sync": "^1.0.6",
-    "socket.io": "~1.2.1",
-    "sprintf": "~0.1.5",
-    "stream": "0.0.2",
-    "utf8": "~2.0.0",
-    "util": "~0.10.3",
-    "yamljs": "~0.2.1"
-  },
-  "main": "duk_debug.js"
+    "name": "@duktape/duk-debug",
+    "version": "0.1.0",
+    "description": "Duktape debugger",
+    "private": true,
+    "author": {
+        "name": "Sami Vaarala",
+        "email": "sami.vaarala@iki.fi"
+    },
+    "dependencies": {
+        "bluebird": "~2.6.4",
+        "body-parser": "~1.9.3",
+        "byline": "~4.2.1",
+        "events": "~1.0.2",
+        "express": "~4.10.1",
+        "http": "0.0.0",
+        "minimist": "~1.2.5",
+        "readline": "0.0.5",
+        "recursive-readdir-sync": "^1.0.6",
+        "socket.io": "~1.2.1",
+        "sprintf": "~0.1.5",
+        "stream": "0.0.2",
+        "utf8": "~2.0.0",
+        "util": "~0.10.3",
+        "yamljs": "~0.2.1"
+    },
+    "main": "duk_debug.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@duktape/duktape-repo",
+    "version": "2.99.99",
+    "description": "Dummy package for Duktape repository",
+    "license": "SEE LICENSE IN LICENSE.txt",
+    "private": true,
+    "homepage": "https://duktape.org/",
+    "author": {
+        "name": "Sami Vaarala",
+        "email": "sami.vaarala@iki.fi"
+    },
+    "contributors": [],
+    "repository": "github:svaarala/duktape",
+    "scripts": {},
+    "bugs": {
+        "url": "https://github.com/svaarala/duktape/issues",
+        "email": "sami.vaarala@iki.fi"
+    },
+    "engines": {
+        "node": ">=14"
+    },
+    "org_duktape": {
+        "comment": "All custom properties should go here.",
+        "extDependencies": {}
+    }
+}

--- a/runtests/package.json
+++ b/runtests/package.json
@@ -1,7 +1,8 @@
 {
-    "name": "duk-runtests",
+    "name": "@duktape/duk-runtests",
     "version": "0.1.0",
     "description": "Duktape test runner",
+    "private": true,
     "author": {
         "name": "Sami Vaarala",
         "email": "sami.vaarala@iki.fi"

--- a/src-tools/package.json
+++ b/src-tools/package.json
@@ -1,6 +1,7 @@
 {
-    "name": "duktool",
+    "name": "@duktape/duktool",
     "version": "3.0.0",
+    "private": true,
     "module": "./index.js",
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
* Add a placeholder package.json for the repo toplevel.
* Add private: true flags to some existing package.json files.
* Add a dummy @duktape scope to private package.json files, just to ensure their name won't conflict with anything else.
* Remove Makefile dependency on 'bc', replace with Node.js dependency.
* Use $(PYTHON2) in the Makefile explicitly when Python tools require python2.
* Minimal fix to allow 'make apitest' to run on macOS.