### PR TITLE
Fixes and improvements to new property code

### DIFF
--- a/src-input/duk_api_bytecode.c
+++ b/src-input/duk_api_bytecode.c
@@ -156,7 +156,7 @@ DUK_LOCAL duk_uint8_t *duk__dump_varmap(duk_hthread *thr, duk_uint8_t *p, duk_bu
 		 * values are numbers; assert for these.  GC and finalizers
 		 * shouldn't affect _Varmap so side effects should be fine.
 		 */
-		for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(h); i++) {
+		for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(h); i++) {
 			duk_hstring *key;
 			duk_tval *tv_val;
 			duk_uint32_t val;
@@ -596,7 +596,7 @@ static const duk_uint8_t *duk__load_func(duk_hthread *thr, const duk_uint8_t *p,
 		DUK_ASSERT(new_env->regbase_byteoff == 0);
 		DUK_HDECENV_ASSERT_VALID(new_env);
 		DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) new_env) == NULL);
-		DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) new_env, func_env);
+		duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) new_env, func_env);
 		DUK_HOBJECT_INCREF(thr, func_env);
 
 		func_env = (duk_hobject *) new_env;

--- a/src-input/duk_api_readable.c
+++ b/src-input/duk_api_readable.c
@@ -167,9 +167,7 @@ DUK_INTERNAL void duk_push_objproto_tostring_tval(duk_hthread *thr, duk_tval *tv
 push_stridx:
 	duk_push_hstring_stridx(thr, stridx); /* -> [ ... tag ] */
 
-#if defined(DUK_USE_SYMBOL_BUILTIN)
 tag_pushed:
-#endif
 	/* [ ... string ] */
 	duk_push_literal(thr, "[object "); /* -> [ ... tag "[object" ] */
 	duk_insert(thr, -2);

--- a/src-input/duk_api_stack.c
+++ b/src-input/duk_api_stack.c
@@ -4914,7 +4914,7 @@ DUK_INTERNAL duk_hobject *duk_push_object_helper(duk_hthread *thr,
 	/* object is now reachable */
 
 	if (prototype_bidx >= 0) {
-		DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, h, thr->builtins[prototype_bidx]);
+		duk_hobject_set_proto_init_incref(thr, h, thr->builtins[prototype_bidx]);
 	} else {
 		DUK_ASSERT(prototype_bidx == -1);
 		DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, h) == NULL);
@@ -4930,7 +4930,7 @@ DUK_INTERNAL duk_hobject *duk_push_object_helper_proto(duk_hthread *thr, duk_uin
 
 	h = duk_push_object_helper(thr, hobject_flags_and_class, -1);
 	DUK_ASSERT(h != NULL);
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, h, proto);
+	duk_hobject_set_proto_init_incref(thr, h, proto);
 	return h;
 }
 
@@ -4958,7 +4958,7 @@ DUK_EXTERNAL duk_idx_t duk_push_array(duk_hthread *thr) {
 	obj = duk_harray_alloc(thr, flags);
 	DUK_ASSERT(obj != NULL);
 
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_ARRAY_PROTOTYPE]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_ARRAY_PROTOTYPE]);
 
 	tv_slot = thr->valstack_top;
 	DUK_TVAL_SET_OBJECT(tv_slot, (duk_hobject *) obj);
@@ -5103,7 +5103,7 @@ DUK_INTERNAL duk_harray *duk_push_arguments_array_noinit(duk_hthread *thr, duk_u
 	obj = duk_harray_alloc(thr, flags);
 	DUK_ASSERT(obj != NULL);
 
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_OBJECT_PROTOTYPE]);
 
 	tv_slot = thr->valstack_top++;
 	DUK_TVAL_SET_OBJECT(tv_slot, (duk_hobject *) obj);
@@ -5165,7 +5165,7 @@ DUK_EXTERNAL duk_idx_t duk_push_thread_raw(duk_hthread *thr, duk_uint_t flags) {
 	}
 
 	/* default prototype */
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, obj->builtins[DUK_BIDX_THREAD_PROTOTYPE]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, obj->builtins[DUK_BIDX_THREAD_PROTOTYPE]);
 
 	/* Initial stack size satisfies the stack slack constraints so there
 	 * is no need to require stack here.
@@ -5205,7 +5205,7 @@ DUK_INTERNAL duk_hcompfunc *duk_push_hcompfunc(duk_hthread *thr) {
 
 	/* default prototype */
 	DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) obj) == NULL);
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE]);
 
 	return obj;
 }
@@ -5276,7 +5276,7 @@ duk__push_c_function_raw(duk_hthread *thr, duk_c_function func, duk_idx_t nargs,
 	thr->valstack_top++;
 
 	DUK_ASSERT_BIDX_VALID(proto_bidx);
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, thr->builtins[proto_bidx]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, thr->builtins[proto_bidx]);
 	return ret;
 
 api_error:
@@ -5375,7 +5375,7 @@ DUK_INTERNAL duk_hbufobj *duk_push_bufobj_raw(duk_hthread *thr,
 	obj = duk_hbufobj_alloc(thr, hobject_flags_and_class);
 	DUK_ASSERT(obj != NULL);
 
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) obj, thr->builtins[prototype_bidx]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) obj, thr->builtins[prototype_bidx]);
 	DUK_HBUFOBJ_ASSERT_VALID(obj);
 
 	tv_slot = thr->valstack_top;

--- a/src-input/duk_bi_function.c
+++ b/src-input/duk_bi_function.c
@@ -267,7 +267,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_hthread *thr) {
 		 * in place.
 		 */
 		bound_proto = duk_hobject_get_proto_raw(thr->heap, h_target);
-		DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) h_bound, bound_proto);
+		duk_hobject_set_proto_init_incref(thr, (duk_hobject *) h_bound, bound_proto);
 
 		/* The 'strict' flag is copied to get the special [[Get]] of E5.1
 		 * Section 15.3.5.4 to apply when a 'caller' value is a strict bound
@@ -305,7 +305,7 @@ DUK_INTERNAL duk_ret_t duk_bi_function_prototype_bind(duk_hthread *thr) {
 		DUK_ASSERT(DUK_TVAL_IS_LIGHTFUNC(tv_tmp));
 		DUK_HOBJECT_SET_STRICT((duk_hobject *) h_bound);
 		bound_proto = thr->builtins[DUK_BIDX_FUNCTION_PROTOTYPE];
-		DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) h_bound, bound_proto);
+		duk_hobject_set_proto_init_incref(thr, (duk_hobject *) h_bound, bound_proto);
 	}
 
 	DUK_TVAL_INCREF(thr, &h_bound->target); /* old values undefined, no decref needed */

--- a/src-input/duk_bi_global.c
+++ b/src-input/duk_bi_global.c
@@ -524,7 +524,7 @@ DUK_INTERNAL duk_ret_t duk_bi_global_object_eval(duk_hthread *thr) {
 			duk_push_hobject(thr, (duk_hobject *) new_env);
 
 			DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) new_env) == NULL);
-			DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) new_env, act_lex_env);
+			duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) new_env, act_lex_env);
 			DUK_HOBJECT_INCREF_ALLOWNULL(thr, act_lex_env);
 			DUK_DDD(DUK_DDDPRINT("new_env allocated: %!iO", (duk_heaphdr *) new_env));
 

