### PR TITLE
Update property methods, update to Node.js 16.x

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -18,6 +18,7 @@ jobs:
         run: |
           build/duk -e "print(Duktape.env); print('Hello world!');"
           build/duk dist-files/mandel.js
+          build/duk-g++ dist-files/mandel.js
   build_duk_macos:
     name: Duk macOS 10.15
     runs-on: macos-10.15

--- a/README.md
+++ b/README.md
@@ -110,19 +110,19 @@ If you intend to change Duktape internals and want to rebuild the source
 distributable in Linux, macOS, or Windows:
 
     # Linux; can often install from packages or using 'pip'
-    # Install Node.js >= 14.x
+    # Install Node.js >= 16.x
     $ sudo apt-get install python python-yaml
     $ python util/dist.py
 
     # macOS
     # Install Python 2.7.x
-    # Install Node.js >= 14.x
+    # Install Node.js >= 16.x
     $ pip install PyYAML
     $ python util/dist.py
 
     # Windows
     ; Install Python 2.7.x from python.org, and add it to PATH
-    ; Install Node.js >= 14.x
+    ; Install Node.js >= 16.x
     > pip install PyYAML
     > python util\dist.py
 

--- a/docker/duktape-base-ubuntu-18.04-x64/Dockerfile
+++ b/docker/duktape-base-ubuntu-18.04-x64/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "=== Timezone setup ===" && \
 # Duktape, the duktape.org website, run tests, etc.
 RUN echo "=== Node.js and package install ===" && \
 	apt-get update && apt-get install -qqy curl && \
-	curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+	curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 	dpkg --add-architecture i386 && \
 	apt-get update && \
 	apt-get install -qqy \

--- a/docker/duktape-base-ubuntu-20.04-arm64/Dockerfile
+++ b/docker/duktape-base-ubuntu-20.04-arm64/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "=== Timezone setup ===" && \
 # Duktape, the duktape.org website, run tests, etc.
 RUN echo "=== Node.js and package install ===" && \
 	apt-get update && apt-get install -qqy curl && \
-	curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+	curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 	apt-get update && \
 	apt-get install -qqy \
 		build-essential llvm valgrind strace libc6-dbg \

--- a/docker/duktape-base-ubuntu-20.04-x64/Dockerfile
+++ b/docker/duktape-base-ubuntu-20.04-x64/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "=== Timezone setup ===" && \
 # Duktape, the duktape.org website, run tests, etc.
 RUN echo "=== Node.js and package install ===" && \
 	apt-get update && apt-get install -qqy curl && \
-	curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+	curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 	dpkg --add-architecture i386 && \
 	apt-get update && \
 	apt-get install -qqy \

