### PR TITLE
Add explicit string char access helpers

### DIFF
--- a/doc/string-table.rst
+++ b/doc/string-table.rst
@@ -300,10 +300,10 @@ check seems to nullify the potential (rare) benefits.
 ROM string link pointer reuse
 -----------------------------
 
-ROM strings don't need a ``h_next`` field.  It could be used fo string
+ROM strings don't need a ``h_next`` field.  It could be used for string
 data, provided that both arridx and clen have been dropped so that the
 ``duk_hstring`` struct itself is actually empty.  This does need a change
-to ``DUK_HSTRING_GET_DATA()`` macro though.
+to ``duk_hstring_get_data()`` accessor though.
 
 Remove heap->st_size field
 --------------------------

--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -25,11 +25,11 @@
  */
 
 DUK_LOCAL const duk_uint8_t *duk__load_string_raw(duk_hthread *thr, const duk_uint8_t *p) {
-	duk_uint32_t len;
+	duk_uint32_t blen;
 
-	len = DUK_RAW_READINC_U32_BE(p);
-	duk_push_lstring(thr, (const char *) p, len);
-	p += len;
+	blen = DUK_RAW_READINC_U32_BE(p);
+	duk_push_lstring(thr, (const char *) p, blen);
+	p += blen;
 	return p;
 }
 
@@ -46,17 +46,18 @@ DUK_LOCAL const duk_uint8_t *duk__load_buffer_raw(duk_hthread *thr, const duk_ui
 }
 
 DUK_LOCAL duk_uint8_t *duk__dump_hstring_raw(duk_uint8_t *p, duk_hstring *h) {
-	duk_size_t len;
+	duk_size_t blen;
 	duk_uint32_t tmp32;
+	const void *data;
 
 	DUK_ASSERT(h != NULL);
 
-	len = DUK_HSTRING_GET_BYTELEN(h);
-	DUK_ASSERT(len <= 0xffffffffUL); /* string limits */
-	tmp32 = (duk_uint32_t) len;
+	data = (const void *) duk_hstring_get_data_and_bytelen(h, &blen);
+	DUK_ASSERT(blen <= 0xffffffffUL); /* string limits */
+	tmp32 = (duk_uint32_t) blen;
 	DUK_RAW_WRITEINC_U32_BE(p, tmp32);
-	duk_memcpy((void *) p, (const void *) DUK_HSTRING_GET_DATA(h), len);
-	p += len;
+	duk_memcpy((void *) p, data, blen);
+	p += blen;
 	return p;
 }
 
@@ -95,7 +96,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_string_prop(duk_hthread *thr,
 		DUK_ASSERT(h_str != NULL);
 	}
 	DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL); /* ensures no overflow */
-	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(h_str), p);
+	p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + duk_hstring_get_bytelen(h_str), p);
 	p = duk__dump_hstring_raw(p, h_str);
 	return p;
 }
@@ -175,7 +176,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_varmap(duk_hthread *thr, duk_uint8_t *p, duk_bu
 #endif
 
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL); /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(key) + 4U, p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + duk_hstring_get_bytelen(key) + 4U, p);
 			p = duk__dump_hstring_raw(p, key);
 			DUK_RAW_WRITEINC_U32_BE(p, val);
 		}
@@ -212,10 +213,10 @@ DUK_LOCAL duk_uint8_t *duk__dump_formals(duk_hthread *thr, duk_uint8_t *p, duk_b
 
 			varname = DUK_TVAL_GET_STRING(tv_val);
 			DUK_ASSERT(varname != NULL);
-			DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(varname) >= 1);
+			DUK_ASSERT(duk_hstring_get_bytelen(varname) >= 1);
 
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL); /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + DUK_HSTRING_GET_BYTELEN(varname), p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 4U + duk_hstring_get_bytelen(varname), p);
 			p = duk__dump_hstring_raw(p, varname);
 		}
 	} else {
@@ -312,7 +313,7 @@ static duk_uint8_t *duk__dump_func(duk_hthread *thr, duk_hcompfunc *func, duk_bu
 			h_str = DUK_TVAL_GET_STRING(tv);
 			DUK_ASSERT(h_str != NULL);
 			DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= 0x7fffffffUL); /* ensures no overflow */
-			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1U + 4U + DUK_HSTRING_GET_BYTELEN(h_str), p);
+			p = DUK_BW_ENSURE_RAW(thr, bw_ctx, 1U + 4U + duk_hstring_get_bytelen(h_str), p);
 			*p++ = DUK__SER_STRING;
 			p = duk__dump_hstring_raw(p, h_str);
 		} else {

--- a/src-input/duk_api_compile.c
+++ b/src-input/duk_api_compile.c
@@ -87,6 +87,7 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_hthread *thr, void *udata) {
 
 	if (!comp_args->src_buffer) {
 		duk_hstring *h_sourcecode;
+		duk_size_t src_length;
 
 		h_sourcecode = duk_get_hstring(thr, -2);
 		if ((flags & DUK_COMPILE_NOSOURCE) || /* args incorrect */
@@ -95,8 +96,8 @@ DUK_LOCAL duk_ret_t duk__do_compile(duk_hthread *thr, void *udata) {
 			DUK_WO_NORETURN(return 0;);
 		}
 		DUK_ASSERT(h_sourcecode != NULL);
-		comp_args->src_buffer = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_sourcecode);
-		comp_args->src_length = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sourcecode);
+		comp_args->src_buffer = (const duk_uint8_t *) duk_hstring_get_data_and_bytelen(h_sourcecode, &src_length);
+		comp_args->src_length = src_length;
 	}
 	DUK_ASSERT(comp_args->src_buffer != NULL);
 

