### PR TITLE
Support for logical assignment operators (&&= and ||=)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * Luca Boccassi (https://github.com/bluca)
 * Radu Rendec (https://github.com/rrendec)
 * tinywrkb (https://github.com/tinywrkb)
+* Christoph Kaser (https://github.com/ChristophKaser)
 
 Other contributions
 ===================

--- a/src-input/duk_lexer.c
+++ b/src-input/duk_lexer.c
@@ -1413,7 +1413,11 @@ restart:
 		break;
 	case DUK_ASC_AMP: /* '&' */
 		if (DUK__L1() == DUK_ASC_AMP) {
-			advtok = DUK__ADVTOK(2, DUK_TOK_LAND);
+			if (DUK__L2() == DUK_ASC_EQUALS) {
+				advtok = DUK__ADVTOK(3, DUK_TOK_LAND_EQ);
+			} else {
+				advtok = DUK__ADVTOK(2, DUK_TOK_LAND);
+			}
 		} else if (DUK__L1() == DUK_ASC_EQUALS) {
 			advtok = DUK__ADVTOK(2, DUK_TOK_BAND_EQ);
 		} else {
@@ -1422,7 +1426,11 @@ restart:
 		break;
 	case DUK_ASC_PIPE: /* '|' */
 		if (DUK__L1() == DUK_ASC_PIPE) {
-			advtok = DUK__ADVTOK(2, DUK_TOK_LOR);
+			if (DUK__L2() == DUK_ASC_EQUALS) {
+				advtok = DUK__ADVTOK(3, DUK_TOK_LOR_EQ);
+			} else {
+				advtok = DUK__ADVTOK(2, DUK_TOK_LOR);
+			}
 		} else if (DUK__L1() == DUK_ASC_EQUALS) {
 			advtok = DUK__ADVTOK(2, DUK_TOK_BOR_EQ);
 		} else {

--- a/src-input/duk_lexer.h
+++ b/src-input/duk_lexer.h
@@ -162,15 +162,17 @@ typedef void (*duk_re_range_callback)(void *user, duk_codepoint_t r1, duk_codepo
 #define DUK_TOK_BAND_EQ    96
 #define DUK_TOK_BOR_EQ     97
 #define DUK_TOK_BXOR_EQ    98
+#define DUK_TOK_LAND_EQ    99
+#define DUK_TOK_LOR_EQ     100
 
 /* literals (E5 Section 7.8), except null, true, false, which are treated
  * like reserved words (above).
  */
-#define DUK_TOK_NUMBER 99
-#define DUK_TOK_STRING 100
-#define DUK_TOK_REGEXP 101
+#define DUK_TOK_NUMBER 101
+#define DUK_TOK_STRING 102
+#define DUK_TOK_REGEXP 103
 
-#define DUK_TOK_MAXVAL 101 /* inclusive */
+#define DUK_TOK_MAXVAL 103 /* inclusive */
 
 #define DUK_TOK_INVALID DUK_SMALL_UINT_MAX
 

--- a/tests/ecmascript/expr/test-expr-logicalop-assignment.js
+++ b/tests/ecmascript/expr/test-expr-logicalop-assignment.js
@@ -1,0 +1,67 @@
+/*
+ *  'logical or assignment' and 'logical and assignment' operators (https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators).
+ */
+
+function testSideEffect(exp, key) {
+    print('tse ' + key);
+    return exp;
+}
+
+/*===
+5
+===*/
+var a = 1;
+a &&= 5;
+print (a);
+
+/*===
+tse 1
+0
+0
+===*/
+a &&= 1 && testSideEffect(0, '1');
+print(a); // Should be 0
+a &&= testSideEffect(false, '2'); // testSideEffect should not be evaluated
+print(a); // Should be 0, not false
+
+/*===
+tse 3
+tse 4
+tse 5
+false
+false
+===*/
+var b = a ||= testSideEffect(0, '3') || testSideEffect(0, '4') || testSideEffect(false, '5');
+print(a); // Should be false, not 0
+print(b); // Should be false, not 0
+
+
+
+/*===
+[object Object]
+false
+===*/
+var obj = {a: false};
+obj.b ||= obj.a;
+obj.a ||= {};
+print(obj.a);
+print(obj.b);
+
+/*===
+tse 6
+true
+===*/
+testSideEffect(obj, '6').b ||= true;
+print(obj.b);
+
+
+/*===
+tse 7
+tse 8
+tse 9
+tse 10
+99
+===*/
+
+testSideEffect(obj, '7').b &&= testSideEffect(obj, '8').b &&= testSideEffect(obj, '9').b = testSideEffect(99, '10');
+print(obj.b);


### PR DESCRIPTION
... as specified in https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators

I wanted to precompile my code for duktape (or rather low.js) using the google closure compiler, which seems to use those operators a lot.

Unfortunately, I had to copy/paste some code in src-input/duk_js_compiler.c from the assignments-label, because logical operators don't quite fit the pattern of the other assignment operators (e.g. they don't always evaluate the rhs).

I have added some basic tests and compared them to the behavior of nodejs.