### PR TITLE
Fixes RangeError in Object.assign for a large number of arguments

### DIFF
--- a/src-input/duk_bi_object.c
+++ b/src-input/duk_bi_object.c
@@ -72,9 +72,8 @@ DUK_INTERNAL duk_ret_t duk_bi_object_constructor_assign(duk_hthread *thr) {
 			duk_put_prop(thr, 0);
 			/* [ target ... enum ] */
 		}
-		/* Could pop enumerator, but unnecessary because of duk_set_top()
-		 * below.
-		 */
+		/* pop the enumerator, because otherwise a large number of argumens will exhaust the valstack */
+		duk_pop_known(thr);
 	}
 
 	duk_set_top(thr, 1);

--- a/tests/ecmascript/bug/test-bug-object-assign.js
+++ b/tests/ecmascript/bug/test-bug-object-assign.js
@@ -1,0 +1,30 @@
+/*
+ *  Test case for https://github.com/svaarala/duktape/issues/2529:
+ *  Check that Object.assign works for a large number of parameters
+ * 
+ * Used to throw:
+ * RangeError: cannot push beyond allocated stack
+ *    at [anon] (duk_api_stack.c:4316) internal
+ *    at assign () native strict preventsyield
+ *    at test (tests/ecmascript/bug/test-bug-object-assign.js:25)
+ *    at global (tests/ecmascript/bug/test-bug-object-assign.js:30) preventsyield
+ *    error in executing file tests/ecmascript/bug/test-bug-object-assign.js
+ */
+
+/*===
+499
+===*/
+
+function test() {
+    var arguments = [{}];
+
+    for (var i = 0; i < 500; i++) {
+        arguments.push({key: i});
+    }
+
+    var result = Object.assign.apply(Object, arguments);
+
+    print(result.key);    
+}
+
+test();


### PR DESCRIPTION
This PR fixes https://github.com/svaarala/duktape/issues/2529.