### PR TITLE
Use WSAPoll() instead of poll() on Win32

### DIFF
--- a/examples/eventloop/c_eventloop.c
+++ b/examples/eventloop/c_eventloop.c
@@ -11,7 +11,14 @@
 #include <string.h>
 #include <stdint.h>
 #include <sys/time.h>
+
+#if defined(_WIN32)
+#include <WinSock2.h>
+#define poll WSAPoll
+#pragma comment(lib, "ws2_32")
+#else
 #include <poll.h>
+#endif
 
 #include "duktape.h"
 #include "c_eventloop.h"


### PR DESCRIPTION
The example event loop does not compile for Win32 because `poll()` is not available. Fix copied from `poll.c` in the same directory.