### PR TITLE
Fixes and improvements to new property code

### DIFF
--- a/src-input/duk_api_debug.c
+++ b/src-input/duk_api_debug.c
@@ -26,7 +26,7 @@ DUK_EXTERNAL void duk_push_context_dump(duk_hthread *thr) {
 	 * Perhaps values need to be coerced individually?
 	 */
 	duk_bi_json_stringify_helper(thr,
-	                             duk_get_top_index(thr), /*idx_value*/
+	                             duk_get_top_index_known(thr), /*idx_value*/
 	                             DUK_INVALID_INDEX, /*idx_replacer*/
 	                             DUK_INVALID_INDEX, /*idx_space*/
 	                             DUK_JSON_FLAG_EXT_CUSTOM | DUK_JSON_FLAG_ASCII_ONLY |

--- a/src-input/duk_api_internal.h
+++ b/src-input/duk_api_internal.h
@@ -97,6 +97,7 @@ DUK_INTERNAL_DECL duk_tval *duk_get_tval_or_unused(duk_hthread *thr, duk_idx_t i
 DUK_INTERNAL_DECL duk_tval *duk_require_tval(duk_hthread *thr, duk_idx_t idx);
 DUK_INTERNAL_DECL void duk_push_tval(duk_hthread *thr, duk_tval *tv);
 DUK_INTERNAL_DECL void duk_push_tval_unsafe(duk_hthread *thr, duk_tval *tv);
+DUK_INTERNAL_DECL void duk_push_tval_unsafe_noincref(duk_hthread *thr, duk_tval *tv);
 DUK_INTERNAL_DECL void duk_push_undefined_unsafe(duk_hthread *thr);
 
 /* Push the current 'this' binding; throw TypeError if binding is not object
@@ -202,8 +203,8 @@ DUK_INTERNAL_DECL duk_bool_t duk_to_boolean_top_pop(duk_hthread *thr);
 #if defined(DUK_USE_DEBUGGER_SUPPORT) /* only needed by debugger for now */
 DUK_INTERNAL_DECL duk_hstring *duk_safe_to_hstring(duk_hthread *thr, duk_idx_t idx);
 #endif
-DUK_INTERNAL_DECL void duk_push_class_string_tval(duk_hthread *thr, duk_tval *tv, duk_bool_t avoid_side_effects);
-DUK_INTERNAL_DECL void duk_push_class_string_hobject(duk_hthread *thr, duk_hobject *obj, duk_bool_t avoid_side_effects);
+DUK_INTERNAL_DECL void duk_push_objproto_tostring_tval(duk_hthread *thr, duk_tval *tv, duk_bool_t avoid_side_effects);
+DUK_INTERNAL_DECL void duk_push_objproto_tostring_hobject(duk_hthread *thr, duk_hobject *obj, duk_bool_t avoid_side_effects);
 
 DUK_INTERNAL_DECL duk_int_t duk_to_int_clamped_raw(duk_hthread *thr,
                                                    duk_idx_t idx,
@@ -382,16 +383,16 @@ DUK_INTERNAL_DECL void duk_push_symbol_descriptive_string(duk_hthread *thr, duk_
 DUK_INTERNAL_DECL void duk_resolve_nonbound_function(duk_hthread *thr);
 
 DUK_INTERNAL_DECL duk_idx_t duk_get_top_require_min(duk_hthread *thr, duk_idx_t min_top);
-DUK_INTERNAL_DECL duk_idx_t duk_get_top_index_unsafe(duk_hthread *thr);
+DUK_INTERNAL_DECL duk_idx_t duk_get_top_index_known(duk_hthread *thr);
 
-DUK_INTERNAL_DECL void duk_pop_n_unsafe(duk_hthread *thr, duk_idx_t count);
-DUK_INTERNAL_DECL void duk_pop_unsafe(duk_hthread *thr);
-DUK_INTERNAL_DECL void duk_pop_2_unsafe(duk_hthread *thr);
-DUK_INTERNAL_DECL void duk_pop_3_unsafe(duk_hthread *thr);
-DUK_INTERNAL_DECL void duk_pop_n_nodecref_unsafe(duk_hthread *thr, duk_idx_t count);
-DUK_INTERNAL_DECL void duk_pop_nodecref_unsafe(duk_hthread *thr);
-DUK_INTERNAL_DECL void duk_pop_2_nodecref_unsafe(duk_hthread *thr);
-DUK_INTERNAL_DECL void duk_pop_3_nodecref_unsafe(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_n_known(duk_hthread *thr, duk_idx_t count);
+DUK_INTERNAL_DECL void duk_pop_known(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_2_known(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_3_known(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_n_nodecref_known(duk_hthread *thr, duk_idx_t count);
+DUK_INTERNAL_DECL void duk_pop_nodecref_known(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_2_nodecref_known(duk_hthread *thr);
+DUK_INTERNAL_DECL void duk_pop_3_nodecref_known(duk_hthread *thr);
 DUK_INTERNAL_DECL void duk_pop_undefined(duk_hthread *thr);
 
 DUK_INTERNAL_DECL void duk_compact_m1(duk_hthread *thr);

--- a/src-input/duk_api_object.c
+++ b/src-input/duk_api_object.c
@@ -47,7 +47,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_string(duk_hthread *thr, duk_idx_t obj_idx,
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	(void) duk_push_string(thr, key);
 	h_key = duk_known_hstring(thr, -1);
-	idx_key = duk_get_top_index_unsafe(thr);
+	idx_key = duk_get_top_index_known(thr);
 	return duk_prop_getvalue_strkey_outidx(thr, obj_idx, h_key, idx_key);
 }
 
@@ -61,7 +61,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	(void) duk_push_lstring(thr, key, key_len);
 	h_key = duk_known_hstring(thr, -1);
-	idx_key = duk_get_top_index_unsafe(thr);
+	idx_key = duk_get_top_index_known(thr);
 	return duk_prop_getvalue_strkey_outidx(thr, obj_idx, h_key, idx_key);
 }
 
@@ -77,7 +77,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_literal_raw(duk_hthread *thr, duk_idx_t obj
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	(void) duk_push_literal_raw(thr, key, key_len);
 	h_key = duk_known_hstring(thr, -1);
-	idx_key = duk_get_top_index_unsafe(thr);
+	idx_key = duk_get_top_index_known(thr);
 	return duk_prop_getvalue_strkey_outidx(thr, obj_idx, h_key, idx_key);
 }
 #endif
@@ -90,7 +90,7 @@ DUK_EXTERNAL duk_bool_t duk_get_prop_index(duk_hthread *thr, duk_idx_t obj_idx, 
 	/* The case of index > 0xfffffffe is handled by the property code. */
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	duk_push_undefined(thr);
-	idx_out = duk_get_top_index_unsafe(thr);
+	idx_out = duk_get_top_index_known(thr);
 	return duk_prop_getvalue_idxkey_outidx(thr, obj_idx, arr_idx, idx_out);
 }
 
@@ -112,7 +112,7 @@ DUK_INTERNAL duk_bool_t duk_get_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx,
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	h_str = DUK_HTHREAD_GET_STRING(thr, stridx);
 	duk_push_undefined(thr);
-	idx_out = duk_get_top_index_unsafe(thr);
+	idx_out = duk_get_top_index_known(thr);
 	return duk_prop_getvalue_strkey_outidx(thr, obj_idx, h_str, idx_out);
 }
 
@@ -199,13 +199,13 @@ DUK_EXTERNAL duk_bool_t duk_put_prop(duk_hthread *thr, duk_idx_t obj_idx) {
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	tv_key = duk_require_tval(thr, -2); /* Also ensures -1 exists. */
 	DUK_ASSERT(duk_is_valid_index(thr, -1));
-	val_idx = duk_get_top_index_unsafe(thr);
+	val_idx = duk_get_top_index_known(thr);
 	throw_flag = duk_is_strict_call(thr);
 
 	rc = duk_prop_putvalue_inidx(thr, obj_idx, tv_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc;
 }
 
@@ -231,7 +231,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_string(duk_hthread *thr, duk_idx_t obj_idx,
 	rc = duk_prop_putvalue_strkey_inidx(thr, obj_idx, h_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc;
 }
 
@@ -253,7 +253,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_lstring(duk_hthread *thr, duk_idx_t obj_idx
 	rc = duk_prop_putvalue_strkey_inidx(thr, obj_idx, h_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc;
 }
 
@@ -277,7 +277,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_literal_raw(duk_hthread *thr, duk_idx_t obj
 	rc = duk_prop_putvalue_strkey_inidx(thr, obj_idx, h_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc;
 }
 #endif
@@ -296,7 +296,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_index(duk_hthread *thr, duk_idx_t obj_idx, 
 	rc = duk_prop_putvalue_idxkey_inidx(thr, obj_idx, arr_idx, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return rc;
 }
 
@@ -317,7 +317,7 @@ DUK_EXTERNAL duk_bool_t duk_put_prop_heapptr(duk_hthread *thr, duk_idx_t obj_idx
 	rc = duk_prop_putvalue_inidx(thr, obj_idx, tv_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc;
 }
 
@@ -339,7 +339,7 @@ DUK_INTERNAL duk_bool_t duk_put_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx,
 	rc = duk_prop_putvalue_strkey_inidx(thr, obj_idx, h_key, val_idx, throw_flag);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return rc;
 }
 
@@ -361,7 +361,7 @@ DUK_EXTERNAL duk_bool_t duk_del_prop(duk_hthread *thr, duk_idx_t obj_idx) {
 	rc = duk_prop_deleteoper(thr, obj_idx, tv_key, delprop_flags);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_unsafe(thr); /* remove key */
+	duk_pop_known(thr); /* remove key */
 	return rc;
 }
 
@@ -444,7 +444,7 @@ DUK_EXTERNAL duk_bool_t duk_has_prop(duk_hthread *thr, duk_idx_t obj_idx) {
 	rc = duk_prop_has(thr, tv_obj, tv_key);
 	DUK_ASSERT(rc == 0 || rc == 1);
 
-	duk_pop_unsafe(thr); /* remove key */
+	duk_pop_known(thr); /* remove key */
 	return rc; /* 1 if property found, 0 otherwise */
 }
 
@@ -524,9 +524,9 @@ DUK_INTERNAL void duk_xdef_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_small_u
 
 	desc_flags |= DUK_DEFPROP_FORCE;
 	desc_flags |= DUK_DEFPROP_HAVE_WEC | DUK_DEFPROP_HAVE_VALUE;
-	(void) duk_prop_defown(thr, obj, tv_key, duk_get_top_index_unsafe(thr), desc_flags);
+	(void) duk_prop_defown(thr, obj, tv_key, duk_get_top_index_known(thr), desc_flags);
 
-	duk_pop_2_unsafe(thr); /* pop key and value */
+	duk_pop_2_known(thr); /* pop key and value */
 }
 
 DUK_INTERNAL void duk_xdef_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_uarridx_t arr_idx, duk_small_uint_t desc_flags) {
@@ -540,8 +540,8 @@ DUK_INTERNAL void duk_xdef_prop_index(duk_hthread *thr, duk_idx_t obj_idx, duk_u
 
 	desc_flags |= DUK_DEFPROP_FORCE;
 	desc_flags |= DUK_DEFPROP_HAVE_WEC | DUK_DEFPROP_HAVE_VALUE;
-	(void) duk_prop_defown_idxkey(thr, obj, arr_idx, duk_get_top_index_unsafe(thr), desc_flags);
-	duk_pop_unsafe(thr);
+	(void) duk_prop_defown_idxkey(thr, obj, arr_idx, duk_get_top_index_known(thr), desc_flags);
+	duk_pop_known(thr);
 }
 
 DUK_INTERNAL void duk_xdef_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx, duk_small_uint_t stridx, duk_small_uint_t desc_flags) {
@@ -559,8 +559,8 @@ DUK_INTERNAL void duk_xdef_prop_stridx(duk_hthread *thr, duk_idx_t obj_idx, duk_
 
 	desc_flags |= DUK_DEFPROP_FORCE;
 	desc_flags |= DUK_DEFPROP_HAVE_WEC | DUK_DEFPROP_HAVE_VALUE;
-	(void) duk_prop_defown_strkey(thr, obj, key, duk_get_top_index_unsafe(thr), desc_flags);
-	duk_pop_unsafe(thr);
+	(void) duk_prop_defown_strkey(thr, obj, key, duk_get_top_index_known(thr), desc_flags);
+	duk_pop_known(thr);
 }
 
 DUK_INTERNAL void duk_xdef_prop_stridx_short_raw(duk_hthread *thr, duk_uint_t packed_args) {
@@ -623,7 +623,7 @@ DUK_EXTERNAL void duk_def_prop(duk_hthread *thr, duk_idx_t obj_idx, duk_uint_t f
 		goto fail_invalid_desc;
 	}
 
-	idx_base = duk_get_top_index(thr);
+	idx_base = duk_get_top_index_known(thr); /* At least one value on valstack. */
 	if (flags & DUK_DEFPROP_HAVE_SETTER) {
 		duk_hobject *set;
 		duk_require_type_mask(thr, idx_base, DUK_TYPE_MASK_UNDEFINED | DUK_TYPE_MASK_OBJECT | DUK_TYPE_MASK_LIGHTFUNC);
@@ -825,8 +825,9 @@ DUK_EXTERNAL void duk_put_number_list(duk_hthread *thr, duk_idx_t obj_idx, const
 	obj_idx = duk_require_normalize_index(thr, obj_idx);
 	if (ent != NULL) {
 		while (ent->key != NULL) {
-			tv = thr->valstack_top++;
+			tv = thr->valstack_top;
 			DUK_ASSERT(DUK_TVAL_IS_UNDEFINED(tv)); /* value stack init policy */
+			duk_push_undefined_unsafe(thr);
 			DUK_TVAL_SET_NUMBER_CHKFAST_SLOW(tv, ent->value); /* no need for decref/incref */
 			duk_put_prop_string(thr, obj_idx, ent->key);
 			ent++;
@@ -967,7 +968,7 @@ DUK_EXTERNAL duk_bool_t duk_put_global_heapptr(duk_hthread *thr, void *ptr) {
 DUK_INTERNAL duk_bool_t duk_get_method_stridx(duk_hthread *thr, duk_idx_t idx, duk_small_uint_t stridx) {
 	(void) duk_get_prop_stridx(thr, idx, stridx);
 	if (duk_is_nullish(thr, -1)) {
-		duk_pop_nodecref_unsafe(thr);
+		duk_pop_nodecref_known(thr);
 		return 0;
 	}
 	if (!duk_is_callable(thr, -1)) {

--- a/src-input/duk_api_string.c
+++ b/src-input/duk_api_string.c
@@ -167,7 +167,7 @@ DUK_INTERNAL void duk_concat_2(duk_hthread *thr) {
 	/* [ ... str1 str2 buf ] */
 
 	duk_replace(thr, -3);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return;
 
 error_overflow:

--- a/src-input/duk_bi_array.c
+++ b/src-input/duk_bi_array.c
@@ -266,7 +266,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_concat(duk_hthread *thr) {
 			} else {
 				spreadable = duk_to_boolean(thr, -1);
 			}
-			duk_pop_nodecref_unsafe(thr);
+			duk_pop_nodecref_known(thr);
 #else
 			spreadable = duk_js_isarray_hobject(thr, h);
 #endif
@@ -408,7 +408,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_join_shared(duk_hthread *thr) {
 
 		duk_get_prop_index(thr, 1, (duk_uarridx_t) idx);
 		if (duk_is_nullish(thr, -1)) {
-			duk_pop_nodecref_unsafe(thr);
+			duk_pop_nodecref_known(thr);
 			duk_push_hstring_empty(thr);
 		} else {
 			if (to_locale_string) {
@@ -726,7 +726,7 @@ DUK_LOCAL duk_small_int_t duk__array_sort_compare(duk_hthread *thr, duk_int_t id
 			ret = 0;
 		}
 
-		duk_pop_nodecref_unsafe(thr);
+		duk_pop_nodecref_known(thr);
 		DUK_DDD(DUK_DDDPRINT("-> result %ld (from comparefn, after coercion)", (long) ret));
 		return ret;
 	}
@@ -743,7 +743,7 @@ DUK_LOCAL duk_small_int_t duk__array_sort_compare(duk_hthread *thr, duk_int_t id
 	goto pop_ret;
 
 pop_ret:
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	DUK_DDD(DUK_DDDPRINT("-> result %ld", (long) ret));
 	return ret;
 }
@@ -919,7 +919,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_sort(duk_hthread *thr) {
 	}
 
 	DUK_ASSERT_TOP(thr, 3);
-	duk_pop_nodecref_unsafe(thr);
+	duk_pop_nodecref_known(thr);
 	return 1; /* return ToObject(this) */
 }
 
@@ -1145,7 +1145,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_reverse(duk_hthread *thr) {
 	}
 
 	DUK_ASSERT_TOP(thr, 2);
-	duk_pop_unsafe(thr); /* -> [ ToObject(this) ] */
+	duk_pop_known(thr); /* -> [ ToObject(this) ] */
 	return 1;
 }
 
@@ -1404,7 +1404,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_indexof_shared(duk_hthread *thr) {
 			}
 		}
 
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 
 not_found:
@@ -1518,7 +1518,7 @@ DUK_INTERNAL duk_ret_t duk_bi_array_prototype_iter_shared(duk_hthread *thr) {
 			DUK_UNREACHABLE();
 			break;
 		}
-		duk_pop_2_unsafe(thr);
+		duk_pop_2_known(thr);
 
 		DUK_ASSERT_TOP(thr, 5);
 	}

--- a/src-input/duk_bi_error.c
+++ b/src-input/duk_bi_error.c
@@ -127,7 +127,7 @@ DUK_LOCAL duk_ret_t duk__error_getter_helper(duk_hthread *thr, duk_small_int_t o
 
 	duk_push_this(thr);
 	duk_xget_owndataprop_stridx_short(thr, -1, DUK_STRIDX_INT_TRACEDATA);
-	idx_td = duk_get_top_index(thr);
+	idx_td = duk_get_top_index_known(thr);
 
 	duk_push_hstring_stridx(thr, DUK_STRIDX_NEWLINE_4SPACE);
 	duk_push_this(thr);

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2993,9 +2993,9 @@ DUK_LOCAL void duk__json_setup_plist_from_array(duk_hthread *thr, duk_json_enc_c
 			duk_dup_top(thr); /* -> [ ... proplist found key key ] */
 			(void) duk_get_prop(thr, -3); /* -> [ ... proplist found key found[key] ] */
 			if (duk_to_boolean(thr, -1)) {
-				duk_pop_2_unsafe(thr);
+				duk_pop_2_known(thr);
 			} else {
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 				duk_dup_top(thr);
 				duk_push_true(thr); /* -> [ ... proplist found key key true ] */
 				(void) duk_put_prop(thr, -4); /* -> [ ... proplist found key ] */
@@ -3003,11 +3003,11 @@ DUK_LOCAL void duk__json_setup_plist_from_array(duk_hthread *thr, duk_json_enc_c
 				plist_idx++;
 			}
 		} else {
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 	}
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	/* [ ... proplist ] */
 }

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -9,7 +9,7 @@ DUK_INTERNAL duk_ret_t duk_bi_object_prototype_to_string(duk_hthread *thr) {
 	duk_tval *tv;
 
 	tv = DUK_HTHREAD_THIS_PTR(thr);
-	duk_push_class_string_tval(thr, tv, 0 /*avoid_side_effects*/);
+	duk_push_objproto_tostring_tval(thr, tv, 0 /*avoid_side_effects*/);
 	return 1;
 }
 

--- a/src-input/duk_bi_proxy.c
+++ b/src-input/duk_bi_proxy.c
@@ -37,6 +37,10 @@ DUK_INTERNAL duk_ret_t duk_bi_proxy_constructor_revocable(duk_hthread *thr) {
 	duk_push_proxy(thr, 0 /*flags*/); /* [ target handler ] -> [ proxy ] */
 	duk_push_object(thr);
 	duk_push_c_function(thr, duk__bi_proxy_revoker, 0);
+	duk_push_hstring_empty(thr);
+	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_NAME, DUK_PROPDESC_FLAGS_C);
+	duk_push_uint(thr, 0);
+	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_LENGTH, DUK_PROPDESC_FLAGS_C);
 	duk_dup(thr, 0); /* -> [ proxy retval revoker proxy ] */
 	duk_xdef_prop_stridx_short(thr, -2, DUK_STRIDX_INT_VALUE, DUK_PROPDESC_FLAGS_NONE);
 	duk_pull(thr, 0); /* -> [ retval revoker proxy ] */

--- a/src-input/duk_bi_string.c
+++ b/src-input/duk_bi_string.c
@@ -636,7 +636,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 		 */
 		h_preserve = duk_push_wtf8_substring_hstring(thr, h_input, end_of_last_match_coff, match_start_coff);
 		DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_preserve);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 
 		end_of_last_match_coff = match_start_coff + duk_hstring_get_charlen(h_match);
 
@@ -673,7 +673,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 			h_repl = duk_to_hstring_m1(thr); /* -> [ ... repl_value ] */
 			DUK_ASSERT(h_repl != NULL);
 			DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_repl);
-			duk_pop_unsafe(thr); /* repl_value */
+			duk_pop_known(thr); /* repl_value */
 		} else {
 			r = r_start;
 
@@ -712,7 +712,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 
 					h_part = duk_push_wtf8_substring_hstring(thr, h_input, 0, match_start_coff);
 					DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_part);
-					duk_pop_unsafe(thr);
+					duk_pop_known(thr);
 					r++;
 					continue;
 				}
@@ -732,7 +732,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 					                                         part_start_coff,
 					                                         duk_hstring_get_charlen(h_input));
 					DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_part);
-					duk_pop_unsafe(thr);
+					duk_pop_known(thr);
 					r++;
 					continue;
 				}
@@ -812,7 +812,7 @@ DUK_INTERNAL duk_ret_t duk_bi_string_prototype_replace(duk_hthread *thr) {
 
 	h_trailer = duk_push_wtf8_substring_hstring(thr, h_input, end_of_last_match_coff, duk_hstring_get_charlen(h_input));
 	DUK_BW_WRITE_ENSURE_HSTRING(thr, bw, h_trailer);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	DUK_ASSERT_TOP(thr, 4);
 	DUK_BW_COMPACT(thr, bw);

--- a/src-input/duk_hobject_misc.c
+++ b/src-input/duk_hobject_misc.c
@@ -218,9 +218,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_object_is_sealed_frozen_helper(duk_hthread *
 		duk_small_int_t attrs;
 
 		(void) duk_get_prop_index(thr, -1, i);
-		attrs = duk_prop_getowndesc_obj_tvkey(thr, obj, DUK_GET_TVAL_NEGIDX(thr, -1));
-		duk_prop_pop_propdesc(thr, attrs);
-		duk_pop_unsafe(thr);
+		attrs = duk_prop_getownattr_obj_tvkey(thr, obj, DUK_GET_TVAL_NEGIDX(thr, -1));
+		duk_pop_known(thr);
 		if (attrs >= 0) {
 			if (attrs & DUK_PROPDESC_FLAG_CONFIGURABLE) {
 				return 0;
@@ -231,7 +230,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_object_is_sealed_frozen_helper(duk_hthread *
 		}
 	}
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return 1;
 }
 

--- a/src-input/duk_hobject_props.c
+++ b/src-input/duk_hobject_props.c
@@ -320,7 +320,7 @@ DUK_INTERNAL duk_size_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *ob
 	duk_push_hstring_stridx(thr, DUK_STRIDX_LENGTH);
 	(void) duk_prop_getvalue_push(thr, duk_normalize_index(thr, -2), DUK_GET_TVAL_NEGIDX(thr, -1));
 	val = duk_to_number_m1(thr);
-	duk_pop_3_unsafe(thr);
+	duk_pop_3_known(thr);
 
 	/* This isn't part of ECMAScript semantics; return a value within
 	 * duk_size_t range, or 0 otherwise.
@@ -450,9 +450,9 @@ DUK_INTERNAL void duk_hobject_object_seal_freeze_helper(duk_hthread *thr, duk_ho
 			defprop_flags = DUK_DEFPROP_CLEAR_CONFIGURABLE | DUK_DEFPROP_THROW;
 			(void) duk_prop_defown(thr, obj, duk_known_tval(thr, -1), 0, defprop_flags);
 		}
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return;
 }

--- a/src-input/duk_hobject_proxy.c
+++ b/src-input/duk_hobject_proxy.c
@@ -51,7 +51,7 @@ DUK_LOCAL duk_bool_t duk__proxy_trap_check(duk_hthread *thr, duk_hproxy *h, duk_
 		duk_insert(thr, -3); /* [ -> [ ... trap handler target ] */
 		return 1;
 	} else {
-		duk_pop_3_unsafe(thr);
+		duk_pop_3_known(thr);
 		return 0;
 	}
 }

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -323,7 +323,7 @@ DUK_LOCAL void duk__create_arguments_object(duk_hthread *thr, duk_hobject *func,
 				duk_put_prop_index(thr, -2 /*map*/, (duk_uarridx_t) i); /* out of spec, must be configurable */
 				DUK_GC_TORTURE(thr->heap);
 			} else {
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 			}
 		}
 		DUK_GC_TORTURE(thr->heap);
@@ -871,6 +871,9 @@ DUK_LOCAL void duk__handle_proxy_for_call(duk_hthread *thr, duk_idx_t idx_func, 
 		 * call, update default instance prototype using the Proxy,
 		 * not the target.  Side effects in trap check may have
 		 * revoked our Proxy so must recheck revocation status.
+		 *
+		 * For Proxy chains the caller will iterate over this step
+		 * multiple times.
 		 */
 
 		if (*call_flags & DUK_CALL_FLAG_CONSTRUCT) {

--- a/src-input/duk_js_ops.c
+++ b/src-input/duk_js_ops.c
@@ -170,7 +170,7 @@ DUK_LOCAL duk_double_t duk__tonumber_string_raw(duk_hthread *thr) {
 
 #if defined(DUK_USE_PREFER_SIZE)
 	d = duk_get_number(thr, -1);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 #else
 	thr->valstack_top--;
 	DUK_ASSERT(DUK_TVAL_IS_NUMBER(thr->valstack_top));
@@ -227,7 +227,7 @@ DUK_INTERNAL duk_double_t duk_js_tonumber(duk_hthread *thr, duk_tval *tv) {
 		DUK_ASSERT(duk_get_tval(thr, -1) != NULL);
 		d = duk_js_tonumber(thr, duk_get_tval(thr, -1));
 
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return d;
 	}
 	case DUK_TAG_POINTER: {
@@ -690,7 +690,7 @@ recursive_call:
 	{
 		duk_bool_t rc;
 		rc = duk_js_equals_helper(thr, DUK_GET_TVAL_NEGIDX(thr, -2), DUK_GET_TVAL_NEGIDX(thr, -1), 0 /*flags:nonstrict*/);
-		duk_pop_2_unsafe(thr);
+		duk_pop_2_known(thr);
 		return rc;
 	}
 }
@@ -931,7 +931,7 @@ DUK_INTERNAL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, 
 
 		if (DUK_LIKELY(!DUK_HSTRING_HAS_SYMBOL(h1) && !DUK_HSTRING_HAS_SYMBOL(h2))) {
 			rc = duk_js_string_compare(h1, h2);
-			duk_pop_2_unsafe(thr);
+			duk_pop_2_known(thr);
 			if (rc < 0) {
 				return retval ^ 1;
 			} else {
@@ -957,11 +957,11 @@ DUK_INTERNAL duk_bool_t duk_js_compare_helper(duk_hthread *thr, duk_tval *tv_x, 
 	d1 = duk_to_number_m2(thr);
 	d2 = duk_to_number_m1(thr);
 
-	/* We want to duk_pop_2_unsafe(thr); because the values are numbers
+	/* We want to duk_pop_2_known(thr); because the values are numbers
 	 * no decref check is needed.
 	 */
 #if defined(DUK_USE_PREFER_SIZE)
-	duk_pop_2_nodecref_unsafe(thr);
+	duk_pop_2_nodecref_known(thr);
 #else
 	DUK_ASSERT(!DUK_TVAL_NEEDS_REFCOUNT_UPDATE(duk_get_tval(thr, -2)));
 	DUK_ASSERT(!DUK_TVAL_NEEDS_REFCOUNT_UPDATE(duk_get_tval(thr, -1)));
@@ -1164,15 +1164,15 @@ DUK_LOCAL duk_bool_t duk__js_instanceof_helper(duk_hthread *thr, duk_tval *tv_x,
 	DUK_WO_NORETURN(return 0;);
 
 pop2_and_false:
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return 0;
 
 pop3_and_false:
-	duk_pop_3_unsafe(thr);
+	duk_pop_3_known(thr);
 	return 0;
 
 pop3_and_true:
-	duk_pop_3_unsafe(thr);
+	duk_pop_3_known(thr);
 	return 1;
 
 error_invalid_rval:

--- a/src-input/duk_js_prop.c
+++ b/src-input/duk_js_prop.c
@@ -16,7 +16,7 @@ DUK_INTERNAL void duk_js_getprototypeof_hproxy(duk_hthread *thr, duk_hproxy *h) 
 		duk_push_hobject(thr, h->target);
 		duk_call_method(thr, 1 /*nargs*/); /* [ ... trap handler target ] -> [ ... result ] */
 	} else {
-		duk_pop_2_unsafe(thr);
+		duk_pop_2_known(thr);
 		duk_js_getprototypeof(thr, h->target);
 	}
 }

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -281,7 +281,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			DUK_HCOMPFUNC_SET_VARENV(thr->heap, fun_clos, (duk_hobject *) new_env);
 			DUK_HOBJECT_INCREF(thr, (duk_hobject *) new_env);
 			DUK_HOBJECT_INCREF(thr, (duk_hobject *) new_env);
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 
 			/* [ ... closure template ] */
 		} else
@@ -350,7 +350,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			duk_xdef_prop_stridx_short(thr, -3, stridx, DUK_PROPDESC_FLAGS_C);
 		} else {
 			DUK_DDD(DUK_DDDPRINT("copying property, stridx=%ld -> not found", (long) stridx));
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 	}
 
@@ -457,7 +457,7 @@ void duk_js_push_closure(duk_hthread *thr,
 		 * it from Function.prototype.name.
 		 */
 		DUK_DD(DUK_DDPRINT("not setting function instance .name"));
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 #endif
 
@@ -495,7 +495,7 @@ void duk_js_push_closure(duk_hthread *thr,
 	                     (duk_tval *) duk_get_tval(thr, -1),
 	                     (duk_tval *) duk_get_tval(thr, -2)));
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	/* [ ... closure ] */
 }
@@ -528,8 +528,12 @@ DUK_LOCAL void duk__preallocate_env_entries(duk_hthread *thr, duk_hobject *varma
 		 */
 		duk_push_undefined(thr);
 		DUK_DDD(DUK_DDDPRINT("preallocate env entry for key %!O", key));
-		(void) duk_prop_defown_strkey(thr, env, key, duk_get_top_index(thr), DUK_DEFPROP_ATTR_WE | DUK_DEFPROP_HAVE_VALUE);
-		duk_pop_unsafe(thr);
+		(void) duk_prop_defown_strkey(thr,
+		                              env,
+		                              key,
+		                              duk_get_top_index_known(thr),
+		                              DUK_DEFPROP_ATTR_WE | DUK_DEFPROP_HAVE_VALUE);
+		duk_pop_known(thr);
 	}
 }
 
@@ -630,7 +634,7 @@ void duk_js_init_activation_environment_records_delayed(duk_hthread *thr, duk_ac
 	DUK_HOBJECT_INCREF(thr, env); /* XXX: incref by count (here 2 times) */
 	DUK_HOBJECT_INCREF(thr, env);
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 }
 
 /*
@@ -735,8 +739,12 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 		                     (long) regnum,
 		                     (duk_tval *) duk_get_tval(thr, -1)));
 
-		(void) duk_prop_defown_strkey(thr, env, key, duk_get_top_index(thr), DUK_DEFPROP_ATTR_WE | DUK_DEFPROP_HAVE_VALUE);
-		duk_pop_unsafe(thr);
+		(void) duk_prop_defown_strkey(thr,
+		                              env,
+		                              key,
+		                              duk_get_top_index_known(thr),
+		                              DUK_DEFPROP_ATTR_WE | DUK_DEFPROP_HAVE_VALUE);
+		duk_pop_known(thr);
 	}
 
 	/* NULL atomically to avoid inconsistent state + side effects. */
@@ -1344,7 +1352,7 @@ void duk__putvar_helper(duk_hthread *thr,
 			duk_push_tval_unsafe(thr, &tv_tmp_val);
 			DUK_TVAL_SET_STRING(&tv_tmp_key, name);
 			(void) duk_prop_putvalue_inidx(thr, duk_get_top(thr) - 2, &tv_tmp_key, duk_get_top(thr) - 1, strict);
-			duk_pop_2_unsafe(thr);
+			duk_pop_2_known(thr);
 
 			/* ref.value invalidated here */
 		}
@@ -1372,7 +1380,7 @@ void duk__putvar_helper(duk_hthread *thr,
 	duk_push_tval_unsafe(thr, &tv_tmp_val);
 	DUK_TVAL_SET_STRING(&tv_tmp_key, name);
 	(void) duk_prop_putvalue_inidx(thr, duk_get_top(thr) - 2, &tv_tmp_key, duk_get_top(thr) - 1, 0 /* no throw */);
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 
 	/* NB: 'val' may be invalidated here because put_value may realloc valstack,
 	 * caller beware.
@@ -1633,9 +1641,9 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 		(void) duk_prop_defown_strkey(thr,
 		                              ref.holder,
 		                              name,
-		                              duk_get_top_index(thr),
+		                              duk_get_top_index_known(thr),
 		                              prop_flags | (do_full_write ? DUK_DEFPROP_HAVE_WEC : 0) | DUK_DEFPROP_HAVE_VALUE);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return 0;
 	}
 
@@ -1676,7 +1684,7 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 	duk_push_hstring(thr, name);
 	duk_push_tval(thr, val);
 	duk_xdef_prop(thr, -3, prop_flags); /* [holder name val] -> [holder] */
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	return 0;
 

--- a/src-input/duk_prop_defown.c
+++ b/src-input/duk_prop_defown.c
@@ -701,7 +701,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_proxy_tail(duk_hthread *thr, duk_hobject *
 
 	trap_rc = duk_to_boolean_top_pop(thr);
 	if (!trap_rc) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return 0;
 	}
 
@@ -712,7 +712,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_proxy_tail(duk_hthread *thr, duk_hobject *
 	rc = 1;
 #endif
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return rc;
 }
 
@@ -832,7 +832,7 @@ retry_target:
 
 check_rc:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	if (DUK_UNLIKELY(rc == 0)) {
 		return duk__prop_defown_error_obj_strkey(thr, target, key, defprop_flags);
@@ -870,7 +870,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_bufobj_write(duk_hthread *thr, duk_hobject
 	(void) duk_to_number_m1(thr);
 
 	our_rc = duk_hbufobj_validate_and_write_top(thr, h, idx);
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return our_rc;
 }
 
@@ -1086,7 +1086,7 @@ DUK_LOCAL duk_small_int_t duk__prop_defown_idxkey_stringobj(duk_hthread *thr,
 
 				duk_prop_push_plainstr_idx(thr, h, idx);
 				match = duk_samevalue(thr, idx_desc, -1);
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 				if (!match) {
 					goto fail_invalid_desc;
 				}
@@ -1147,7 +1147,7 @@ DUK_LOCAL DUK_NOINLINE duk_bool_t duk__prop_defown_idxkey_arguments(duk_hthread 
 		DUK_D(DUK_DPRINT("write protecting arguments mapped idxkey with no [[Value]], force current variable value"));
 		(void) duk_js_getvar_envrec(thr, env, varname, 1 /*throw*/); /* -> [ ... value this_binding ] */
 		rc_ordinary = duk__prop_defown_idxkey_array(thr, obj, idx, duk_get_top(thr) - 2, modified_flags);
-		duk_pop_2_unsafe(thr);
+		duk_pop_2_known(thr);
 	} else {
 		rc_ordinary = duk__prop_defown_idxkey_array(thr, obj, idx, idx_desc, defprop_flags);
 	}
@@ -1177,7 +1177,7 @@ DUK_LOCAL DUK_NOINLINE duk_bool_t duk__prop_defown_idxkey_arguments(duk_hthread 
 				DUK_DD(DUK_DDPRINT("update variable after arguments defprop, index %ld", (long) idx));
 				duk_dup(thr, idx_desc);
 				duk_js_putvar_envrec(thr, env, varname, DUK_GET_TVAL_NEGIDX(thr, -1), 0 /*throw_flag*/);
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 			}
 			if ((defprop_flags & (DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_WRITABLE)) == DUK_DEFPROP_HAVE_WRITABLE) {
 				DUK_D(DUK_DPRINT("delete arguments mapping for index %ld because setting writable=false",
@@ -1187,8 +1187,8 @@ DUK_LOCAL DUK_NOINLINE duk_bool_t duk__prop_defown_idxkey_arguments(duk_hthread 
 		}
 		if (delete_mapping) {
 			duk_push_hobject(thr, map);
-			(void) duk_prop_delete_idxkey(thr, duk_get_top_index(thr), idx, 0 /*delprop_flags*/);
-			duk_pop_unsafe(thr);
+			(void) duk_prop_delete_idxkey(thr, duk_get_top_index_known(thr), idx, 0 /*delprop_flags*/);
+			duk_pop_known(thr);
 		}
 	}
 
@@ -1334,7 +1334,7 @@ retry_target:
 
 check_rc:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	if (DUK_UNLIKELY(rc == 0)) {
 		return duk__prop_defown_error_obj_idxkey(thr, target, idx, defprop_flags);
@@ -1418,7 +1418,7 @@ duk_prop_defown_idxkey(duk_hthread *thr, duk_hobject *obj, duk_uarridx_t idx, du
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_defown_strkey_unsafe(thr, obj, key, idx_desc, defprop_flags);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top);
 		return rc;
 	}
@@ -1506,7 +1506,7 @@ duk_prop_defown(duk_hthread *thr, duk_hobject *obj, duk_tval *tv_key, duk_idx_t 
 	key = duk_to_property_key_hstring(thr, -1);
 	DUK_ASSERT(key != NULL);
 	rc = duk_prop_defown_strkey(thr, obj, key, idx_desc, defprop_flags);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top);
 	return rc;
 

--- a/src-input/duk_prop_delete.c
+++ b/src-input/duk_prop_delete.c
@@ -281,7 +281,7 @@ DUK_LOCAL duk_bool_t duk__prop_delete_proxy_tail(duk_hthread *thr, duk_hobject *
 	DUK_DD(DUK_DDPRINT("proxy policy check for 'deleteProperty' trap disabled in configuration"));
 #endif
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	return trap_rc;
 }
@@ -502,7 +502,7 @@ retry_target:
 	 */
 	if (side_effect_safe) {
 		duk_bool_t del_rc = duk__prop_delete_obj_strkey_ordinary(thr, target, key, delprop_flags);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return del_rc;
 	} else {
 		return duk__prop_delete_obj_strkey_ordinary(thr, target, key, delprop_flags);
@@ -510,14 +510,14 @@ retry_target:
 
 success:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return 1;
 
 fail_not_configurable:
 fail_proxy:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return duk__prop_delete_error_obj_strkey(thr, target, key, delprop_flags);
 
@@ -791,7 +791,7 @@ retry_target:
 
 	if (side_effect_safe) {
 		duk_bool_t del_rc = duk__prop_delete_obj_idxkey_ordinary(thr, target, idx, delprop_flags);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return del_rc;
 	} else {
 		return duk__prop_delete_obj_idxkey_ordinary(thr, target, idx, delprop_flags);
@@ -799,14 +799,14 @@ retry_target:
 
 success:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return 1;
 
 fail_not_configurable:
 fail_proxy:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return duk__prop_delete_error_obj_idxkey(thr, target, idx, delprop_flags);
 
@@ -856,7 +856,7 @@ DUK_INTERNAL duk_bool_t duk_prop_delete_obj_idxkey(duk_hthread *thr,
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_delete_obj_strkey_unsafe(thr, obj, key, delprop_flags);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return rc;
 	}
 }
@@ -1032,7 +1032,7 @@ DUK_INTERNAL duk_bool_t duk_prop_delete_idxkey(duk_hthread *thr,
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_delete_strkey(thr, idx_obj, key, delprop_flags);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top);
 		return rc;
 	}
@@ -1121,7 +1121,7 @@ DUK_INTERNAL duk_bool_t duk_prop_deleteoper(duk_hthread *thr, duk_idx_t idx_obj,
 	key = duk_to_property_key_hstring(thr, -1);
 	DUK_ASSERT(key != NULL);
 	rc = duk_prop_delete_strkey(thr, idx_obj, key, delprop_flags);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top);
 	return rc;
 

--- a/src-input/duk_prop_enum.c
+++ b/src-input/duk_prop_enum.c
@@ -132,7 +132,7 @@ DUK_INTERNAL void duk_prop_enum_keylist(duk_hthread *thr, duk_hobject *obj, duk_
 				duk_bool_t keep = 1;
 
 				duk_push_true(thr);
-				duk_prop_putvalue_inidx(thr, idx_visited, tv_key, duk_get_top_index(thr), 0 /*throw_flag*/);
+				duk_prop_putvalue_inidx(thr, idx_visited, tv_key, duk_get_top_index_known(thr), 0 /*throw_flag*/);
 
 				if (keep) {
 					duk_push_tval(thr, tv_key);
@@ -146,7 +146,7 @@ DUK_INTERNAL void duk_prop_enum_keylist(duk_hthread *thr, duk_hobject *obj, duk_
 		}
 
 		DUK_ASSERT(duk_get_top(thr) == idx_base_top + 1);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == idx_base_top);
 
 		if (enum_flags & DUK_ENUM_OWN_PROPERTIES_ONLY) {
@@ -170,7 +170,7 @@ DUK_INTERNAL void duk_prop_enum_keylist(duk_hthread *thr, duk_hobject *obj, duk_
 
 	DUK_ASSERT(duk_get_top(thr) == idx_base_top);
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top + 1);
 
 	/* [ ... res ] */
@@ -225,7 +225,7 @@ DUK_INTERNAL duk_bool_t duk_prop_enum_next(duk_hthread *thr, duk_idx_t idx_enum,
 
 	(void) duk_get_prop_index(thr, -3, idx_next);
 	if (duk_is_undefined(thr, -1)) {
-		duk_pop_n_unsafe(thr, 4);
+		duk_pop_n_known(thr, 4);
 		return 0;
 	}
 
@@ -249,7 +249,7 @@ DUK_INTERNAL duk_bool_t duk_prop_enum_next(duk_hthread *thr, duk_idx_t idx_enum,
 
 	/* [ ... key val? .keys .target .index ] */
 
-	duk_pop_3_unsafe(thr);
+	duk_pop_3_known(thr);
 
 	/* [ ... key val? ] */
 

--- a/src-input/duk_prop_get.c
+++ b/src-input/duk_prop_get.c
@@ -444,7 +444,7 @@ DUK_LOCAL duk_bool_t duk__prop_get_own_proxy_tail(duk_hthread *thr, duk_hobject 
 	/* [ ... key result ] */
 
 	duk_replace_posidx_unsafe(thr, idx_out);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	return DUK__GETOWN_FOUND;
 }
@@ -504,7 +504,7 @@ DUK_LOCAL duk_bool_t duk__prop_get_check_arguments_map_for_get(duk_hthread *thr,
 	 * e.g. by a with(proxy).
 	 */
 	(void) duk_js_getvar_envrec(thr, env, varname, 1 /*throw*/); /* -> [ ... value this_binding ] */
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	/* Leave result on stack top. */
 	return 1;
@@ -578,9 +578,9 @@ duk__get_own_prop_idxkey_arguments(duk_hthread *thr, duk_hobject *obj, duk_uarri
 	 * be unreachable except for this value stack reference.)
 	 */
 	if (rc_map) {
-		duk_pop_2_unsafe(thr);
+		duk_pop_2_known(thr);
 	} else {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return DUK__GETOWN_NOTFOUND;
 
@@ -591,7 +591,7 @@ found_do_map_check:
 		 */
 		duk_replace(thr, idx_out);
 	}
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	/* Side effects have occurred so all bets are off.  This is OK in this
 	 * path because caller will terminate property lookup anyway.
@@ -1365,14 +1365,14 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__prop_get_stroridx_helper(duk_hthread
 not_found:
 	if (side_effect_safe) {
 		DUK_ASSERT(duk_get_hobject(thr, -1) == target);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return duk__prop_get_write_notfound_result(thr, idx_out);
 
 found:
 	DUK_ASSERT(rc == 1);
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return 1;
 	} else {
 		return rc;
@@ -1710,7 +1710,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_idxkey_outidx(duk_hthread *thr,
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_getvalue_strkey_outidx(thr, idx_recv, key, idx_out);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top);
 		return rc;
 	}
@@ -1850,7 +1850,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_outidx(duk_hthread *thr, duk_idx_t idx
 	key = duk_to_property_key_hstring(thr, -1);
 	DUK_ASSERT(key != NULL);
 	rc = duk_prop_getvalue_strkey_outidx(thr, idx_recv, key, idx_out);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top);
 	return rc;
 
@@ -1882,7 +1882,7 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_push(duk_hthread *thr, duk_idx_t idx_r
 #endif
 
 	duk_push_undefined(thr);
-	idx_out = duk_get_top_index_unsafe(thr);
+	idx_out = duk_get_top_index_known(thr);
 
 	return duk_prop_getvalue_outidx(thr, idx_recv, tv_key, idx_out);
 }

--- a/src-input/duk_prop_getown.c
+++ b/src-input/duk_prop_getown.c
@@ -86,7 +86,7 @@ DUK_LOCAL duk_small_int_t duk__prop_getown_proxy_policy(duk_hthread *thr, duk_ho
 			}
 		}
 		attrs = -1;
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	} else {
 		DUK_ASSERT(duk_is_object(thr, -1));
 		attrs = (duk_small_int_t) duk_prop_topropdesc(thr); /* -> [ ... <variable> ] */
@@ -327,9 +327,9 @@ DUK_LOCAL duk_small_int_t duk__prop_getowndesc_idxkey_arguments(duk_hthread *thr
 			 * looked up above may no longer be mapped, but this doesn't
 			 * matter for safety.
 			 */
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 			(void) duk_js_getvar_envrec(thr, env, varname, 1 /*throw*/); /* -> [ ... value this_binding ] */
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 	}
 
@@ -517,7 +517,7 @@ DUK_INTERNAL duk_small_int_t duk_prop_getowndesc_obj_idxkey(duk_hthread *thr, du
 
 		key = duk_push_u32_tohstring(thr, idx);
 		attrs = duk__prop_getowndesc_strkey_unsafe(thr, obj, key);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top + duk_prop_propdesc_valcount(attrs));
 		return attrs;
 	}

--- a/src-input/duk_prop_has.c
+++ b/src-input/duk_prop_has.c
@@ -248,7 +248,7 @@ DUK_LOCAL duk_bool_t duk__prop_has_proxy_tail(duk_hthread *thr) {
 		}
 	}
 
-	duk_pop_3_unsafe(thr);
+	duk_pop_3_known(thr);
 	DUK_ASSERT(DUK__HASOWN_NOTFOUND == 0 && DUK__HASOWN_FOUND == 1);
 	DUK_ASSERT(rc == DUK__HASOWN_NOTFOUND || rc == DUK__HASOWN_FOUND);
 	return rc;
@@ -346,7 +346,7 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__prop_has_obj_stroridx_helper(duk_hth
 
 done:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 
 	return rc;
@@ -499,7 +499,7 @@ DUK_INTERNAL duk_bool_t duk_prop_has_idxkey(duk_hthread *thr, duk_tval *tv_obj, 
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_has_strkey(thr, tv_obj, key);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top);
 		return rc;
 	}
@@ -598,7 +598,7 @@ DUK_INTERNAL duk_bool_t duk_prop_has(duk_hthread *thr, duk_tval *tv_obj, duk_tva
 	duk_push_tval(thr, tv_key);
 	(void) duk_to_property_key_hstring(thr, -1);
 	rc = duk_prop_has(thr, DUK_GET_TVAL_NEGIDX(thr, -2), DUK_GET_TVAL_NEGIDX(thr, -1));
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top);
 	return rc;
 

--- a/src-input/duk_prop_ownpropkeys.c
+++ b/src-input/duk_prop_ownpropkeys.c
@@ -410,7 +410,7 @@ DUK_LOCAL void duk__prop_ownpropkeys_proxy_policy(duk_hthread *thr, duk_hobject 
 		continue;
 
 	skip_key:
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		continue;
 	}
 

--- a/src-input/duk_prop_set.c
+++ b/src-input/duk_prop_set.c
@@ -538,7 +538,7 @@ DUK_LOCAL duk_bool_t duk__setcheck_found_setter_helper(duk_hthread *thr,
 		DUK_UNREF(use_key);
 		duk_call_method(thr, 1); /* [ setter receiver(= this) val ] -> [ retval ] */
 #endif
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		return 1;
 	} else {
 		/* If setter is missing, fail write. */
@@ -748,7 +748,7 @@ DUK_LOCAL DUK_COLD DUK_NOINLINE duk_bool_t duk__setcheck_idxkey_arguments_helper
 	/* Arguments map write. */
 	duk_dup(thr, idx_val);
 	duk_js_putvar_envrec(thr, env, varname, DUK_GET_TVAL_NEGIDX(thr, -1), throw_flag);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	/* Then normal [[Set]] check which may not hit a property, may hit
 	 * a setter, etc, due to side effects from above.
@@ -856,7 +856,7 @@ DUK_LOCAL duk_bool_t duk__setcheck_idxkey_typedarray(duk_hthread *thr,
 		rc = DUK__SETCHECK_DONE_SUCCESS;
 	}
 
-	duk_pop_2_unsafe(thr);
+	duk_pop_2_known(thr);
 	return rc; /* Never continue lookup. */
 }
 #else
@@ -1560,8 +1560,8 @@ DUK_LOCAL duk_bool_t duk__setfinal_strkey_proxy(duk_hthread *thr, duk_hobject *o
 		defprop_flags = DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_SET_WEC;
 	}
 	duk_dup(thr, idx_val);
-	rc = duk_prop_defown_strkey(thr, obj, key, duk_get_top_index(thr), defprop_flags);
-	duk_pop_unsafe(thr);
+	rc = duk_prop_defown_strkey(thr, obj, key, duk_get_top_index_known(thr), defprop_flags);
+	duk_pop_known(thr);
 	return rc;
 
 fail_accessor:
@@ -1686,8 +1686,8 @@ DUK_LOCAL duk_bool_t duk__setfinal_idxkey_proxy(duk_hthread *thr, duk_hobject *o
 		defprop_flags = DUK_DEFPROP_HAVE_VALUE | DUK_DEFPROP_SET_WEC;
 	}
 	duk_dup(thr, idx_val);
-	rc = duk_prop_defown_idxkey(thr, obj, idx, duk_get_top_index(thr), defprop_flags);
-	duk_pop_unsafe(thr);
+	rc = duk_prop_defown_idxkey(thr, obj, idx, duk_get_top_index_known(thr), defprop_flags);
+	duk_pop_known(thr);
 	return rc;
 
 fail_accessor:
@@ -2400,7 +2400,7 @@ DUK_LOCAL duk_bool_t duk__prop_set_proxy_tail(duk_hthread *thr, duk_hobject *obj
 	DUK_DD(DUK_DDPRINT("proxy policy check for 'set' trap disabled in configuration"));
 #endif
 
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 
 	return trap_rc;
 }
@@ -2676,7 +2676,7 @@ allow_write:
 
 success:
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	return 1;
 
@@ -2685,7 +2685,7 @@ fail:
 	 * in which case we don't actually throw.
 	 */
 	if (side_effect_safe) {
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 	}
 	if (use_key) {
 		return duk__prop_set_error_objidx_strkey(thr, idx_recv, key, throw_flag);
@@ -2909,7 +2909,7 @@ duk__prop_putvalue_idxkey_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_uarrid
 			/* Cannot alter value at 'idx_val' so must dup for now. */
 			duk_dup(thr, idx_val);
 			coerced_val = duk_to_uint32(thr, -1); /* arbitrary side effects */
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 
 		if (DUK_LIKELY(idx < DUK_HBUFFER_GET_SIZE(h))) {
@@ -3082,7 +3082,7 @@ duk_prop_putvalue_idxkey_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_uarridx
 		DUK_DD(DUK_DDPRINT("corner case, input idx 0xffffffff is not an arridx, must coerce to string"));
 		key = duk_push_u32_tohstring(thr, idx);
 		rc = duk__prop_putvalue_strkey_inidx(thr, idx_recv, key, idx_val, throw_flag);
-		duk_pop_unsafe(thr);
+		duk_pop_known(thr);
 		DUK_ASSERT(duk_get_top(thr) == entry_top);
 		return rc;
 	}
@@ -3208,7 +3208,7 @@ duk_prop_putvalue_inidx(duk_hthread *thr, duk_idx_t idx_recv, duk_tval *tv_key, 
 	tv_key = NULL;
 	key = duk_to_property_key_hstring(thr, -1);
 	rc = duk_prop_putvalue_strkey_inidx(thr, idx_recv, key, idx_val, throw_flag);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	DUK_ASSERT(duk_get_top(thr) == entry_top);
 	return rc;
 

--- a/src-input/duk_prop_util.c
+++ b/src-input/duk_prop_util.c
@@ -128,7 +128,7 @@ DUK_LOCAL duk_bool_t duk__prop_has_get_prop_stridx_toboolean(duk_hthread *thr,
 		return 0;
 	}
 	*out_bool = duk_to_boolean(thr, -1);
-	duk_pop_unsafe(thr);
+	duk_pop_known(thr);
 	return 1;
 }
 

--- a/src-input/duk_regexp_executor.c
+++ b/src-input/duk_regexp_executor.c
@@ -481,7 +481,7 @@ DUK_LOCAL duk_re_sp_t duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_ui
 				                     (long) (idx_start + idx_count - 1),
 				                     (long) (idx_start / 2),
 				                     (long) ((idx_start + idx_count - 1) / 2)));
-				duk_pop_unsafe(re_ctx->thr);
+				duk_pop_known(re_ctx->thr);
 				sp = sub_sp;
 				goto match;
 			}
@@ -495,7 +495,7 @@ DUK_LOCAL duk_re_sp_t duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_ui
 			duk_memcpy((void *) (re_ctx->saved + idx_start),
 			           (const void *) range_save,
 			           sizeof(duk_re_sp_t) * idx_count);
-			duk_pop_unsafe(re_ctx->thr);
+			duk_pop_known(re_ctx->thr);
 			goto fail;
 		}
 		case DUK_REOP_LOOKPOS:
@@ -539,7 +539,7 @@ DUK_LOCAL duk_re_sp_t duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_ui
 			sub_sp = duk__match_regexp(re_ctx, pc + skip, sp);
 			if (DUK__RE_SP_VALID(sub_sp)) {
 				/* match: keep saves */
-				duk_pop_unsafe(re_ctx->thr);
+				duk_pop_known(re_ctx->thr);
 				sp = sub_sp;
 				goto match;
 			}
@@ -549,7 +549,7 @@ DUK_LOCAL duk_re_sp_t duk__match_regexp(duk_re_matcher_ctx *re_ctx, const duk_ui
 		lookahead_fail:
 			/* fail: restore saves */
 			duk_memcpy((void *) re_ctx->saved, (const void *) full_save, sizeof(duk_re_sp_t) * re_ctx->nsaved);
-			duk_pop_unsafe(re_ctx->thr);
+			duk_pop_known(re_ctx->thr);
 			goto fail;
 		}
 		case DUK_REOP_BACKREFERENCE: {
@@ -758,7 +758,7 @@ DUK_LOCAL void duk__regexp_match_helper(duk_hthread *thr, duk_small_int_t force_
 	duk_get_prop_stridx_short(thr, -4, DUK_STRIDX_LAST_INDEX); /* -> [ ... re_obj input bc saved_buf lastIndex ] */
 	(void) duk_to_int(thr, -1); /* ToInteger(lastIndex) */
 	d = duk_get_number(thr, -1); /* integer, but may be +/- Infinite, +/- zero (not NaN, though) */
-	duk_pop_nodecref_unsafe(thr);
+	duk_pop_nodecref_known(thr);
 
 	if (global) {
 		if (d < 0.0 || d > (double) duk_hstring_get_charlen(h_input)) {
@@ -963,7 +963,7 @@ match_over:
 
 	/* [ ... res_obj re_obj input bc saved_buf ] */
 
-	duk_pop_n_unsafe(thr, 4);
+	duk_pop_n_known(thr, 4);
 
 	/* [ ... res_obj ] */
 

--- a/src-input/duk_unicode_wtf8.c
+++ b/src-input/duk_unicode_wtf8.c
@@ -664,10 +664,10 @@ DUK_LOCAL duk_int_t duk__unicode_wtf8_search_forwards_reference(duk_hthread *thr
 
 			/* Rely on string interning! */
 			if (h_tmp == h_search) {
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 				return (duk_int_t) charoff;
 			}
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 	}
 	return -1;
@@ -801,10 +801,10 @@ DUK_LOCAL duk_int_t duk__unicode_wtf8_search_backwards_reference(duk_hthread *th
 
 			/* Rely on string interning! */
 			if (h_tmp == h_search) {
-				duk_pop_unsafe(thr);
+				duk_pop_known(thr);
 				return (duk_int_t) charoff;
 			}
-			duk_pop_unsafe(thr);
+			duk_pop_known(thr);
 		}
 	}
 	return -1;

--- a/tests/ecmascript/test-bi-proxy-chaining-call.js
+++ b/tests/ecmascript/test-bi-proxy-chaining-call.js
@@ -1,0 +1,46 @@
+/*===
+myFunc called
+myRetval
+P2.apply called false true ["foo",123,"bar"]
+p2Retval
+done
+===*/
+
+// Basic case: no traps, just proceed to target.
+var target = function myFunc() {
+    print('myFunc called');
+    return 'myRetval';
+};
+
+var P1 = new Proxy(target, {
+});
+
+var P2 = new Proxy(P1, {
+});
+
+var P3 = new Proxy(P2, {
+});
+
+print(P3());
+
+// Trap in the middle of a Proxy chain.
+var target = function myFunc() {
+    print('myFunc called');
+    return 'myRetval';
+};
+
+var P1 = new Proxy(target, {
+});
+
+var P2 = new Proxy(P1, {
+    apply: function (targ, argThis, argList) {
+        print('P2.apply called', targ == P3, argThis == void 0, JSON.stringify(argList));
+        return 'p2Retval';
+    }
+});
+
+var P3 = new Proxy(P2, {
+});
+
+print(P3('foo', 123, 'bar'));
+print('done');

--- a/tests/ecmascript/test-bi-proxy-revocable-creation.js
+++ b/tests/ecmascript/test-bi-proxy-revocable-creation.js
@@ -5,8 +5,8 @@ true
 true true true
 [object Function]
 true true true
-undefined undefined undefined undefined
-undefined undefined undefined undefined
+ false false true
+0 false false true
 ===*/
 
 var target = { foo: 123 };
@@ -34,7 +34,7 @@ Object.getOwnPropertySymbols(P).forEach(function (s) {
 });
 
 var pd = Object.getOwnPropertyDescriptor(P.revoke, 'name') || {};
-print(pd.value, pd.writable, pd.enumerable, pd.writable);
+print(pd.value, pd.writable, pd.enumerable, pd.configurable);
 
 var pd = Object.getOwnPropertyDescriptor(P.revoke, 'length') || {};
-print(pd.value, pd.writable, pd.enumerable, pd.writable);
+print(pd.value, pd.writable, pd.enumerable, pd.configurable);

--- a/tests/ecmascript/test-bi-proxy-revoked-object-proto-tostring.js
+++ b/tests/ecmascript/test-bi-proxy-revoked-object-proto-tostring.js
@@ -1,0 +1,19 @@
+/*===
+[object Function]
+[object Math]
+[object Math]
+TypeError
+===*/
+
+print(Object.prototype.toString.call(new Proxy(Math.cos,{})));
+print(Object.prototype.toString.call(new Proxy(Math,{})));
+
+var P = Proxy.revocable(Math, {});
+
+print(Object.prototype.toString.call(P.proxy));
+P.revoke();
+try {
+    print(Object.prototype.toString.call(P.proxy));
+} catch (e) {
+    print(e.name);
+}

--- a/tests/ecmascript/test-bi-proxy-revoked-readable-summary.js
+++ b/tests/ecmascript/test-bi-proxy-revoked-readable-summary.js
@@ -1,0 +1,41 @@
+// Test how a revoked Proxy is summarized in error messages by
+// duk_api_readable.c.
+
+/*---
+{
+    "custom": true
+}
+---*/
+
+/*===
+TypeError cannot write property [object Object] of null
+TypeError cannot write property [object RevokedProxy] of null
+TypeError cannot write property [object Function] of null
+TypeError cannot write property [object RevokedProxy] of null
+===*/
+
+var p = Proxy.revocable(Math, {});
+try {
+    null[p.proxy] = 123;
+} catch (e) {
+    print(e.name, e.message);
+}
+p.revoke();
+try {
+    null[p.proxy] = 123;
+} catch (e) {
+    print(e.name, e.message);
+}
+
+var p = Proxy.revocable(Math.cos, {});
+try {
+    null[p.proxy] = 123;
+} catch (e) {
+    print(e.name, e.message);
+}
+p.revoke();
+try {
+    null[p.proxy] = 123;
+} catch (e) {
+    print(e.name, e.message);
+}


### PR DESCRIPTION
* Fix Proxy.revocable() revoker function .name and .length properties (empty name, 0 length).
* Summarize a revoked proxy as '[object RevokedProxy]' in internal readable summary string, and add test coverage.
* Rename internal duk_push_class_string() as duk_push_objproto_tostring() for clarity, the helper has Object.prototype.toString() semantics (except when avoid_side_effects = 1).
* Fix duk_push_objproto_tostring() behavior for revoked Proxies, required behavior is to throw (this happens in the @@toStringTag lookup which is unconditional).
* Rename duk_get_top_index_unsafe() -> duk_get_top_index_known() for clarity.
* Add more duk_get_top_index_known() call sites when value stack is known to have >= 1 entries.
* Rename duk_pop_unsafe() and variants to duk_pop_known() which is more descriptive.
* Use duk_push_{undefined,tval}_unsafe() instead of direct valstack_top manipulation in executor and a few other places.
* Add test coverage for chained Proxies in call setup.
* Minor code improvements.