### PR TITLE
Fix realloc() leak with existing allocation, zero new size, and GC triggered before first realloc() attempt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ CCOPTS_DEBUG += -g -ggdb
 CLANG_CCOPTS_NONDEBUG = $(CCOPTS_NONDEBUG)
 CLANG_CCOPTS_NONDEBUG += -Wshorten-64-to-32
 CLANG_CCOPTS_NONDEBUG += -Wcomma
-#CLANG_CCOPTS_NONDEBUG += -fsanitize=undefined
+
+CLANG_CCOPTS_DEBUG = $(CCOPTS_DEBUG)
 
 GXXOPTS_SHARED = -pedantic -ansi -std=c++11 -fstrict-aliasing -Wall -Wextra -Wunused-result -Wunused-function
 GXXOPTS_SHARED += -DDUK_CMDLINE_PRINTALERT_SUPPORT
@@ -476,22 +477,22 @@ build/duk-clang: $(DUK_SOURCE_DEPS) | build prep/nondebug
 	@# Use -Wcast-align to trigger issues like: https://github.com/svaarala/duktape/issues/270
 	@# Use -Wshift-sign-overflow to trigger issues like: https://github.com/svaarala/duktape/issues/812
 	@# -Weverything
-	$(CLANG) -o $@ -Wcast-align -Wshift-sign-overflow -Iprep/nondebug $(CLANG_CCOPTS_NONDEBUG) prep/nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
+	$(CLANG) -o $@ $(CLANG_CCOPTS_NONDEBUG) -Wcast-align -Wshift-sign-overflow prep/nondebug/duktape.c -Iprep/nondebug $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
 	-@ls -l $@ && size $@
 build/duk-clang-asan: $(DUK_SOURCE_DEPS) | build prep/nondebug
 	# Binary fails to start with linenoise included, so add -UDUK_CMDLINE_FANCY to disable linenoise.
-	$(CLANG) -o $@ -Wcast-align -Wshift-sign-overflow -fsanitize=address -fno-omit-frame-pointer -Iprep/nondebug $(CLANG_CCOPTS_NONDEBUG) -UDUK_CMDLINE_FANCY prep/nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(CCLIBS)
+	$(CLANG) -o $@ $(CLANG_CCOPTS_NONDEBUG) -Wcast-align -Wshift-sign-overflow -fsanitize=address -fno-omit-frame-pointer -Iprep/nondebug $(CLANG_CCOPTS_DEBUG) -O0 -g -UDUK_CMDLINE_FANCY prep/nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(CCLIBS)
 	-@ls -l $@ && size $@
 build/duk-clang-ubsan: $(DUK_SOURCE_DEPS) | build prep/nondebug
-	$(CLANG) -o $@ -Wcast-align -Wshift-sign-overflow -fsanitize=undefined -Iprep/nondebug $(CLANG_CCOPTS_NONDEBUG) prep/nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
+	$(CLANG) -o $@ $(CLANG_CCOPTS_NONDEBUG) -Wcast-align -Wshift-sign-overflow -fsanitize=undefined prep/nondebug/duktape.c -Iprep/nondebug $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
 	-@ls -l $@ && size $@
 build/duk-perf-clang: $(DUK_SOURCE_DEPS) | build prep/nondebug-perf
-	$(CLANG) -o $@ -Wcast-align -Wshift-sign-overflow -Iprep/nondebug-perf $(CLANG_CCOPTS_NONDEBUG) prep/nondebug-perf/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
+	$(CLANG) -o $@ $(CLANG_CCOPTS_NONDEBUG) -Wcast-align -Wshift-sign-overflow -Iprep/nondebug-perf prep/nondebug-perf/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
 	-@ls -l $@ && size $@
 
 build/duk-fuzzilli: $(DUK_SOURCE_DEPS) | build prep/fuzz
 	# Target for fuzzilli.  Adds in the appropriate debug flags, without doing the debug prints.
-	$(CLANG) -O3 -o $@ -Wall -Wextra -Wcast-align -Wshift-sign-overflow -fsanitize=undefined -fsanitize-coverage=trace-pc-guard  -Iprep/fuzz $(CLANG_CCOPTS_DEBUG) prep/fuzz/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
+	$(CLANG) -O3 -o $@ $(CLANG_CCOPTS_DEBUG) -Wall -Wextra -Wcast-align -Wshift-sign-overflow -fsanitize=undefined -fsanitize-coverage=trace-pc-guard -Iprep/fuzz prep/fuzz/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(LINENOISE_SOURCES) $(CCLIBS)
 
 build/duk-g++: $(DUK_SOURCE_DEPS) | build prep/nondebug
 	$(GXX) -o $@ -Iprep/nondebug $(GXXOPTS_NONDEBUG) prep/nondebug/duktape.c $(DUKTAPE_CMDLINE_SOURCES) $(CCLIBS)

--- a/examples/cmdline/duk_cmdline.c
+++ b/examples/cmdline/duk_cmdline.c
@@ -1373,7 +1373,6 @@ void __sanitizer_cov_reset_edgeguards(void) {
 	}
 }
 
-
 void __sanitizer_cov_trace_pc_guard_init(duk_uint32_t *start, duk_uint32_t *stop) {
 	/* Avoid duplicate initialization. */
 	if (start == stop || *start) {
@@ -1394,7 +1393,11 @@ void __sanitizer_cov_trace_pc_guard_init(duk_uint32_t *start, duk_uint32_t *stop
 		puts("[COV] no shared memory bitmap available, skipping");
 		__shmem = (struct shmem_data *) malloc(SHM_SIZE);
 	} else {
+#if defined(S_IRUSR) && defined(S_IWUSR)
+		int fd = shm_open(shm_key, O_RDWR, S_IRUSR | S_IWUSR);
+#else
 		int fd = shm_open(shm_key, O_RDWR, S_IREAD | S_IWRITE);
+#endif
 		if (fd <= -1) {
 			fprintf(stderr, "Failed to open shared memory region: %s\n", strerror(errno));
 			_exit(-1);

--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1385,3 +1385,4 @@ duktape_releases:
     - "Reformat source with clang-format-12 (GH-2416, GH-2421, GH-2423, GH-2424, GH-2425, GH-2426, GH-2427, GH-2428)"
     - "Fix DUK_USE_GET_RANDOM_DOUBLE() argument handling (GH-2432, GH-2435)"
     - "Fix memory unsafe behavior when valstack size limit hit in call setup (GH-2448, GH-2451)"
+    - "Fix a realloc() memory leak triggered when (1) previous allocation exists, (2) new realloc size is 0, (3) GC is triggered before first realloc() attempt (GH-2468)"

--- a/tests/shell/leak/asan_misc_expressions.sh
+++ b/tests/shell/leak/asan_misc_expressions.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 make build/duk-clang-asan
-build/duk-clang-asan tests/ecmascript/test-misc-large-expressions.js
+ASAN_OPTIONS=fast_unwind_on_malloc=0 build/duk-clang-asan tests/ecmascript/test-misc-large-expressions.js


### PR DESCRIPTION
Fix a realloc() memory leak which would happen when:
- a previous allocation exists ('ptr' is non-NULL); and
- the new 'size' is zero; and
- a voluntary GC (or GC torture) causes the initial realloc() attempt to be bypassed

In this case the slow path would incorrectly assume that it was entered after realloc() had returned a NULL, which for a zero new 'size' would mean that 'ptr' was successfully freed and no further action was necessary. But because the realloc() had actually been bypassed, this would cause the old 'ptr' to leak.