### PR TITLE
dist-files/Makefile.sharedlibrary: link against libm

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Vladislavs Sokurenko (https://github.com/sokurenko)
 * Luca Boccassi (https://github.com/bluca)
 * Radu Rendec (https://github.com/rrendec)
+* tinywrkb (https://github.com/tinywrkb)
 
 Other contributions
 ===================

--- a/dist-files/Makefile.sharedlibrary
+++ b/dist-files/Makefile.sharedlibrary
@@ -71,11 +71,11 @@ all: libduktape.$(SO_REALNAME_SUFFIX) libduktaped.$(SO_REALNAME_SUFFIX) duktape.
 
 libduktape.$(SO_REALNAME_SUFFIX):
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC -Wall -Wextra -Os -Wl,$(LD_SONAME_ARG),libduktape.$(SO_SONAME_SUFFIX) \
-		-o $@ $(DUKTAPE_SRCDIR)/duktape.c
+		-o $@ $(DUKTAPE_SRCDIR)/duktape.c -lm
 
 libduktaped.$(SO_REALNAME_SUFFIX):
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC -g -Wall -Wextra -Os -Wl,$(LD_SONAME_ARG),libduktaped.$(SO_SONAME_SUFFIX) \
-		-o $@ $(DUKTAPE_SRCDIR)/duktape.c
+		-o $@ $(DUKTAPE_SRCDIR)/duktape.c -lm
 
 duktape.pc:
 	sed -e "s|@PREFIX@|$(INSTALL_PREFIX)|" \


### PR DESCRIPTION
Closes #2464.

I hit an issue with polkit, it segfaults if libduktape.so is not linked against libm.so.  
As an alternative, I tried to make sure polkit's daemon and all libs are linked against libm (see the attached patch), but this didn't help.  
Unless there's something I miss, it doesn't look like linking duktape against libm is optional, so I'm adding it to the example `Makefile.sharedlibrary`.

`polkit-force-libm-link.patch`
```
diff --git a/meson.build b/meson.build
index dd09b28..e8ba5e6 100644
--- a/meson.build
+++ b/meson.build
@@ -138,7 +138,7 @@ duktape_req_version = '>= 2.2.0'
 js_engine = get_option('js_engine')
 if js_engine == 'duktape'
   js_dep = dependency('duktape', version: duktape_req_version)
-  libm_dep = cc.find_library('m')
+  libm_dep = declare_dependency( link_args : [ '-Wl,--no-as-needed' , '-lm', '-Wl,--as-needed' ] )
   thread_dep = dependency('threads')
   func = 'pthread_condattr_setclock'
   config_h.set('HAVE_' + func.to_upper(), cc.has_function(func, prefix : '#include <pthread.h>'))
diff --git a/src/polkit/meson.build b/src/polkit/meson.build
index 63dc1e8..22b2988 100644
--- a/src/polkit/meson.build
+++ b/src/polkit/meson.build
@@ -38,6 +38,7 @@ install_headers(
 common_deps = [
   gio_dep,
   glib_dep,
+  libm_dep,
 ]
 
 enum_sources = gnome.mkenums_simple(
@@ -110,7 +111,7 @@ pkg.generate(
   description: 'PolicyKit Authorization API',
   filebase: name,
   subdirs: pk_api_name,
-  requires: common_deps,
+  libraries: common_deps,
   variables: [
     'exec_prefix=${prefix}',
     'datadir=' + ('${prefix}' / pk_datadir),
diff --git a/src/polkitagent/meson.build b/src/polkitagent/meson.build
index bee3820..e4e3438 100644
--- a/src/polkitagent/meson.build
+++ b/src/polkitagent/meson.build
@@ -39,6 +39,7 @@ deps = [
   expat_dep,
   gio_unix_dep,
   libpolkit_gobject_dep,
+  libm_dep,
 ]
 
 c_flags = [
```