--- a/src-input/duk_api_inspect.c
+++ b/src-input/duk_api_inspect.c
@@ -101,7 +101,7 @@ DUK_EXTERNAL void duk_inspect_value(duk_hthread *thr, duk_idx_t idx) {
 	switch ((duk_small_int_t) DUK_HEAPHDR_GET_TYPE(h)) {
 	case DUK_HTYPE_STRING: {
 		duk_hstring *h_str = (duk_hstring *) h;
-		vals[DUK__IDX_HBYTES] = (duk_int_t) (sizeof(duk_hstring) + DUK_HSTRING_GET_BYTELEN(h_str) + 1);
+		vals[DUK__IDX_HBYTES] = (duk_int_t) (sizeof(duk_hstring) + duk_hstring_get_bytelen(h_str) + 1);
 #if defined(DUK_USE_HSTRING_EXTDATA)
 		if (DUK_HSTRING_HAS_EXTDATA(h_str)) {
 			vals[DUK__IDX_VARIANT] = 1;

--- a/src-input/duk_bi_encoding.c
+++ b/src-input/duk_bi_encoding.c
@@ -368,7 +368,7 @@ DUK_INTERNAL duk_ret_t duk_bi_textencoder_prototype_encode(duk_hthread *thr) {
 		h_input = duk_to_hstring(thr, 0);
 		DUK_ASSERT(h_input != NULL);
 
-		len = (duk_size_t) DUK_HSTRING_GET_CHARLEN(h_input);
+		len = (duk_size_t) duk_hstring_get_charlen(h_input);
 		if (len >= DUK_HBUFFER_MAX_BYTELEN / 3) {
 			DUK_ERROR_TYPE(thr, DUK_STR_RESULT_TOO_LONG);
 			DUK_WO_NORETURN(return 0;);

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -197,7 +197,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 				h_name = duk_get_hstring_notsymbol(thr, -2); /* may be NULL */
 				funcname = (h_name == NULL || h_name == DUK_HTHREAD_STRING_EMPTY_STRING(thr)) ?
                                                "[anon]" :
-                                               (const char *) DUK_HSTRING_GET_DATA(h_name);
+                                               (const char *) duk_hstring_get_data(h_name);
 				filename = duk_get_string_notsymbol(thr, -1);
 				filename = filename ? filename : "";
 				DUK_ASSERT(funcname != NULL);

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -14,6 +14,8 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype(duk_hthread *thr) {
 #if defined(DUK_USE_FUNCTION_BUILTIN)
 DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_hthread *thr) {
 	duk_hstring *h_sourcecode;
+	const duk_uint8_t *source_data;
+	size_t source_blen;
 	duk_idx_t nargs;
 	duk_idx_t i;
 	duk_small_uint_t comp_flags;
@@ -64,10 +66,8 @@ DUK_INTERNAL duk_ret_t duk_bi_function_constructor(duk_hthread *thr) {
 
 	duk_push_hstring_stridx(thr, DUK_STRIDX_COMPILE); /* XXX: copy from caller? */ /* XXX: ignored now */
 	h_sourcecode = duk_require_hstring(thr, -2); /* no symbol check needed; -2 is concat'd code */
-	duk_js_compile(thr,
-	               (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_sourcecode),
-	               (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sourcecode),
-	               comp_flags);
+	source_data = duk_hstring_get_data_and_bytelen(h_sourcecode, &source_blen);
+	duk_js_compile(thr, source_data, source_blen, comp_flags);
 
 	/* Force .name to 'anonymous' (ES2015). */
 	duk_push_literal(thr, "anonymous");

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -115,16 +115,18 @@ DUK_LOCAL int duk__transform_helper(duk_hthread *thr, duk__transform_callback ca
 	duk__transform_context tfm_ctx_alloc;
 	duk__transform_context *tfm_ctx = &tfm_ctx_alloc;
 	duk_codepoint_t cp;
+	duk_size_t input_blen;
 
 	tfm_ctx->thr = thr;
 
 	tfm_ctx->h_str = duk_to_hstring(thr, 0);
 	DUK_ASSERT(tfm_ctx->h_str != NULL);
 
-	DUK_BW_INIT_PUSHBUF(thr, &tfm_ctx->bw, DUK_HSTRING_GET_BYTELEN(tfm_ctx->h_str)); /* initial size guess */
+	input_blen = duk_hstring_get_bytelen(tfm_ctx->h_str);
+	DUK_BW_INIT_PUSHBUF(thr, &tfm_ctx->bw, input_blen); /* initial size guess */
 
-	tfm_ctx->p_start = DUK_HSTRING_GET_DATA(tfm_ctx->h_str);
-	tfm_ctx->p_end = tfm_ctx->p_start + DUK_HSTRING_GET_BYTELEN(tfm_ctx->h_str);
+	tfm_ctx->p_start = duk_hstring_get_data(tfm_ctx->h_str);
+	tfm_ctx->p_end = tfm_ctx->p_start + input_blen;
 	tfm_ctx->p = tfm_ctx->p_start;
 
 	while (tfm_ctx->p < tfm_ctx->p_end) {
@@ -179,6 +181,7 @@ DUK_LOCAL void duk__transform_callback_encode_uri(duk__transform_context *tfm_ct
 		 * back because of strict UTF-8 checks in URI decoding.
 		 * (However, we could just as well allow them here.)
 		 */
+
 		goto uri_error;
 	} else {
 		/* Non-BMP characters within valid UTF-8 range: encode as is.
@@ -481,7 +484,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_hthread *thr) {
 	}
 
 	duk_push_hstring_stridx(thr, DUK_STRIDX_INPUT); /* XXX: copy from caller? */
-	duk_js_compile(thr, (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h), (duk_size_t) DUK_HSTRING_GET_BYTELEN(h), comp_flags);
+	duk_js_compile(thr, (const duk_uint8_t *) duk_hstring_get_data(h), (duk_size_t) duk_hstring_get_bytelen(h), comp_flags);
 	func = (duk_hcompfunc *) duk_known_hobject(thr, -1);
 	DUK_ASSERT(DUK_HOBJECT_IS_COMPFUNC((duk_hobject *) func));
 

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -307,7 +307,7 @@ DUK_LOCAL void duk__json_dec_req_stridx(duk_json_dec_ctx *js_ctx, duk_small_uint
 	h = DUK_HTHREAD_GET_STRING(js_ctx->thr, stridx);
 	DUK_ASSERT(h != NULL);
 
-	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h) + 1;
+	p = (const duk_uint8_t *) duk_hstring_get_data(h) + 1;
 	DUK_ASSERT(*(js_ctx->p - 1) == *(p - 1)); /* first character has been matched */
 
 	for (;;) {
@@ -1180,8 +1180,8 @@ DUK_LOCAL void duk__json_enc_key_autoquote(duk_json_enc_ctx *js_ctx, duk_hstring
 	 */
 
 	if (js_ctx->flag_avoid_key_quotes) {
-		k_len = DUK_HSTRING_GET_BYTELEN(k);
-		p_start = (const duk_int8_t *) DUK_HSTRING_GET_DATA(k);
+		k_len = duk_hstring_get_bytelen(k);
+		p_start = (const duk_int8_t *) duk_hstring_get_data(k);
 		p_end = p_start + k_len;
 		p = p_start;
 
@@ -1225,8 +1225,8 @@ DUK_LOCAL void duk__json_enc_quote_string(duk_json_enc_ctx *js_ctx, duk_hstring 
 	DUK_DDD(DUK_DDDPRINT("duk__json_enc_quote_string: h_str=%!O", (duk_heaphdr *) h_str));
 
 	DUK_ASSERT(h_str != NULL);
-	p_start = DUK_HSTRING_GET_DATA(h_str);
-	p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_str);
+	p_start = duk_hstring_get_data(h_str);
+	p_end = p_start + duk_hstring_get_bytelen(h_str);
 	p = p_start;
 
 	DUK__EMIT_1(js_ctx, DUK_ASC_DOUBLEQUOTE);
@@ -1684,7 +1684,7 @@ DUK_LOCAL void duk__json_enc_bufobj(duk_json_enc_ctx *js_ctx, duk_hbufobj *h_buf
 #if defined(DUK_USE_PREFER_SIZE)
 DUK_LOCAL void duk__json_enc_newline_indent(duk_json_enc_ctx *js_ctx, duk_uint_t depth) {
 	DUK_ASSERT(js_ctx->h_gap != NULL);
-	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(js_ctx->h_gap) > 0); /* caller guarantees */
+	DUK_ASSERT(duk_hstring_get_bytelen(js_ctx->h_gap) > 0); /* caller guarantees */
 
 	DUK__EMIT_1(js_ctx, 0x0a);
 	while (depth-- > 0) {
@@ -1701,7 +1701,7 @@ DUK_LOCAL void duk__json_enc_newline_indent(duk_json_enc_ctx *js_ctx, duk_uint_t
 	duk_uint8_t *p;
 
 	DUK_ASSERT(js_ctx->h_gap != NULL);
-	DUK_ASSERT(DUK_HSTRING_GET_BYTELEN(js_ctx->h_gap) > 0); /* caller guarantees */
+	DUK_ASSERT(duk_hstring_get_bytelen(js_ctx->h_gap) > 0); /* caller guarantees */
 
 	DUK__EMIT_1(js_ctx, 0x0a);
 	if (DUK_UNLIKELY(depth == 0)) {
@@ -1714,8 +1714,7 @@ DUK_LOCAL void duk__json_enc_newline_indent(duk_json_enc_ctx *js_ctx, duk_uint_t
 	 * avoid multiply with gap_len on every loop.
 	 */
 
-	gap_data = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(js_ctx->h_gap);
-	gap_len = (duk_size_t) DUK_HSTRING_GET_BYTELEN(js_ctx->h_gap);
+	gap_data = (const duk_uint8_t *) duk_hstring_get_data_and_bytelen(js_ctx->h_gap, &gap_len);
 	DUK_ASSERT(gap_len > 0);
 
 	need_bytes = gap_len * depth;
@@ -2843,9 +2842,9 @@ void duk_bi_json_parse_helper(duk_hthread *thr, duk_idx_t idx_value, duk_idx_t i
 	 * valid and points to the string NUL terminator (which is always
 	 * guaranteed for duk_hstrings.
 	 */
-	js_ctx->p_start = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_text);
+	js_ctx->p_start = (const duk_uint8_t *) duk_hstring_get_data(h_text);
 	js_ctx->p = js_ctx->p_start;
-	js_ctx->p_end = ((const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_text)) + DUK_HSTRING_GET_BYTELEN(h_text);
+	js_ctx->p_end = js_ctx->p_start + duk_hstring_get_bytelen(h_text);
 	DUK_ASSERT(*(js_ctx->p_end) == 0x00);
 
 	duk__json_dec_value(js_ctx); /* -> [ ... value ] */
@@ -3100,7 +3099,7 @@ void duk_bi_json_stringify_helper(duk_hthread *thr,
 		 * against byte length because character length is more
 		 * expensive.
 		 */
-		if (DUK_HSTRING_GET_BYTELEN(js_ctx->h_gap) == 0) {
+		if (duk_hstring_get_bytelen(js_ctx->h_gap) == 0) {
 			js_ctx->h_gap = NULL;
 		}
 	}

--- a/src-input/duk_bi_regexp.c
+++ b/src-input/duk_bi_regexp.c
@@ -170,7 +170,7 @@ DUK_INTERNAL duk_ret_t duk_bi_regexp_prototype_shared_getter(duk_hthread *thr) {
 		duk_xget_owndataprop_stridx_short(thr, 0, DUK_STRIDX_INT_SOURCE);
 		duk_xget_owndataprop_stridx_short(thr, 0, DUK_STRIDX_INT_BYTECODE);
 		h_bc = duk_require_hstring(thr, -1);
-		re_flags = (duk_small_uint_t) DUK_HSTRING_GET_DATA(h_bc)[0]; /* Safe even if h_bc length is 0 (= NUL) */
+		re_flags = (duk_small_uint_t) duk_hstring_get_data(h_bc)[0]; /* Safe even if h_bc length is 0 (= NUL) */
 		duk_pop(thr);
 	} else if (h == thr->builtins[DUK_BIDX_REGEXP_PROTOTYPE]) {
 		/* In ES2015 and ES2016 a TypeError would be thrown here.

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -52,8 +52,8 @@ duk__str_search_shared(duk_hthread *thr, duk_hstring *h_this, duk_hstring *h_sea
 	 * (If q_blen were < 0 due to clamped coercion, it would also be
 	 * caught here.)
 	 */
-	q_start = DUK_HSTRING_GET_DATA(h_search);
-	q_blen = (duk_int_t) DUK_HSTRING_GET_BYTELEN(h_search);
+	q_start = duk_hstring_get_data(h_search);
+	q_blen = (duk_int_t) duk_hstring_get_bytelen(h_search);
 	if (q_blen <= 0) {
 		return cpos;
 	}
@@ -61,8 +61,8 @@ duk__str_search_shared(duk_hthread *thr, duk_hstring *h_this, duk_hstring *h_sea
 
 	bpos = (duk_int_t) duk_heap_strcache_offset_char2byte(thr, h_this, (duk_uint32_t) cpos);
 
-	p_start = DUK_HSTRING_GET_DATA(h_this);
-	p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_this);
+	p_start = duk_hstring_get_data(h_this);
+	p_end = p_start + duk_hstring_get_bytelen(h_this);
 	p = p_start + bpos;
 
 	/* This loop is optimized for size.  For speed, there should be
@@ -286,7 +286,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_char_at(duk_hthread *thr) {
 		/* If size_t is smaller than int, explicit bounds checks
 		 * are needed because an int may wrap multiple times.
 		 */
-		if (DUK_UNLIKELY(pos < 0 || (duk_uint_t) pos >= (duk_uint_t) DUK_HSTRING_GET_CHARLEN(h))) {
+		if (DUK_UNLIKELY(pos < 0 || (duk_uint_t) pos >= (duk_uint_t) duk_hstring_get_charlen(h))) {
 			duk_push_hstring_empty(thr);
 		} else {
 			duk_substring(thr, -1, (duk_size_t) pos, (duk_size_t) pos + 1U);
@@ -314,7 +314,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_char_code_at(duk_hthread *thr) {
 	pos = duk_to_int_clamped_raw(thr,
 	                             0 /*index*/,
 	                             0 /*min(incl)*/,
-	                             (duk_int_t) DUK_HSTRING_GET_CHARLEN(h) - 1 /*max(incl)*/,
+	                             (duk_int_t) duk_hstring_get_charlen(h) - 1 /*max(incl)*/,
 	                             &clamped /*out_clamped*/);
 #if defined(DUK_USE_ES6)
 	magic = duk_get_current_magic(thr);
@@ -353,7 +353,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_substring(duk_hthread *thr) {
 
 	h = duk_push_this_coercible_to_string(thr);
 	DUK_ASSERT(h != NULL);
-	len = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h);
+	len = (duk_int_t) duk_hstring_get_charlen(h);
 
 	/* [ start end str ] */
 
@@ -391,7 +391,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_substr(duk_hthread *thr) {
 	duk_push_this(thr);
 	h = duk_to_hstring_m1(thr); /* Reject Symbols. */
 	DUK_ASSERT(h != NULL);
-	len = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h);
+	len = (duk_int_t) duk_hstring_get_charlen(h);
 
 	/* [ start length str ] */
 
@@ -430,7 +430,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_slice(duk_hthread *thr) {
 
 	h = duk_push_this_coercible_to_string(thr);
 	DUK_ASSERT(h != NULL);
-	len = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h);
+	len = (duk_int_t) duk_hstring_get_charlen(h);
 
 	/* [ start end str ] */
 
@@ -484,7 +484,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_indexof_shared(duk_hthread *thr) 
 
 	h_this = duk_push_this_coercible_to_string(thr);
 	DUK_ASSERT(h_this != NULL);
-	clen_this = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h_this);
+	clen_this = (duk_int_t) duk_hstring_get_charlen(h_this);
 
 	h_search = duk_to_hstring(thr, 0);
 	DUK_ASSERT(h_search != NULL);
@@ -545,7 +545,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 	DUK_ASSERT(h_input != NULL);
 
 	bw = &bw_alloc;
-	DUK_BW_INIT_PUSHBUF(thr, bw, DUK_HSTRING_GET_BYTELEN(h_input)); /* input size is good output starting point */
+	DUK_BW_INIT_PUSHBUF(thr, bw, duk_hstring_get_bytelen(h_input)); /* input size is good output starting point */
 
 	DUK_ASSERT_TOP(thr, 4);
 
@@ -587,8 +587,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 		is_repl_func = 0;
 		h_repl = duk_to_hstring(thr, 1); /* reject symbols */
 		DUK_ASSERT(h_repl != NULL);
-		r_start = DUK_HSTRING_GET_DATA(h_repl);
-		r_end = r_start + DUK_HSTRING_GET_BYTELEN(h_repl);
+		r_start = duk_hstring_get_data(h_repl);
+		r_end = r_start + duk_hstring_get_bytelen(h_repl);
 	}
 
 	prev_match_end_boff = 0;
@@ -639,7 +639,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 			h_match = duk_known_hstring(thr, -1);
 			duk_pop(thr); /* h_match is borrowed, remains reachable through match_obj */
 
-			if (DUK_HSTRING_GET_BYTELEN(h_match) == 0) {
+			if (duk_hstring_get_bytelen(h_match) == 0) {
 				/* This should be equivalent to match() algorithm step 8.f.iii.2:
 				 * detect an empty match and allow it, but don't allow it twice.
 				 */
@@ -670,14 +670,12 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 			DUK_ASSERT(!is_global); /* single match always */
 #endif
 
-			p_start = DUK_HSTRING_GET_DATA(h_input);
-			p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_input);
-			p_blen = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_input);
+			p_start = duk_hstring_get_data_and_bytelen(h_input, &p_blen);
+			p_end = p_start + p_blen;
 			p = p_start;
 
 			h_search = duk_known_hstring(thr, 0);
-			q_start = DUK_HSTRING_GET_DATA(h_search);
-			q_blen = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_search);
+			q_start = duk_hstring_get_data_and_bytelen(h_search, &q_blen);
 
 			if (q_blen > p_blen) {
 				break; /* no match */
@@ -689,7 +687,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 			match_start_coff = 0;
 
 			while (p <= p_end) {
-				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
+				DUK_ASSERT(p + q_blen <= duk_hstring_get_data(h_input) + duk_hstring_get_bytelen(h_input));
 				if (duk_memcmp((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 					duk_dup_0(thr);
 					h_match = duk_known_hstring(thr, -1);
@@ -721,9 +719,9 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 		match_start_boff = (duk_uint32_t) duk_heap_strcache_offset_char2byte(thr, h_input, match_start_coff);
 
 		tmp_sz = (duk_size_t) (match_start_boff - prev_match_end_boff);
-		DUK_BW_WRITE_ENSURE_BYTES(thr, bw, DUK_HSTRING_GET_DATA(h_input) + prev_match_end_boff, tmp_sz);
+		DUK_BW_WRITE_ENSURE_BYTES(thr, bw, duk_hstring_get_data(h_input) + prev_match_end_boff, tmp_sz);
 
-		prev_match_end_boff = match_start_boff + DUK_HSTRING_GET_BYTELEN(h_match);
+		prev_match_end_boff = match_start_boff + duk_hstring_get_bytelen(h_match);
 
 		if (is_repl_func) {
 			duk_idx_t idx_args;
@@ -796,7 +794,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 				}
 				case DUK_ASC_GRAVE: {
 					tmp_sz = (duk_size_t) match_start_boff;
-					DUK_BW_WRITE_ENSURE_BYTES(thr, bw, DUK_HSTRING_GET_DATA(h_input), tmp_sz);
+					DUK_BW_WRITE_ENSURE_BYTES(thr, bw, duk_hstring_get_data(h_input), tmp_sz);
 					r++;
 					continue;
 				}
@@ -810,10 +808,10 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 					match_end_boff = (duk_uint32_t) duk_heap_strcache_offset_char2byte(
 					    thr,
 					    h_input,
-					    match_start_coff + (duk_uint_fast32_t) DUK_HSTRING_GET_CHARLEN(h_match));
+					    match_start_coff + (duk_uint_fast32_t) duk_hstring_get_charlen(h_match));
 
-					tmp_sz = (duk_size_t) (DUK_HSTRING_GET_BYTELEN(h_input) - match_end_boff);
-					DUK_BW_WRITE_ENSURE_BYTES(thr, bw, DUK_HSTRING_GET_DATA(h_input) + match_end_boff, tmp_sz);
+					tmp_sz = (duk_size_t) (duk_hstring_get_bytelen(h_input) - match_end_boff);
+					DUK_BW_WRITE_ENSURE_BYTES(thr, bw, duk_hstring_get_data(h_input) + match_end_boff, tmp_sz);
 					r++;
 					continue;
 				}
@@ -891,8 +889,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 	}
 
 	/* trailer */
-	tmp_sz = (duk_size_t) (DUK_HSTRING_GET_BYTELEN(h_input) - prev_match_end_boff);
-	DUK_BW_WRITE_ENSURE_BYTES(thr, bw, DUK_HSTRING_GET_DATA(h_input) + prev_match_end_boff, tmp_sz);
+	tmp_sz = (duk_size_t) (duk_hstring_get_bytelen(h_input) - prev_match_end_boff);
+	DUK_BW_WRITE_ENSURE_BYTES(thr, bw, duk_hstring_get_data(h_input) + prev_match_end_boff, tmp_sz);
 
 	DUK_ASSERT_TOP(thr, 4);
 	DUK_BW_COMPACT(thr, bw);
@@ -1006,7 +1004,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 			match_start_boff = (duk_uint32_t) duk_heap_strcache_offset_char2byte(thr, h_input, match_start_coff);
 			duk_pop(thr);
 
-			if (match_start_coff == DUK_HSTRING_GET_CHARLEN(h_input)) {
+			if (match_start_coff == duk_hstring_get_charlen(h_input)) {
 				/* don't allow an empty match at the end of the string */
 				duk_pop(thr);
 				break;
@@ -1031,16 +1029,15 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 #endif /* DUK_USE_REGEXP_SUPPORT */
 			const duk_uint8_t *p_start, *p_end, *p; /* input string scan */
 			const duk_uint8_t *q_start; /* match string */
-			duk_size_t q_blen, q_clen;
+			duk_size_t p_blen, q_blen, q_clen;
 
-			p_start = DUK_HSTRING_GET_DATA(h_input);
-			p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_input);
+			p_start = duk_hstring_get_data_and_bytelen(h_input, &p_blen);
+			p_end = p_start + p_blen;
 			p = p_start + prev_match_end_boff;
 
 			h_sep = duk_known_hstring(thr, 0); /* symbol already rejected above */
-			q_start = DUK_HSTRING_GET_DATA(h_sep);
-			q_blen = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h_sep);
-			q_clen = (duk_size_t) DUK_HSTRING_GET_CHARLEN(h_sep);
+			q_start = duk_hstring_get_data_and_bytelen(h_sep, &q_blen);
+			q_clen = (duk_size_t) duk_hstring_get_charlen(h_sep);
 
 			p_end -= q_blen; /* ensure full memcmp() fits in while */
 
@@ -1070,7 +1067,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 
 			DUK_ASSERT(q_blen > 0 && q_clen > 0);
 			while (p <= p_end) {
-				DUK_ASSERT(p + q_blen <= DUK_HSTRING_GET_DATA(h_input) + DUK_HSTRING_GET_BYTELEN(h_input));
+				DUK_ASSERT(p + q_blen <= duk_hstring_get_data(h_input) + duk_hstring_get_bytelen(h_input));
 				DUK_ASSERT(q_blen > 0); /* no issues with empty memcmp() */
 				if (duk_memcmp((const void *) p, (const void *) q_start, (size_t) q_blen) == 0) {
 					/* never an empty match, so step 13.c.iii can't be triggered */
@@ -1118,7 +1115,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 		                     (long) prev_match_end_coff));
 
 		duk_push_lstring(thr,
-		                 (const char *) (DUK_HSTRING_GET_DATA(h_input) + prev_match_end_boff),
+		                 (const char *) (duk_hstring_get_data(h_input) + prev_match_end_boff),
 		                 (duk_size_t) (match_start_boff - prev_match_end_boff));
 		duk_put_prop_index(thr, 3, arr_idx);
 		arr_idx++;
@@ -1160,15 +1157,15 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_split(duk_hthread *thr) {
 
 	DUK_DDD(DUK_DDDPRINT("split trailer; prev_end b=%ld,c=%ld", (long) prev_match_end_boff, (long) prev_match_end_coff));
 
-	if (DUK_HSTRING_GET_BYTELEN(h_input) > 0 || !matched) {
+	if (duk_hstring_get_bytelen(h_input) > 0 || !matched) {
 		/* Add trailer if:
 		 *   a) non-empty input
 		 *   b) empty input and no (zero size) match found (step 11)
 		 */
 
 		duk_push_lstring(thr,
-		                 (const char *) DUK_HSTRING_GET_DATA(h_input) + prev_match_end_boff,
-		                 (duk_size_t) (DUK_HSTRING_GET_BYTELEN(h_input) - prev_match_end_boff));
+		                 (const char *) duk_hstring_get_data(h_input) + prev_match_end_boff,
+		                 (duk_size_t) (duk_hstring_get_bytelen(h_input) - prev_match_end_boff));
 		duk_put_prop_index(thr, 3, arr_idx);
 		/* No arr_idx update or limit check */
 	}
@@ -1362,7 +1359,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 	DUK_ASSERT_TOP(thr, 1);
 	h_input = duk_push_this_coercible_to_string(thr);
 	DUK_ASSERT(h_input != NULL);
-	input_blen = DUK_HSTRING_GET_BYTELEN(h_input);
+	input_blen = duk_hstring_get_bytelen(h_input);
 
 	/* Count is ToNumber() coerced; +Infinity must be always rejected
 	 * (even if input string is zero length), as well as negative values
@@ -1389,7 +1386,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_repeat(duk_hthread *thr) {
 	/* Temporary fixed buffer, later converted to string. */
 	buf = (duk_uint8_t *) duk_push_fixed_buffer_nozero(thr, result_len);
 	DUK_ASSERT(buf != NULL);
-	src = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
+	src = (const duk_uint8_t *) duk_hstring_get_data(h_input);
 	DUK_ASSERT(src != NULL);
 
 #if defined(DUK_USE_PREFER_SIZE)
@@ -1470,12 +1467,12 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_locale_compare(duk_hthread *thr) 
 	h2 = duk_to_hstring(thr, 0);
 	DUK_ASSERT(h2 != NULL);
 
-	h1_len = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h1);
-	h2_len = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h2);
+	h1_len = (duk_size_t) duk_hstring_get_bytelen(h1);
+	h2_len = (duk_size_t) duk_hstring_get_bytelen(h2);
 	prefix_len = (h1_len <= h2_len ? h1_len : h2_len);
 
-	rc = (duk_small_int_t) duk_memcmp((const void *) DUK_HSTRING_GET_DATA(h1),
-	                                  (const void *) DUK_HSTRING_GET_DATA(h2),
+	rc = (duk_small_int_t) duk_memcmp((const void *) duk_hstring_get_data(h1),
+	                                  (const void *) duk_hstring_get_data(h2),
 	                                  (size_t) prefix_len);
 
 	if (rc < 0) {
@@ -1528,8 +1525,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_startswith_endswith(duk_hthread *
 
 	/* Careful to avoid pointer overflows in the matching logic. */
 
-	blen_target = DUK_HSTRING_GET_BYTELEN(h_target);
-	blen_search = DUK_HSTRING_GET_BYTELEN(h_search);
+	blen_target = duk_hstring_get_bytelen(h_target);
+	blen_search = duk_hstring_get_bytelen(h_search);
 
 #if 0
 	/* If search string is longer than the target string, we can
@@ -1553,7 +1550,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_startswith_endswith(duk_hthread *
 		duk_int_t pos;
 
 		DUK_ASSERT(DUK_HSTRING_MAX_BYTELEN <= DUK_INT_MAX);
-		len = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h_target);
+		len = (duk_int_t) duk_hstring_get_charlen(h_target);
 		pos = duk_to_int_clamped(thr, 1, 0, len);
 		DUK_ASSERT(pos >= 0 && pos <= len);
 
@@ -1577,8 +1574,8 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_startswith_endswith(duk_hthread *
 	DUK_ASSERT((duk_size_t) off <= blen_target);
 	blen_left = blen_target - (duk_size_t) off;
 	if (blen_left >= blen_search) {
-		const duk_uint8_t *p_cmp_start = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_target) + off;
-		const duk_uint8_t *p_search = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_search);
+		const duk_uint8_t *p_cmp_start = (const duk_uint8_t *) duk_hstring_get_data(h_target) + off;
+		const duk_uint8_t *p_search = (const duk_uint8_t *) duk_hstring_get_data(h_search);
 		if (duk_memcmp_unsafe((const void *) p_cmp_start, (const void *) p_search, (size_t) blen_search) == 0) {
 			result = 1;
 		}
@@ -1603,7 +1600,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_includes(duk_hthread *thr) {
 	h_search = duk__str_tostring_notregexp(thr, 0);
 	DUK_ASSERT(h_search != NULL);
 
-	len = (duk_int_t) DUK_HSTRING_GET_CHARLEN(h);
+	len = (duk_int_t) duk_hstring_get_charlen(h);
 	pos = duk_to_int_clamped(thr, 1, 0, len);
 	DUK_ASSERT(pos >= 0 && pos <= len);
 

--- a/src-input/duk_bi_symbol.c
+++ b/src-input/duk_bi_symbol.c
@@ -139,7 +139,7 @@ DUK_INTERNAL duk_ret_t duk_bi_symbol_key_for(duk_hthread *thr) {
 	h = duk_require_hstring(thr, 0);
 	DUK_ASSERT(h != NULL);
 
-	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h);
+	p = (const duk_uint8_t *) duk_hstring_get_data(h);
 	DUK_ASSERT(p != NULL);
 
 	/* Even for zero length strings there's at least one NUL byte so
@@ -147,7 +147,7 @@ DUK_INTERNAL duk_ret_t duk_bi_symbol_key_for(duk_hthread *thr) {
 	 */
 	if (p[0] == 0x80) {
 		/* Global symbol, return its key (bytes just after the initial byte). */
-		duk_push_lstring(thr, (const char *) (p + 1), (duk_size_t) (DUK_HSTRING_GET_BYTELEN(h) - 1));
+		duk_push_lstring(thr, (const char *) (p + 1), (duk_size_t) (duk_hstring_get_bytelen(h) - 1));
 		return 1;
 	} else if (p[0] == 0x81 || p[0] == 0x82 || p[0] == 0xff) {
 		/* Local symbol or hidden symbol, return undefined. */

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -263,8 +263,8 @@ DUK_LOCAL void duk__print_hstring(duk__dprint_state *st, duk_hstring *h, duk_boo
 		return;
 	}
 
-	p = DUK_HSTRING_GET_DATA(h);
-	p_end = p + DUK_HSTRING_GET_BYTELEN(h);
+	p = duk_hstring_get_data(h);
+	p_end = p + duk_hstring_get_bytelen(h);
 
 	if (p_end > p && p[0] == DUK_ASC_UNDERSCORE) {
 		/* If property key begins with underscore, encode it with

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -818,8 +818,8 @@ DUK_INTERNAL void duk_debug_write_hstring(duk_hthread *thr, duk_hstring *h) {
 
 	/* XXX: differentiate null pointer from empty string? */
 	duk_debug_write_string(thr,
-	                       (h != NULL ? (const char *) DUK_HSTRING_GET_DATA(h) : NULL),
-	                       (h != NULL ? (duk_size_t) DUK_HSTRING_GET_BYTELEN(h) : 0));
+	                       (h != NULL ? (const char *) duk_hstring_get_data(h) : NULL),
+	                       (h != NULL ? (duk_size_t) duk_hstring_get_bytelen(h) : 0));
 }
 
 DUK_LOCAL void duk__debug_write_hstring_safe_top(duk_hthread *thr) {
@@ -1754,9 +1754,9 @@ DUK_LOCAL void duk__debug_dump_heaphdr(duk_hthread *thr, duk_heap *heap, duk_hea
 	case DUK_HTYPE_STRING: {
 		duk_hstring *h = (duk_hstring *) hdr;
 
-		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_BYTELEN(h));
-		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_CHARLEN(h));
-		duk_debug_write_uint(thr, (duk_uint32_t) DUK_HSTRING_GET_HASH(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) duk_hstring_get_bytelen(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) duk_hstring_get_charlen(h));
+		duk_debug_write_uint(thr, (duk_uint32_t) duk_hstring_get_hash(h));
 		duk_debug_write_hstring(thr, h);
 		break;
 	}
@@ -2160,9 +2160,9 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 		                           duk__debug_getinfo_hstring_keys,
 		                           duk__debug_getinfo_hstring_masks,
 		                           DUK_HEAPHDR_GET_FLAGS_RAW(h));
-		duk__debug_getinfo_prop_uint(thr, "bytelen", (duk_uint_t) DUK_HSTRING_GET_BYTELEN(h_str));
-		duk__debug_getinfo_prop_uint(thr, "charlen", (duk_uint_t) DUK_HSTRING_GET_CHARLEN(h_str));
-		duk__debug_getinfo_prop_uint(thr, "hash", (duk_uint_t) DUK_HSTRING_GET_HASH(h_str));
+		duk__debug_getinfo_prop_uint(thr, "bytelen", (duk_uint_t) duk_hstring_get_bytelen(h_str));
+		duk__debug_getinfo_prop_uint(thr, "charlen", (duk_uint_t) duk_hstring_get_charlen(h_str));
+		duk__debug_getinfo_prop_uint(thr, "hash", (duk_uint_t) duk_hstring_get_hash(h_str));
 		duk__debug_getinfo_flags_key(thr, "data");
 		duk_debug_write_hstring(thr, h_str);
 		break;

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -96,8 +96,8 @@ DUK_INTERNAL void duk_free_hstring(duk_heap *heap, duk_hstring *h) {
 #if defined(DUK_USE_HSTRING_EXTDATA) && defined(DUK_USE_EXTSTR_FREE)
 	if (DUK_HSTRING_HAS_EXTDATA(h)) {
 		DUK_DDD(
-		    DUK_DDDPRINT("free extstr: hstring %!O, extdata: %p", h, DUK_HSTRING_GET_EXTDATA((duk_hstring_external *) h)));
-		DUK_USE_EXTSTR_FREE(heap->heap_udata, (const void *) DUK_HSTRING_GET_EXTDATA((duk_hstring_external *) h));
+		    DUK_DDDPRINT("free extstr: hstring %!O, extdata: %p", h, duk_hstring_get_extdata((duk_hstring_external *) h)));
+		DUK_USE_EXTSTR_FREE(heap->heap_udata, (const void *) duk_hstring_get_extdata((duk_hstring_external *) h));
 	}
 #endif
 	DUK_FREE(heap, (void *) h);
@@ -451,12 +451,12 @@ DUK_LOCAL duk_bool_t duk__init_heap_strings(duk_heap *heap) {
 
 		h = duk_rom_strings_lookup[i];
 		while (h != NULL) {
-			hash = duk_heap_hashstring(heap, (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+			hash = duk_heap_hashstring(heap, (const duk_uint8_t *) duk_hstring_get_data(h), duk_hstring_get_bytelen(h));
 			DUK_DD(DUK_DDPRINT("duk_rom_strings_lookup[%d] -> hash 0x%08lx, computed 0x%08lx",
 			                   (int) i,
-			                   (unsigned long) DUK_HSTRING_GET_HASH(h),
+			                   (unsigned long) duk_hstring_get_hash(h),
 			                   (unsigned long) hash));
-			DUK_ASSERT(hash == (duk_uint32_t) DUK_HSTRING_GET_HASH(h));
+			DUK_ASSERT(hash == (duk_uint32_t) duk_hstring_get_hash(h));
 
 			h = (const duk_hstring *) h->hdr.h_next;
 		}

--- a/src-input/duk_heap_stringcache.c
+++ b/src-input/duk_heap_stringcache.c
@@ -106,14 +106,14 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	 *  For ASCII strings, the answer is simple.
 	 */
 
-	if (DUK_LIKELY(DUK_HSTRING_IS_ASCII(h))) {
+	if (DUK_LIKELY(duk_hstring_is_ascii(h) != 0)) {
 		return char_offset;
 	}
 
-	char_length = (duk_uint_fast32_t) DUK_HSTRING_GET_CHARLEN(h);
+	char_length = (duk_uint_fast32_t) duk_hstring_get_charlen(h);
 	DUK_ASSERT(char_offset <= char_length);
 
-	if (DUK_LIKELY(DUK_HSTRING_IS_ASCII(h))) {
+	if (DUK_LIKELY(duk_hstring_is_ascii(h) != 0)) {
 		/* Must recheck because the 'is ascii' flag may be set
 		 * lazily.  Alternatively, we could just compare charlen
 		 * to bytelen.
@@ -135,8 +135,8 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	DUK_DDD(DUK_DDDPRINT("non-ascii string %p, char_offset=%ld, clen=%ld, blen=%ld",
 	                     (void *) h,
 	                     (long) char_offset,
-	                     (long) DUK_HSTRING_GET_CHARLEN(h),
-	                     (long) DUK_HSTRING_GET_BYTELEN(h)));
+	                     (long) duk_hstring_get_charlen(h),
+	                     (long) duk_hstring_get_bytelen(h)));
 
 	heap = thr->heap;
 	sce = NULL;
@@ -172,14 +172,14 @@ DUK_INTERNAL duk_uint_fast32_t duk_heap_strcache_offset_char2byte(duk_hthread *t
 	 *    - cache entry (if exists)
 	 */
 
-	DUK_ASSERT(DUK_HSTRING_GET_CHARLEN(h) >= char_offset);
+	DUK_ASSERT(duk_hstring_get_charlen(h) >= char_offset);
 	dist_start = char_offset;
 	dist_end = char_length - char_offset;
 	dist_sce = 0;
 	DUK_UNREF(dist_sce); /* initialize for debug prints, needed if sce==NULL */
 
-	p_start = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h);
-	p_end = (const duk_uint8_t *) (p_start + DUK_HSTRING_GET_BYTELEN(h));
+	p_start = (const duk_uint8_t *) duk_hstring_get_data(h);
+	p_end = (const duk_uint8_t *) (p_start + duk_hstring_get_bytelen(h));
 	p_found = NULL;
 
 	if (sce) {

--- a/src-input/duk_heap_stringtable.c
+++ b/src-input/duk_heap_stringtable.c
@@ -116,7 +116,7 @@ DUK_LOCAL void duk__strtable_assert_checks(duk_heap *heap) {
 		for (i = 0; i < heap->st_size; i++) {
 			h = DUK__HEAPPTR_DEC16(heap, strtable[i]);
 			while (h != NULL) {
-				DUK_ASSERT((DUK_HSTRING_GET_HASH(h) & heap->st_mask) == i);
+				DUK_ASSERT((duk_hstring_get_hash(h) & heap->st_mask) == i);
 				count++;
 				h = h->hdr.h_next;
 			}
@@ -207,8 +207,8 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 		data = (const duk_uint8_t *) data_tmp;
 	}
 
-	DUK_HSTRING_SET_BYTELEN(res, blen);
-	DUK_HSTRING_SET_HASH(res, strhash);
+	duk_hstring_set_bytelen(res, blen);
+	duk_hstring_set_hash(res, strhash);
 
 	DUK_ASSERT(!DUK_HSTRING_HAS_ARRIDX(res));
 #if defined(DUK_USE_HSTRING_ARRIDX)
@@ -254,8 +254,8 @@ DUK_LOCAL duk_hstring *duk__strtable_alloc_hstring(duk_heap *heap,
 	}
 
 	DUK_DDD(DUK_DDDPRINT("interned string, hash=0x%08lx, blen=%ld, has_arridx=%ld, has_extdata=%ld",
-	                     (unsigned long) DUK_HSTRING_GET_HASH(res),
-	                     (long) DUK_HSTRING_GET_BYTELEN(res),
+	                     (unsigned long) duk_hstring_get_hash(res),
+	                     (long) duk_hstring_get_bytelen(res),
 	                     (long) (DUK_HSTRING_HAS_ARRIDX(res) ? 1 : 0),
 	                     (long) (DUK_HSTRING_HAS_EXTDATA(res) ? 1 : 0)));
 
@@ -346,7 +346,7 @@ DUK_LOCAL void duk__strtable_grow_inplace(duk_heap *heap) {
 		while (h != NULL) {
 			duk_uint32_t mask;
 
-			DUK_ASSERT((DUK_HSTRING_GET_HASH(h) & heap->st_mask) == i);
+			DUK_ASSERT((duk_hstring_get_hash(h) & heap->st_mask) == i);
 			next = h->hdr.h_next;
 
 			/* Example: if previous size was 256, previous mask is 0xFF
@@ -355,7 +355,7 @@ DUK_LOCAL void duk__strtable_grow_inplace(duk_heap *heap) {
 			 */
 			DUK_ASSERT(heap->st_mask == old_st_size - 1);
 			mask = old_st_size;
-			if (DUK_HSTRING_GET_HASH(h) & mask) {
+			if (duk_hstring_get_hash(h) & mask) {
 				if (prev != NULL) {
 					prev->hdr.h_next = h->hdr.h_next;
 				} else {
@@ -709,12 +709,12 @@ DUK_LOCAL duk_hstring *duk__strtab_romstring_lookup(duk_heap *heap, const duk_ui
 	curr = (duk_hstring *) DUK_LOSE_CONST(duk_rom_strings_lookup[lookup_hash]);
 	while (curr != NULL) {
 		/* Unsafe memcmp() because for zero blen, str may be NULL. */
-		if (strhash == DUK_HSTRING_GET_HASH(curr) && blen == DUK_HSTRING_GET_BYTELEN(curr) &&
-		    duk_memcmp_unsafe((const void *) str, (const void *) DUK_HSTRING_GET_DATA(curr), blen) == 0) {
+		if (strhash == duk_hstring_get_hash(curr) && blen == duk_hstring_get_bytelen(curr) &&
+		    duk_memcmp_unsafe((const void *) str, (const void *) duk_hstring_get_data(curr), blen) == 0) {
 			DUK_DDD(DUK_DDDPRINT("intern check: rom string: %!O, computed hash 0x%08lx, rom hash 0x%08lx",
 			                     curr,
 			                     (unsigned long) strhash,
-			                     (unsigned long) DUK_HSTRING_GET_HASH(curr)));
+			                     (unsigned long) duk_hstring_get_hash(curr)));
 			return curr;
 		}
 		curr = curr->hdr.h_next;
@@ -860,8 +860,8 @@ DUK_INTERNAL duk_hstring *duk_heap_strtable_intern(duk_heap *heap, const duk_uin
 	h = heap->strtable[strhash & heap->st_mask];
 #endif
 	while (h != NULL) {
-		if (DUK_HSTRING_GET_HASH(h) == strhash && DUK_HSTRING_GET_BYTELEN(h) == blen &&
-		    duk_memcmp_unsafe((const void *) str, (const void *) DUK_HSTRING_GET_DATA(h), (size_t) blen) == 0) {
+		if (duk_hstring_get_hash(h) == strhash && duk_hstring_get_bytelen(h) == blen &&
+		    duk_memcmp_unsafe((const void *) str, (const void *) duk_hstring_get_data(h), (size_t) blen) == 0) {
 			/* Found existing entry. */
 			DUK_STATS_INC(heap, stats_strtab_intern_hit);
 			goto done;
@@ -1040,8 +1040,8 @@ DUK_INTERNAL void duk_heap_strtable_unlink(duk_heap *heap, duk_hstring *h) {
 	DUK_DDD(DUK_DDDPRINT("remove: heap=%p, h=%p, blen=%lu, strhash=%lx",
 	                     (void *) heap,
 	                     (void *) h,
-	                     (unsigned long) (h != NULL ? DUK_HSTRING_GET_BYTELEN(h) : 0),
-	                     (unsigned long) (h != NULL ? DUK_HSTRING_GET_HASH(h) : 0)));
+	                     (unsigned long) (h != NULL ? duk_hstring_get_bytelen(h) : 0),
+	                     (unsigned long) (h != NULL ? duk_hstring_get_hash(h) : 0)));
 
 	DUK_ASSERT(heap != NULL);
 	DUK_ASSERT(h != NULL);
@@ -1052,9 +1052,9 @@ DUK_INTERNAL void duk_heap_strtable_unlink(duk_heap *heap, duk_hstring *h) {
 #endif
 
 #if defined(DUK_USE_STRTAB_PTRCOMP)
-	slot = heap->strtable16 + (DUK_HSTRING_GET_HASH(h) & heap->st_mask);
+	slot = heap->strtable16 + (duk_hstring_get_hash(h) & heap->st_mask);
 #else
-	slot = heap->strtable + (DUK_HSTRING_GET_HASH(h) & heap->st_mask);
+	slot = heap->strtable + (duk_hstring_get_hash(h) & heap->st_mask);
 #endif
 	other = DUK__HEAPPTR_DEC16(heap, *slot);
 	DUK_ASSERT(other != NULL); /* At least argument string is in the chain. */
@@ -1091,8 +1091,8 @@ DUK_INTERNAL void duk_heap_strtable_unlink_prev(duk_heap *heap, duk_hstring *h, 
 	                     (void *) heap,
 	                     (void *) prev,
 	                     (void *) h,
-	                     (unsigned long) (h != NULL ? DUK_HSTRING_GET_BYTELEN(h) : 0),
-	                     (unsigned long) (h != NULL ? DUK_HSTRING_GET_HASH(h) : 0)));
+	                     (unsigned long) (h != NULL ? duk_hstring_get_bytelen(h) : 0),
+	                     (unsigned long) (h != NULL ? duk_hstring_get_hash(h) : 0)));
 
 	DUK_ASSERT(heap != NULL);
 	DUK_ASSERT(h != NULL);
@@ -1109,9 +1109,9 @@ DUK_INTERNAL void duk_heap_strtable_unlink_prev(duk_heap *heap, duk_hstring *h, 
 	} else {
 		/* Head of list. */
 #if defined(DUK_USE_STRTAB_PTRCOMP)
-		slot = heap->strtable16 + (DUK_HSTRING_GET_HASH(h) & heap->st_mask);
+		slot = heap->strtable16 + (duk_hstring_get_hash(h) & heap->st_mask);
 #else
-		slot = heap->strtable + (DUK_HSTRING_GET_HASH(h) & heap->st_mask);
+		slot = heap->strtable + (duk_hstring_get_hash(h) & heap->st_mask);
 #endif
 		DUK_ASSERT(DUK__HEAPPTR_DEC16(heap, *slot) == h);
 		*slot = DUK__HEAPPTR_ENC16(heap, h->hdr.h_next);

--- a/src-input/duk_hobject_enum.c
+++ b/src-input/duk_hobject_enum.c
@@ -76,9 +76,9 @@ DUK_LOCAL duk__sort_key_t duk__hstring_sort_key(duk_hstring *x) {
 	 * the masked flag field into the arridx temporary.
 	 */
 	DUK_ASSERT(x != NULL);
-	DUK_ASSERT(!DUK_HSTRING_HAS_SYMBOL(x) || DUK_HSTRING_GET_ARRIDX_FAST(x) == DUK_HSTRING_NO_ARRAY_INDEX);
+	DUK_ASSERT(!DUK_HSTRING_HAS_SYMBOL(x) || duk_hstring_get_arridx_fast(x) == DUK_HSTRING_NO_ARRAY_INDEX);
 
-	val = (duk__sort_key_t) DUK_HSTRING_GET_ARRIDX_FAST(x);
+	val = (duk__sort_key_t) duk_hstring_get_arridx_fast(x);
 
 #if defined(DUK_USE_SYMBOL_BUILTIN)
 	val = val + (duk__sort_key_t) (DUK_HEAPHDR_GET_FLAGS_RAW((duk_heaphdr *) x) & DUK_HSTRING_FLAG_SYMBOL);
@@ -356,7 +356,7 @@ skip_proxy:
 				duk_hstring *h_val;
 				h_val = duk_hobject_get_internal_value_string(thr->heap, curr);
 				DUK_ASSERT(h_val != NULL); /* string objects must not created without internal value */
-				len = (duk_uint_fast32_t) DUK_HSTRING_GET_CHARLEN(h_val);
+				len = (duk_uint_fast32_t) duk_hstring_get_charlen(h_val);
 			}
 #if defined(DUK_USE_BUFFEROBJECT_SUPPORT)
 			else {

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -191,7 +191,7 @@ DUK_LOCAL duk_uint32_t duk__to_property_key(duk_hthread *thr, duk_idx_t idx, duk
 	DUK_ASSERT(h != NULL);
 	*out_h = h;
 
-	arr_idx = DUK_HSTRING_GET_ARRIDX_FAST(h);
+	arr_idx = duk_hstring_get_arridx_fast(h);
 	return arr_idx;
 }
 
@@ -995,7 +995,7 @@ DUK_INTERNAL void duk_hobject_realloc_props(duk_hthread *thr,
 			duk_uint32_t j, step;
 
 			DUK_ASSERT(key != NULL);
-			j = DUK_HSTRING_GET_HASH(key) & mask;
+			j = duk_hstring_get_hash(key) & mask;
 			step = 1; /* Cache friendly but clustering prone. */
 
 			for (;;) {
@@ -1399,7 +1399,7 @@ duk_hobject_find_entry(duk_heap *heap, duk_hobject *obj, duk_hstring *key, duk_i
 		h_base = DUK_HOBJECT_H_GET_BASE(heap, obj);
 		n = DUK_HOBJECT_GET_HSIZE(obj);
 		mask = n - 1;
-		i = DUK_HSTRING_GET_HASH(key) & mask;
+		i = duk_hstring_get_hash(key) & mask;
 		step = 1; /* Cache friendly but clustering prone. */
 
 		for (;;) {
@@ -1547,7 +1547,7 @@ DUK_LOCAL duk_int_t duk__hobject_alloc_entry_checked(duk_hthread *thr, duk_hobje
 
 		n = DUK_HOBJECT_GET_HSIZE(obj);
 		mask = n - 1;
-		i = DUK_HSTRING_GET_HASH(key) & mask;
+		i = duk_hstring_get_hash(key) & mask;
 		step = 1; /* Cache friendly but clustering prone. */
 
 		for (;;) {
@@ -2029,7 +2029,7 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr,
 
 			h_val = duk_hobject_get_internal_value_string(thr->heap, obj);
 			DUK_ASSERT(h_val);
-			if (arr_idx < DUK_HSTRING_GET_CHARLEN(h_val)) {
+			if (arr_idx < duk_hstring_get_charlen(h_val)) {
 				DUK_DDD(DUK_DDDPRINT("-> found, array index inside string"));
 				if (flags & DUK_GETDESC_FLAG_PUSH_VALUE) {
 					duk_push_hstring(thr, h_val);
@@ -2057,7 +2057,7 @@ DUK_LOCAL duk_bool_t duk__get_own_propdesc_raw(duk_hthread *thr,
 			h_val = duk_hobject_get_internal_value_string(thr->heap, obj);
 			DUK_ASSERT(h_val != NULL);
 			if (flags & DUK_GETDESC_FLAG_PUSH_VALUE) {
-				duk_push_uint(thr, (duk_uint_t) DUK_HSTRING_GET_CHARLEN(h_val));
+				duk_push_uint(thr, (duk_uint_t) duk_hstring_get_charlen(h_val));
 			}
 			out_desc->flags = DUK_PROPDESC_FLAG_VIRTUAL; /* E5 Section 15.5.5.1 */
 			out_desc->get = NULL;
@@ -2217,7 +2217,7 @@ duk_hobject_get_own_propdesc(duk_hthread *thr, duk_hobject *obj, duk_hstring *ke
 	DUK_ASSERT(out_desc != NULL);
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
 
-	return duk__get_own_propdesc_raw(thr, obj, key, DUK_HSTRING_GET_ARRIDX_SLOW(key), out_desc, flags);
+	return duk__get_own_propdesc_raw(thr, obj, key, duk_hstring_get_arridx_slow(key), out_desc, flags);
 }
 
 /*
@@ -2254,7 +2254,7 @@ duk__get_propdesc(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_prop
 
 	DUK_STATS_INC(thr->heap, stats_getpropdesc_count);
 
-	arr_idx = DUK_HSTRING_GET_ARRIDX_FAST(key);
+	arr_idx = duk_hstring_get_arridx_fast(key);
 
 	DUK_DDD(DUK_DDDPRINT("duk__get_propdesc: thr=%p, obj=%p, key=%p, out_desc=%p, flags=%lx, "
 	                     "arr_idx=%ld (obj -> %!O, key -> %!O)",
@@ -2666,7 +2666,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 			pop_count = 1;
 		}
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < duk_hstring_get_charlen(h)) {
 			duk_pop_n_unsafe(thr, pop_count);
 			duk_push_hstring(thr, h);
 			duk_substring(thr, -1, arr_idx, arr_idx + 1); /* [str] -> [substr] */
@@ -2692,7 +2692,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_getprop(duk_hthread *thr, duk_tval *tv_obj, 
 
 		if (key == DUK_HTHREAD_STRING_LENGTH(thr)) {
 			duk_pop_unsafe(thr); /* [key] -> [] */
-			duk_push_uint(thr, (duk_uint_t) DUK_HSTRING_GET_CHARLEN(h)); /* [] -> [res] */
+			duk_push_uint(thr, (duk_uint_t) duk_hstring_get_charlen(h)); /* [] -> [res] */
 
 			DUK_STATS_INC(thr->heap, stats_getprop_stringlen);
 			DUK_DDD(DUK_DDDPRINT("-> %!T (base is string, key is 'length' after coercion -> "
@@ -3386,7 +3386,7 @@ duk_bool_t duk__handle_put_array_length_smaller(duk_hthread *thr,
 
 			DUK_ASSERT(
 			    DUK_HSTRING_HAS_ARRIDX(key)); /* XXX: macro checks for array index flag, which is unnecessary here */
-			arr_idx = DUK_HSTRING_GET_ARRIDX_SLOW(key);
+			arr_idx = duk_hstring_get_arridx_slow(key);
 			DUK_ASSERT(arr_idx != DUK__NO_ARRAY_INDEX);
 			DUK_ASSERT(arr_idx < old_len); /* consistency requires this */
 
@@ -3437,7 +3437,7 @@ duk_bool_t duk__handle_put_array_length_smaller(duk_hthread *thr,
 
 			DUK_ASSERT(
 			    DUK_HSTRING_HAS_ARRIDX(key)); /* XXX: macro checks for array index flag, which is unnecessary here */
-			arr_idx = DUK_HSTRING_GET_ARRIDX_SLOW(key);
+			arr_idx = duk_hstring_get_arridx_slow(key);
 			DUK_ASSERT(arr_idx != DUK__NO_ARRAY_INDEX);
 			DUK_ASSERT(arr_idx < old_len); /* consistency requires this */
 
@@ -3682,7 +3682,7 @@ duk_hobject_putprop(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key, duk_tv
 			goto fail_not_writable;
 		}
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < duk_hstring_get_charlen(h)) {
 			goto fail_not_writable;
 		}
 
@@ -4482,7 +4482,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop_raw(duk_hthread *thr, duk_hobject *o
 
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
 
-	arr_idx = DUK_HSTRING_GET_ARRIDX_FAST(key);
+	arr_idx = duk_hstring_get_arridx_fast(key);
 
 	/* 0 = don't push current value */
 	if (!duk__get_own_propdesc_raw(thr, obj, key, arr_idx, &desc, 0 /*flags*/)) { /* don't push value */
@@ -4741,7 +4741,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_delprop(duk_hthread *thr, duk_tval *tv_obj, 
 			goto fail_not_configurable;
 		}
 
-		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (arr_idx != DUK__NO_ARRAY_INDEX && arr_idx < duk_hstring_get_charlen(h)) {
 			goto fail_not_configurable;
 		}
 	} else if (DUK_TVAL_IS_BUFFER(tv_obj)) {
@@ -4858,7 +4858,7 @@ DUK_INTERNAL void duk_hobject_define_property_internal(duk_hthread *thr,
 	DUK_ASSERT_VALSTACK_SPACE(thr, DUK__VALSTACK_SPACE);
 	DUK_ASSERT(duk_is_valid_index(thr, -1)); /* contains value */
 
-	arr_idx = DUK_HSTRING_GET_ARRIDX_SLOW(key);
+	arr_idx = duk_hstring_get_arridx_slow(key);
 
 	if (duk__get_own_propdesc_raw(thr, obj, key, arr_idx, &desc, 0 /*flags*/)) { /* don't push value */
 		if (desc.e_idx >= 0) {
@@ -5351,7 +5351,7 @@ duk_bool_t duk_hobject_define_property_helper(duk_hthread *thr,
 	is_configurable = (defprop_flags & DUK_DEFPROP_CONFIGURABLE);
 	force_flag = (defprop_flags & DUK_DEFPROP_FORCE);
 
-	arr_idx = DUK_HSTRING_GET_ARRIDX_SLOW(key);
+	arr_idx = duk_hstring_get_arridx_slow(key);
 
 	arridx_new_array_length = 0;
 	pending_write_protect = 0;

--- a/src-input/duk_hstring.h
+++ b/src-input/duk_hstring.h
@@ -82,89 +82,10 @@
 #define DUK_HSTRING_CLEAR_EXTDATA(x)              DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_EXTDATA)
 #define DUK_HSTRING_CLEAR_PINNED_LITERAL(x)       DUK_HEAPHDR_CLEAR_FLAG_BITS(&(x)->hdr, DUK_HSTRING_FLAG_PINNED_LITERAL)
 
-#if 0 /* Slightly smaller code without explicit flag, but explicit flag \
-       * is very useful when 'clen' is dropped. \
-       */
-#define DUK_HSTRING_IS_ASCII(x) (DUK_HSTRING_GET_BYTELEN((x)) == DUK_HSTRING_GET_CHARLEN((x)))
-#endif
-#define DUK_HSTRING_IS_ASCII(x) DUK_HSTRING_HAS_ASCII((x)) /* lazily set! */
-#define DUK_HSTRING_IS_EMPTY(x) (DUK_HSTRING_GET_BYTELEN((x)) == 0)
-
-#if defined(DUK_USE_STRHASH16)
-#define DUK_HSTRING_GET_HASH(x) ((x)->hdr.h_flags >> 16)
-#define DUK_HSTRING_SET_HASH(x, v) \
-	do { \
-		(x)->hdr.h_flags = ((x)->hdr.h_flags & 0x0000ffffUL) | ((v) << 16); \
-	} while (0)
-#else
-#define DUK_HSTRING_GET_HASH(x) ((x)->hash)
-#define DUK_HSTRING_SET_HASH(x, v) \
-	do { \
-		(x)->hash = (v); \
-	} while (0)
-#endif
-
-#if defined(DUK_USE_STRLEN16)
-#define DUK_HSTRING_GET_BYTELEN(x) ((x)->hdr.h_strextra16)
-#define DUK_HSTRING_SET_BYTELEN(x, v) \
-	do { \
-		(x)->hdr.h_strextra16 = (v); \
-	} while (0)
-#if defined(DUK_USE_HSTRING_CLEN)
-#define DUK_HSTRING_GET_CHARLEN(x) duk_hstring_get_charlen((x))
-#define DUK_HSTRING_SET_CHARLEN(x, v) \
-	do { \
-		(x)->clen16 = (v); \
-	} while (0)
-#else
-#define DUK_HSTRING_GET_CHARLEN(x) duk_hstring_get_charlen((x))
-#define DUK_HSTRING_SET_CHARLEN(x, v) \
-	do { \
-		DUK_ASSERT(0); /* should never be called */ \
-	} while (0)
-#endif
-#else
-#define DUK_HSTRING_GET_BYTELEN(x) ((x)->blen)
-#define DUK_HSTRING_SET_BYTELEN(x, v) \
-	do { \
-		(x)->blen = (v); \
-	} while (0)
-#define DUK_HSTRING_GET_CHARLEN(x) duk_hstring_get_charlen((x))
-#define DUK_HSTRING_SET_CHARLEN(x, v) \
-	do { \
-		(x)->clen = (v); \
-	} while (0)
-#endif
-
-#if defined(DUK_USE_HSTRING_EXTDATA)
-#define DUK_HSTRING_GET_EXTDATA(x) ((x)->extdata)
-#define DUK_HSTRING_GET_DATA(x) \
-	(DUK_HSTRING_HAS_EXTDATA((x)) ? DUK_HSTRING_GET_EXTDATA((const duk_hstring_external *) (x)) : \
-                                        ((const duk_uint8_t *) ((x) + 1)))
-#else
-#define DUK_HSTRING_GET_DATA(x) ((const duk_uint8_t *) ((x) + 1))
-#endif
-
-#define DUK_HSTRING_GET_DATA_END(x) (DUK_HSTRING_GET_DATA((x)) + (x)->blen)
-
 /* Marker value; in E5 2^32-1 is not a valid array index (2^32-2 is highest
  * valid).
  */
 #define DUK_HSTRING_NO_ARRAY_INDEX (0xffffffffUL)
-
-#if defined(DUK_USE_HSTRING_ARRIDX)
-#define DUK_HSTRING_GET_ARRIDX_FAST(h) ((h)->arridx)
-#define DUK_HSTRING_GET_ARRIDX_SLOW(h) ((h)->arridx)
-#else
-/* Get array index related to string (or return DUK_HSTRING_NO_ARRAY_INDEX);
- * avoids helper call if string has no array index value.
- */
-#define DUK_HSTRING_GET_ARRIDX_FAST(h) \
-	(DUK_HSTRING_HAS_ARRIDX((h)) ? duk_js_to_arrayindex_hstring_fast_known((h)) : DUK_HSTRING_NO_ARRAY_INDEX)
-
-/* Slower but more compact variant. */
-#define DUK_HSTRING_GET_ARRIDX_SLOW(h) (duk_js_to_arrayindex_hstring_fast((h)))
-#endif
 
 /* XXX: these actually fit into duk_hstring */
 #define DUK_SYMBOL_TYPE_HIDDEN    0
@@ -252,14 +173,31 @@ struct duk_hstring_external {
  *  Prototypes
  */
 
+DUK_INTERNAL_DECL duk_bool_t duk_hstring_is_ascii(duk_hstring *h);
+DUK_INTERNAL_DECL duk_bool_t duk_hstring_is_empty(duk_hstring *h);
+DUK_INTERNAL_DECL duk_uint32_t duk_hstring_get_hash(duk_hstring *h);
+DUK_INTERNAL_DECL void duk_hstring_set_hash(duk_hstring *h, duk_uint32_t hash);
+DUK_INTERNAL_DECL duk_size_t duk_hstring_get_bytelen(duk_hstring *h);
+DUK_INTERNAL_DECL void duk_hstring_set_bytelen(duk_hstring *h, duk_size_t len);
+DUK_INTERNAL_DECL duk_size_t duk_hstring_get_charlen(duk_hstring *h);
+#if !defined(DUK_USE_HSTRING_LAZY_CLEN)
+DUK_INTERNAL_DECL void duk_hstring_init_charlen(duk_hstring *h);
+#endif
+/* No duk_hstring_set_charlen(), set via duk_hstring_init_charlen(). */
+DUK_INTERNAL_DECL duk_uarridx_t duk_hstring_get_arridx_fast(duk_hstring *h);
+DUK_INTERNAL_DECL duk_uarridx_t duk_hstring_get_arridx_fast_known(duk_hstring *h);
+DUK_INTERNAL_DECL duk_uarridx_t duk_hstring_get_arridx_slow(duk_hstring *h);
+#if defined(DUK_USE_HSTRING_EXTDATA)
+DUK_INTERNAL_DECL const duk_uint8_t *duk_hstring_get_extdata(duk_hstring *h);
+#endif
+DUK_INTERNAL_DECL const duk_uint8_t *duk_hstring_get_data(duk_hstring *h);
+DUK_INTERNAL_DECL const duk_uint8_t *duk_hstring_get_data_and_bytelen(duk_hstring *h, duk_size_t *out_blen);
+DUK_INTERNAL_DECL const duk_uint8_t *duk_hstring_get_data_end(duk_hstring *h);
+
 DUK_INTERNAL_DECL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr,
                                                                 duk_hstring *h,
                                                                 duk_uint_t pos,
                                                                 duk_bool_t surrogate_aware);
 DUK_INTERNAL_DECL duk_bool_t duk_hstring_equals_ascii_cstring(duk_hstring *h, const char *cstr);
-DUK_INTERNAL_DECL duk_size_t duk_hstring_get_charlen(duk_hstring *h);
-#if !defined(DUK_USE_HSTRING_LAZY_CLEN)
-DUK_INTERNAL_DECL void duk_hstring_init_charlen(duk_hstring *h);
-#endif
 
 #endif /* DUK_HSTRING_H_INCLUDED */

--- a/src-input/duk_hstring_misc.c
+++ b/src-input/duk_hstring_misc.c
@@ -5,54 +5,67 @@
 #include "duk_internal.h"
 
 /*
- *  duk_hstring charCodeAt, with and without surrogate awareness
+ *  Simple getters and setters
  */
 
-DUK_INTERNAL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr,
-                                                           duk_hstring *h,
-                                                           duk_uint_t pos,
-                                                           duk_bool_t surrogate_aware) {
-	duk_uint32_t boff;
-	const duk_uint8_t *p, *p_start, *p_end;
-	duk_ucodepoint_t cp1;
-	duk_ucodepoint_t cp2;
-
-	/* Caller must check character offset to be inside the string. */
-	DUK_ASSERT(thr != NULL);
-	DUK_ASSERT(h != NULL);
-	DUK_ASSERT_DISABLE(pos >= 0); /* unsigned */
-	DUK_ASSERT(pos < (duk_uint_t) DUK_HSTRING_GET_CHARLEN(h));
-
-	boff = (duk_uint32_t) duk_heap_strcache_offset_char2byte(thr, h, (duk_uint32_t) pos);
-	DUK_DDD(DUK_DDDPRINT("charCodeAt: pos=%ld -> boff=%ld, str=%!O", (long) pos, (long) boff, (duk_heaphdr *) h));
-	DUK_ASSERT_DISABLE(boff >= 0);
-	DUK_ASSERT(boff < DUK_HSTRING_GET_BYTELEN(h));
-
-	p_start = DUK_HSTRING_GET_DATA(h);
-	p_end = p_start + DUK_HSTRING_GET_BYTELEN(h);
-	p = p_start + boff;
-	DUK_DDD(DUK_DDDPRINT("p_start=%p, p_end=%p, p=%p", (const void *) p_start, (const void *) p_end, (const void *) p));
-
-	/* For invalid UTF-8 (never happens for standard ECMAScript strings)
-	 * return U+FFFD replacement character.
+DUK_INTERNAL duk_bool_t duk_hstring_is_ascii(duk_hstring *h) {
+#if 0
+	/* Slightly smaller code without explicit flag, but explicit flag
+	 * is very useful when 'clen' is dropped.
 	 */
-	if (duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp1)) {
-		if (surrogate_aware && cp1 >= 0xd800UL && cp1 <= 0xdbffUL) {
-			/* The decode helper is memory safe even if 'cp1' was
-			 * decoded at the end of the string and 'p' is no longer
-			 * within string memory range.
-			 */
-			cp2 = 0; /* If call fails, this is left untouched and won't match cp2 check. */
-			(void) duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp2);
-			if (cp2 >= 0xdc00UL && cp2 <= 0xdfffUL) {
-				cp1 = (duk_ucodepoint_t) (((cp1 - 0xd800UL) << 10) + (cp2 - 0xdc00UL) + 0x10000UL);
-			}
-		}
-	} else {
-		cp1 = DUK_UNICODE_CP_REPLACEMENT_CHARACTER;
-	}
+	return duk_hstring_get_bytelen(h) == duk_hstring_get_charlen(h);
+#endif
+	return DUK_HSTRING_HAS_ASCII(h); /* lazily set! */
+}
 
-	return cp1;
+DUK_INTERNAL duk_bool_t duk_hstring_is_empty(duk_hstring *h) {
+	return duk_hstring_get_bytelen(h) == 0U;
+}
+
+DUK_INTERNAL duk_uint32_t duk_hstring_get_hash(duk_hstring *h) {
+#if defined(DUK_USE_STRHASH16)
+	return h->hdr.h_flags >> 16U;
+#else
+	return h->hash;
+#endif
+}
+
+DUK_INTERNAL void duk_hstring_set_hash(duk_hstring *h, duk_uint32_t hash) {
+#if defined(DUK_USE_STRHASH16)
+	DUK_ASSERT(hash <= 0xffffUL);
+	h->hdr.h_flags = (h->hdr.h_flags & 0x0000ffffUL) | (hash << 16U);
+#else
+	h->hash = hash;
+#endif
+}
+
+#if defined(DUK_USE_HSTRING_EXTDATA)
+DUK_INTERNAL const duk_uint8_t *duk_hstring_get_extdata(duk_hstring *h) {
+	DUK_ASSERT(DUK_HSTRING_HAS_EXTDATA(h));
+	return h->extdata;
+}
+#endif
+
+DUK_INTERNAL const duk_uint8_t *duk_hstring_get_data(duk_hstring *h) {
+#if defined(DUK_USE_HSTRING_EXTDATA)
+	if (DUK_HSTRING_HAS_EXTDATA(h)) {
+		return duk_hstring_get_extdata(h);
+	} else {
+		return (const duk_uint8_t *) (x + 1);
+	}
+#else
+	return (const duk_uint8_t *) (h + 1);
+#endif
+}
+
+DUK_INTERNAL const duk_uint8_t *duk_hstring_get_data_and_bytelen(duk_hstring *h, duk_size_t *out_blen) {
+	DUK_ASSERT(out_blen != NULL);
+	*out_blen = duk_hstring_get_bytelen(h);
+	return duk_hstring_get_data(h);
+}
+
+DUK_INTERNAL const duk_uint8_t *duk_hstring_get_data_end(duk_hstring *h) {
+	return duk_hstring_get_data(h) + duk_hstring_get_bytelen(h);
 }
 
 /*
@@ -70,14 +83,14 @@ DUK_INTERNAL void duk_hstring_init_charlen(duk_hstring *h) {
 	DUK_ASSERT(!DUK_HSTRING_HAS_ASCII(h));
 	DUK_ASSERT(!DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h));
 
-	clen = duk_unicode_unvalidated_utf8_length(DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+	clen = duk_unicode_unvalidated_utf8_length(duk_hstring_get_data(h), duk_hstring_get_bytelen(h));
 #if defined(DUK_USE_STRLEN16)
 	DUK_ASSERT(clen <= 0xffffUL); /* Bytelength checked during interning. */
 	h->clen16 = (duk_uint16_t) clen;
 #else
 	h->clen = (duk_uint32_t) clen;
 #endif
-	if (DUK_LIKELY(clen == DUK_HSTRING_GET_BYTELEN(h))) {
+	if (DUK_LIKELY(clen == duk_hstring_get_bytelen(h))) {
 		DUK_HSTRING_SET_ASCII(h);
 	}
 }
@@ -111,14 +124,14 @@ DUK_LOCAL DUK_COLD duk_size_t duk__hstring_get_charlen_slowpath(duk_hstring *h) 
 	}
 #endif
 
-	res = duk_unicode_unvalidated_utf8_length(DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+	res = duk_unicode_unvalidated_utf8_length(duk_hstring_get_data(h), duk_hstring_get_bytelen(h));
 #if defined(DUK_USE_STRLEN16)
 	DUK_ASSERT(res <= 0xffffUL); /* Bytelength checked during interning. */
 	h->clen16 = (duk_uint16_t) res;
 #else
 	h->clen = (duk_uint32_t) res;
 #endif
-	if (DUK_LIKELY(res == DUK_HSTRING_GET_BYTELEN(h))) {
+	if (DUK_LIKELY(res == duk_hstring_get_bytelen(h))) {
 		DUK_HSTRING_SET_ASCII(h);
 	}
 	return res;
@@ -127,7 +140,7 @@ DUK_LOCAL DUK_COLD duk_size_t duk__hstring_get_charlen_slowpath(duk_hstring *h) 
 DUK_LOCAL duk_size_t duk__hstring_get_charlen_slowpath(duk_hstring *h) {
 	if (DUK_LIKELY(DUK_HSTRING_HAS_ASCII(h))) {
 		/* Most practical strings will go here. */
-		return DUK_HSTRING_GET_BYTELEN(h);
+		return duk_hstring_get_bytelen(h);
 	} else {
 		/* ASCII flag is lazy, so set it here. */
 		duk_size_t res;
@@ -136,7 +149,7 @@ DUK_LOCAL duk_size_t duk__hstring_get_charlen_slowpath(duk_hstring *h) {
 		 * computation (matters for 'i < str.length' loops).
 		 */
 
-		res = duk_unicode_unvalidated_utf8_length(DUK_HSTRING_GET_DATA(h), DUK_HSTRING_GET_BYTELEN(h));
+		res = duk_unicode_unvalidated_utf8_length(duk_hstring_get_data(h), duk_hstring_get_bytelen(h));
 
 #if defined(DUK_USE_ROM_STRINGS)
 		if (DUK_HEAPHDR_HAS_READONLY((duk_heaphdr *) h)) {
@@ -146,7 +159,7 @@ DUK_LOCAL duk_size_t duk__hstring_get_charlen_slowpath(duk_hstring *h) {
 			return res;
 		}
 #endif
-		if (DUK_LIKELY(res == DUK_HSTRING_GET_BYTELEN(h))) {
+		if (DUK_LIKELY(res == duk_hstring_get_bytelen(h))) {
 			DUK_HSTRING_SET_ASCII(h);
 		}
 		return res;
@@ -176,6 +189,116 @@ DUK_INTERNAL DUK_HOT duk_size_t duk_hstring_get_charlen(duk_hstring *h) {
 #endif /* DUK_USE_HSTRING_LAZY_CLEN */
 
 /*
+ *  duk_hstring charCodeAt, with and without surrogate awareness
+ */
+
+DUK_INTERNAL duk_ucodepoint_t duk_hstring_char_code_at_raw(duk_hthread *thr,
+                                                           duk_hstring *h,
+                                                           duk_uint_t pos,
+                                                           duk_bool_t surrogate_aware) {
+	duk_uint32_t boff;
+	const duk_uint8_t *p, *p_start, *p_end;
+	duk_ucodepoint_t cp1;
+	duk_ucodepoint_t cp2;
+
+	/* Caller must check character offset to be inside the string. */
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(h != NULL);
+	DUK_ASSERT_DISABLE(pos >= 0); /* unsigned */
+	DUK_ASSERT(pos < (duk_uint_t) duk_hstring_get_charlen(h));
+
+	boff = (duk_uint32_t) duk_heap_strcache_offset_char2byte(thr, h, (duk_uint32_t) pos);
+	DUK_DDD(DUK_DDDPRINT("charCodeAt: pos=%ld -> boff=%ld, str=%!O", (long) pos, (long) boff, (duk_heaphdr *) h));
+	DUK_ASSERT_DISABLE(boff >= 0);
+	DUK_ASSERT(boff < duk_hstring_get_bytelen(h));
+
+	p_start = duk_hstring_get_data(h);
+	p_end = p_start + duk_hstring_get_bytelen(h);
+	p = p_start + boff;
+	DUK_DDD(DUK_DDDPRINT("p_start=%p, p_end=%p, p=%p", (const void *) p_start, (const void *) p_end, (const void *) p));
+
+	/* For invalid UTF-8 (never happens for standard ECMAScript strings)
+	 * return U+FFFD replacement character.
+	 */
+	if (duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp1)) {
+		if (surrogate_aware && cp1 >= 0xd800UL && cp1 <= 0xdbffUL) {
+			/* The decode helper is memory safe even if 'cp1' was
+			 * decoded at the end of the string and 'p' is no longer
+			 * within string memory range.
+			 */
+			cp2 = 0; /* If call fails, this is left untouched and won't match cp2 check. */
+			(void) duk_unicode_decode_xutf8(thr, &p, p_start, p_end, &cp2);
+			if (cp2 >= 0xdc00UL && cp2 <= 0xdfffUL) {
+				cp1 = (duk_ucodepoint_t) (((cp1 - 0xd800UL) << 10) + (cp2 - 0xdc00UL) + 0x10000UL);
+			}
+		}
+	} else {
+		cp1 = DUK_UNICODE_CP_REPLACEMENT_CHARACTER;
+	}
+
+	return cp1;
+}
+
+/*
+ *  Bytelen.
+ */
+
+DUK_INTERNAL DUK_HOT duk_size_t duk_hstring_get_bytelen(duk_hstring *h) {
+#if defined(DUK_USE_STRLEN16)
+	return h->hdr.h_strextra16;
+#else
+	return h->blen;
+#endif
+}
+
+DUK_INTERNAL void duk_hstring_set_bytelen(duk_hstring *h, duk_size_t len) {
+#if defined(DUK_USE_STRLEN16)
+	DUK_ASSERT(len <= 0xffffUL);
+	h->hdr.h_strextra16 = len;
+#else
+	DUK_ASSERT(len <= 0xffffffffUL);
+	h->blen = len;
+#endif
+}
+
+/*
+ *  Arridx
+ */
+
+DUK_INTERNAL duk_uarridx_t duk_hstring_get_arridx_fast(duk_hstring *h) {
+#if defined(DUK_USE_HSTRING_ARRIDX)
+	return h->arridx;
+#else
+	/* Get array index related to string (or return DUK_HSTRING_NO_ARRAY_INDEX);
+	 * avoids helper call if string has no array index value.
+	 */
+	if (DUK_HSTRING_HAS_ARRIDX(h)) {
+		return duk_js_to_arrayindex_hstring_fast_known(h);
+	} else {
+		return DUK_HSTRING_NO_ARRAY_INDEX;
+	}
+#endif
+}
+
+DUK_INTERNAL duk_uarridx_t duk_hstring_get_arridx_fast_known(duk_hstring *h) {
+	DUK_ASSERT(DUK_HSTRING_HAS_ARRIDX(h));
+
+#if defined(DUK_USE_HSTRING_ARRIDX)
+	return h->arridx;
+#else
+	return duk_js_to_arrayindex_hstring_fast_known(h);
+#endif
+}
+
+DUK_INTERNAL duk_uarridx_t duk_hstring_get_arridx_slow(duk_hstring *h) {
+#if defined(DUK_USE_HSTRING_ARRIDX)
+	return h->arridx;
+#else
+	return duk_js_to_arrayindex_hstring_fast(h);
+#endif
+}
+
+/*
  *  Compare duk_hstring to an ASCII cstring.
  */
 
@@ -186,10 +309,10 @@ DUK_INTERNAL duk_bool_t duk_hstring_equals_ascii_cstring(duk_hstring *h, const c
 	DUK_ASSERT(cstr != NULL);
 
 	len = DUK_STRLEN(cstr);
-	if (len != DUK_HSTRING_GET_BYTELEN(h)) {
+	if (len != duk_hstring_get_bytelen(h)) {
 		return 0;
 	}
-	if (duk_memcmp((const void *) cstr, (const void *) DUK_HSTRING_GET_DATA(h), len) == 0) {
+	if (duk_memcmp((const void *) cstr, (const void *) duk_hstring_get_data(h), len) == 0) {
 		return 1;
 	}
 	return 0;

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -2175,9 +2175,9 @@ duk_regconst_t duk__ispec_toregconst_raw(duk_compiler_ctx *comp_ctx,
 
 #if 0 /* XXX: to be implemented? */
 			/* Use special opcodes to load short strings */
-			if (DUK_HSTRING_GET_BYTELEN(h) <= 2) {
+			if (duk_hstring_get_bytelen(h) <= 2) {
 				/* Encode into a single opcode (18 bits can encode 1-2 bytes + length indicator) */
-			} else if (DUK_HSTRING_GET_BYTELEN(h) <= 6) {
+			} else if (duk_hstring_get_bytelen(h) <= 6) {
 				/* Encode into a double constant (53 bits can encode 6*8 = 48 bits + 3-bit length */
 			}
 #endif
@@ -6743,8 +6743,8 @@ retry_parse:
 				 * strings like "use strict\u0000foo" as required.
 				 */
 
-				if (DUK_HSTRING_GET_BYTELEN(h_dir) == 10 &&
-				    DUK_STRCMP((const char *) DUK_HSTRING_GET_DATA(h_dir), "use strict") == 0) {
+				if (duk_hstring_get_bytelen(h_dir) == 10 &&
+				    DUK_STRCMP((const char *) duk_hstring_get_data(h_dir), "use strict") == 0) {
 #if defined(DUK_USE_STRICT_DECL)
 					DUK_DDD(DUK_DDDPRINT("use strict directive detected: strict flag %ld -> %ld",
 					                     (long) comp_ctx->curr_func.is_strict,
@@ -6753,8 +6753,8 @@ retry_parse:
 #else
 					DUK_DDD(DUK_DDDPRINT("use strict detected but strict declarations disabled, ignoring"));
 #endif
-				} else if (DUK_HSTRING_GET_BYTELEN(h_dir) == 14 &&
-				           DUK_STRCMP((const char *) DUK_HSTRING_GET_DATA(h_dir), "use duk notail") == 0) {
+				} else if (duk_hstring_get_bytelen(h_dir) == 14 &&
+				           DUK_STRCMP((const char *) duk_hstring_get_data(h_dir), "use duk notail") == 0) {
 					DUK_DDD(DUK_DDDPRINT("use duk notail directive detected: notail flag %ld -> %ld",
 					                     (long) comp_ctx->curr_func.is_notail,
 					                     (long) 1));

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -2147,9 +2147,9 @@ DUK_LOCAL void duk__executor_recheck_debugger(duk_hthread *thr, duk_activation *
 				bp_match = 1;
 				DUK_DD(DUK_DDPRINT("breakpoint filename and line match: "
 				                   "%s:%ld vs. %s (line %ld vs. %ld-%ld)",
-				                   DUK_HSTRING_GET_DATA(bp->filename),
+				                   duk_hstring_get_data(bp->filename),
 				                   (long) bp->line,
-				                   DUK_HSTRING_GET_DATA(filename),
+				                   duk_hstring_get_data(filename),
 				                   (long) bp->line,
 				                   (long) fun->start_line,
 				                   (long) fun->end_line));

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -70,7 +70,7 @@ DUK_INTERNAL duk_bool_t duk_js_toboolean(duk_tval *tv) {
 		 */
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv);
 		DUK_ASSERT(h != NULL);
-		return (DUK_HSTRING_GET_BYTELEN(h) > 0 ? 1 : 0);
+		return (duk_hstring_get_bytelen(h) > 0 ? 1 : 0);
 	}
 	case DUK_TAG_OBJECT: {
 		return 1;
@@ -754,10 +754,10 @@ DUK_INTERNAL duk_small_int_t duk_js_string_compare(duk_hstring *h1, duk_hstring 
 	DUK_ASSERT(h1 != NULL);
 	DUK_ASSERT(h2 != NULL);
 
-	return duk_js_data_compare((const duk_uint8_t *) DUK_HSTRING_GET_DATA(h1),
-	                           (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h2),
-	                           (duk_size_t) DUK_HSTRING_GET_BYTELEN(h1),
-	                           (duk_size_t) DUK_HSTRING_GET_BYTELEN(h2));
+	return duk_js_data_compare((const duk_uint8_t *) duk_hstring_get_data(h1),
+	                           (const duk_uint8_t *) duk_hstring_get_data(h2),
+	                           (duk_size_t) duk_hstring_get_bytelen(h1),
+	                           (duk_size_t) duk_hstring_get_bytelen(h2));
 }
 
 #if 0 /* unused */
@@ -1432,7 +1432,7 @@ DUK_INTERNAL duk_uarridx_t duk_js_to_arrayindex_hstring_fast_known(duk_hstring *
 	DUK_ASSERT(h != NULL);
 	DUK_ASSERT(DUK_HSTRING_HAS_ARRIDX(h));
 
-	p = DUK_HSTRING_GET_DATA(h);
+	p = duk_hstring_get_data(h);
 	res = 0;
 	for (;;) {
 		t = *p++;

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -1236,7 +1236,7 @@ duk_bool_t duk__getvar_helper(duk_hthread *thr, duk_hobject *env, duk_activation
 			DUK_ERROR_FMT1(thr,
 			               DUK_ERR_REFERENCE_ERROR,
 			               "identifier '%s' undefined",
-			               (const char *) DUK_HSTRING_GET_DATA(name));
+			               (const char *) duk_hstring_get_data(name));
 			DUK_WO_NORETURN(return 0;);
 		}
 
@@ -1363,7 +1363,7 @@ void duk__putvar_helper(duk_hthread *thr,
 		DUK_ERROR_FMT1(thr,
 		               DUK_ERR_REFERENCE_ERROR,
 		               "identifier '%s' undefined",
-		               (const char *) DUK_HSTRING_GET_DATA(name));
+		               (const char *) duk_hstring_get_data(name));
 		DUK_WO_NORETURN(return;);
 	}
 

--- a/src-input/duk_numconv.c
+++ b/src-input/duk_numconv.c
@@ -1845,7 +1845,7 @@ DUK_LOCAL DUK_NOINLINE void duk__numconv_parse_raw(duk_hthread *thr, duk_small_i
 	}
 	h_str = duk_require_hstring(thr, -1);
 	DUK_ASSERT(h_str != NULL);
-	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_str);
+	p = (const duk_uint8_t *) duk_hstring_get_data(h_str);
 
 	neg = 0;
 	ch = *p;
@@ -2153,7 +2153,7 @@ DUK_LOCAL DUK_NOINLINE void duk__numconv_parse_raw(duk_hthread *thr, duk_small_i
 			if ((flags & DUK_S2N_FLAG_ALLOW_EMPTY_AS_ZERO) == 0) {
 				DUK_DDD(DUK_DDDPRINT("parse failed: empty string not allowed (as zero)"));
 				goto parse_fail;
-			} else if (DUK_HSTRING_GET_BYTELEN(h_str) != 0) {
+			} else if (duk_hstring_get_bytelen(h_str) != 0) {
 				DUK_DDD(DUK_DDDPRINT("parse failed: no digits, but not empty (had a +/- sign)"));
 				goto parse_fail;
 			}

--- a/src-input/duk_prop_defown.c
+++ b/src-input/duk_prop_defown.c
@@ -532,7 +532,7 @@ DUK_LOCAL DUK_COLD duk_bool_t duk__prop_defown_strkey_stringobj_length(duk_hthre
 		DUK_ASSERT((defprop_flags & (DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_SETTER)) == 0U);
 		if (defprop_flags & DUK_DEFPROP_HAVE_VALUE) {
 			duk_tval tv_tmp;
-			DUK_TVAL_SET_U32(&tv_tmp, DUK_HSTRING_GET_CHARLEN(h));
+			DUK_TVAL_SET_U32(&tv_tmp, duk_hstring_get_charlen(h));
 			if (!duk_js_samevalue(duk_require_tval(thr, idx_desc), &tv_tmp)) {
 				goto fail_invalid_desc;
 			}
@@ -1045,7 +1045,7 @@ DUK_LOCAL duk_small_int_t duk__prop_defown_idxkey_stringobj(duk_hthread *thr,
 
 	h = duk_hobject_lookup_intvalue_hstring(thr, obj);
 	if (DUK_LIKELY(h != NULL)) {
-		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < DUK_HSTRING_GET_CHARLEN(h))) {
+		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < duk_hstring_get_charlen(h))) {
 			if (duk__prop_validate_immutable_data_desc(DUK_PROPDESC_FLAGS_E, defprop_flags) == 0) {
 				goto fail_invalid_desc;
 			}
@@ -1335,7 +1335,7 @@ duk_prop_defown_strkey(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk
 	DUK_ASSERT(idx_desc >= 0);
 
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_defown_idxkey_unsafe(thr, obj, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key), idx_desc, defprop_flags);
+		return duk__prop_defown_idxkey_unsafe(thr, obj, duk_hstring_get_arridx_fast_known(key), idx_desc, defprop_flags);
 	} else {
 		return duk__prop_defown_strkey_unsafe(thr, obj, key, idx_desc, defprop_flags);
 	}
@@ -1383,7 +1383,7 @@ duk_prop_defown(duk_hthread *thr, duk_hobject *obj, duk_tval *tv_key, duk_idx_t 
 	case DUK_TAG_STRING:
 		key = DUK_TVAL_GET_STRING(tv_key);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-			idx = DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key);
+			idx = duk_hstring_get_arridx_fast_known(key);
 			goto use_idx;
 		} else {
 			goto use_str;

--- a/src-input/duk_prop_delete.c
+++ b/src-input/duk_prop_delete.c
@@ -685,7 +685,7 @@ retry_target:
 
 		h = duk_hobject_lookup_intvalue_hstring(thr, target);
 		if (DUK_LIKELY(h != NULL)) {
-			if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < DUK_HSTRING_GET_CHARLEN(h))) {
+			if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < duk_hstring_get_charlen(h))) {
 				goto fail_not_configurable;
 			}
 		}
@@ -772,7 +772,7 @@ DUK_INTERNAL duk_bool_t duk_prop_delete_obj_strkey(duk_hthread *thr,
                                                    duk_hstring *key,
                                                    duk_small_uint_t delprop_flags) {
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_delete_obj_idxkey_unsafe(thr, obj, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key), delprop_flags);
+		return duk__prop_delete_obj_idxkey_unsafe(thr, obj, duk_hstring_get_arridx_fast_known(key), delprop_flags);
 	} else {
 		return duk__prop_delete_obj_strkey_unsafe(thr, obj, key, delprop_flags);
 	}
@@ -876,7 +876,7 @@ DUK_LOCAL duk_bool_t duk__prop_delete_idxkey(duk_hthread *thr,
 	case DUK_TAG_STRING: {
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv_obj);
 
-		if (!DUK_HSTRING_HAS_SYMBOL(h) && idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (!DUK_HSTRING_HAS_SYMBOL(h) && idx < duk_hstring_get_charlen(h)) {
 			goto fail_not_configurable;
 		}
 		break;
@@ -915,7 +915,7 @@ DUK_INTERNAL duk_bool_t duk_prop_delete_strkey(duk_hthread *thr,
                                                duk_hstring *key,
                                                duk_small_uint_t delprop_flags) {
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_delete_idxkey(thr, idx_obj, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key), delprop_flags);
+		return duk__prop_delete_idxkey(thr, idx_obj, duk_hstring_get_arridx_fast_known(key), delprop_flags);
 	} else {
 		return duk__prop_delete_strkey(thr, idx_obj, key, delprop_flags);
 	}
@@ -955,7 +955,7 @@ DUK_INTERNAL duk_bool_t duk_prop_deleteoper(duk_hthread *thr, duk_idx_t idx_obj,
 	case DUK_TAG_STRING:
 		key = DUK_TVAL_GET_STRING(tv_key);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-			idx = DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key);
+			idx = duk_hstring_get_arridx_fast_known(key);
 			goto use_idx;
 		} else {
 			DUK_ASSERT(!DUK_HSTRING_HAS_ARRIDX(key));

--- a/src-input/duk_prop_get.c
+++ b/src-input/duk_prop_get.c
@@ -211,7 +211,7 @@ DUK_LOCAL duk_bool_t duk__prop_get_write_plainstr_length(duk_hthread *thr, duk_h
 
 	tv_out = thr->valstack_bottom + idx_out;
 	DUK_ASSERT(DUK_HTHREAD_TVAL_IN_VSFRAME(thr, tv_out));
-	len = (duk_uint32_t) DUK_HSTRING_GET_CHARLEN(h);
+	len = (duk_uint32_t) duk_hstring_get_charlen(h);
 	DUK_TVAL_SET_U32_UPDREF(thr, tv_out, len);
 	return 1;
 }
@@ -568,7 +568,7 @@ duk__get_own_prop_idxkey_stringobj(duk_hthread *thr, duk_hobject *obj, duk_uarri
 
 	h = duk_hobject_lookup_intvalue_hstring(thr, obj);
 	if (DUK_LIKELY(h != NULL)) {
-		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < DUK_HSTRING_GET_CHARLEN(h))) {
+		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < duk_hstring_get_charlen(h))) {
 			return (duk_small_int_t) duk__prop_getvalue_plainstr_index(thr, idx_recv, idx, idx_out, h);
 		}
 	}
@@ -1042,7 +1042,7 @@ DUK_LOCAL duk_bool_t duk__prop_getvalue_idx_outidx(duk_hthread *thr, duk_idx_t i
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv_recv);
 
 		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h))) {
-			if (DUK_LIKELY(idx < DUK_HSTRING_GET_CHARLEN(h))) {
+			if (DUK_LIKELY(idx < duk_hstring_get_charlen(h))) {
 				return duk__prop_getvalue_plainstr_index(thr, idx_recv, idx, idx_out, h);
 			}
 			next_bidx = DUK_BIDX_STRING_PROTOTYPE;
@@ -1159,7 +1159,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_str_outidx(duk_hthread *thr, duk_idx_t
 	DUK_ASSERT(duk_is_valid_posidx(thr, idx_out));
 
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_getvalue_idx_outidx(thr, idx_recv, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key), idx_out);
+		return duk__prop_getvalue_idx_outidx(thr, idx_recv, duk_hstring_get_arridx_fast_known(key), idx_out);
 	} else {
 		return duk__prop_getvalue_str_outidx(thr, idx_recv, key, idx_out);
 	}
@@ -1238,7 +1238,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_outidx(duk_hthread *thr, duk_idx_t idx
 	case DUK_TAG_STRING:
 		key = DUK_TVAL_GET_STRING(tv_key);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-			idx = DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key);
+			idx = duk_hstring_get_arridx_fast_known(key);
 			goto use_idx;
 		} else {
 			goto use_str;

--- a/src-input/duk_prop_getown.c
+++ b/src-input/duk_prop_getown.c
@@ -123,7 +123,7 @@ retry_target:
 	case DUK_HTYPE_STRING_OBJECT:
 		if (DUK_HSTRING_HAS_LENGTH(key)) {
 			duk_hstring *h = duk_hobject_lookup_intvalue_hstring(thr, target);
-			duk_push_u32(thr, DUK_HSTRING_GET_CHARLEN(h));
+			duk_push_u32(thr, duk_hstring_get_charlen(h));
 			rc = DUK_PROPDESC_FLAGS_NONE;
 			goto return_rc;
 		}
@@ -307,7 +307,7 @@ retry_target:
 		goto return_rc;
 	case DUK_HTYPE_STRING_OBJECT: {
 		duk_hstring *h = duk_hobject_lookup_intvalue_hstring(thr, target);
-		if (idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (idx < duk_hstring_get_charlen(h)) {
 			duk_prop_push_plainstr_idx(thr, h, idx);
 			rc = DUK_PROPDESC_FLAGS_E;
 			goto return_rc;
@@ -387,7 +387,7 @@ DUK_INTERNAL duk_small_int_t duk_prop_getowndesc_obj_strkey(duk_hthread *thr, du
 	DUK_ASSERT(key != NULL);
 
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_getowndesc_idxkey_unsafe(thr, obj, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key));
+		return duk__prop_getowndesc_idxkey_unsafe(thr, obj, duk_hstring_get_arridx_fast_known(key));
 	} else {
 		return duk__prop_getowndesc_strkey_unsafe(thr, obj, key);
 	}

--- a/src-input/duk_prop_has.c
+++ b/src-input/duk_prop_has.c
@@ -51,7 +51,7 @@ DUK_LOCAL duk_small_int_t duk__prop_hasown_idxkey_stringobj(duk_hthread *thr, du
 
 	h = duk_hobject_lookup_intvalue_hstring(thr, obj);
 	if (DUK_LIKELY(h != NULL)) {
-		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < DUK_HSTRING_GET_CHARLEN(h))) {
+		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h) && idx < duk_hstring_get_charlen(h))) {
 			return DUK__HASOWN_FOUND;
 		}
 	}
@@ -443,7 +443,7 @@ DUK_INTERNAL duk_bool_t duk_prop_has_strkey(duk_hthread *thr, duk_tval *tv_obj, 
 	DUK_ASSERT(key != NULL);
 
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_has_idxkey(thr, tv_obj, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key));
+		return duk__prop_has_idxkey(thr, tv_obj, duk_hstring_get_arridx_fast_known(key));
 	} else {
 		return duk__prop_has_strkey(thr, tv_obj, key);
 	}
@@ -500,7 +500,7 @@ DUK_INTERNAL duk_bool_t duk_prop_has(duk_hthread *thr, duk_tval *tv_obj, duk_tva
 	case DUK_TAG_STRING:
 		key = DUK_TVAL_GET_STRING(tv_key);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-			idx = DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key);
+			idx = duk_hstring_get_arridx_fast_known(key);
 			goto use_idx;
 		} else {
 			DUK_ASSERT(!DUK_HSTRING_HAS_ARRIDX(key));

--- a/src-input/duk_prop_set.c
+++ b/src-input/duk_prop_set.c
@@ -1176,7 +1176,7 @@ DUK_LOCAL duk_bool_t duk__setcheck_own_prop_idxkey(duk_hthread *thr,
 		duk_hstring *h;
 
 		h = duk_hobject_lookup_intvalue_hstring(thr, obj);
-		if (h != NULL && idx < DUK_HSTRING_GET_CHARLEN(h)) {
+		if (h != NULL && idx < duk_hstring_get_charlen(h)) {
 			goto fail_not_writable;
 		}
 		/* Out of bounds, go to normal property table. */
@@ -2011,7 +2011,7 @@ duk__prop_putvalue_idx_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_uarridx_t
 		duk_hstring *h = DUK_TVAL_GET_STRING(tv_recv);
 
 		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h))) {
-			if (idx < DUK_HSTRING_GET_CHARLEN(h)) {
+			if (idx < duk_hstring_get_charlen(h)) {
 				goto fail_not_writable;
 			}
 			next_bidx = DUK_BIDX_STRING_PROTOTYPE;
@@ -2225,7 +2225,7 @@ duk_prop_putvalue_str_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_hstring *k
 	DUK_ASSERT(throw_flag == 0 || throw_flag == 1);
 
 	if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-		return duk__prop_putvalue_idx_inidx(thr, idx_recv, DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key), idx_val, throw_flag);
+		return duk__prop_putvalue_idx_inidx(thr, idx_recv, duk_hstring_get_arridx_fast_known(key), idx_val, throw_flag);
 	} else {
 		return duk__prop_putvalue_str_inidx(thr, idx_recv, key, idx_val, throw_flag);
 	}
@@ -2254,7 +2254,7 @@ duk_prop_putvalue_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_tval *tv_key, 
 	case DUK_TAG_STRING:
 		key = DUK_TVAL_GET_STRING(tv_key);
 		if (DUK_UNLIKELY(DUK_HSTRING_HAS_ARRIDX(key))) {
-			idx = DUK_HSTRING_GET_ARRIDX_FAST_KNOWN(key);
+			idx = duk_hstring_get_arridx_fast_known(key);
 			goto use_idx;
 		} else {
 			goto use_str;

--- a/src-input/duk_regexp_compiler.c
+++ b/src-input/duk_regexp_compiler.c
@@ -1015,8 +1015,8 @@ DUK_LOCAL duk_uint32_t duk__parse_regexp_flags(duk_hthread *thr, duk_hstring *h)
 	const duk_uint8_t *p_end;
 	duk_uint32_t flags = 0;
 
-	p = DUK_HSTRING_GET_DATA(h);
-	p_end = p + DUK_HSTRING_GET_BYTELEN(h);
+	p = duk_hstring_get_data(h);
+	p_end = p + duk_hstring_get_bytelen(h);
 
 	/* Note: can be safely scanned as bytes (undecoded) */
 
@@ -1087,8 +1087,7 @@ DUK_LOCAL void duk__create_escaped_source(duk_hthread *thr, int idx_pattern) {
 	duk_uint_fast8_t c_prev, c;
 
 	h = duk_known_hstring(thr, idx_pattern);
-	p = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h);
-	n = (duk_size_t) DUK_HSTRING_GET_BYTELEN(h);
+	p = (const duk_uint8_t *) duk_hstring_get_data_and_bytelen(h, &n);
 
 	if (n == 0) {
 		duk_push_literal(thr, "(?:)");
@@ -1175,8 +1174,8 @@ DUK_INTERNAL void duk_regexp_compile(duk_hthread *thr) {
 	DUK_LEXER_INITCTX(&re_ctx.lex); /* duplicate zeroing, expect for (possible) NULL inits */
 	re_ctx.thr = thr;
 	re_ctx.lex.thr = thr;
-	re_ctx.lex.input = DUK_HSTRING_GET_DATA(h_pattern);
-	re_ctx.lex.input_length = DUK_HSTRING_GET_BYTELEN(h_pattern);
+	re_ctx.lex.input = duk_hstring_get_data(h_pattern);
+	re_ctx.lex.input_length = duk_hstring_get_bytelen(h_pattern);
 	re_ctx.lex.token_limit = DUK_RE_COMPILE_TOKEN_LIMIT;
 	re_ctx.recursion_limit = DUK_USE_REGEXP_COMPILER_RECLIMIT;
 	re_ctx.re_flags = duk__parse_regexp_flags(thr, h_flags);

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -759,10 +759,10 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	duk_memzero(&re_ctx, sizeof(re_ctx));
 
 	re_ctx.thr = thr;
-	re_ctx.input = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
-	re_ctx.input_end = re_ctx.input + DUK_HSTRING_GET_BYTELEN(h_input);
-	re_ctx.bytecode = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_bytecode);
-	re_ctx.bytecode_end = re_ctx.bytecode + DUK_HSTRING_GET_BYTELEN(h_bytecode);
+	re_ctx.input = (const duk_uint8_t *) duk_hstring_get_data(h_input);
+	re_ctx.input_end = re_ctx.input + duk_hstring_get_bytelen(h_input);
+	re_ctx.bytecode = (const duk_uint8_t *) duk_hstring_get_data(h_bytecode);
+	re_ctx.bytecode_end = re_ctx.bytecode + duk_hstring_get_bytelen(h_bytecode);
 	re_ctx.saved = NULL;
 	re_ctx.recursion_limit = DUK_USE_REGEXP_EXECUTOR_RECLIMIT;
 	re_ctx.steps_limit = DUK_RE_EXECUTE_STEPS_LIMIT;
@@ -827,7 +827,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	duk_pop_nodecref_unsafe(thr);
 
 	if (global) {
-		if (d < 0.0 || d > (double) DUK_HSTRING_GET_CHARLEN(h_input)) {
+		if (d < 0.0 || d > (double) duk_hstring_get_charlen(h_input)) {
 			/* match fail */
 			char_offset = 0; /* not really necessary */
 			DUK_ASSERT(match == 0);
@@ -843,7 +843,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 		char_offset = (duk_uint32_t) 0;
 	}
 
-	DUK_ASSERT(char_offset <= DUK_HSTRING_GET_CHARLEN(h_input));
+	DUK_ASSERT(char_offset <= duk_hstring_get_charlen(h_input));
 	sp = re_ctx.input + duk_heap_strcache_offset_char2byte(thr, h_input, char_offset);
 
 	/*
@@ -859,7 +859,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	for (;;) {
 		/* char offset in [0, h_input->clen] (both ends inclusive), checked before entry */
 		DUK_ASSERT_DISABLE(char_offset >= 0);
-		DUK_ASSERT(char_offset <= DUK_HSTRING_GET_CHARLEN(h_input));
+		DUK_ASSERT(char_offset <= duk_hstring_get_charlen(h_input));
 
 		/* Note: re_ctx.steps is intentionally not reset, it applies to the entire unanchored match */
 		DUK_ASSERT(re_ctx.recursion_depth == 0);
@@ -897,7 +897,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 
 		/* advance by one character (code point) and one char_offset */
 		char_offset++;
-		if (char_offset > DUK_HSTRING_GET_CHARLEN(h_input)) {
+		if (char_offset > duk_hstring_get_charlen(h_input)) {
 			/*
 			 *  Note:
 			 *

--- a/src-input/duk_unicode_support.c
+++ b/src-input/duk_unicode_support.c
@@ -1080,12 +1080,12 @@ DUK_INTERNAL void duk_unicode_case_convert_string(duk_hthread *thr, duk_bool_t u
 	DUK_ASSERT(h_input != NULL);
 
 	bw = &bw_alloc;
-	DUK_BW_INIT_PUSHBUF(thr, bw, DUK_HSTRING_GET_BYTELEN(h_input));
+	DUK_BW_INIT_PUSHBUF(thr, bw, duk_hstring_get_bytelen(h_input));
 
 	/* [ ... input buffer ] */
 
-	p_start = (const duk_uint8_t *) DUK_HSTRING_GET_DATA(h_input);
-	p_end = p_start + DUK_HSTRING_GET_BYTELEN(h_input);
+	p_start = (const duk_uint8_t *) duk_hstring_get_data(h_input);
+	p_end = p_start + duk_hstring_get_bytelen(h_input);
 	p = p_start;
 
 	prev = -1;

--- a/src-input/duk_util.h
+++ b/src-input/duk_util.h
@@ -352,8 +352,8 @@ DUK_INTERNAL_DECL void duk_bw_assert_valid(duk_hthread *thr, duk_bufwriter_ctx *
 #define DUK_BW_WRITE_RAW_HSTRING(thr, bw_ctx, val) \
 	do { \
 		duk_size_t duk__val_len; \
-		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
-		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk__val_len = duk_hstring_get_bytelen((val)); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) duk_hstring_get_data((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_RAW_HBUFFER(thr, bw_ctx, val) \
@@ -471,9 +471,9 @@ DUK_INTERNAL_DECL void duk_bw_assert_valid(duk_hthread *thr, duk_bufwriter_ctx *
 #define DUK_BW_WRITE_ENSURE_HSTRING(thr, bw_ctx, val) \
 	do { \
 		duk_size_t duk__val_len; \
-		duk__val_len = DUK_HSTRING_GET_BYTELEN((val)); \
+		duk__val_len = duk_hstring_get_bytelen((val)); \
 		DUK_BW_ENSURE((thr), (bw_ctx), duk__val_len); \
-		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) DUK_HSTRING_GET_DATA((val)), duk__val_len); \
+		duk_memcpy_unsafe((void *) ((bw_ctx)->p), (const void *) duk_hstring_get_data((val)), duk__val_len); \
 		(bw_ctx)->p += duk__val_len; \
 	} while (0)
 #define DUK_BW_WRITE_ENSURE_HBUFFER(thr, bw_ctx, val) \


### PR DESCRIPTION
Isolate all char-offset-to-byte-offset and character access calls behind helpers to help prepare for a switch to WTF-8 representation. This change should have no visible effect yet.