### PR TITLE
Add DJGPP platform support

### DIFF
--- a/config/compilers/compiler_gcc.h.in
+++ b/config/compilers/compiler_gcc.h.in
@@ -55,6 +55,8 @@
 #else
 #define DUK_USE_COMPILER_STRING "mingw"
 #endif
+#elif defined(DUK_F_DJGPP)
+#define DUK_USE_COMPILER_STRING "djgpp"
 #else
 #if defined(DUK_F_CPP)
 #define DUK_USE_COMPILER_STRING "g++"

--- a/config/helper-snippets/DUK_F_DJGPP.h.in
+++ b/config/helper-snippets/DUK_F_DJGPP.h.in
@@ -1,0 +1,12 @@
+/* DJGPP (MSDOS), see https://sourceforge.net/p/predef/wiki/Compilers/ */
+#if defined(__DJGPP__)
+#define DUK_F_DJGPP
+#define DUK_F_DJGPP_MAJOR __DJGPP__
+#if defined(__DJGPP_MINOR__)
+#define DUK_F_DJGPP_MINOR __DJGPP_MINOR__
+#else
+#define DUK_F_DJGPP_MINOR 0
+#endif
+#define DUK_F_DJGPP_PATCH 0
+#define DUK_F_DJGPP_VERSION (DUK_F_DJGPP_MAJOR * 10000L + DUK_F_DJGPP_MINOR * 100L + DUK_F_DJGPP_PATCH)
+#endif

--- a/config/helper-snippets/DUK_F_MSDOS.h.in
+++ b/config/helper-snippets/DUK_F_MSDOS.h.in
@@ -1,0 +1,3 @@
+#if defined(__MSDOS__) || defined(__MSDOS) || defined(MSDOS)
+#define DUK_F_MSDOS
+#endif

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -12,6 +12,10 @@ autodetect:
     check: DUK_F_ORBIS
     include: platform_orbis.h.in
   -
+    name: MS-DOS
+    check: DUK_F_MSDOS
+    include: platform_msdos.h.in
+  -
     name: OpenBSD
     check: DUK_F_OPENBSD
     include: platform_openbsd.h.in

--- a/config/platforms/platform_msdos.h.in
+++ b/config/platforms/platform_msdos.h.in
@@ -1,0 +1,19 @@
+#if defined(DUK_F_DJGPP)
+/* These are for DJGPP, add #ifdefs for other MS-DOS compilers as needed. */
+#define DUK_USE_DATE_NOW_GETTIMEOFDAY
+#define DUK_USE_DATE_TZO_GMTIME_R
+#undef DUK_USE_DATE_PRS_STRPTIME  /* Not supported, see: https://github.com/svaarala/duktape/issues/2472 */
+#define DUK_USE_DATE_FMT_STRFTIME
+#include <time.h>
+#include <sys/time.h>
+#else
+/* Placeholder, unlikely to work outside of DJGPP. */
+#define DUK_USE_DATE_NOW_GETTIMEOFDAY
+#define DUK_USE_DATE_TZO_GMTIME_R
+#undef DUK_USE_DATE_PRS_STRPTIME
+#define DUK_USE_DATE_FMT_STRFTIME
+#include <time.h>
+#include <sys/time.h>
+#endif
+
+#define DUK_USE_OS_STRING "msdos"

--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -1394,3 +1394,4 @@ duktape_releases:
     - "Use wasm for dukweb.js compilation (including duktape.org site), fix async loading of emcc-compiled code in dukweb.html (GH-2244)"
     - "Improve DUK_USE_OS_STRING for macOS, iOS, watchOS, and tvOS (GH-2288)"
     - "Fix JSON.stringify() handling of Array 'replacer' duplicates (e.g. JSON.stringify({foo: 123}, [\"foo\", \"foo\"])); previously incorrectly serialized multiple times, now only once (GH-2379)"
+    - "Add support for DJGPP (MSDOS) platform (GH-2472, GH-2473)"


### PR DESCRIPTION
* Add DUK_F_DJGPP.h.in to detect and provide DJGPP convenience defines.
* Add a separate platform for MSDOS, now supporting DJGPP only.
* Add DJGPP identification to compiler_gcc.h.in.

Fixes #2472.