### PR TITLE
dist-files: generated formatted version for pkg-config file

### DIFF
--- a/dist-files/Makefile.sharedlibrary
+++ b/dist-files/Makefile.sharedlibrary
@@ -24,7 +24,9 @@
 # convention is to set soname version to (100*MAJOR + MINOR), e.g. 104 for
 # Duktape 1.4.x, so that it gets automatically bumped for major and minor
 # releases (potentially binary incompatible), but not for patch releases.
+# The formatted version is used for the pkg-config file.
 DUK_VERSION = @DUK_VERSION@
+DUK_VERSION_FORMATTED = @DUK_VERSION_FORMATTED@
 SONAME_VERSION = @SONAME_VERSION@
 REAL_VERSION = $(SONAME_VERSION).$(DUK_VERSION)
 
@@ -78,7 +80,7 @@ libduktaped.$(SO_REALNAME_SUFFIX):
 duktape.pc:
 	sed -e "s|@PREFIX@|$(INSTALL_PREFIX)|" \
 		-e "s|@LIBDIR@|$(LIBDIR)|" \
-		-e "s|@VERSION@|$(DUK_VERSION_PACKAGE_JSON)|" \
+		-e "s|@VERSION@|$(DUK_VERSION_FORMATTED)|" \
 		duktape.pc.in \
 		> duktape.pc
 

--- a/src-tools/lib/dist/dist_sources.js
+++ b/src-tools/lib/dist/dist_sources.js
@@ -492,6 +492,7 @@ function createTempFiles(args) {
     copyFileUtf8AtSignReplace(pathJoin(repoDirectory, 'dist-files', 'Makefile.sharedlibrary'),
                               pathJoin(distTempDirectory, 'Makefile.sharedlibrary'), {
                                   DUK_VERSION: String(dukVersion),
+                                  DUK_VERSION_FORMATTED: String(args.dukVersionFormatted),
                                   SONAME_VERSION: String(Math.floor(dukVersion / 100))  // 10500 -> 105
                               });
 


### PR DESCRIPTION
Rather than letting users set it manually, just generate it with
the other version formats when creating the distributable sources.

Follow-up for https://github.com/svaarala/duktape/pull/2454