### PR TITLE
Add support for LoongArch.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ and agreed to irrevocably license their contributions under the Duktape
 * tinywrkb (https://github.com/tinywrkb)
 * Christoph Kaser (https://github.com/ChristophKaser)
 * Jonne Ransijn <jonne@yyny.dev>
+* Liu Xiang <liuxiang@loongson.cn>
 
 Other contributions
 ===================

--- a/config/architectures.yaml
+++ b/config/architectures.yaml
@@ -54,6 +54,10 @@ autodetect:
     check: DUK_F_RISCV64
     include: architecture_riscv64.h.in
   -
+    name: LOONGARCH 64-bit
+    check: DUK_F_LOONGARCH64
+    include: architecture_loongarch64.h.in
+  -
     name: SuperH
     check: DUK_F_SUPERH
     include: architecture_superh.h.in

--- a/config/architectures/architecture_loongarch64.h.in
+++ b/config/architectures/architecture_loongarch64.h.in
@@ -1,0 +1,3 @@
+#define DUK_USE_ARCH_STRING "loongarch64"
+#define DUK_USE_BYTEORDER 1
+#undef DUK_USE_PACKED_TVAL

--- a/config/helper-snippets/DUK_F_LOONGARCH.h.in
+++ b/config/helper-snippets/DUK_F_LOONGARCH.h.in
@@ -1,0 +1,4 @@
+/* LOONGARCH64, https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html */
+#if defined(__loongarch64)
+#define DUK_F_LOONGARCH64
+#endif


### PR DESCRIPTION
Add support for LoongArch.The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html