--- a/src-input/duk_bi_json.c
+++ b/src-input/duk_bi_json.c
@@ -2532,7 +2532,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 		if (c_bit & c_object) {
 			/* All other object types. */
 			duk_propvalue *idx_pv_base;
-			duk_uint32_t *idx_pk_base;
+			duk_uarridx_t *idx_pk_base;
 			duk_uint8_t *idx_attr_base;
 
 			DUK__EMIT_1(js_ctx, DUK_ASC_LCURLY);
@@ -2543,7 +2543,7 @@ DUK_LOCAL duk_bool_t duk__json_stringify_fast_value(duk_json_enc_ctx *js_ctx, du
 				goto abort_fastpath;
 			}
 
-			for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(obj); i++) {
+			for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(obj); i++) {
 				duk_hstring *k;
 				duk_size_t prev_size;
 

--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -161,8 +161,6 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_define_properties(duk_hthread *
 		DUK_ASSERT_TOP(thr, 3);
 
 		for (;;) {
-			duk_hstring *key;
-
 			/* [ hobject props enum(props) ] */
 
 			duk_set_top(thr, 3);
@@ -651,7 +649,6 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_prevent_extensions(duk_hthread 
 		rc = duk_js_preventextensions(thr, h);
 	}
 
-done:
 	if (magic == 0) {
 		if (rc == 0) {
 			DUK_ERROR_TYPE(thr, DUK_STR_CANNOT_PREVENT_EXTENSIONS);

--- a/src-input/duk_debug_vsnprintf.c
+++ b/src-input/duk_debug_vsnprintf.c
@@ -59,7 +59,7 @@
 /* Needed for pointer compression, but we don't have a caller-given heap/thr
  * pointer for debug logs now.
  */
-DUK_LOCAL duk__debug_get_heap(void) {
+DUK_LOCAL duk_heap *duk__debug_get_heap(void) {
 #if defined(DUK_USE_DEBUG) && (defined(DUK_USE_HEAPPTR_ENC16) || defined(DUK_USE_DATAPTR_ENC16) || defined(DUK_USE_FUNCPTR_ENC16))
 	return duk_debug_global_heap_singleton;
 #else
@@ -418,7 +418,7 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 			duk__print_tval(st, tv);
 		}
 	}
-	if (h->idx_props != NULL) {
+	if (duk_hobject_get_idxprops(duk__debug_get_heap(), h) != NULL) {
 		for (i = 0; i < h->i_next; i++) {
 			duk_propvalue *val_base;
 			duk_uarridx_t *key_base;
@@ -427,9 +427,7 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 			duk_uarridx_t idx;
 			duk_uint8_t attrs;
 
-			val_base = (duk_propvalue *) (void *) h->idx_props;
-			key_base = (duk_uarridx_t *) (void *) (val_base + h->i_size);
-			attr_base = (duk_uint8_t *) (void *) (key_base + h->i_size);
+			duk_hobject_get_idxprops_key_attr(duk__debug_get_heap(), h, &val_base, &key_base, &attr_base);
 			pv = val_base + i;
 			idx = key_base[i];
 			attrs = attr_base[i];
@@ -451,8 +449,8 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 			}
 		}
 	}
-	if (DUK_HOBJECT_GET_PROPS(duk__debug_get_heap(), h)) {
-		for (i = 0; i < DUK_HOBJECT_GET_ENEXT(h); i++) {
+	if (duk_hobject_get_strprops(duk__debug_get_heap(), h)) {
+		for (i = 0; i < duk_hobject_get_enext(h); i++) {
 			key = DUK_HOBJECT_E_GET_KEY(duk__debug_get_heap(), h, i);
 			if (!key) {
 				continue;
@@ -723,7 +721,7 @@ DUK_LOCAL void duk__print_hobject(duk__dprint_state *st, duk_hobject *h) {
 		duk_uint32_t hsize = duk_hobject_get_hsize(duk__debug_get_heap(), h);
 		duk_fb_put_byte(fb, (duk_uint8_t) DUK_ASC_LANGLE);
 		for (i = 0; i < hsize; i++) {
-			duk_uint_t h_idx = DUK_HOBJECT_H_GET_INDEX(duk__debug_get_heap(), h, i);
+			duk_uint_t h_idx = duk_hobject_get_strhash(duk__debug_get_heap(), h)[i];
 			if (i > 0) {
 				duk_fb_put_byte(fb, (duk_uint8_t) DUK_ASC_COMMA);
 			}

--- a/src-input/duk_debugger.c
+++ b/src-input/duk_debugger.c
@@ -1904,7 +1904,7 @@ DUK_LOCAL void duk__debug_dump_heaphdr(duk_hthread *thr, duk_heap *heap, duk_hea
 		duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_get_asize(h));
 		duk_debug_write_uint(thr, (duk_uint32_t) duk_hobject_get_hsize(heap, h));
 
-		for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(h); i++) {
+		for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(h); i++) {
 			duk_debug_write_uint(thr, (duk_uint32_t) DUK_HOBJECT_E_GET_FLAGS(heap, h, i));
 			k = DUK_HOBJECT_E_GET_KEY(heap, h, i);
 			duk_debug_write_heapptr(thr, (duk_heaphdr *) k);
@@ -2195,7 +2195,7 @@ DUK_LOCAL duk_bool_t duk__debug_getprop_index(duk_hthread *thr, duk_heap *heap, 
 	}
 
 	idx -= a_size;
-	if (idx >= DUK_HOBJECT_GET_ENEXT(h_obj)) {
+	if (idx >= duk_hobject_get_enext(h_obj)) {
 		return 0;
 	}
 
@@ -2297,7 +2297,7 @@ DUK_LOCAL void duk__debug_handle_get_heap_obj_info(duk_hthread *thr, duk_heap *h
 			duk_debug_write_null(thr);
 		}
 		duk__debug_getinfo_flags_key(thr, "props");
-		duk_debug_write_pointer(thr, (void *) DUK_HOBJECT_GET_PROPS(heap, h_obj));
+		duk_debug_write_pointer(thr, (void *) duk_hobject_get_strprops(heap, h_obj));
 		duk__debug_getinfo_prop_uint(thr, "e_size", (duk_uint_t) duk_hobject_get_esize(h_obj));
 		duk__debug_getinfo_prop_uint(thr, "e_next", (duk_uint_t) duk_hobject_get_enext(h_obj));
 		duk__debug_getinfo_prop_uint(thr, "a_size", (duk_uint_t) duk_hobject_get_asize(h_obj));

--- a/src-input/duk_error.h
+++ b/src-input/duk_error.h
@@ -342,13 +342,13 @@
 		DUK_ERROR_TYPE_INVALID_STATE((thr)); \
 		return 0; \
 	} while (0)
-#define DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr) \
+#define DUK_ERROR_TYPE_PROXY_REJECTED(thr) \
 	do { \
-		duk_err_type_invalid_trap_result((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO); \
+		duk_err_type_proxy_rejected((thr), DUK_FILE_MACRO, (duk_int_t) DUK_LINE_MACRO); \
 	} while (0)
-#define DUK_DCERROR_TYPE_INVALID_TRAP_RESULT(thr) \
+#define DUK_DCERROR_TYPE_PROXY_REJECTED(thr) \
 	do { \
-		DUK_ERROR_TYPE((thr), DUK_STR_INVALID_TRAP_RESULT); \
+		DUK_ERROR_TYPE((thr), DUK_STR_PROXY_REJECTED); \
 	} while (0)
 #define DUK_ERROR_TYPE_PROXY_REVOKED(thr) \
 	do { \
@@ -476,11 +476,11 @@
 	do { \
 		duk_err_type((thr)); \
 	} while (0)
-#define DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr) \
+#define DUK_ERROR_TYPE_PROXY_REJECTED(thr) \
 	do { \
 		duk_err_type((thr)); \
 	} while (0)
-#define DUK_DCERROR_TYPE_INVALID_TRAP_RESULT(thr) \
+#define DUK_DCERROR_TYPE_PROXY_REJECTED(thr) \
 	do { \
 		DUK_UNREF((thr)); \
 		return DUK_RET_TYPE_ERROR; \
@@ -693,7 +693,7 @@ DUK_NORETURN(
     DUK_INTERNAL_DECL void duk_err_range(duk_hthread *thr, const char *filename, duk_int_t linenumber, const char *message));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_args(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_state(duk_hthread *thr, const char *filename, duk_int_t linenumber));
-DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber));
+DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_proxy_rejected(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_proxy_revoked(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_buffer_detached(duk_hthread *thr, const char *filename, duk_int_t linenumber));
 DUK_NORETURN(DUK_INTERNAL_DECL void duk_err_type_invalid_rvalue(duk_hthread *thr, const char *filename, duk_int_t linenumber));

--- a/src-input/duk_error_macros.c
+++ b/src-input/duk_error_macros.c
@@ -102,8 +102,8 @@ DUK_INTERNAL DUK_COLD void duk_err_type_invalid_args(duk_hthread *thr, const cha
 DUK_INTERNAL DUK_COLD void duk_err_type_invalid_state(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_STATE);
 }
-DUK_INTERNAL DUK_COLD void duk_err_type_invalid_trap_result(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
-	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_INVALID_TRAP_RESULT);
+DUK_INTERNAL DUK_COLD void duk_err_type_proxy_rejected(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
+	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REJECTED);
 }
 DUK_INTERNAL DUK_COLD void duk_err_type_proxy_revoked(duk_hthread *thr, const char *filename, duk_int_t linenumber) {
 	DUK_ERROR_RAW(thr, filename, linenumber, DUK_ERR_TYPE_ERROR, DUK_STR_PROXY_REVOKED);

--- a/src-input/duk_heap_alloc.c
+++ b/src-input/duk_heap_alloc.c
@@ -27,11 +27,11 @@ DUK_INTERNAL void duk_free_hobject(duk_heap *heap, duk_hobject *h) {
 	DUK_ASSERT(heap != NULL);
 	DUK_ASSERT(h != NULL);
 
-	DUK_FREE(heap, DUK_HOBJECT_GET_PROPS(heap, h));
+	DUK_FREE(heap, duk_hobject_get_strprops(heap, h));
 #if defined(DUK_USE_HOBJECT_HASH_PART)
-	DUK_FREE(heap, DUK_HOBJECT_GET_HASH(heap, h));
+	DUK_FREE(heap, duk_hobject_get_strhash(heap, h));
 #endif
-	DUK_FREE(heap, h->idx_props);
+	DUK_FREE(heap, duk_hobject_get_idxprops(heap, h));
 	DUK_FREE(heap, h->idx_hash);
 
 	if (DUK_HOBJECT_IS_HARRAY(h)) {
@@ -298,7 +298,7 @@ DUK_LOCAL void duk__free_run_finalizers(duk_heap *heap) {
 				 */
 				DUK_ASSERT(curr != NULL);
 
-				if (DUK_HOBJECT_HAS_FINALIZER_FAST(heap, (duk_hobject *) curr)) {
+				if (duk_hobject_has_finalizer_fast_raw(heap, (duk_hobject *) curr)) {
 					if (!DUK_HEAPHDR_HAS_FINALIZED((duk_heaphdr *) curr)) {
 						DUK_ASSERT(
 						    DUK_HEAP_HAS_FINALIZER_NORESCUE(heap)); /* maps to finalizer 2nd argument */
@@ -596,7 +596,7 @@ DUK_LOCAL duk_bool_t duk__init_heap_thread(duk_heap *heap) {
 	duk_hthread_create_builtin_objects(thr);
 
 	/* default prototype */
-	DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, (duk_hobject *) thr, thr->builtins[DUK_BIDX_THREAD_PROTOTYPE]);
+	duk_hobject_set_proto_init_incref(thr, (duk_hobject *) thr, thr->builtins[DUK_BIDX_THREAD_PROTOTYPE]);
 
 	return 1;
 }

--- a/src-input/duk_heap_markandsweep.c
+++ b/src-input/duk_heap_markandsweep.c
@@ -34,7 +34,7 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 
 	/* XXX: use advancing pointers instead of index macros -> faster and smaller? */
 
-	for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(h); i++) {
+	for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(h); i++) {
 		duk_hstring *key = DUK_HOBJECT_E_GET_KEY(heap, h, i);
 		if (key == NULL) {
 			continue;
@@ -49,9 +49,11 @@ DUK_LOCAL void duk__mark_hobject(duk_heap *heap, duk_hobject *h) {
 	}
 
 	{
-		duk_propvalue *val_base = (duk_propvalue *) (void *) h->idx_props;
-		duk_uarridx_t *key_base = (duk_uarridx_t *) (void *) (val_base + h->i_size);
-		duk_uint8_t *attr_base = (duk_uint8_t *) (void *) (key_base + h->i_size);
+		duk_propvalue *val_base;
+		duk_uarridx_t *key_base;
+		duk_uint8_t *attr_base;
+
+		duk_hobject_get_idxprops_key_attr(heap, h, &val_base, &key_base, &attr_base);
 
 		for (i = 0; i < (duk_uint_fast32_t) h->i_next; i++) {
 			duk_propvalue *pv = val_base + i;
@@ -353,7 +355,7 @@ DUK_LOCAL void duk__mark_finalizable(duk_heap *heap) {
 		 */
 
 		if (!DUK_HEAPHDR_HAS_REACHABLE(hdr) && DUK_HEAPHDR_IS_ANY_OBJECT(hdr) && !DUK_HEAPHDR_HAS_FINALIZED(hdr) &&
-		    DUK_HOBJECT_HAS_FINALIZER_FAST(heap, (duk_hobject *) hdr)) {
+		    duk_hobject_has_finalizer_fast_raw(heap, (duk_hobject *) hdr)) {
 			/* heaphdr:
 			 *  - is not reachable
 			 *  - is an object

--- a/src-input/duk_hobject.h
+++ b/src-input/duk_hobject.h
@@ -256,152 +256,26 @@ DUK_INTERNAL_DECL void duk_hobject_assert_key_absent(duk_heap *heap, duk_hobject
  *  Macros to access the 'props' allocation.
  */
 
-#if defined(DUK_USE_HEAPPTR16)
-#define DUK_HOBJECT_GET_PROPS(heap, h) ((duk_uint8_t *) DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, ((duk_heaphdr *) (h))->h_extra16))
-#define DUK_HOBJECT_SET_PROPS(heap, h, x) \
-	do { \
-		((duk_heaphdr *) (h))->h_extra16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (x)); \
-	} while (0)
-#define DUK_HOBJECT_GET_HASH(heap, h) ((duk_uint8_t *) DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, (h)->hash16))
-#define DUK_HOBJECT_SET_HASH(heap, h, x) \
-	do { \
-		(h)->hash16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (x)); \
-	} while (0)
-#else
-#define DUK_HOBJECT_GET_PROPS(heap, h) ((h)->props)
-#define DUK_HOBJECT_SET_PROPS(heap, h, x) \
-	do { \
-		(h)->props = (duk_uint8_t *) (x); \
-	} while (0)
-#define DUK_HOBJECT_GET_HASH(heap, h) ((h)->hash)
-#define DUK_HOBJECT_SET_HASH(heap, h, x) \
-	do { \
-		(h)->hash = (duk_uint32_t *) (x); \
-	} while (0)
-
-#endif
-
-#define DUK_HOBJECT_E_GET_KEY_BASE(heap, h) \
-	((duk_hstring **) (void *) (DUK_HOBJECT_GET_PROPS((heap), (h)) + DUK_HOBJECT_GET_ESIZE((h)) * sizeof(duk_propvalue)))
-#define DUK_HOBJECT_E_GET_VALUE_BASE(heap, h) ((duk_propvalue *) (void *) (DUK_HOBJECT_GET_PROPS((heap), (h))))
-#define DUK_HOBJECT_E_GET_FLAGS_BASE(heap, h) \
-	((duk_uint8_t *) (void *) (DUK_HOBJECT_GET_PROPS((heap), (h)) + \
-	                           DUK_HOBJECT_GET_ESIZE((h)) * (sizeof(duk_propvalue) + sizeof(duk_hstring *))))
-#define DUK_HOBJECT_H_GET_BASE(heap, h)    ((duk_uint32_t *) (void *) (DUK_HOBJECT_GET_HASH((heap), (h))))
-#define DUK_HOBJECT_P_COMPUTE_SIZE(n_ent)  ((n_ent) * (sizeof(duk_propvalue) + sizeof(duk_hstring *) + sizeof(duk_uint8_t)))
-#define DUK_HOBJECT_H_COMPUTE_SIZE(n_hash) ((n_hash + 1) * (sizeof(duk_uint32_t)))
-
-#define DUK_HOBJECT_E_GET_KEY(heap, h, i)              (DUK_HOBJECT_E_GET_KEY_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_E_GET_KEY_PTR(heap, h, i)          (&DUK_HOBJECT_E_GET_KEY_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_E_GET_VALUE(heap, h, i)            (DUK_HOBJECT_E_GET_VALUE_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_E_GET_VALUE_PTR(heap, h, i)        (&DUK_HOBJECT_E_GET_VALUE_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_E_GET_VALUE_TVAL(heap, h, i)       (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).v)
-#define DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(heap, h, i)   (&DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).v)
-#define DUK_HOBJECT_E_GET_VALUE_GETTER(heap, h, i)     (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.get)
-#define DUK_HOBJECT_E_GET_VALUE_GETTER_PTR(heap, h, i) (&DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.get)
-#define DUK_HOBJECT_E_GET_VALUE_SETTER(heap, h, i)     (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.set)
-#define DUK_HOBJECT_E_GET_VALUE_SETTER_PTR(heap, h, i) (&DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.set)
-#define DUK_HOBJECT_E_GET_FLAGS(heap, h, i)            (DUK_HOBJECT_E_GET_FLAGS_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_E_GET_FLAGS_PTR(heap, h, i)        (&DUK_HOBJECT_E_GET_FLAGS_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_H_GET_INDEX(heap, h, i)            (DUK_HOBJECT_H_GET_BASE((heap), (h))[(i)])
-#define DUK_HOBJECT_H_GET_INDEX_PTR(heap, h, i)        (&DUK_HOBJECT_H_GET_BASE((heap), (h))[(i)])
+#define DUK_HOBJECT_E_GET_KEY(heap, h, i)            (duk_hobject_get_strprops_keys((heap), (h))[(i)])
+#define DUK_HOBJECT_E_GET_VALUE(heap, h, i)          (duk_hobject_get_strprops_values((heap), (h))[(i)])
+#define DUK_HOBJECT_E_GET_VALUE_PTR(heap, h, i)      (&duk_hobject_get_strprops_values((heap), (h))[(i)])
+#define DUK_HOBJECT_E_GET_VALUE_TVAL(heap, h, i)     (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).v)
+#define DUK_HOBJECT_E_GET_VALUE_TVAL_PTR(heap, h, i) (&DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).v)
+#define DUK_HOBJECT_E_GET_VALUE_GETTER(heap, h, i)   (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.get)
+#define DUK_HOBJECT_E_GET_VALUE_SETTER(heap, h, i)   (DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.set)
+#define DUK_HOBJECT_E_GET_FLAGS(heap, h, i)          (duk_hobject_get_strprops_attrs((heap), (h))[(i)])
 
 #define DUK_HOBJECT_E_SET_KEY(heap, h, i, k) \
 	do { \
 		DUK_HOBJECT_E_GET_KEY((heap), (h), (i)) = (k); \
 	} while (0)
-#define DUK_HOBJECT_E_SET_VALUE(heap, h, i, v) \
-	do { \
-		DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)) = (v); \
-	} while (0)
-#define DUK_HOBJECT_E_SET_VALUE_TVAL(heap, h, i, v) \
-	do { \
-		DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).v = (v); \
-	} while (0)
-#define DUK_HOBJECT_E_SET_VALUE_GETTER(heap, h, i, v) \
-	do { \
-		DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.get = (v); \
-	} while (0)
-#define DUK_HOBJECT_E_SET_VALUE_SETTER(heap, h, i, v) \
-	do { \
-		DUK_HOBJECT_E_GET_VALUE((heap), (h), (i)).a.set = (v); \
-	} while (0)
-#define DUK_HOBJECT_E_SET_FLAGS(heap, h, i, f) \
-	do { \
-		DUK_HOBJECT_E_GET_FLAGS((heap), (h), (i)) = (duk_uint8_t) (f); \
-	} while (0)
-#define DUK_HOBJECT_H_SET_INDEX(heap, h, i, v) \
-	do { \
-		DUK_HOBJECT_H_GET_INDEX((heap), (h), (i)) = (v); \
-	} while (0)
 
-#define DUK_HOBJECT_E_SET_FLAG_BITS(heap, h, i, mask) \
-	do { \
-		DUK_HOBJECT_E_GET_FLAGS_BASE((heap), (h))[(i)] |= (mask); \
-	} while (0)
-
-#define DUK_HOBJECT_E_CLEAR_FLAG_BITS(heap, h, i, mask) \
-	do { \
-		DUK_HOBJECT_E_GET_FLAGS_BASE((heap), (h))[(i)] &= ~(mask); \
-	} while (0)
-
-#define DUK_HOBJECT_E_SLOT_IS_WRITABLE(heap, h, i) ((DUK_HOBJECT_E_GET_FLAGS((heap), (h), (i)) & DUK_PROPDESC_FLAG_WRITABLE) != 0)
 #define DUK_HOBJECT_E_SLOT_IS_ENUMERABLE(heap, h, i) \
 	((DUK_HOBJECT_E_GET_FLAGS((heap), (h), (i)) & DUK_PROPDESC_FLAG_ENUMERABLE) != 0)
-#define DUK_HOBJECT_E_SLOT_IS_CONFIGURABLE(heap, h, i) \
-	((DUK_HOBJECT_E_GET_FLAGS((heap), (h), (i)) & DUK_PROPDESC_FLAG_CONFIGURABLE) != 0)
 #define DUK_HOBJECT_E_SLOT_IS_ACCESSOR(heap, h, i) ((DUK_HOBJECT_E_GET_FLAGS((heap), (h), (i)) & DUK_PROPDESC_FLAG_ACCESSOR) != 0)
-
-#define DUK_HOBJECT_E_SLOT_SET_WRITABLE(heap, h, i)   DUK_HOBJECT_E_SET_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_WRITABLE)
-#define DUK_HOBJECT_E_SLOT_SET_ENUMERABLE(heap, h, i) DUK_HOBJECT_E_SET_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_ENUMERABLE)
-#define DUK_HOBJECT_E_SLOT_SET_CONFIGURABLE(heap, h, i) \
-	DUK_HOBJECT_E_SET_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_CONFIGURABLE)
-#define DUK_HOBJECT_E_SLOT_SET_ACCESSOR(heap, h, i) DUK_HOBJECT_E_SET_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_ACCESSOR)
-
-#define DUK_HOBJECT_E_SLOT_CLEAR_WRITABLE(heap, h, i) DUK_HOBJECT_E_CLEAR_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_WRITABLE)
-#define DUK_HOBJECT_E_SLOT_CLEAR_ENUMERABLE(heap, h, i) \
-	DUK_HOBJECT_E_CLEAR_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_ENUMERABLE)
-#define DUK_HOBJECT_E_SLOT_CLEAR_CONFIGURABLE(heap, h, i) \
-	DUK_HOBJECT_E_CLEAR_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_CONFIGURABLE)
-#define DUK_HOBJECT_E_SLOT_CLEAR_ACCESSOR(heap, h, i) DUK_HOBJECT_E_CLEAR_FLAG_BITS((heap), (h), (i), DUK_PROPDESC_FLAG_ACCESSOR)
-
-#define DUK_PROPDESC_IS_WRITABLE(p)     (((p)->flags & DUK_PROPDESC_FLAG_WRITABLE) != 0)
-#define DUK_PROPDESC_IS_ENUMERABLE(p)   (((p)->flags & DUK_PROPDESC_FLAG_ENUMERABLE) != 0)
-#define DUK_PROPDESC_IS_CONFIGURABLE(p) (((p)->flags & DUK_PROPDESC_FLAG_CONFIGURABLE) != 0)
-#define DUK_PROPDESC_IS_ACCESSOR(p)     (((p)->flags & DUK_PROPDESC_FLAG_ACCESSOR) != 0)
 
 #define DUK_HOBJECT_HASHIDX_UNUSED  0xffffffffUL
 #define DUK_HOBJECT_HASHIDX_DELETED 0xfffffffeUL
-
-/*
- *  Macros for accessing size fields
- */
-
-#if defined(DUK_USE_OBJSIZES16)
-#define DUK_HOBJECT_GET_ESIZE(h) ((h)->e_size16)
-#define DUK_HOBJECT_SET_ESIZE(h, v) \
-	do { \
-		(h)->e_size16 = (v); \
-	} while (0)
-#define DUK_HOBJECT_GET_ENEXT(h) ((h)->e_next16)
-#define DUK_HOBJECT_SET_ENEXT(h, v) \
-	do { \
-		(h)->e_next16 = (v); \
-	} while (0)
-#define DUK_HOBJECT_POSTINC_ENEXT(h) ((h)->e_next16++)
-#else
-#define DUK_HOBJECT_GET_ESIZE(h) ((h)->e_size)
-#define DUK_HOBJECT_SET_ESIZE(h, v) \
-	do { \
-		(h)->e_size = (v); \
-	} while (0)
-#define DUK_HOBJECT_GET_ENEXT(h) ((h)->e_next)
-#define DUK_HOBJECT_SET_ENEXT(h, v) \
-	do { \
-		(h)->e_next = (v); \
-	} while (0)
-#define DUK_HOBJECT_POSTINC_ENEXT(h) ((h)->e_next++)
-#endif
 
 /*
  *  Misc
@@ -428,51 +302,6 @@ DUK_INTERNAL_DECL void duk_hobject_assert_key_absent(duk_heap *heap, duk_hobject
 
 /* Range check not necessary because all 6-bit values are mapped. */
 #define DUK_HOBJECT_HTYPE_TO_STRIDX(n) duk_htype_to_stridx[(n)]
-
-#define DUK_HOBJECT_GET_CLASS_STRING(heap, h) \
-	DUK_HEAP_GET_STRING((heap), DUK_HOBJECT_CLASS_NUMBER_TO_STRIDX(DUK_HOBJECT_GET_CLASS_NUMBER((h))))
-
-/*
- *  Macros for property handling
- */
-
-#if defined(DUK_USE_HEAPPTR16)
-#define DUK_HOBJECT_GET_PROTOTYPE(heap, h) ((duk_hobject *) DUK_USE_HEAPPTR_DEC16((heap)->heap_udata, (h)->prototype16))
-#define DUK_HOBJECT_SET_PROTOTYPE(heap, h, x) \
-	do { \
-		(h)->prototype16 = DUK_USE_HEAPPTR_ENC16((heap)->heap_udata, (void *) (x)); \
-	} while (0)
-#else
-#define DUK_HOBJECT_GET_PROTOTYPE(heap, h) ((h)->prototype)
-#define DUK_HOBJECT_SET_PROTOTYPE(heap, h, x) \
-	do { \
-		(h)->prototype = (x); \
-	} while (0)
-#endif
-
-/* Set initial prototype, assume NULL previous prototype, INCREF new value,
- * tolerate NULL.
- */
-#define DUK_HOBJECT_SET_PROTOTYPE_INIT_INCREF(thr, h, proto) \
-	do { \
-		duk_hthread *duk__thr = (thr); \
-		duk_hobject *duk__obj = (h); \
-		duk_hobject *duk__proto = (proto); \
-		DUK_UNREF(duk__thr); \
-		DUK_ASSERT(DUK_HOBJECT_GET_PROTOTYPE(duk__thr->heap, duk__obj) == NULL); \
-		DUK_HOBJECT_SET_PROTOTYPE(duk__thr->heap, duk__obj, duk__proto); \
-		DUK_HOBJECT_INCREF_ALLOWNULL(duk__thr, duk__proto); \
-	} while (0)
-
-/*
- *  Finalizer check
- */
-
-#if defined(DUK_USE_HEAPPTR16)
-#define DUK_HOBJECT_HAS_FINALIZER_FAST(heap, h) duk_hobject_has_finalizer_fast_raw((heap), (h))
-#else
-#define DUK_HOBJECT_HAS_FINALIZER_FAST(heap, h) duk_hobject_has_finalizer_fast_raw((h))
-#endif
 
 /*
  *  Resizing and hash behavior
@@ -626,11 +455,7 @@ DUK_INTERNAL_DECL duk_tval *duk_hobject_find_array_entry_tval_ptr(duk_heap *heap
 #define DUK_DELPROP_FLAG_THROW (1U << 0)
 #define DUK_DELPROP_FLAG_FORCE (1U << 1)
 DUK_INTERNAL_DECL duk_size_t duk_hobject_get_length(duk_hthread *thr, duk_hobject *obj);
-#if defined(DUK_USE_HEAPPTR16)
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_has_finalizer_fast_raw(duk_heap *heap, duk_hobject *obj);
-#else
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_has_finalizer_fast_raw(duk_hobject *obj);
-#endif
 
 /* Object built-in methods */
 DUK_INTERNAL_DECL void duk_hobject_object_seal_freeze_helper(duk_hthread *thr, duk_hobject *obj, duk_bool_t is_freeze);
@@ -663,9 +488,11 @@ DUK_INTERNAL_DECL duk_bool_t duk_proxy_trap_check_nokey(duk_hthread *thr, duk_hp
 #endif
 DUK_INTERNAL_DECL void duk_proxy_revoke(duk_hthread *thr, duk_hproxy *h);
 
-/* macros */
+/* prototype */
 DUK_INTERNAL_DECL duk_hobject *duk_hobject_get_proto_raw(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL void duk_hobject_set_proto_raw(duk_heap *heap, duk_hobject *h, duk_hobject *p);
 DUK_INTERNAL_DECL void duk_hobject_set_proto_raw_updref(duk_hthread *thr, duk_hobject *h, duk_hobject *p);
+DUK_INTERNAL_DECL void duk_hobject_set_proto_init_incref(duk_hthread *thr, duk_hobject *h, duk_hobject *p);
 
 /* pc2line */
 #if defined(DUK_USE_PC2LINE)
@@ -673,23 +500,74 @@ DUK_INTERNAL_DECL void duk_hobject_pc2line_pack(duk_hthread *thr, duk_compiler_i
 DUK_INTERNAL_DECL duk_uint_fast32_t duk_hobject_pc2line_query(duk_hthread *thr, duk_idx_t idx_func, duk_uint_fast32_t pc);
 #endif
 
+/* strprops */
+DUK_INTERNAL_DECL void duk_hobject_get_strprops_key_attr(duk_heap *heap,
+                                                         duk_hobject *obj,
+                                                         duk_propvalue **out_val_base,
+                                                         duk_hstring ***out_key_base,
+                                                         duk_uint8_t **out_attr_base);
+DUK_INTERNAL_DECL duk_propvalue *duk_hobject_get_strprops(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL duk_hstring **duk_hobject_get_strprops_keys(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL duk_propvalue *duk_hobject_get_strprops_values(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL duk_uint8_t *duk_hobject_get_strprops_attrs(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL void duk_hobject_set_strprops(duk_heap *heap, duk_hobject *h, duk_uint8_t *props);
+DUK_INTERNAL_DECL duk_uint32_t *duk_hobject_get_strhash(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL void duk_hobject_set_strhash(duk_heap *heap, duk_hobject *h, duk_uint32_t *v);
+DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_esize(duk_hobject *h);
+DUK_INTERNAL_DECL void duk_hobject_set_esize(duk_hobject *h, duk_uint32_t v);
+DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_enext(duk_hobject *h);
+DUK_INTERNAL_DECL void duk_hobject_set_enext(duk_hobject *h, duk_uint32_t v);
+DUK_INTERNAL_DECL duk_uint32_t duk_hobject_postinc_enext(duk_hobject *h);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_compute_strprops_size(duk_uint32_t n_ent);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_compute_strhash_size(duk_uint32_t n_hash);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_get_ebytes(duk_hobject *h);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_index(duk_hthread *thr,
+                                                              duk_hobject *obj,
+                                                              duk_hstring *key,
+                                                              duk_uint_fast32_t *out_idx);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
+                                                                duk_hobject *obj,
+                                                                duk_hstring *key,
+                                                                duk_uint_fast32_t *out_idx,
+                                                                duk_int_fast32_t *out_hashidx);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_val_attrs(duk_hthread *thr,
+                                                                  duk_hobject *obj,
+                                                                  duk_hstring *key,
+                                                                  duk_propvalue **out_valptr,
+                                                                  duk_uint8_t *out_attrs);
+
+/* idxprops */
+DUK_INTERNAL_DECL void duk_hobject_get_idxprops_key_attr(duk_heap *heap,
+                                                         duk_hobject *obj,
+                                                         duk_propvalue **out_val_base,
+                                                         duk_uarridx_t **out_key_base,
+                                                         duk_uint8_t **out_attr_base);
+DUK_INTERNAL_DECL duk_propvalue *duk_hobject_get_idxprops(duk_heap *heap, duk_hobject *h);
+DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_isize(duk_hobject *h);
+DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_inext(duk_hobject *h);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_get_ibytes(duk_hobject *h);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_compute_idxprops_size(duk_uint32_t n_ent);
+DUK_INTERNAL_DECL duk_size_t duk_hobject_compute_idxhash_size(duk_uint32_t n_hash);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_index(duk_hthread *thr,
+                                                              duk_hobject *obj,
+                                                              duk_uarridx_t idx,
+                                                              duk_uint_fast32_t *out_idx);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_indices(duk_hthread *thr,
+                                                                duk_hobject *obj,
+                                                                duk_uarridx_t idx,
+                                                                duk_uint_fast32_t *out_idx,
+                                                                duk_int_fast32_t *out_hashidx);
+DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_val_attrs(duk_hthread *thr,
+                                                                  duk_hobject *obj,
+                                                                  duk_uarridx_t idx,
+                                                                  duk_propvalue **out_valptr,
+                                                                  duk_uint8_t *out_attrs);
+
 /* misc */
 DUK_INTERNAL_DECL duk_bool_t duk_hobject_prototype_chain_contains(duk_hthread *thr,
                                                                   duk_hobject *h,
                                                                   duk_hobject *p,
                                                                   duk_bool_t ignore_loop);
-DUK_INTERNAL_DECL void duk_hobject_get_props_key_attr(duk_heap *heap,
-                                                      duk_hobject *obj,
-                                                      duk_propvalue **out_val_base,
-                                                      duk_hstring ***out_key_base,
-                                                      duk_uint8_t **out_attr_base);
-DUK_INTERNAL_DECL duk_propvalue *duk_hobject_get_props(duk_heap *heap, duk_hobject *h);
-DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_esize(duk_hobject *h);
-DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_enext(duk_hobject *h);
-DUK_INTERNAL_DECL duk_size_t duk_hobject_get_ebytes(duk_hobject *h);
-DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_isize(duk_hobject *h);
-DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_inext(duk_hobject *h);
-DUK_INTERNAL_DECL duk_size_t duk_hobject_get_ibytes(duk_hobject *h);
 DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_hsize(duk_heap *heap, duk_hobject *h);
 DUK_INTERNAL_DECL duk_size_t duk_hobject_get_hbytes(duk_heap *heap, duk_hobject *h);
 DUK_INTERNAL_DECL duk_uint32_t duk_hobject_get_asize(duk_hobject *h);
@@ -697,7 +575,7 @@ DUK_INTERNAL_DECL duk_size_t duk_hobject_get_abytes(duk_hobject *h);
 
 #if !defined(DUK_USE_OBJECT_BUILTIN)
 /* These declarations are needed when related built-in is disabled and
- * genbuiltins.py won't automatically emit the declerations.
+ * configure tooling won't automatically emit the declarations.
  */
 DUK_INTERNAL_DECL duk_ret_t duk_bi_object_prototype_to_string(duk_hthread *thr);
 DUK_INTERNAL_DECL duk_ret_t duk_bi_function_prototype(duk_hthread *thr);
@@ -716,36 +594,6 @@ DUK_INTERNAL_DECL duk_tval *duk_harray_append_reserve_items(duk_hthread *thr,
                                                             duk_harray *a,
                                                             duk_uarridx_t start_idx,
                                                             duk_uint32_t count);
-
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_index(duk_hthread *thr,
-                                                              duk_hobject *obj,
-                                                              duk_hstring *key,
-                                                              duk_uint_fast32_t *out_idx);
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
-                                                                duk_hobject *obj,
-                                                                duk_hstring *key,
-                                                                duk_uint_fast32_t *out_idx,
-                                                                duk_int_fast32_t *out_hashidx);
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_strprop_val_attrs(duk_hthread *thr,
-                                                                  duk_hobject *obj,
-                                                                  duk_hstring *key,
-                                                                  duk_propvalue **out_valptr,
-                                                                  duk_uint8_t *out_attrs);
-
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_index(duk_hthread *thr,
-                                                              duk_hobject *obj,
-                                                              duk_uarridx_t idx,
-                                                              duk_uint_fast32_t *out_idx);
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_indices(duk_hthread *thr,
-                                                                duk_hobject *obj,
-                                                                duk_uarridx_t idx,
-                                                                duk_uint_fast32_t *out_idx,
-                                                                duk_int_fast32_t *out_hashidx);
-DUK_INTERNAL_DECL duk_bool_t duk_hobject_lookup_idxprop_val_attrs(duk_hthread *thr,
-                                                                  duk_hobject *obj,
-                                                                  duk_uarridx_t idx,
-                                                                  duk_propvalue **out_valptr,
-                                                                  duk_uint8_t *out_attrs);
 
 DUK_INTERNAL_DECL duk_hobject *duk_hobject_lookup_strprop_known_hobject(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);
 DUK_INTERNAL_DECL duk_tval *duk_hobject_lookup_strprop_data_tvalptr(duk_hthread *thr, duk_hobject *obj, duk_hstring *key);

--- a/src-input/duk_hobject_alloc.c
+++ b/src-input/duk_hobject_alloc.c
@@ -24,8 +24,8 @@ DUK_LOCAL void duk__init_object_parts(duk_heap *heap, duk_uint_t hobject_flags, 
 	obj->hdr.h_flags = hobject_flags;
 
 #if defined(DUK_USE_EXPLICIT_NULL_INIT)
-	DUK_HOBJECT_SET_PROTOTYPE(heap, obj, NULL);
-	DUK_HOBJECT_SET_PROPS(heap, obj, NULL);
+	duk_hobject_set_proto_raw(heap, obj, NULL);
+	duk_hobject_set_strprops(heap, obj, NULL);
 #endif
 #if defined(DUK_USE_HEAPPTR16)
 	/* Zero encoded pointer is required to match NULL. */

--- a/src-input/duk_hobject_array.c
+++ b/src-input/duk_hobject_array.c
@@ -146,9 +146,7 @@ DUK_INTERNAL duk_bool_t duk_harray_put_array_length_u32_smaller(duk_hthread *thr
 		 * When forcing, ignore non-configurability.
 		 */
 
-		val_base = (duk_propvalue *) (void *) obj->idx_props;
-		key_base = (duk_uarridx_t *) (void *) (val_base + obj->i_size);
-		attr_base = (duk_uint8_t *) (void *) (key_base + obj->i_size);
+		duk_hobject_get_idxprops_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
 
 		target_len = new_len;
 		if (force_flag) {

--- a/src-input/duk_hobject_assert.c
+++ b/src-input/duk_hobject_assert.c
@@ -28,8 +28,8 @@ DUK_INTERNAL void duk_hobject_assert_valid(duk_heap *heap, duk_hobject *h) {
 	           (DUK_HOBJECT_GET_HTYPE(h) != DUK_HTYPE_ARRAY && !DUK_HOBJECT_HAS_EXOTIC_ARRAY(h)));
 
 	/* No duplicate keys. */
-	n = DUK_HOBJECT_GET_ENEXT(h);
-	keys = DUK_HOBJECT_E_GET_KEY_BASE(heap, h);
+	n = duk_hobject_get_enext(h);
+	keys = duk_hobject_get_strprops_keys(heap, h);
 	for (i = 0; i < n; i++) {
 		duk_hstring *k1 = keys[i];
 		if (k1 == NULL) {
@@ -45,8 +45,8 @@ DUK_INTERNAL void duk_hobject_assert_valid(duk_heap *heap, duk_hobject *h) {
 	}
 
 	/* Keys in string property part must never be arridx keys. */
-	n = DUK_HOBJECT_GET_ENEXT(h);
-	keys = DUK_HOBJECT_E_GET_KEY_BASE(heap, h);
+	n = duk_hobject_get_enext(h);
+	keys = duk_hobject_get_strprops_keys(heap, h);
 	for (i = 0; i < n; i++) {
 		duk_hstring *k1 = keys[i];
 		if (k1 == NULL) {
@@ -59,7 +59,7 @@ DUK_INTERNAL void duk_hobject_assert_valid(duk_heap *heap, duk_hobject *h) {
 	 * index key part.
 	 */
 	if (DUK_HOBJECT_HAS_ARRAY_ITEMS(h)) {
-		DUK_ASSERT(h->idx_props == NULL);
+		DUK_ASSERT(duk_hobject_get_idxprops(heap, h) == NULL);
 		DUK_ASSERT(h->idx_hash == NULL);
 		DUK_ASSERT(h->i_size == 0);
 		DUK_ASSERT(h->i_next == 0);
@@ -72,8 +72,8 @@ DUK_INTERNAL void duk_hobject_assert_compact(duk_heap *heap, duk_hobject *h) {
 
 	DUK_HOBJECT_ASSERT_VALID(heap, h);
 
-	n = DUK_HOBJECT_GET_ENEXT(h);
-	keys = DUK_HOBJECT_E_GET_KEY_BASE(heap, h);
+	n = duk_hobject_get_enext(h);
+	keys = duk_hobject_get_strprops_keys(heap, h);
 	for (i = 0; i < n; i++) {
 		duk_hstring *k1 = keys[i];
 		DUK_ASSERT(k1 != NULL);
@@ -98,8 +98,8 @@ DUK_INTERNAL void duk_hobject_assert_key_absent(duk_heap *heap, duk_hobject *h, 
 
 	DUK_HOBJECT_ASSERT_VALID(heap, h);
 
-	n = DUK_HOBJECT_GET_ENEXT(h);
-	keys = DUK_HOBJECT_E_GET_KEY_BASE(heap, h);
+	n = duk_hobject_get_enext(h);
+	keys = duk_hobject_get_strprops_keys(heap, h);
 	for (i = 0; i < n; i++) {
 		duk_hstring *k = keys[i];
 		if (k == NULL) {
@@ -139,7 +139,7 @@ DUK_INTERNAL void duk_harray_assert_valid(duk_heap *heap, duk_harray *h) {
 	}
 
 	if (DUK_HOBJECT_HAS_ARRAY_ITEMS((duk_hobject *) h)) {
-		DUK_ASSERT(((duk_hobject *) h)->idx_props == NULL);
+		DUK_ASSERT(duk_hobject_get_idxprops(heap, (duk_hobject *) h) == NULL);
 		DUK_ASSERT(((duk_hobject *) h)->idx_hash == NULL);
 		DUK_ASSERT(((duk_hobject *) h)->i_size == 0);
 		DUK_ASSERT(((duk_hobject *) h)->i_next == 0);

--- a/src-input/duk_hobject_lookup.c
+++ b/src-input/duk_hobject_lookup.c
@@ -4,7 +4,6 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_index(duk_hthread *thr,
                                                          duk_hobject *obj,
                                                          duk_hstring *key,
                                                          duk_uint_fast32_t *out_idx) {
-	duk_tval *tv;
 #if defined(DUK_USE_HOBJECT_HASH_PART)
 	duk_uint32_t *hash;
 #endif
@@ -17,19 +16,19 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_index(duk_hthread *thr,
 	DUK_ASSERT(key != NULL);
 	DUK_ASSERT(out_idx != NULL);
 
-	val_base = duk_hobject_get_props(thr->heap, obj);
+	val_base = duk_hobject_get_strprops(thr->heap, obj);
 	key_base = (duk_hstring **) (void *) (val_base + duk_hobject_get_esize(obj));
 	/* attr_base not needed */
 
 #if defined(DUK_USE_HOBJECT_HASH_PART)
-	hash = DUK_HOBJECT_GET_HASH(heap, obj);
+	hash = duk_hobject_get_strhash(thr->heap, obj);
 	if (DUK_LIKELY(hash == NULL))
 #endif
 	{
 		duk_uint_fast32_t i;
 		duk_uint_fast32_t n;
 
-		n = DUK_HOBJECT_GET_ENEXT(obj);
+		n = duk_hobject_get_enext(obj);
 		for (i = 0; i < n; i++) {
 			if (key_base[i] == key) {
 				*out_idx = i;
@@ -56,12 +55,12 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_index(duk_hthread *thr,
 			DUK_ASSERT(i < n);
 			t = hash[i];
 			DUK_ASSERT(t == DUK_HOBJECT_HASHIDX_UNUSED || t == DUK_HOBJECT_HASHIDX_DELETED ||
-			           (t < DUK_HOBJECT_GET_ESIZE(obj))); /* t >= 0 always true, unsigned */
+			           (t < duk_hobject_get_esize(obj))); /* t >= 0 always true, unsigned */
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_UNUSED > DUK_HOBJECT_HASHIDX_DELETED);
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_DELETED >= 0x80000000UL);
 
 			if (DUK_LIKELY(t < 0x80000000UL)) {
-				DUK_ASSERT(t < DUK_HOBJECT_GET_ESIZE(obj));
+				DUK_ASSERT(t < duk_hobject_get_esize(obj));
 				if (DUK_LIKELY(key_base[t] == key)) {
 					*out_idx = t;
 					return 1;
@@ -88,7 +87,6 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_val_attrs(duk_hthread *thr,
                                                              duk_hstring *key,
                                                              duk_propvalue **out_valptr,
                                                              duk_uint8_t *out_attrs) {
-	duk_tval *tv;
 #if defined(DUK_USE_HOBJECT_HASH_PART)
 	duk_uint32_t *hash;
 #endif
@@ -103,18 +101,18 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_val_attrs(duk_hthread *thr,
 	DUK_ASSERT(out_valptr != NULL);
 	DUK_ASSERT(out_attrs != NULL);
 
-	val_base = duk_hobject_get_props(thr->heap, obj);
+	val_base = duk_hobject_get_strprops(thr->heap, obj);
 	key_base = (duk_hstring **) (void *) (val_base + duk_hobject_get_esize(obj));
 
 #if defined(DUK_USE_HOBJECT_HASH_PART)
-	hash = DUK_HOBJECT_GET_HASH(heap, obj);
+	hash = duk_hobject_get_strhash(thr->heap, obj);
 	if (DUK_LIKELY(hash == NULL))
 #endif
 	{
 		duk_uint_fast32_t i;
 		duk_uint_fast32_t n;
 
-		n = DUK_HOBJECT_GET_ENEXT(obj);
+		n = duk_hobject_get_enext(obj);
 		for (i = 0; i < n; i++) {
 			if (key_base[i] == key) {
 				attr_base = (duk_uint8_t *) (void *) (key_base + duk_hobject_get_esize(obj));
@@ -143,12 +141,12 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_val_attrs(duk_hthread *thr,
 			DUK_ASSERT(i < n);
 			t = hash[i];
 			DUK_ASSERT(t == DUK_HOBJECT_HASHIDX_UNUSED || t == DUK_HOBJECT_HASHIDX_DELETED ||
-			           (t < DUK_HOBJECT_GET_ESIZE(obj))); /* t >= 0 always true, unsigned */
+			           (t < duk_hobject_get_esize(obj))); /* t >= 0 always true, unsigned */
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_UNUSED > DUK_HOBJECT_HASHIDX_DELETED);
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_DELETED >= 0x80000000UL);
 
 			if (DUK_LIKELY(t < 0x80000000UL)) {
-				DUK_ASSERT(t < DUK_HOBJECT_GET_ESIZE(obj));
+				DUK_ASSERT(t < duk_hobject_get_esize(obj));
 				if (DUK_LIKELY(key_base[t] == key)) {
 					attr_base = (duk_uint8_t *) (void *) (key_base + duk_hobject_get_esize(obj));
 					*out_valptr = val_base + t;
@@ -178,7 +176,6 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
                                                            duk_hstring *key,
                                                            duk_uint_fast32_t *out_idx,
                                                            duk_int_fast32_t *out_hashidx) {
-	duk_tval *tv;
 #if defined(DUK_USE_HOBJECT_HASH_PART)
 	duk_uint32_t *hash;
 #endif
@@ -190,7 +187,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
 	DUK_ASSERT(out_idx != NULL);
 
 #if defined(DUK_USE_HOBJECT_HASH_PART)
-	hash = DUK_HOBJECT_GET_HASH(heap, obj);
+	hash = duk_hobject_get_strhash(thr->heap, obj);
 	if (DUK_LIKELY(hash == NULL))
 #endif
 	{
@@ -198,8 +195,8 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
 		duk_uint_fast32_t n;
 		duk_hstring **key_base;
 
-		key_base = DUK_HOBJECT_E_GET_KEY_BASE(thr->heap, obj);
-		n = DUK_HOBJECT_GET_ENEXT(obj);
+		key_base = duk_hobject_get_strprops_keys(thr->heap, obj);
+		n = duk_hobject_get_enext(obj);
 		for (i = 0; i < n; i++) {
 			if (key_base[i] == key) {
 				*out_idx = i;
@@ -221,7 +218,7 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
 		i = duk_hstring_get_hash(key) & mask;
 		step = 1; /* Cache friendly but clustering prone. */
 
-		key_base = DUK_HOBJECT_E_GET_KEY_BASE(thr->heap, obj);
+		key_base = duk_hobject_get_strprops_keys(thr->heap, obj);
 
 		for (;;) {
 			duk_uint32_t t;
@@ -230,12 +227,12 @@ DUK_INTERNAL duk_bool_t duk_hobject_lookup_strprop_indices(duk_hthread *thr,
 			DUK_ASSERT(i < n);
 			t = hash[i];
 			DUK_ASSERT(t == DUK_HOBJECT_HASHIDX_UNUSED || t == DUK_HOBJECT_HASHIDX_DELETED ||
-			           (t < DUK_HOBJECT_GET_ESIZE(obj))); /* t >= 0 always true, unsigned */
+			           (t < duk_hobject_get_esize(obj))); /* t >= 0 always true, unsigned */
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_UNUSED > DUK_HOBJECT_HASHIDX_DELETED);
 			DUK_ASSERT(DUK_HOBJECT_HASHIDX_DELETED >= 0x80000000UL);
 
 			if (t < 0x80000000UL) {
-				DUK_ASSERT(t < DUK_HOBJECT_GET_ESIZE(obj));
+				DUK_ASSERT(t < duk_hobject_get_esize(obj));
 				if (key_base[t] == key) {
 					*out_idx = t;
 					*out_hashidx = i;
@@ -528,8 +525,8 @@ DUK_INTERNAL duk_hobject *duk_hobject_lookup_strprop_known_hobject(duk_hthread *
 		return NULL;
 	}
 
-	pv = DUK_HOBJECT_E_GET_VALUE_BASE(thr->heap, obj) + ent_idx;
-	DUK_ASSERT((DUK_HOBJECT_E_GET_FLAGS_BASE(thr->heap, obj)[ent_idx] & DUK_PROPDESC_FLAG_ACCESSOR) == 0);
+	pv = duk_hobject_get_strprops_values(thr->heap, obj) + ent_idx;
+	DUK_ASSERT((duk_hobject_get_strprops_attrs(thr->heap, obj)[ent_idx] & DUK_PROPDESC_FLAG_ACCESSOR) == 0);
 	tv_res = &pv->v;
 	DUK_ASSERT(DUK_TVAL_IS_OBJECT(tv_res));
 	res = DUK_TVAL_GET_OBJECT(tv_res);
@@ -541,8 +538,8 @@ DUK_INTERNAL duk_tval *duk_hobject_lookup_strprop_data_tvalptr(duk_hthread *thr,
 	duk_uint_fast32_t ent_idx;
 
 	if (duk_hobject_lookup_strprop_index(thr, obj, key, &ent_idx)) {
-		duk_propvalue *pv = DUK_HOBJECT_E_GET_VALUE_BASE(thr->heap, obj) + ent_idx;
-		duk_uint8_t attrs = *(DUK_HOBJECT_E_GET_FLAGS_BASE(thr->heap, obj) + ent_idx);
+		duk_propvalue *pv = duk_hobject_get_strprops_values(thr->heap, obj) + ent_idx;
+		duk_uint8_t attrs = *(duk_hobject_get_strprops_attrs(thr->heap, obj) + ent_idx);
 		if ((attrs & DUK_PROPDESC_FLAG_ACCESSOR) == 0) {
 			return &pv->v;
 		}

--- a/src-input/duk_hobject_proxy.c
+++ b/src-input/duk_hobject_proxy.c
@@ -79,6 +79,7 @@ DUK_INTERNAL_DECL duk_bool_t duk_proxy_trap_check_idxkey(duk_hthread *thr,
                                                          duk_hproxy *h,
                                                          duk_uarridx_t idx,
                                                          duk_small_uint_t trap_stridx) {
+	DUK_UNREF(idx);
 	return duk_proxy_trap_check_nokey(thr, h, trap_stridx);
 }
 
@@ -147,6 +148,7 @@ DUK_INTERNAL duk_hobject *duk_hobject_resolve_proxy_target_autothrow(duk_hthread
 		return res;
 	} else {
 		DUK_ERROR_TYPE_PROXY_REVOKED(thr);
+		DUK_WO_NORETURN(return res;);
 	}
 }
 

--- a/src-input/duk_hthread_builtins.c
+++ b/src-input/duk_hthread_builtins.c
@@ -72,18 +72,18 @@ DUK_LOCAL void duk__duplicate_ram_global_object(duk_hthread *thr) {
 	DUK_ASSERT(alloc_size > 0);
 	props = DUK_ALLOC_CHECKED(thr, alloc_size);
 	DUK_ASSERT(props != NULL);
-	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal) != NULL);
-	duk_memcpy((void *) props, (const void *) DUK_HOBJECT_GET_PROPS(thr->heap, h_oldglobal), alloc_size);
+	DUK_ASSERT(duk_hobject_get_strprops(thr->heap, h_oldglobal) != NULL);
+	duk_memcpy((void *) props, (const void *) duk_hobject_get_strprops(thr->heap, h_oldglobal), alloc_size);
 
 	/* XXX: keep property attributes or tweak them here?
 	 * Properties will now be non-configurable even when they're
 	 * normally configurable for the global object.
 	 */
 
-	DUK_ASSERT(DUK_HOBJECT_GET_PROPS(thr->heap, h_global) == NULL);
-	DUK_HOBJECT_SET_PROPS(thr->heap, h_global, props);
-	DUK_HOBJECT_SET_ESIZE(h_global, DUK_HOBJECT_GET_ESIZE(h_oldglobal));
-	DUK_HOBJECT_SET_ENEXT(h_global, DUK_HOBJECT_GET_ENEXT(h_oldglobal));
+	DUK_ASSERT(duk_hobject_get_strprops(thr->heap, h_global) == NULL);
+	duk_hobject_set_strprops(thr->heap, h_global, props);
+	duk_hobject_set_esize(h_global, duk_hobject_get_esize(h_oldglobal));
+	duk_hobject_set_enext(h_global, duk_hobject_get_enext(h_oldglobal));
 #else
 #error internal error in config defines
 #endif

--- a/src-input/duk_js_call.c
+++ b/src-input/duk_js_call.c
@@ -486,7 +486,7 @@ DUK_INTERNAL void duk_call_construct_postprocess(duk_hthread *thr, duk_small_uin
 	} else {
 		if (DUK_UNLIKELY(proxy_invariant != 0U)) {
 			/* Proxy 'construct' return value invariant violated. */
-			DUK_ERROR_TYPE_INVALID_TRAP_RESULT(thr);
+			DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 			DUK_WO_NORETURN(return;);
 		}
 		/* XXX: direct value stack access */

--- a/src-input/duk_js_compiler.c
+++ b/src-input/duk_js_compiler.c
@@ -655,7 +655,7 @@ DUK_LOCAL duk_int_t duk__cleanup_varmap(duk_compiler_ctx *comp_ctx) {
 	DUK_ASSERT(h_varmap != NULL);
 
 	ret = 0;
-	e_next = DUK_HOBJECT_GET_ENEXT(h_varmap);
+	e_next = duk_hobject_get_enext(h_varmap);
 	for (i = 0; i < e_next; i++) {
 		h_key = DUK_HOBJECT_E_GET_KEY(thr->heap, h_varmap, i);
 		if (!h_key) {

--- a/src-input/duk_js_executor.c
+++ b/src-input/duk_js_executor.c
@@ -1002,7 +1002,7 @@ DUK_LOCAL void duk__handle_catch_part2(duk_hthread *thr) {
 
 	DUK_ASSERT(act == thr->callstack_curr);
 	DUK_ASSERT(act != NULL);
-	DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) new_env, act->lex_env);
+	duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) new_env, act->lex_env);
 	act->lex_env = (duk_hobject *) new_env;
 	DUK_HOBJECT_INCREF(thr, (duk_hobject *) new_env); /* reachable through activation */
 	/* Net refcount change to act->lex_env is 0: incref for new_env's
@@ -2390,7 +2390,7 @@ DUK_LOCAL DUK_EXEC_NOINLINE_PERF void duk__handle_op_trycatch(duk_hthread *thr, 
 		DUK_ASSERT(act == thr->callstack_curr);
 		DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) env) == NULL);
 		DUK_ASSERT(act->lex_env != NULL);
-		DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) env, act->lex_env);
+		duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) env, act->lex_env);
 		act->lex_env = (duk_hobject *) env; /* Now reachable. */
 		DUK_HOBJECT_INCREF(thr, (duk_hobject *) env);
 		/* Net refcount change to act->lex_env is 0: incref for env's

--- a/src-input/duk_js_prop.c
+++ b/src-input/duk_js_prop.c
@@ -115,6 +115,7 @@ retry_obj:
 }
 
 /* [[PreventExtensions]] */
+#if defined(DUK_USE_PROXY_POLICY)
 DUK_LOCAL void duk__preventextensions_proxy_policy(duk_hthread *thr, duk_hobject *obj, duk_bool_t trap_rc) {
 	duk_hobject *target;
 
@@ -123,9 +124,10 @@ DUK_LOCAL void duk__preventextensions_proxy_policy(duk_hthread *thr, duk_hobject
 
 	if (trap_rc != 0 && duk_js_isextensible(thr, target)) {
 		DUK_DD(DUK_DDPRINT("preventExtensions() trap successful, but target is still extensible"));
-		DUK_ERROR_TYPE(thr, "proxy invariant violated for 'preventExtensions'");
+		DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 	}
 }
+#endif
 
 DUK_LOCAL duk_bool_t duk__preventextensions_proxy(duk_hthread *thr, duk_hobject *obj) {
 	/* 'obj' stability assumed from caller. */
@@ -202,7 +204,7 @@ DUK_LOCAL duk_bool_t duk__isextensible_proxy(duk_hthread *thr, duk_hobject *obj)
 		DUK_ASSERT(target != NULL);
 		target_rc = duk_js_isextensible(thr, target);
 		if (trap_rc != target_rc) {
-			DUK_ERROR_TYPE(thr, "proxy invariant violated for 'isExtensible'");
+			DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 		}
 #else
 		DUK_DD(DUK_DDPRINT("proxy policy check for 'isExtensible' trap disabled in configuration"));
@@ -214,7 +216,6 @@ DUK_LOCAL duk_bool_t duk__isextensible_proxy(duk_hthread *thr, duk_hobject *obj)
 }
 DUK_INTERNAL_DECL duk_bool_t duk_js_isextensible(duk_hthread *thr, duk_hobject *obj) {
 	duk_small_uint_t htype;
-	duk_bool_t rc;
 
 retry_obj:
 	htype = DUK_HOBJECT_GET_HTYPE(obj);

--- a/src-input/duk_js_var.c
+++ b/src-input/duk_js_var.c
@@ -254,7 +254,7 @@ void duk_js_push_closure(duk_hthread *thr,
 			duk_push_hobject(thr, (duk_hobject *) new_env);
 
 			DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) new_env) == NULL);
-			DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) new_env, proto);
+			duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) new_env, proto);
 			DUK_HOBJECT_INCREF_ALLOWNULL(thr, proto);
 
 			DUK_ASSERT(new_env->thread == NULL); /* Closed. */
@@ -510,7 +510,7 @@ void duk_js_push_closure(duk_hthread *thr,
 DUK_LOCAL void duk__preallocate_env_entries(duk_hthread *thr, duk_hobject *varmap, duk_hobject *env) {
 	duk_uint_fast32_t i;
 
-	for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(varmap); i++) {
+	for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(varmap); i++) {
 		duk_hstring *key;
 
 		key = DUK_HOBJECT_E_GET_KEY(thr->heap, varmap, i);
@@ -560,7 +560,7 @@ duk_hobject *duk_create_activation_environment_record(duk_hthread *thr, duk_hobj
 	duk_push_hobject(thr, (duk_hobject *) env);
 
 	DUK_ASSERT(duk_hobject_get_proto_raw(thr->heap, (duk_hobject *) env) == NULL);
-	DUK_HOBJECT_SET_PROTOTYPE(thr->heap, (duk_hobject *) env, parent);
+	duk_hobject_set_proto_raw(thr->heap, (duk_hobject *) env, parent);
 	DUK_HOBJECT_INCREF_ALLOWNULL(thr, parent); /* parent env is the prototype */
 
 	/* open scope information, for compiled functions only */
@@ -686,7 +686,7 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 	 *  - having correct value types
 	 */
 
-	DUK_DDD(DUK_DDDPRINT("copying bound register values, %ld bound regs", (long) DUK_HOBJECT_GET_ENEXT(varmap)));
+	DUK_DDD(DUK_DDDPRINT("copying bound register values, %ld bound regs", (long) duk_hobject_get_enext(varmap)));
 
 	/* Copy over current variable values from value stack to the
 	 * environment record.  The scope object is empty but may
@@ -697,7 +697,7 @@ DUK_INTERNAL void duk_js_close_environment_record(duk_hthread *thr, duk_hobject 
 	 * Hash part would need special treatment however (maybe copy, and
 	 * then realloc with hash part if large enough).
 	 */
-	for (i = 0; i < (duk_uint_fast32_t) DUK_HOBJECT_GET_ENEXT(varmap); i++) {
+	for (i = 0; i < (duk_uint_fast32_t) duk_hobject_get_enext(varmap); i++) {
 		duk_size_t regbase_byteoff;
 
 		key = DUK_HOBJECT_E_GET_KEY(thr->heap, varmap, i);
@@ -1539,7 +1539,6 @@ duk_bool_t duk__declvar_helper(duk_hthread *thr,
 	duk_hobject *holder;
 	duk_bool_t parents;
 	duk__id_lookup_result ref;
-	duk_tval *tv;
 
 	DUK_DDD(DUK_DDDPRINT("declvar: thr=%p, env=%p, name=%!O, val=%!T, prop_flags=0x%08lx, is_func_decl=%ld "
 	                     "(env -> %!iO)",

--- a/src-input/duk_prop_defown.c
+++ b/src-input/duk_prop_defown.c
@@ -493,7 +493,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_strkey_ordinary(duk_hthread *thr,
 		duk_propvalue *pv_slot;
 		duk_uint8_t *attr_slot;
 
-		duk_hobject_get_props_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
+		duk_hobject_get_strprops_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
 
 		DUK_ASSERT(key_base[ent_idx] == key);
 		pv_slot = val_base + ent_idx;
@@ -512,7 +512,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_strkey_ordinary(duk_hthread *thr,
 		}
 
 		ent_idx = (duk_uint_fast32_t) duk_hobject_alloc_strentry_checked(thr, obj, key);
-		duk_hobject_get_props_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
+		duk_hobject_get_strprops_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
 		DUK_ASSERT(key_base[ent_idx] == key);
 		pv_slot = val_base + ent_idx;
 		attr_slot = attr_base + ent_idx;
@@ -891,9 +891,8 @@ DUK_LOCAL duk_bool_t duk__prop_defown_idxkey_ordinary(duk_hthread *thr,
 		duk_propvalue *pv_slot;
 		duk_uint8_t *attr_slot;
 
-		val_base = (duk_propvalue *) (void *) obj->idx_props;
-		key_base = (duk_uarridx_t *) (void *) (val_base + obj->i_size);
-		attr_base = (duk_uint8_t *) (void *) (key_base + obj->i_size);
+		duk_hobject_get_idxprops_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
+
 		DUK_ASSERT(key_base[ent_idx] == idx);
 		pv_slot = val_base + ent_idx;
 		attr_slot = attr_base + ent_idx;
@@ -910,9 +909,7 @@ DUK_LOCAL duk_bool_t duk__prop_defown_idxkey_ordinary(duk_hthread *thr,
 			goto fail_not_extensible;
 		}
 		ent_idx = (duk_uint_fast32_t) duk_hobject_alloc_idxentry_checked(thr, obj, idx);
-		val_base = (duk_propvalue *) (void *) obj->idx_props;
-		key_base = (duk_uarridx_t *) (void *) (val_base + obj->i_size);
-		attr_base = (duk_uint8_t *) (void *) (key_base + obj->i_size);
+		duk_hobject_get_idxprops_key_attr(thr->heap, obj, &val_base, &key_base, &attr_base);
 		DUK_ASSERT(key_base[ent_idx] == idx);
 		pv_slot = val_base + ent_idx;
 		attr_slot = attr_base + ent_idx;

--- a/src-input/duk_prop_get.c
+++ b/src-input/duk_prop_get.c
@@ -382,6 +382,7 @@ duk__get_own_prop_idxkey_ordinary(duk_hthread *thr, duk_hobject *obj, duk_uarrid
 	}
 }
 
+#if defined(DUK_USE_PROXY_POLICY)
 DUK_LOCAL void duk__prop_get_own_proxy_policy(duk_hthread *thr, duk_hobject *obj) {
 	duk_hobject *target;
 	duk_small_int_t attrs;
@@ -417,8 +418,9 @@ DUK_LOCAL void duk__prop_get_own_proxy_policy(duk_hthread *thr, duk_hobject *obj
 	return;
 
 reject:
-	DUK_ERROR_TYPE(thr, DUK_STR_PROXY_REJECTED);
+	DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 }
+#endif
 
 DUK_LOCAL duk_bool_t duk__prop_get_own_proxy_tail(duk_hthread *thr, duk_hobject *obj, duk_idx_t idx_out, duk_idx_t idx_recv) {
 	DUK_ASSERT(thr != NULL);
@@ -1321,7 +1323,7 @@ DUK_LOCAL DUK_ALWAYS_INLINE duk_bool_t duk__prop_get_stroridx_helper(duk_hthread
 #endif
 #endif
 
-		next = DUK_HOBJECT_GET_PROTOTYPE(thr->heap, target);
+		next = duk_hobject_get_proto_raw(thr->heap, target);
 		if (next == NULL) {
 			if (DUK_UNLIKELY(DUK_HOBJECT_HAS_EXOTIC_PROXYOBJ(target))) {
 				if (side_effect_safe) {
@@ -1884,7 +1886,9 @@ DUK_INTERNAL duk_bool_t duk_prop_getvalue_push(duk_hthread *thr, duk_idx_t idx_r
 	duk_push_undefined(thr);
 	idx_out = duk_get_top_index_known(thr);
 
-	return duk_prop_getvalue_outidx(thr, idx_recv, tv_key, idx_out);
+	rc = duk_prop_getvalue_outidx(thr, idx_recv, tv_key, idx_out);
+	DUK_ASSERT(duk_get_top(thr) == entry_top + 1);
+	return rc;
 }
 
 DUK_INTERNAL duk_bool_t duk_prop_getvalue_stridx_outidx(duk_hthread *thr,

--- a/src-input/duk_prop_getown.c
+++ b/src-input/duk_prop_getown.c
@@ -98,7 +98,7 @@ DUK_LOCAL duk_small_int_t duk__prop_getown_proxy_policy(duk_hthread *thr, duk_ho
 	return attrs;
 
 fail:
-	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_TRAP_RESULT);
+	DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 	DUK_WO_NORETURN(return 0;);
 }
 #endif
@@ -138,7 +138,7 @@ DUK_LOCAL duk_small_int_t duk__prop_getown_proxy_tail(duk_hthread *thr, duk_hobj
 	return attrs;
 
 invalid_result:
-	DUK_ERROR_TYPE(thr, DUK_STR_INVALID_TRAP_RESULT);
+	DUK_ERROR_TYPE_PROXY_REJECTED(thr);
 	DUK_WO_NORETURN(return 0;);
 }
 

--- a/src-input/duk_prop_util.c
+++ b/src-input/duk_prop_util.c
@@ -272,8 +272,8 @@ DUK_INTERNAL duk_hstring *duk_prop_arguments_map_prep_idxkey(duk_hthread *thr,
 	if (!rc) {
 		return NULL;
 	}
-	DUK_ASSERT((*out_map)->idx_props != NULL);
-	pv = ((duk_propvalue *) (*out_map)->idx_props) + ent_idx;
+	DUK_ASSERT(duk_hobject_get_idxprops(thr->heap, *out_map) != NULL);
+	pv = duk_hobject_get_idxprops(thr->heap, *out_map) + ent_idx;
 	tv_varname = &pv->v;
 	DUK_ASSERT(DUK_TVAL_IS_STRING(tv_varname));
 	varname = DUK_TVAL_GET_STRING(tv_varname);

--- a/src-input/duk_strings.h
+++ b/src-input/duk_strings.h
@@ -89,7 +89,6 @@
 /* Object property access */
 #define DUK_STR_INVALID_BASE          "invalid base value"
 #define DUK_STR_STRICT_CALLER_READ    "cannot read strict 'caller'"
-#define DUK_STR_PROXY_REJECTED        "proxy rejected"
 #define DUK_STR_INVALID_ARRAY_LENGTH  "invalid array length"
 #define DUK_STR_SETTER_UNDEFINED      "setter undefined"
 #define DUK_STR_INVALID_DESCRIPTOR    "invalid descriptor"
@@ -99,8 +98,8 @@
 #define DUK_STR_INVALID_RVALUE        "invalid rvalue"
 
 /* Proxy */
-#define DUK_STR_PROXY_REVOKED       "proxy revoked"
-#define DUK_STR_INVALID_TRAP_RESULT "invalid trap result"
+#define DUK_STR_PROXY_REVOKED  "proxy revoked"
+#define DUK_STR_PROXY_REJECTED "proxy rejected"
 
 /* Variables */
 

--- a/tests/ecmascript/test-bi-proxy-ownkeys-result-types.js
+++ b/tests/ecmascript/test-bi-proxy-ownkeys-result-types.js
@@ -11,7 +11,7 @@
 
 /*===
 ["foo","bar"]
-TypeError: invalid trap result
+TypeError: proxy rejected
 ===*/
 
 function test() {

--- a/tests/ecmascript/test-bi-proxy-preventextensions.js
+++ b/tests/ecmascript/test-bi-proxy-preventextensions.js
@@ -1,0 +1,156 @@
+/*===
+- passthrough
+true
+false
+- falsish
+true
+preventExtensions trap: true true
+TypeError
+true
+- truish, but target still extensible
+true
+preventExtensions trap: true true
+TypeError
+true
+- truish, target not extensible
+true
+preventExtensions trap: true true
+false
+- side effects, truish
+true
+preventExtensions trap: true true
+isExtensible trap: true true
+false
+- side effects, falsish
+true
+preventExtensions trap: true true
+TypeError
+false
+===*/
+
+function testBasic() {
+    // Pass-through case.
+    print('- passthrough');
+    var target = { foo: 123 };
+    var P = new Proxy(target, {});
+    print(Object.isExtensible(target));
+    Object.preventExtensions(P);
+    print(Object.isExtensible(target));
+
+    // Proxy trap returns falsish, i.e. fail to prevent extensions.
+    print('- falsish');
+    var target = { foo: 123 };
+    var handler = {};
+    handler.preventExtensions = function (targ) {
+        print('preventExtensions trap:', this === handler, targ === target);
+        return 0;  // Failed to prevent.
+    };
+    var P = new Proxy(target, handler);
+    print(Object.isExtensible(target));
+    try {
+        Object.preventExtensions(P);
+    } catch (e) {
+        print(e.name);
+        //print(e.stack);
+    }
+    print(Object.isExtensible(target));
+
+    // Proxy trap returns truish, i.e. succeeded to prevent extensions, but target is still
+    // extensible.
+    print('- truish, but target still extensible');
+    var target = { foo: 123 };
+    var handler = {};
+    handler.preventExtensions = function (targ) {
+        print('preventExtensions trap:', this === handler, targ === target);
+        return 1;
+    };
+    var P = new Proxy(target, handler);
+    print(Object.isExtensible(target));
+    try {
+        Object.preventExtensions(P);
+    } catch (e) {
+        print(e.name);
+        //print(e.stack);
+    }
+    print(Object.isExtensible(target));
+
+    // Proxy trap returns truish, i.e. succeeded to prevent extensions, target also
+    // made non-extensible.
+    print('- truish, target not extensible');
+    var target = { foo: 123 };
+    var handler = {};
+    handler.preventExtensions = function (targ) {
+        print('preventExtensions trap:', this === handler, targ === target);
+        Object.preventExtensions(target);
+        return 1;
+    };
+    var P = new Proxy(target, handler);
+    print(Object.isExtensible(target));
+    try {
+        Object.preventExtensions(P);
+    } catch (e) {
+        print(e.name);
+        //print(e.stack);
+    }
+    print(Object.isExtensible(target));
+}
+
+function testSideEffects() {
+    // Observe IsExtensible(target) by making target a proxy.  Called only when
+    // proxy trap returns truish.
+    print('- side effects, truish');
+    var finalTarget = { foo: 123 };
+    var targetHandler = {};
+    targetHandler.isExtensible = function (targ) {
+        print('isExtensible trap:', this === targetHandler, targ === finalTarget);
+        return Object.isExtensible(finalTarget);
+    };
+    var target = new Proxy(finalTarget, targetHandler);
+    var handler = {};
+    handler.preventExtensions = function (targ) {
+        print('preventExtensions trap:', this === handler, targ === target);
+        Object.preventExtensions(target);
+        return 1;
+    };
+    var P = new Proxy(target, handler);
+    print(Object.isExtensible(finalTarget));
+    try {
+        Object.preventExtensions(P);
+    } catch (e) {
+        print(e.name);
+        //print(e.stack);
+    }
+    print(Object.isExtensible(finalTarget));
+
+    // With falsish trap result isExtensible not called.
+    print('- side effects, falsish');
+    var finalTarget = { foo: 123 };
+    var targetHandler = {};
+    targetHandler.isExtensible = function (targ) {
+        print('isExtensible trap:', this === targetHandler, targ === finalTarget);
+        return Object.isExtensible(finalTarget);
+    };
+    var target = new Proxy(finalTarget, targetHandler);
+    var handler = {};
+    handler.preventExtensions = function (targ) {
+        print('preventExtensions trap:', this === handler, targ === target);
+        Object.preventExtensions(target);
+        return 0;
+    };
+    var P = new Proxy(target, handler);
+    print(Object.isExtensible(finalTarget));
+    try {
+        Object.preventExtensions(P);
+    } catch (e) {
+        print(e.name);
+        //print(e.stack);
+    }
+    print(Object.isExtensible(finalTarget));
+}
+
+try {
+    testBasic();
+    testSideEffects();
+} catch (e) {
+    print(e.stack || e);
+}


### PR DESCRIPTION
* Use same "proxy rejected" for all Proxy invariant rejects.
* #ifdef guard for proxy policy checks.
* Test coverage for 'preventExtensions' trap.
* Convert many duk_hobject.h macro calls into function calls.
* Add functions to interact with idx_props allocation.
* Compile warning fixes.