--- a/src-input/duk_prop.h
+++ b/src-input/duk_prop.h
@@ -1,0 +1,95 @@
+#if !defined(DUK_PROP_H_INCLUDED)
+#define DUK_PROP_H_INCLUDED
+
+#include "duk_internal.h"
+
+#define DUK_DELPROP_FLAG_THROW (1U << 0)
+#define DUK_DELPROP_FLAG_FORCE (1U << 1)
+
+DUK_INTERNAL_DECL duk_bool_t duk_prop_double_idx_check(duk_double_t d, duk_uarridx_t *out_idx);
+DUK_INTERNAL_DECL void duk_prop_push_plainstr_idx(duk_hthread *thr, duk_hstring *h, duk_uarridx_t idx);
+DUK_INTERNAL_DECL void duk_prop_frompropdesc_propattrs(duk_hthread *thr, duk_int_t attrs);
+DUK_INTERNAL_DECL void duk_prop_frompropdesc_with_idx(duk_hthread *thr, duk_idx_t idx_desc, duk_int_t attrs);
+DUK_INTERNAL_DECL duk_small_uint_t duk_prop_topropdesc(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_prop_pop_propdesc(duk_hthread *thr, duk_small_int_t attrs);
+DUK_INTERNAL_DECL duk_hobject *duk_prop_switch_stabilized_target_top(duk_hthread *thr, duk_hobject *target, duk_hobject *next);
+
+DUK_INTERNAL_DECL duk_bool_t duk_prop_arguments_map_prep(duk_hthread *thr,
+                                                         duk_hobject *obj,
+                                                         duk_hobject **out_map,
+                                                         duk_hobject **out_env);
+DUK_INTERNAL_DECL duk_hstring *duk_prop_arguments_map_prep_idxkey(duk_hthread *thr,
+                                                                  duk_hobject *obj,
+                                                                  duk_uarridx_t idx,
+                                                                  duk_hobject **out_map,
+                                                                  duk_hobject **out_env);
+
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_outidx(duk_hthread *thr, duk_idx_t idx_obj, duk_tval *tv_key, duk_idx_t idx_out);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_idxkey_outidx(duk_hthread *thr,
+                                                             duk_idx_t idx_obj,
+                                                             duk_uarridx_t idx,
+                                                             duk_idx_t idx_out);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_strkey_outidx(duk_hthread *thr,
+                                                             duk_idx_t idx_obj,
+                                                             duk_hstring *key,
+                                                             duk_idx_t idx_out);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_push(duk_hthread *thr, duk_idx_t idx_obj, duk_tval *tv_key);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_stridx_push(duk_hthread *thr, duk_idx_t idx_obj, duk_small_uint_t stridx);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_getvalue_stridx_outidx(duk_hthread *thr,
+                                                             duk_idx_t idx_obj,
+                                                             duk_small_uint_t stridx,
+                                                             duk_idx_t idx_out);
+
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_putvalue_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_tval *tv_key, duk_idx_t idx_val, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_putvalue_strkey_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_hstring *key, duk_idx_t idx_val, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_putvalue_idxkey_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_uarridx_t idx, duk_idx_t idx_val, duk_bool_t throw_flag);
+
+DUK_INTERNAL_DECL duk_bool_t duk_prop_deleteoper(duk_hthread *thr, duk_idx_t idx_obj, duk_tval *tv_key, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_delete_strkey(duk_hthread *thr, duk_idx_t idx_obj, duk_hstring *key, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_delete_obj_strkey(duk_hthread *thr,
+                                                        duk_hobject *obj,
+                                                        duk_hstring *key,
+                                                        duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_delete_idxkey(duk_hthread *thr, duk_idx_t idx_obj, duk_uarridx_t idx, duk_bool_t throw_flag);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_delete_obj_idxkey(duk_hthread *thr,
+                                                        duk_hobject *obj,
+                                                        duk_uarridx_t idx,
+                                                        duk_bool_t throw_flag);
+
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getowndesc_obj_strkey(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getowndesc_obj_idxkey(duk_hthread *thr, duk_hobject *obj, duk_uarridx_t idx);
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getowndesc_obj_tvkey(duk_hthread *thr, duk_hobject *obj, duk_tval *tv_key);
+
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getownattr_obj_strkey(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getownattr_obj_idxkey(duk_hthread *thr, duk_hobject *obj, duk_uarridx_t idx);
+DUK_INTERNAL_DECL duk_small_int_t duk_prop_getownattr_obj_tvkey(duk_hthread *thr, duk_hobject *obj, duk_tval *tv_key);
+
+DUK_INTERNAL_DECL duk_bool_t duk_prop_has(duk_hthread *thr, duk_tval *tv_obj, duk_tval *tv_key);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_has_strkey(duk_hthread *thr, duk_tval *tv_obj, duk_hstring *key);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_has_idxkey(duk_hthread *thr, duk_tval *tv_obj, duk_uarridx_t idx);
+
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_defown(duk_hthread *thr, duk_hobject *obj, duk_tval *tv_key, duk_idx_t idx_desc, duk_uint_t defprop_flags);
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_defown_strkey(duk_hthread *thr, duk_hobject *obj, duk_hstring *key, duk_idx_t idx_desc, duk_uint_t defprop_flags);
+DUK_INTERNAL_DECL duk_bool_t
+duk_prop_defown_idxkey(duk_hthread *thr, duk_hobject *obj, duk_uarridx_t idx, duk_idx_t idx_desc, duk_uint_t defprop_flags);
+
+#define DUK_OWNPROPKEYS_FLAG_INCLUDE_ARRIDX     (1U << 0)
+#define DUK_OWNPROPKEYS_FLAG_INCLUDE_STRING     (1U << 1)
+#define DUK_OWNPROPKEYS_FLAG_INCLUDE_SYMBOL     (1U << 2)
+#define DUK_OWNPROPKEYS_FLAG_INCLUDE_HIDDEN     (1U << 3)
+#define DUK_OWNPROPKEYS_FLAG_REQUIRE_ENUMERABLE (1U << 4)
+#define DUK_OWNPROPKEYS_FLAG_STRING_COERCE      (1U << 5)
+#define DUK_OWNPROPKEYS_FLAG_NO_PROXY_BEHAVIOR  (1U << 6)
+
+DUK_INTERNAL_DECL void duk_prop_ownpropkeys(duk_hthread *thr, duk_hobject *obj, duk_uint_t ownpropkeys_flags);
+
+DUK_INTERNAL_DECL void duk_prop_enum_keylist(duk_hthread *thr, duk_hobject *obj, duk_uint_t enum_flags);
+DUK_INTERNAL_DECL void duk_prop_enum_create_enumerator(duk_hthread *thr, duk_hobject *obj, duk_uint_t enum_flags);
+DUK_INTERNAL_DECL duk_bool_t duk_prop_enum_next(duk_hthread *thr, duk_idx_t idx_enum, duk_bool_t get_value);
+
+#endif /* DUK_PROP_H_INCLUDED */

--- a/src-input/duk_prop_enum.c
+++ b/src-input/duk_prop_enum.c
@@ -96,7 +96,7 @@ DUK_INTERNAL void duk_prop_enum_keylist(duk_hthread *thr, duk_hobject *obj, duk_
 
 		/* [ ... res visited obj keys ] */
 
-		a = duk_require_harray(thr, -1);
+		a = duk_require_harray(thr, -1); /* May not be the case if 'ownKeys' trap result is not validated. */
 		val_base = DUK_HARRAY_GET_ITEMS(thr->heap, a);
 		DUK_ASSERT(DUK_HARRAY_GET_LENGTH(a) <= DUK_HARRAY_GET_ITEMS_LENGTH(a));
 		for (i = 0, n = DUK_HARRAY_GET_LENGTH(a); i < n; i++) {

--- a/src-input/duk_prop_util.c
+++ b/src-input/duk_prop_util.c
@@ -1,0 +1,278 @@
+/*
+ *  Utilities for property operations.
+ */
+
+DUK_INTERNAL DUK_INLINE_PERF duk_bool_t duk_prop_double_idx_check(duk_double_t d, duk_uarridx_t *out_idx) {
+	duk_bool_t iswhole = duk_double_equals(DUK_FLOOR(d), d);
+	if (iswhole && d >= 0.0 && d <= (duk_double_t) 0xfffffffeUL) {
+		/* Negative zero is allowed as arridx. */
+		*out_idx = (duk_uarridx_t) d;
+		return 1;
+	}
+	return 0;
+}
+
+DUK_INTERNAL void duk_prop_push_plainstr_idx(duk_hthread *thr, duk_hstring *h, duk_uarridx_t idx) {
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(h != NULL);
+	DUK_ASSERT(DUK_HEAPHDR_IS_ANY_STRING((duk_heaphdr *) h));
+	DUK_ASSERT(idx < duk_hstring_get_charlen(h));
+
+	/* Fast path for pure ASCII strings. */
+#if 1
+	if (duk_hstring_is_ascii(h)) {
+		duk_push_lstring(thr, (const char *) duk_hstring_get_data(h) + idx, 1);
+	} else
+#endif
+	{
+		duk_push_wtf8_substring_hstring(thr, h, idx, idx + 1);
+	}
+}
+
+/* FromPropertyDescriptor(): convert result of duk_prop_getown.c lookup
+ * (0-2 value stack entries on stack top + attributes), considered a
+ * specification Property Descriptor type, into an ECMAScript descriptor
+ * object.
+ *
+ * No partial descriptor support.
+ */
+DUK_INTERNAL void duk_prop_frompropdesc_propattrs(duk_hthread *thr, duk_int_t attrs) {
+	duk_uint_t uattrs;
+	if (attrs < 0) {
+		duk_push_undefined(thr);
+		return;
+	}
+	uattrs = (duk_uint_t) attrs;
+
+	duk_push_object(thr);
+
+	if (uattrs & DUK_PROPDESC_FLAG_ACCESSOR) {
+		/* [ ... get set res ] */
+		duk_pull(thr, -3);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_GET);
+		duk_pull(thr, -2);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_SET);
+	} else {
+		/* [ ... value res ] */
+		duk_pull(thr, -2);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_VALUE);
+		duk_push_boolean(thr, uattrs & DUK_PROPDESC_FLAG_WRITABLE);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_WRITABLE);
+	}
+	duk_push_boolean(thr, uattrs & DUK_PROPDESC_FLAG_ENUMERABLE);
+	duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_ENUMERABLE);
+	duk_push_boolean(thr, uattrs & DUK_PROPDESC_FLAG_CONFIGURABLE);
+	duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_CONFIGURABLE);
+}
+
+DUK_INTERNAL void duk_prop_frompropdesc_with_idx(duk_hthread *thr, duk_idx_t idx_desc, duk_int_t defprop_flags) {
+	duk_uint_t uflags;
+	if (defprop_flags < 0) {
+		duk_push_undefined(thr);
+		return;
+	}
+	uflags = (duk_uint_t) defprop_flags;
+
+	duk_push_object(thr);
+
+	if (uflags & DUK_DEFPROP_HAVE_GETTER) {
+		duk_dup(thr, idx_desc);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_GET);
+	}
+	if (uflags & DUK_DEFPROP_HAVE_SETTER) {
+		duk_dup(thr, idx_desc + 1);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_SET);
+	}
+	if (uflags & DUK_DEFPROP_HAVE_VALUE) {
+		duk_dup(thr, idx_desc);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_VALUE);
+	}
+	if (uflags & DUK_DEFPROP_HAVE_WRITABLE) {
+		duk_push_boolean(thr, uflags & DUK_DEFPROP_WRITABLE);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_WRITABLE);
+	}
+	if (uflags & DUK_DEFPROP_HAVE_ENUMERABLE) {
+		duk_push_boolean(thr, uflags & DUK_DEFPROP_ENUMERABLE);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_ENUMERABLE);
+	}
+	if (uflags & DUK_DEFPROP_HAVE_CONFIGURABLE) {
+		duk_push_boolean(thr, uflags & DUK_DEFPROP_CONFIGURABLE);
+		duk_xdef_prop_stridx_short_wec(thr, -2, DUK_STRIDX_CONFIGURABLE);
+	}
+}
+
+/* [[HasProperty]] followed by [[Get]] if property exists.  This specific
+ * sequence is visible for e.g. Proxies.
+ */
+DUK_LOCAL duk_bool_t duk__prop_has_get_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx) {
+	if (!duk_has_prop_stridx(thr, obj_idx, stridx)) {
+		return 0;
+	}
+	(void) duk_get_prop_stridx(thr, obj_idx, stridx);
+	return 1;
+}
+
+DUK_LOCAL duk_bool_t duk__prop_has_get_prop_stridx_toboolean(duk_hthread *thr,
+                                                             duk_idx_t obj_idx,
+                                                             duk_small_uint_t stridx,
+                                                             duk_bool_t *out_bool) {
+	if (!duk__prop_has_get_prop_stridx(thr, obj_idx, stridx)) {
+		return 0;
+	}
+	*out_bool = duk_to_boolean(thr, -1);
+	duk_pop_unsafe(thr);
+	return 1;
+}
+
+DUK_LOCAL duk_bool_t duk__prop_getset_check_and_promote(duk_hthread *thr) {
+	/* NOTE: lightfuncs are coerced to full functions because
+	 * lightfuncs don't fit into a property value slot.  This
+	 * has some side effects, see test-dev-lightfunc-accessor.js.
+	 */
+	if (duk_is_callable(thr, -1)) {
+		(void) duk_get_hobject_promote_lfunc(thr, -1);
+	} else if (duk_is_undefined(thr, -1)) {
+		;
+	} else {
+		return 0;
+	}
+	return 1;
+}
+
+/* ToPropertyDescriptor(): convert an ECMAScript descriptor object into
+ * a specification Property Descriptor type (0-2 value stack entries and
+ * attributes).
+ *
+ * Supports partial descriptors.
+ */
+DUK_INTERNAL duk_small_uint_t duk_prop_topropdesc(duk_hthread *thr) {
+	duk_idx_t obj_idx;
+	duk_bool_t flag;
+	duk_small_uint_t attrs = 0U;
+
+	obj_idx = duk_require_normalize_index(thr, -1);
+	duk_require_object(thr, -1);
+
+	/* The checks and coercions may have arbitrary side effects (for
+	 * example, the input value may be a Proxy) so all steps must be
+	 * in the exact specification order.  Also must check for property
+	 * existence ([[HasProperty]]) before reading the property value,
+	 * as this side effect is visible for a Proxy.
+	 */
+
+	if (duk__prop_has_get_prop_stridx_toboolean(thr, obj_idx, DUK_STRIDX_ENUMERABLE, &flag)) {
+		attrs |= (flag ? (DUK_DEFPROP_HAVE_ENUMERABLE | DUK_DEFPROP_ENUMERABLE) : (DUK_DEFPROP_HAVE_ENUMERABLE));
+	}
+
+	if (duk__prop_has_get_prop_stridx_toboolean(thr, obj_idx, DUK_STRIDX_CONFIGURABLE, &flag)) {
+		attrs |= (flag ? (DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_CONFIGURABLE) : (DUK_DEFPROP_HAVE_CONFIGURABLE));
+	}
+
+	if (duk__prop_has_get_prop_stridx(thr, obj_idx, DUK_STRIDX_VALUE)) {
+		attrs |= DUK_DEFPROP_HAVE_VALUE;
+	}
+
+	if (duk__prop_has_get_prop_stridx_toboolean(thr, obj_idx, DUK_STRIDX_WRITABLE, &flag)) {
+		attrs |= (flag ? (DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE) : (DUK_DEFPROP_HAVE_WRITABLE));
+	}
+
+	if (duk__prop_has_get_prop_stridx(thr, obj_idx, DUK_STRIDX_GET)) {
+		if (!duk__prop_getset_check_and_promote(thr)) {
+			goto invalid_desc;
+		}
+		attrs |= DUK_DEFPROP_HAVE_GETTER;
+	}
+
+	if (duk__prop_has_get_prop_stridx(thr, obj_idx, DUK_STRIDX_SET)) {
+		if (!duk__prop_getset_check_and_promote(thr)) {
+			goto invalid_desc;
+		}
+		attrs |= DUK_DEFPROP_HAVE_SETTER;
+	}
+
+	if (attrs & (DUK_DEFPROP_HAVE_GETTER | DUK_DEFPROP_HAVE_SETTER)) {
+		if (attrs & (DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_HAVE_WRITABLE)) {
+			goto invalid_desc;
+		}
+	}
+
+	return attrs;
+
+invalid_desc:
+	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_DESCRIPTOR);
+	DUK_WO_NORETURN(return attrs;);
+}
+
+DUK_INTERNAL duk_bool_t duk_prop_arguments_map_prep(duk_hthread *thr,
+                                                    duk_hobject *obj,
+                                                    duk_hobject **out_map,
+                                                    duk_hobject **out_env) {
+	duk_hobject *map;
+	duk_hobject *env;
+
+	if (!DUK_HOBJECT_HAS_EXOTIC_ARGUMENTS(obj)) {
+		return 0;
+	}
+	map = duk_hobject_lookup_strprop_known_hobject(thr, obj, DUK_HTHREAD_STRING_INT_MAP(thr));
+	if (map == NULL) {
+		return 0;
+	}
+	*out_map = map;
+	env = duk_hobject_lookup_strprop_known_hobject(thr, obj, DUK_HTHREAD_STRING_INT_VARENV(thr));
+	if (env == NULL) {
+		return 0;
+	}
+	*out_env = env;
+	return 1;
+}
+
+DUK_INTERNAL duk_hstring *duk_prop_arguments_map_prep_idxkey(duk_hthread *thr,
+                                                             duk_hobject *obj,
+                                                             duk_uarridx_t idx,
+                                                             duk_hobject **out_map,
+                                                             duk_hobject **out_env) {
+	duk_bool_t rc;
+	duk_uint_fast32_t ent_idx;
+	duk_propvalue *pv;
+	duk_tval *tv_varname;
+	duk_hstring *varname;
+
+	if (!duk_prop_arguments_map_prep(thr, obj, out_map, out_env)) {
+		return NULL;
+	}
+	rc = duk_hobject_lookup_idxprop_index(thr, *out_map, idx, &ent_idx);
+	if (!rc) {
+		return NULL;
+	}
+	DUK_ASSERT((*out_map)->idx_props != NULL);
+	pv = ((duk_propvalue *) (*out_map)->idx_props) + ent_idx;
+	tv_varname = &pv->v;
+	DUK_ASSERT(DUK_TVAL_IS_STRING(tv_varname));
+	varname = DUK_TVAL_GET_STRING(tv_varname);
+
+	return varname;
+}
+
+DUK_INTERNAL void duk_prop_pop_propdesc(duk_hthread *thr, duk_small_int_t attrs) {
+	if (attrs >= 0) {
+		duk_small_uint_t uattrs = (duk_small_uint_t) attrs;
+		duk_pop_n(thr, (uattrs & DUK_PROPDESC_FLAG_ACCESSOR) ? 2 : 1);
+	}
+}
+
+DUK_INTERNAL duk_hobject *duk_prop_switch_stabilized_target_top(duk_hthread *thr, duk_hobject *target, duk_hobject *next) {
+	duk_tval *tv_target;
+
+	DUK_ASSERT(thr != NULL);
+	DUK_ASSERT(target != NULL);
+	DUK_ASSERT(next != NULL);
+	DUK_ASSERT(duk_get_top(thr) > 0U);
+
+	tv_target = thr->valstack_top - 1;
+	DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv_target));
+	DUK_ASSERT(DUK_TVAL_GET_OBJECT(tv_target) == target);
+	DUK_HOBJECT_INCREF(thr, next);
+	DUK_TVAL_UPDATE_OBJECT(tv_target, next);
+	DUK_HOBJECT_DECREF(thr, target);
+	return next;
+}

--- a/tests/perf/.eslintignore
+++ b/tests/perf/.eslintignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/tests/perf/.eslintrc.yml
+++ b/tests/perf/.eslintrc.yml
@@ -1,0 +1,27 @@
+env:
+  browser: true
+  commonjs: true
+  es6: true
+extends: 'eslint:recommended'
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+  process: readonly
+  __dirname: readonly
+  Buffer: readonly
+  CBOR: readonly
+  print: writable
+  Duktape: readonly
+parserOptions:
+  ecmaVersion: 2018
+rules:
+  strict: off
+  no-self-assign: off
+  no-unused-vars: off
+  no-empty: off
+  no-constant-condition: off
+  no-unreachable: off
+  no-tabs: error
+  no-control-regex: off
+  no-trailing-spaces: error
+  no-warning-comments: [ 1, { "terms": ["todo", "fixme", "xxx"], "location": "anywhere" } ]


### PR DESCRIPTION
Update new property code before switchover. No behavior change to running code.

Update to Node.js 16.x in Docker images and README.