### PR TITLE
Add Radu Rendec (myself) to AUTHORS.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -71,6 +71,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Sam Hellawell (https://github.com/samhellawell)
 * Vladislavs Sokurenko (https://github.com/sokurenko)
 * Luca Boccassi (https://github.com/bluca)
+* Radu Rendec (https://github.com/rrendec)
 
 Other contributions
 ===================


### PR DESCRIPTION
I would like to add a new project to the "Projects using Duktape" wiki page. It looks like adding myself to the AUTHORS.rst is the first step in order to be allowed to make pull requests against the wiki repo. Thank you!